### PR TITLE
DMP-58 Connecting DARTS API to Azure Application Insights hosted in Darts Shared Infrastructure

### DIFF
--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.9
+version: 0.0.10
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.8
+version: 0.0.9
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -8,6 +8,6 @@ java:
       secrets:
         - name: GovukNotifyApiKey
           alias: GOVUK_NOTIFY_API_KEY
-#        - name: AppInsightsInstrumentationKey
-#          alias: azure.application-insights.instrumentation-key
+        - name: AppInsightsInstrumentationKey
+          alias: azure.application-insights.instrumentation-key
   environment:

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -10,4 +10,6 @@ java:
           alias: GOVUK_NOTIFY_API_KEY
         - name: AppInsightsInstrumentationKey
           alias: azure.application-insights.instrumentation-key
+        - name: AppInsightsConnectionString
+          alias: azure.application-insights.connection-string
   environment:

--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -1,4 +1,5 @@
 {
+  "connectionString": "${file:/mnt/secrets/darts/AppInsightsConnectionString}",
   "role": {
     "name": "rpe-demo"
   }

--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -1,6 +1,6 @@
 {
   "connectionString": "${file:/mnt/secrets/darts/AppInsightsConnectionString}",
   "role": {
-    "name": "rpe-demo"
+    "name": "Darts"
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-58


### Change description ###
Initial commit of secrets to allow for connection to Azure App Insights. There is no real consistency across the HMCTS Repos on how this is achieved.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
