### PR TITLE
DMP-114: Integrate caching, token validation and basic exception hand…

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/UriProvider.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/UriProvider.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.darts.authentication.component;
+
+import java.net.URI;
+
+public interface UriProvider {
+
+    URI getAuthorizationUri();
+
+    URI getLandingPageUri();
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/SimpleInMemorySessionCacheImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/SimpleInMemorySessionCacheImpl.java
@@ -27,6 +27,7 @@ public class SimpleInMemorySessionCacheImpl implements SessionCache {
         }
 
         cache.put(sessionId, session);
+        log.debug("Added session to cache: {}:{}", sessionId, session);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/TokenValidatorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/TokenValidatorImpl.java
@@ -51,9 +51,7 @@ public class TokenValidatorImpl implements TokenValidator {
 
         try {
             jwtProcessor.process(accessToken, null);
-        } catch (ParseException | JOSEException e) {
-            throw new IllegalArgumentException(e);
-        } catch (BadJOSEException e) {
+        } catch (ParseException | JOSEException | BadJOSEException e) {
             log.debug("Validation failed", e);
             return new JwtValidationResult(false, e.getMessage());
         }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImpl.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.darts.authentication.component.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.http.client.utils.URIBuilder;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.authentication.component.UriProvider;
+import uk.gov.hmcts.darts.authentication.config.AuthenticationConfiguration;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Component
+@RequiredArgsConstructor
+public class UriProviderImpl implements UriProvider {
+
+    private final AuthenticationConfiguration authConfig;
+
+    @Override
+    @SneakyThrows(URISyntaxException.class)
+    public URI getAuthorizationUri() {
+        URIBuilder uriBuilder = new URIBuilder(
+            authConfig.getExternalADauthorizationUri());
+        uriBuilder.addParameter("client_id", authConfig.getExternalADclientId());
+        uriBuilder.addParameter("response_type", authConfig.getExternalADresponseType());
+        uriBuilder.addParameter(
+            "redirect_uri",
+            authConfig.getExternalADredirectUri()
+        );
+        uriBuilder.addParameter("response_mode", authConfig.getExternalADresponseMode());
+        uriBuilder.addParameter("scope", authConfig.getExternalADscope());
+        uriBuilder.addParameter("prompt", authConfig.getExternalADprompt());
+        return uriBuilder.build();
+    }
+
+    @Override
+    public URI getLandingPageUri() {
+        return URI.create("/");
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/AuthenticationController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/AuthenticationController.java
@@ -12,7 +12,7 @@ public interface AuthenticationController {
     ModelAndView loginOrRefresh(HttpSession session);
 
     @PostMapping("/handle-oauth-code")
-    ModelAndView handleOauthCode(@RequestParam("code") String code);
+    ModelAndView handleOauthCode(HttpSession session, @RequestParam("code") String code);
 
     @GetMapping("/logout")
     ModelAndView logout();

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
@@ -27,10 +27,9 @@ public class AuthenticationExternalUserController implements AuthenticationContr
     }
 
     @Override
-    public ModelAndView handleOauthCode(String code) {
-        log.info("Authorization Token received successfully");
-        authenticationService.fetchAccessToken(code);
-        return new ModelAndView("redirect:/");
+    public ModelAndView handleOauthCode(HttpSession session, String code) {
+        URI url = authenticationService.handleOauthCode(session.getId(), code);
+        return new ModelAndView("redirect:" + url.toString());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserController.java
@@ -19,7 +19,7 @@ public class AuthenticationInternalUserController implements AuthenticationContr
     }
 
     @Override
-    public ModelAndView handleOauthCode(String code) {
+    public ModelAndView handleOauthCode(HttpSession session, String code) {
         log.info("Authorization Token received successfully");
 
         throw new NotImplementedException("Internal users not yet supported");

--- a/src/main/java/uk/gov/hmcts/darts/authentication/dao/AzureDao.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/dao/AzureDao.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.darts.authentication.dao;
+
+import uk.gov.hmcts.darts.authentication.exception.AzureDaoException;
+import uk.gov.hmcts.darts.authentication.model.OAuthProviderRawResponse;
+
+public interface AzureDao {
+    OAuthProviderRawResponse fetchAccessToken(String code) throws AzureDaoException;
+}

--- a/src/main/java/uk/gov/hmcts/darts/authentication/dao/impl/AzureDaoImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/dao/impl/AzureDaoImpl.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.darts.authentication.dao.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StreamUtils;
+import uk.gov.hmcts.darts.authentication.config.AuthenticationConfiguration;
+import uk.gov.hmcts.darts.authentication.dao.AzureDao;
+import uk.gov.hmcts.darts.authentication.exception.AzureDaoException;
+import uk.gov.hmcts.darts.authentication.model.OAuthProviderRawResponse;
+import uk.gov.hmcts.darts.authentication.service.AzureActiveDirectoryB2CClient;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AzureDaoImpl implements AzureDao {
+
+    private final AuthenticationConfiguration authConfig;
+    private final AzureActiveDirectoryB2CClient azureActiveDirectoryB2CClient;
+
+    @Override
+    public OAuthProviderRawResponse fetchAccessToken(String code) throws AzureDaoException {
+        log.debug("Fetching access token(s) for authorization code: {}", code);
+
+        if (StringUtils.isBlank(code)) {
+            throw new AzureDaoException("Null code not permitted");
+        }
+
+        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+        requestBody.add("grant_type", authConfig.getExternalADauthorizationGrantType());
+        requestBody.add("redirect_uri", authConfig.getExternalADredirectUri());
+        requestBody.add("code", code);
+        requestBody.add("client_id", authConfig.getExternalADclientId());
+        requestBody.add("client_secret", authConfig.getExternalADclientSecret());
+        requestBody.add("scope", authConfig.getExternalADscope());
+
+        try (Response response = azureActiveDirectoryB2CClient.fetchAccessToken(requestBody)) {
+            String parsedResponse = StreamUtils.copyToString(
+                response.body().asInputStream(),
+                StandardCharsets.UTF_8
+            );
+            if (HttpStatus.SC_OK != response.status()) {
+                throw new AzureDaoException("Unexpected HTTP response code received from Azure",
+                                            parsedResponse,
+                                            response.status());
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            OAuthProviderRawResponse tokenResponse = mapper.readValue(
+                parsedResponse,
+                OAuthProviderRawResponse.class
+            );
+
+            log.debug("Obtained access tokens for authorization code: {}, {}", code, tokenResponse);
+            return tokenResponse;
+
+        } catch (IOException e) {
+            throw new AzureDaoException("Failed to fetch Azure AD Access Token", e);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/authentication/exception/AuthenticationException.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/exception/AuthenticationException.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.darts.authentication.exception;
+
+@SuppressWarnings("PMD.MissingSerialVersionUID")
+public class AuthenticationException extends RuntimeException {
+
+    public AuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AuthenticationException(String message, String cause) {
+        super(String.format("%s: %s", message, cause));
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/authentication/exception/AzureDaoException.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/exception/AzureDaoException.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.darts.authentication.exception;
+
+import lombok.Getter;
+
+@SuppressWarnings("PMD.MissingSerialVersionUID")
+@Getter
+public class AzureDaoException extends Exception {
+
+    private int httpStatus;
+
+    public AzureDaoException(String message) {
+        super(message);
+    }
+
+    public AzureDaoException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AzureDaoException(String message, String reason, int httpStatus) {
+        super(String.format("%s: %s", message, reason));
+        this.httpStatus = httpStatus;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/authentication/model/OAuthProviderRawResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/model/OAuthProviderRawResponse.java
@@ -3,15 +3,13 @@ package uk.gov.hmcts.darts.authentication.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter
-@Setter
+@Data
 public class OAuthProviderRawResponse {
 
     @JsonProperty("id_token")

--- a/src/main/java/uk/gov/hmcts/darts/authentication/model/Session.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/model/Session.java
@@ -1,6 +1,4 @@
 package uk.gov.hmcts.darts.authentication.model;
 
-import java.util.UUID;
-
-public record Session(UUID sessionId, String accessToken, String refreshToken) {
+public record Session(String sessionId, String accessToken, long accessTokenExpiresIn) {
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
@@ -1,16 +1,12 @@
 package uk.gov.hmcts.darts.authentication.service;
 
 
-import uk.gov.hmcts.darts.authentication.model.OAuthProviderRawResponse;
-
 import java.net.URI;
 
 public interface AuthenticationService {
 
     URI loginOrRefresh(String sessionId);
 
-    OAuthProviderRawResponse fetchAccessToken(String code);
-
-
+    URI handleOauthCode(String sessionId, String code);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/SessionService.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/SessionService.java
@@ -6,4 +6,6 @@ public interface SessionService {
 
     Session getSession(String sessionId);
 
+    void putSession(String sessionId, Session session);
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
@@ -1,94 +1,64 @@
 package uk.gov.hmcts.darts.authentication.service.impl;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import feign.Response;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.utils.URIBuilder;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.util.StreamUtils;
-import uk.gov.hmcts.darts.authentication.config.AuthenticationConfiguration;
+import uk.gov.hmcts.darts.authentication.component.TokenValidator;
+import uk.gov.hmcts.darts.authentication.component.UriProvider;
+import uk.gov.hmcts.darts.authentication.dao.AzureDao;
+import uk.gov.hmcts.darts.authentication.exception.AuthenticationException;
+import uk.gov.hmcts.darts.authentication.exception.AzureDaoException;
 import uk.gov.hmcts.darts.authentication.model.OAuthProviderRawResponse;
 import uk.gov.hmcts.darts.authentication.model.Session;
 import uk.gov.hmcts.darts.authentication.service.AuthenticationService;
-import uk.gov.hmcts.darts.authentication.service.AzureActiveDirectoryB2CClient;
 import uk.gov.hmcts.darts.authentication.service.SessionService;
 
-import java.io.IOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthenticationServiceImpl implements AuthenticationService {
 
-    private final AuthenticationConfiguration authServiceConfiguration;
     private final SessionService sessionService;
-    private final AzureActiveDirectoryB2CClient azureActiveDirectoryB2CClient;
+    private final TokenValidator tokenValidator;
+    private final AzureDao azureDao;
+    private final UriProvider uriProvider;
 
     @Override
     public URI loginOrRefresh(String sessionId) {
+        log.debug("Session {} has initiated login or refresh flow", sessionId);
+
         Session session = sessionService.getSession(sessionId);
         if (session == null) {
-            return getAuthorizationUrl();
+            return uriProvider.getAuthorizationUri();
         }
 
         throw new NotImplementedException("Active session support not yet implemented");
     }
 
-    @SneakyThrows
-    URI getAuthorizationUrl() {
-        URIBuilder uriBuilder = new URIBuilder(
-            authServiceConfiguration.getExternalADauthorizationUri());
-        uriBuilder.addParameter("client_id", authServiceConfiguration.getExternalADclientId());
-        uriBuilder.addParameter("response_type", authServiceConfiguration.getExternalADresponseType());
-        uriBuilder.addParameter(
-            "redirect_uri",
-            authServiceConfiguration.getExternalADredirectUri()
-        );
-        uriBuilder.addParameter("response_mode", authServiceConfiguration.getExternalADresponseMode());
-        uriBuilder.addParameter("scope", authServiceConfiguration.getExternalADscope());
-        uriBuilder.addParameter("prompt", authServiceConfiguration.getExternalADprompt());
-        return uriBuilder.build();
-    }
-
     @Override
-    public OAuthProviderRawResponse fetchAccessToken(String code) {
+    public URI handleOauthCode(String sessionId, String code) {
+        log.debug("Session {} has presented authorization code {}", sessionId, code);
 
-        OAuthProviderRawResponse rawResponse = new OAuthProviderRawResponse();
-        MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
-        requestBody.add("grant_type", authServiceConfiguration.getExternalADauthorizationGrantType());
-        requestBody.add("redirect_uri", authServiceConfiguration.getExternalADredirectUri());
-        requestBody.add("code", code);
-        requestBody.add("client_id", authServiceConfiguration.getExternalADclientId());
-        requestBody.add("client_secret", authServiceConfiguration.getExternalADclientSecret());
-        requestBody.add("resource", authServiceConfiguration.getExternalADclientId());
-        requestBody.add("scope", authServiceConfiguration.getExternalADscope());
-
-        try (Response response = azureActiveDirectoryB2CClient.fetchAccessToken(requestBody)) {
-            String parsedResponse = StreamUtils.copyToString(
-                response.body().asInputStream(),
-                StandardCharsets.UTF_8
-            );
-            if (HttpStatus.SC_OK != response.status()) {
-                log.info(
-                    "Access Token & Response Status Received from oauth provider **** {} *** Response status : {}",
-                    parsedResponse, response.status()
-                );
-            }
-
-            ObjectMapper mapper = new ObjectMapper();
-            rawResponse = mapper.readValue(parsedResponse, OAuthProviderRawResponse.class);
-
-        } catch (IOException e) {
-            log.error("Failed to fetch Azure AD Access Token", e);
+        OAuthProviderRawResponse tokenResponse;
+        try {
+            tokenResponse = azureDao.fetchAccessToken(code);
+        } catch (AzureDaoException e) {
+            throw new AuthenticationException("Failed to obtain access token", e);
         }
-        return rawResponse;
+        var accessToken = tokenResponse.getAccessToken();
+
+        var validationResult = tokenValidator.validate(accessToken);
+        if (!validationResult.valid()) {
+            throw new AuthenticationException("Failed to validate access token", validationResult.reason());
+        }
+
+        var session = new Session(sessionId, accessToken, tokenResponse.getExpiresIn());
+        sessionService.putSession(sessionId, session);
+
+        return uriProvider.getLandingPageUri();
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/SessionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/SessionServiceImpl.java
@@ -19,4 +19,9 @@ public class SessionServiceImpl implements SessionService {
         return sessionCache.get(sessionId);
     }
 
+    @Override
+    public void putSession(String sessionId, Session session) {
+        sessionCache.put(sessionId, session);
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/SimpleInMemorySessionCacheImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/SimpleInMemorySessionCacheImplTest.java
@@ -46,7 +46,7 @@ class SimpleInMemorySessionCacheImplTest {
     }
 
     private Session createSession() {
-        return new Session(null, null, null);
+        return new Session(null, null, 0);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/TokenValidatorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/TokenValidatorImplTest.java
@@ -35,7 +35,6 @@ import java.util.StringJoiner;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -158,11 +157,13 @@ class TokenValidatorImplTest {
     void validateShouldThrowExceptionWhenNonParsableTokenIsPresented() {
         String jwt = "I AM NOT PARSABLE AS A JWT";
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-            tokenValidator.validate(jwt));
+        JwtValidationResult validationResult = tokenValidator.validate(jwt);
 
-        assertEquals("java.text.ParseException: Invalid JWT serialization: Missing dot delimiter(s)",
-                     exception.getMessage());
+        assertFalse(validationResult.valid());
+        assertEquals(
+            "Invalid JWT serialization: Missing dot delimiter(s)",
+            validationResult.reason()
+        );
     }
 
     @SneakyThrows(NoSuchAlgorithmException.class)

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImplTest.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.darts.authentication.component.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.authentication.config.AuthenticationConfiguration;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.LinguisticNaming")
+class UriProviderImplTest {
+
+    @Mock
+    private AuthenticationConfiguration authConfig;
+
+    @InjectMocks
+    private UriProviderImpl uriProvider;
+
+    @Test
+    void getAuthorizationUriShouldReturnExpectedUri() {
+        mockStubsForAuthorization();
+
+        URI authUrl = uriProvider.getAuthorizationUri();
+
+        assertEquals("AuthUrl?client_id=ClientId&response_type=ResponseType&redirect_uri=RedirectId"
+                         + "&response_mode=ResponseMode&scope=Scope&prompt=Prompt",
+                     authUrl.toString());
+    }
+
+    @Test
+    void getLandingPageUriShouldReturnExpectedUri() {
+        URI landingPageUri = uriProvider.getLandingPageUri();
+
+        assertEquals("/", landingPageUri.toString());
+    }
+
+    private void mockStubsForAuthorization() {
+        when(authConfig.getExternalADauthorizationUri()).thenReturn("AuthUrl");
+        when(authConfig.getExternalADclientId()).thenReturn("ClientId");
+        when(authConfig.getExternalADresponseType()).thenReturn("ResponseType");
+        when(authConfig.getExternalADredirectUri()).thenReturn("RedirectId");
+        when(authConfig.getExternalADresponseMode()).thenReturn("ResponseMode");
+        when(authConfig.getExternalADscope()).thenReturn("Scope");
+        when(authConfig.getExternalADprompt()).thenReturn("Prompt");
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
@@ -8,7 +8,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.web.servlet.ModelAndView;
-import uk.gov.hmcts.darts.authentication.model.OAuthProviderRawResponse;
 import uk.gov.hmcts.darts.authentication.service.AuthenticationService;
 
 import java.net.URI;
@@ -16,6 +15,7 @@ import java.net.URI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 class AuthenticationExternalUserControllerTest {
 
     private static final URI DUMMY_AUTHORIZATION_URI = URI.create("https://www.example.com/authorization?param=value");
+    private static final URI DUMMY_LANDING_PAGE_URI = URI.create("/");
 
     @InjectMocks
     private AuthenticationExternalUserController controller;
@@ -46,9 +47,16 @@ class AuthenticationExternalUserControllerTest {
 
     @Test
     void handleOauthCodeFromAzureWhenCodeIsReturned() {
-        when(authenticationService.fetchAccessToken("code")).thenReturn(new OAuthProviderRawResponse());
-        ModelAndView mv = controller.handleOauthCode("code");
-        assertNotNull(mv);
+        MockHttpSession session = new MockHttpSession();
+
+        when(authenticationService.handleOauthCode(any(), anyString()))
+            .thenReturn(DUMMY_LANDING_PAGE_URI);
+
+        ModelAndView modelAndView = controller.handleOauthCode(session, "code");
+
+        assertNotNull(modelAndView);
+        assertEquals("redirect:/", modelAndView.getViewName(),
+                     "Redirect url was not as expected");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
@@ -16,12 +16,12 @@ class AuthenticationInternalUserControllerTest {
 
     @Test
     void loginAndRefreshTokenFromAzureWhenTokenDoesntExistsInSession() {
-        assertThrows(NotImplementedException.class, () -> controller.handleOauthCode(null));
+        assertThrows(NotImplementedException.class, () -> controller.handleOauthCode(null, null));
     }
 
     @Test
     void handleOauthCodeFromAzureWhenCodeIsReturned() {
-        assertThrows(NotImplementedException.class, () -> controller.handleOauthCode(null));
+        assertThrows(NotImplementedException.class, () -> controller.handleOauthCode(null, null));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/authentication/dao/impl/AzureDaoImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/dao/impl/AzureDaoImplTest.java
@@ -1,0 +1,103 @@
+package uk.gov.hmcts.darts.authentication.dao.impl;
+
+import feign.Request;
+import feign.Response;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.authentication.config.AuthenticationConfiguration;
+import uk.gov.hmcts.darts.authentication.exception.AzureDaoException;
+import uk.gov.hmcts.darts.authentication.model.OAuthProviderRawResponse;
+import uk.gov.hmcts.darts.authentication.service.AzureActiveDirectoryB2CClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AzureDaoImplTest {
+
+    @Mock
+    private AzureActiveDirectoryB2CClient azureActiveDirectoryB2CClient;
+
+    @Mock
+    private AuthenticationConfiguration authenticationConfiguration;
+
+    @InjectMocks
+    private AzureDaoImpl azureDaoImpl;
+
+    @Test
+    void fetchAccessTokenShouldReturnResponseWhenAzureCallIsSuccessful() throws AzureDaoException {
+        mockConfig();
+        try (Response response = mockSuccessResponse()) {
+            when(azureActiveDirectoryB2CClient.fetchAccessToken(any())).thenReturn(response);
+
+            OAuthProviderRawResponse rawResponse = azureDaoImpl.fetchAccessToken("CODE");
+
+            assertEquals("test_id_token", rawResponse.getAccessToken());
+            assertEquals(1234L, rawResponse.getExpiresIn());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" "})
+    @NullAndEmptySource
+    void fetchAccessTokenShouldThrowExceptionWhenProvidedCodeIsBlankOrNull(String code) {
+        AzureDaoException exception = assertThrows(AzureDaoException.class, () -> azureDaoImpl.fetchAccessToken(code));
+
+        assertEquals("Null code not permitted", exception.getMessage());
+    }
+
+    @Test
+    void fetchAccessTokenShouldThrowExceptionWhenAzureCallIsNotSuccessful() {
+        mockConfig();
+        try (Response response = mockSuccessResponse()) {
+            try (Response failedResponse = mockFailedResponse(response)) {
+                when(azureActiveDirectoryB2CClient.fetchAccessToken(any())).thenReturn(failedResponse);
+
+                AzureDaoException exception = assertThrows(
+                    AzureDaoException.class,
+                    () -> azureDaoImpl.fetchAccessToken("CODE")
+                );
+
+                assertEquals("Unexpected HTTP response code received from Azure: body", exception.getMessage());
+                assertEquals(400, exception.getHttpStatus());
+            }
+        }
+    }
+
+    private Response mockSuccessResponse() {
+        String body = "{\"id_token\":\"test_id_token\", \"id_token_expires_in\":\"1234\"}";
+        Map<String, Collection<String>> headersError = new ConcurrentHashMap<>();
+
+        return Response.builder().reason("REASON").body(body, StandardCharsets.UTF_8).status(HttpStatus.SC_OK)
+            .headers(new HashMap<>())
+            .request(Request.create(Request.HttpMethod.POST, "dummy/test", headersError, null, null, null)).build();
+    }
+
+    private Response mockFailedResponse(Response response) {
+        return response.toBuilder().status(HttpStatus.SC_BAD_REQUEST).body("body", StandardCharsets.UTF_8).build();
+    }
+
+    private void mockConfig() {
+        when(authenticationConfiguration.getExternalADclientId()).thenReturn("ClientId");
+        when(authenticationConfiguration.getExternalADredirectUri()).thenReturn("RedirectId");
+        when(authenticationConfiguration.getExternalADscope()).thenReturn("Scope");
+        when(authenticationConfiguration.getExternalADauthorizationGrantType()).thenReturn("GrantType");
+        when(authenticationConfiguration.getExternalADclientSecret()).thenReturn("ClientSecret");
+    }
+
+}


### PR DESCRIPTION
### [DMP-114](https://tools.hmcts.net/jira/browse/DMP-114)

This PR is part 1 of 2 related to DMP-114, containing changes to enhance the existing handle-oauth-code functionality:
- Integration of a session caching mechanism
- Integration of a token validation mechanism
- Custom exceptions are introduced to facilitate basic error handling
- Refactoring to tighten the focus of main service layer class `AuthenticationServiceImpl`. Functionality which was calling Azure is moved to a new DAO class `AzureDaoImpl`, and functionality related to generating uris is moved to new class `UriProviderImpl`. This change is made to improve the testability of these components, and unit tests are adjusted to suit.

**Note: Integration testing of the handle-oauth-code functionality will be delivered by a separate PR under DMP-114.**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
