### PR TITLE
DMP-114: Integration test for handle-oauth-code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,6 +254,7 @@ dependencies {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
+  testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner', version: '4.0.2'
 
   compileJava.dependsOn generateDailyListApi
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/HandleOAuthCodeIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/HandleOAuthCodeIntTest.java
@@ -1,0 +1,159 @@
+package uk.gov.hmcts.darts.authentication.controller.impl;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Base64.Encoder;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@AutoConfigureWireMock
+@ActiveProfiles("intTest")
+@SuppressWarnings("PMD.ExcessiveImports")
+class HandleOAuthCodeIntTest {
+
+    private static final String EXTERNAL_USER_HANDLE_OAUTH_CODE_ENDPOINT_WITH_CODE =
+        "/external-user/handle-oauth-code?code=abc";
+    private static final String KEY_ID_VALUE = "dummy_key_id";
+    private static final String CONFIGURED_ISSUER_VALUE = "dummy_issuer_uri";
+    private static final String CONFIGURED_AUDIENCE_VALUE = "dummy_client_id";
+    private static final String OAUTH_TOKEN_ENDPOINT = "/oauth2/v2.0/token";
+    private static final String OAUTH_KEYS_ENDPOINT = "/discovery/v2.0/keys";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void handOAuthCodeShouldReturnRedirectWhenValidAuthTokenIsObtainedForProvidedAuthCode() throws Exception {
+        setWiremockStubs();
+
+        mockMvc.perform(MockMvcRequestBuilders.post(EXTERNAL_USER_HANDLE_OAUTH_CODE_ENDPOINT_WITH_CODE))
+            .andExpect(status().isFound())
+            .andExpect(header().string(
+                HttpHeaders.LOCATION,
+                "/"
+            ));
+    }
+
+    /**
+     * To test the access token validation aspects of the /handle-oauth-code flow, we must ensure the Azure /token stub
+     * provides a token whose signature can be verified against a public key provided by the configured Remote JWKS.
+     * This setup method generates these private and public RSA keys and sets the stub responses accordingly.
+     */
+    @SneakyThrows
+    private void setWiremockStubs() {
+        JWTClaimsSet jwtClaimsSet = new JWTClaimsSet.Builder()
+            .audience(CONFIGURED_AUDIENCE_VALUE)
+            .issuer(CONFIGURED_ISSUER_VALUE)
+            .expirationTime(createDateInFuture())
+            .build();
+
+        KeyPair keyPair = createKeys();
+
+        String signedJwt = createSignedJwt(jwtClaimsSet, keyPair).serialize();
+
+        stubFor(
+            WireMock.post(OAUTH_TOKEN_ENDPOINT)
+                .willReturn(
+                    aResponse().withStatus(200).withBody("{\"id_token\":\"" + signedJwt + "\"}")
+                )
+        );
+
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        Encoder encoder = Base64.getEncoder();
+        JwksKey jwksKey = new JwksKey(
+            "RSA",
+            "sig",
+            KEY_ID_VALUE,
+            encoder.encodeToString(publicKey.getModulus().toByteArray()),
+            encoder.encodeToString(publicKey.getPublicExponent().toByteArray()),
+            CONFIGURED_ISSUER_VALUE
+        );
+        JwksKeySet jwksKeySet = new JwksKeySet(Collections.singletonList(jwksKey));
+
+        String jwksKeySetJson = new ObjectMapper().writeValueAsString(jwksKeySet);
+
+        stubFor(
+            WireMock.get(OAUTH_KEYS_ENDPOINT)
+                .willReturn(
+                    aResponse().withStatus(200).withBody(jwksKeySetJson)
+                )
+        );
+    }
+
+    @SneakyThrows(NoSuchAlgorithmException.class)
+    private KeyPair createKeys() {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+
+        return generator.generateKeyPair();
+    }
+
+    @SneakyThrows(JOSEException.class)
+    private SignedJWT createSignedJwt(JWTClaimsSet jwtClaimsSet, KeyPair keyPair) {
+        JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256)
+            .keyID(KEY_ID_VALUE)
+            .type(JOSEObjectType.JWT)
+            .build();
+
+        SignedJWT signedJwt = new SignedJWT(jwsHeader, jwtClaimsSet);
+
+        RSASSASigner signer = new RSASSASigner(keyPair.getPrivate());
+        signedJwt.sign(signer);
+
+        return signedJwt;
+    }
+
+    private Date createDateInFuture() {
+        return Date.from(Instant.now().plus(1, ChronoUnit.HOURS));
+    }
+
+    private record JwksKeySet(@JsonProperty("keys") List<JwksKey> keys) {
+
+    }
+
+    private record JwksKey(@JsonProperty("kty") String algorithm,
+                           @JsonProperty("use") String use,
+                           @JsonProperty("kid") String keyId,
+                           @JsonProperty("n") String modulus,
+                           @JsonProperty("e") String exponent,
+                           @JsonProperty("issuer") String issuer) {
+
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LoginOrRefreshIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LoginOrRefreshIntTest.java
@@ -18,9 +18,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest
 @ActiveProfiles("intTest")
-class AuthenticationExternalUserControllerTest {
+class LoginOrRefreshIntTest {
 
-    private static final String EXPECTED_LOGIN_REDIRECT_URL = "https://localhost:8080/oauth2/v2.0/authorize?client_id=dummy_client_id&response_type=code&redirect_uri=https%3A%2F%2Fexample.com%2Fhandle-oauth-code&response_mode=form_post&scope=openid&prompt=login";
+    private static final String EXPECTED_LOGIN_REDIRECT_URL = "http://localhost:8080/oauth2/v2.0/authorize?client_id=dummy_client_id&response_type=code&redirect_uri=https%3A%2F%2Fexample.com%2Fhandle-oauth-code&response_mode=form_post&scope=openid&prompt=login";
     private static final String EXTERNAL_USER_LOGIN_OR_REFRESH_ENDPOINT = "/external-user/login-or-refresh";
 
     @MockBean
@@ -57,3 +57,4 @@ class AuthenticationExternalUserControllerTest {
     }
 
 }
+

--- a/src/integrationTest/resources/application-intTest.yaml
+++ b/src/integrationTest/resources/application-intTest.yaml
@@ -12,9 +12,10 @@ spring:
             response-type: code
             response-mode: form_post
             prompt: login
+            issuer-uri: dummy_issuer_uri
             provider: external-azure-ad-provider
         provider:
           external-azure-ad-provider:
-            authorization-uri: https://localhost:8080/oauth2/v2.0/authorize
-            token-uri: https://localhost:8080/oauth2/v2.0/token
-            jwk-set-uri: https://localhost:8080/discovery/v2.0/keys
+            authorization-uri: http://localhost:8080/oauth2/v2.0/authorize
+            token-uri: http://localhost:8080/oauth2/v2.0/token
+            jwk-set-uri: http://localhost:8080/discovery/v2.0/keys


### PR DESCRIPTION
### [DMP-114](https://tools.hmcts.net/jira/browse/DMP-114)

This PR is part 2 of 2 related to DMP-114, containing a happy-path integration test for handle-oauth-code functionality.

Unhappy path tests are out of scope until an error response schema is defined.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
