### PR TITLE
DMP-115: Add logout redirect

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/UriProvider.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/UriProvider.java
@@ -8,4 +8,6 @@ public interface UriProvider {
 
     URI getLandingPageUri();
 
+    URI getLogoutPageUri();
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImpl.java
@@ -38,4 +38,9 @@ public class UriProviderImpl implements UriProvider {
         return URI.create("/");
     }
 
+    @Override
+    public URI getLogoutPageUri() {
+        return URI.create("/");
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.authentication.controller.impl;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
@@ -33,7 +32,8 @@ public class AuthenticationExternalUserController implements AuthenticationContr
 
     @Override
     public ModelAndView logout() {
-        throw new NotImplementedException("To be implemented by DMP-115");
+        URI url = authenticationService.logout();
+        return new ModelAndView("redirect:" + url.toString());
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
@@ -9,4 +9,5 @@ public interface AuthenticationService {
 
     String handleOauthCode(String sessionId, String code);
 
+    URI logout();
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
@@ -60,4 +60,9 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         return accessToken;
     }
 
+    @Override
+    public URI logout() {
+        return uriProvider.getLogoutPageUri();
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImplTest.java
@@ -40,6 +40,13 @@ class UriProviderImplTest {
         assertEquals("/", landingPageUri.toString());
     }
 
+    @Test
+    void getLogoutPageUriShouldReturnExpectedUri() {
+        URI logoutPageUri = uriProvider.getLogoutPageUri();
+
+        assertEquals("/", logoutPageUri.toString());
+    }
+
     private void mockStubsForAuthorization() {
         when(authConfig.getExternalADauthorizationUri()).thenReturn("AuthUrl");
         when(authConfig.getExternalADclientId()).thenReturn("ClientId");

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.authentication.controller.impl;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,7 +13,6 @@ import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -23,6 +21,7 @@ import static org.mockito.Mockito.when;
 class AuthenticationExternalUserControllerTest {
 
     private static final URI DUMMY_AUTHORIZATION_URI = URI.create("https://www.example.com/authorization?param=value");
+    private static final URI DUMMY_LOGOUT_URI = URI.create("https://www.example.com/logoutpage");
     private static final String DUMMY_TOKEN = "token";
 
     @InjectMocks
@@ -58,8 +57,13 @@ class AuthenticationExternalUserControllerTest {
     }
 
     @Test
-    void logoutWhenUserLogoutFromdarts() {
-        assertThrows(NotImplementedException.class, () -> controller.logout());
+    void logoutShouldReturnRedirectToLogoutPage() {
+        when(authenticationService.logout())
+            .thenReturn(DUMMY_LOGOUT_URI);
+
+        ModelAndView modelAndView = controller.logout();
+
+        assertEquals("redirect:https://www.example.com/logoutpage", modelAndView.getViewName());
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
@@ -28,6 +28,7 @@ class AuthenticationServiceImplTest {
     private static final String DUMMY_SESSION_ID = "9D65049E1787A924E269747222F60CAA";
     private static final URI DUMMY_AUTH_URI = URI.create("DUMMY_AUTH_URI");
     private static final URI DUMMY_LANDING_PAGE_URI = URI.create("DUMMY_LANDING_PAGE_URI");
+    private static final URI DUMMY_LOGOUT_PAGE_URI = URI.create("DUMMY_LOGOUT_PAGE_URI");
     private static final String DUMMY_CODE = "DUMMY CODE";
     private static final String DUMMY_ID_TOKEN = "DUMMY ID TOKEN";
 
@@ -108,6 +109,16 @@ class AuthenticationServiceImplTest {
         );
 
         assertEquals("Failed to validate access token: validation failure reason", exception.getMessage());
+    }
+
+    @Test
+    void logoutShouldReturnLogoutPage() {
+        when(uriProvider.getLogoutPageUri())
+            .thenReturn(DUMMY_LOGOUT_PAGE_URI);
+
+        URI uri = authenticationService.logout();
+        
+        assertEquals(DUMMY_LOGOUT_PAGE_URI, uri);
     }
 
 }


### PR DESCRIPTION
## [DMP-115](https://tools.hmcts.net/jira/browse/DMP-115)

This change adds redirect functionality to the darts-api /logout endpoint for external users.

The change is accompanied by manual configuration changes made to Azure B2C config:

- `B2C_1_darts_externaluser_signin` policy has property `Require ID Token in logout requests` set to `Yes`
- `darts-stg` Authentication property `Front-channel logout` set to `https://darts-portal.staging.platform.hmcts.net/external-user/logout`

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
