### PR TITLE
DMP-496: Implement logout endpoint (external users)

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.darts.authentication.controller.impl;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.darts.audio.repository.AudioRequestRepository;
+import uk.gov.hmcts.darts.authentication.model.Session;
+import uk.gov.hmcts.darts.authentication.service.SessionService;
+import uk.gov.hmcts.darts.courthouse.CourthouseRepository;
+import uk.gov.hmcts.darts.notification.repository.NotificationRepository;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"intTest", "h2db"})
+public class LogoutIntTest {
+
+    private static final String EXPECTED_LOGOUT_REDIRECT_URL = """
+        https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin\
+        /oauth2/v2.0/logout\
+        ?id_token_hint=1\
+        &post_logout_redirect_uri=https%3A%2F%2Fdarts-portal.staging.platform.hmcts.net%2Fauth%2Flogout-callback""";
+    private static final String EXTERNAL_USER_LOGOUT_ENDPOINT = "/external-user/logout";
+
+    @MockBean
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private AudioRequestRepository audioRequestRepository;
+
+    @MockBean
+    private CourthouseRepository courthouseRepository;
+
+    @Autowired
+    private SessionService sessionService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void logoutShouldReturnRedirectWhenSessionExists() throws Exception {
+        sessionService.putSession("1", new Session(null, null, 0));
+
+        MockHttpServletRequestBuilder requestBuilder = get(EXTERNAL_USER_LOGOUT_ENDPOINT);
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(status().isFound())
+            .andExpect(header().string(
+                HttpHeaders.LOCATION,
+                EXPECTED_LOGOUT_REDIRECT_URL
+            ));
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles({"intTest", "h2db"})
-public class LogoutIntTest {
+class LogoutIntTest {
 
     private static final String EXTERNAL_USER_LOGOUT_ENDPOINT = "/external-user/logout";
 
@@ -43,6 +43,7 @@ public class LogoutIntTest {
     private MockMvc mockMvc;
 
     @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     void logoutShouldReturnRedirectWhenSessionExists() throws Exception {
         MockHttpSession mockHttpSession = new MockHttpSession();
         String id = mockHttpSession.getId();

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/UriProvider.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/UriProvider.java
@@ -8,4 +8,5 @@ public interface UriProvider {
 
     URI getLandingPageUri();
 
+    URI getLogoutUri(String sessionId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImpl.java
@@ -38,4 +38,15 @@ public class UriProviderImpl implements UriProvider {
         return URI.create("/");
     }
 
+    @Override
+    @SneakyThrows(URISyntaxException.class)
+    public URI getLogoutUri(String sessionId) {
+        URIBuilder uriBuilder = new URIBuilder(
+            authConfig.getExternalADlogoutUri());
+        uriBuilder.addParameter("id_token_hint", sessionId);
+        uriBuilder.addParameter("post_logout_redirect_uri", authConfig.getExternalADlogoutRedirectUri());
+
+        return uriBuilder.build();
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/config/AuthenticationConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/config/AuthenticationConfiguration.java
@@ -19,6 +19,9 @@ public class AuthenticationConfiguration {
     @Value("${spring.security.oauth2.client.provider.external-azure-ad-provider.authorization-uri}")
     private String externalADauthorizationUri;
 
+    @Value("${spring.security.oauth2.client.provider.external-azure-ad-provider.logout-uri}")
+    private String externalADlogoutUri;
+
     @Value("${spring.security.oauth2.client.provider.external-azure-ad-provider.token-uri}")
     private String externalADtokenUri;
 
@@ -30,6 +33,9 @@ public class AuthenticationConfiguration {
 
     @Value("${spring.security.oauth2.client.registration.external-azure-ad.redirect-uri}")
     private String externalADredirectUri;
+
+    @Value("${spring.security.oauth2.client.registration.external-azure-ad.logout-redirect-uri}")
+    private String externalADlogoutRedirectUri;
 
     @Value("${spring.security.oauth2.client.registration.external-azure-ad.authorization-grant-type}")
     private String externalADauthorizationGrantType;

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/AuthenticationController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/AuthenticationController.java
@@ -15,6 +15,5 @@ public interface AuthenticationController {
     String handleOauthCode(HttpSession session, @RequestParam("code") String code);
 
     @GetMapping("/logout")
-    ModelAndView logout();
-
+    ModelAndView logout(HttpSession session);
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.authentication.controller.impl;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
@@ -32,8 +31,9 @@ public class AuthenticationExternalUserController implements AuthenticationContr
     }
 
     @Override
-    public ModelAndView logout() {
-        throw new NotImplementedException("To be implemented by DMP-115");
+    public ModelAndView logout(HttpSession session) {
+        URI url = authenticationService.logout(session.getId());
+        return new ModelAndView("redirect:" + url.toString());
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserController.java
@@ -26,7 +26,7 @@ public class AuthenticationInternalUserController implements AuthenticationContr
     }
 
     @Override
-    public ModelAndView logout() {
+    public ModelAndView logout(HttpSession httpSession) {
         throw new NotImplementedException("Internal users not yet supported");
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/authentication/exception/AuthenticationException.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/exception/AuthenticationException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.darts.authentication.exception;
 @SuppressWarnings("PMD.MissingSerialVersionUID")
 public class AuthenticationException extends RuntimeException {
 
+    public AuthenticationException(String message) {
+        super(message);
+    }
+
     public AuthenticationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
@@ -9,4 +9,5 @@ public interface AuthenticationService {
 
     String handleOauthCode(String sessionId, String code);
 
+    URI logout(String sessionId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
@@ -60,4 +60,17 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         return accessToken;
     }
 
+    @Override
+    public URI logout(String sessionId) {
+        log.debug("Session {} has initiated logout flow", sessionId);
+
+        Session session = sessionService.getSession(sessionId);
+        if (session == null) {
+            throw new AuthenticationException(
+                String.format("Session %s attempted logout but this session is not active", sessionId));
+        }
+
+        return uriProvider.getLogoutUri(sessionId);
+    }
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,7 @@ spring:
             client-secret: ${AAD_B2C_CLIENT_SECRET_KEY:}
             scope: openid
             redirect-uri: https://darts-portal.staging.platform.hmcts.net/auth/callback
+            logout-redirect-uri: https://darts-portal.staging.platform.hmcts.net/auth/logout-callback
             authorization-grant-type: authorization_code
             response-type: code
             response-mode: form_post
@@ -54,6 +55,7 @@ spring:
             authorization-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/authorize
             token-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/token
             jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
+            logout-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/logout
           internal-azure-ad-provider:
             authorization-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/authorize
             token-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/token

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImplTest.java
@@ -40,6 +40,17 @@ class UriProviderImplTest {
         assertEquals("/", landingPageUri.toString());
     }
 
+    @Test
+    void getLogoutUriShouldReturnExpectedUri() {
+        when(authConfig.getExternalADlogoutUri()).thenReturn("LogoutUrl");
+        when(authConfig.getExternalADlogoutRedirectUri()).thenReturn("LogoutRedirectUrl");
+
+        URI logoutUri = uriProvider.getLogoutUri("DUMMY_SESSION_ID");
+
+        assertEquals("LogoutUrl?id_token_hint=DUMMY_SESSION_ID&post_logout_redirect_uri=LogoutRedirectUrl",
+                     logoutUri.toString());
+    }
+
     private void mockStubsForAuthorization() {
         when(authConfig.getExternalADauthorizationUri()).thenReturn("AuthUrl");
         when(authConfig.getExternalADclientId()).thenReturn("ClientId");

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.authentication.controller.impl;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,7 +13,6 @@ import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -23,6 +21,7 @@ import static org.mockito.Mockito.when;
 class AuthenticationExternalUserControllerTest {
 
     private static final URI DUMMY_AUTHORIZATION_URI = URI.create("https://www.example.com/authorization?param=value");
+    private static final URI DUMMY_LOGOUT_URI = URI.create("https://www.example.com/logout?param=value");
     private static final String DUMMY_TOKEN = "token";
 
     @InjectMocks
@@ -41,8 +40,7 @@ class AuthenticationExternalUserControllerTest {
         ModelAndView modelAndView = controller.loginOrRefresh(session);
 
         assertNotNull(modelAndView);
-        assertEquals("redirect:https://www.example.com/authorization?param=value", modelAndView.getViewName(),
-                     "Redirect url was not as expected");
+        assertEquals("redirect:https://www.example.com/authorization?param=value", modelAndView.getViewName());
     }
 
     @Test
@@ -58,8 +56,16 @@ class AuthenticationExternalUserControllerTest {
     }
 
     @Test
-    void logoutWhenUserLogoutFromdarts() {
-        assertThrows(NotImplementedException.class, () -> controller.logout());
+    void logoutShouldReturnLogoutPageUriWhenTokenExistsInSession() {
+        MockHttpSession session = new MockHttpSession();
+
+        when(authenticationService.logout(any()))
+            .thenReturn(DUMMY_LOGOUT_URI);
+
+        ModelAndView modelAndView = controller.logout(session);
+
+        assertNotNull(modelAndView);
+        assertEquals("redirect:https://www.example.com/logout?param=value", modelAndView.getViewName());
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
@@ -26,7 +26,7 @@ class AuthenticationInternalUserControllerTest {
 
     @Test
     void logoutWhenUserLogoutFromdarts() {
-        assertThrows(NotImplementedException.class, () -> controller.logout());
+        assertThrows(NotImplementedException.class, () -> controller.logout(null));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
@@ -27,6 +27,7 @@ class AuthenticationServiceImplTest {
 
     private static final String DUMMY_SESSION_ID = "9D65049E1787A924E269747222F60CAA";
     private static final URI DUMMY_AUTH_URI = URI.create("DUMMY_AUTH_URI");
+    private static final URI DUMMY_LOGOUT_URI = URI.create("DUMMY_LOGOUT_URI");
     private static final URI DUMMY_LANDING_PAGE_URI = URI.create("DUMMY_LANDING_PAGE_URI");
     private static final String DUMMY_CODE = "DUMMY CODE";
     private static final String DUMMY_ID_TOKEN = "DUMMY ID TOKEN";
@@ -53,19 +54,19 @@ class AuthenticationServiceImplTest {
         when(uriProvider.getAuthorizationUri())
             .thenReturn(DUMMY_AUTH_URI);
 
-        URI uri = authenticationService.loginOrRefresh("DUMMY_SESSION_ID");
+        URI uri = authenticationService.loginOrRefresh(DUMMY_SESSION_ID);
 
         assertEquals(DUMMY_AUTH_URI, uri);
     }
 
     @Test
-    void loginOrRefreshShouldThrowExceptionWhenExistingSessionExists() {
+    void loginOrRefreshShouldReturnLandingPageUriWhenSessionExists() {
         when(sessionService.getSession(anyString()))
             .thenReturn(new Session(null, null, 0));
         when(uriProvider.getLandingPageUri())
             .thenReturn(DUMMY_LANDING_PAGE_URI);
 
-        URI uri = authenticationService.loginOrRefresh("DUMMY_SESSION_ID");
+        URI uri = authenticationService.loginOrRefresh(DUMMY_SESSION_ID);
 
         assertEquals(DUMMY_LANDING_PAGE_URI, uri);
     }
@@ -108,6 +109,32 @@ class AuthenticationServiceImplTest {
         );
 
         assertEquals("Failed to validate access token: validation failure reason", exception.getMessage());
+    }
+
+    @Test
+    void logoutShouldThrowExceptionWhenNoExistingSessionExists() {
+        when(sessionService.getSession(anyString()))
+            .thenReturn(null);
+
+        AuthenticationException exception = assertThrows(
+            AuthenticationException.class,
+            () -> authenticationService.logout(DUMMY_SESSION_ID)
+        );
+
+        assertEquals("Session 9D65049E1787A924E269747222F60CAA attempted logout but this session is not active",
+                     exception.getMessage());
+    }
+
+    @Test
+    void logoutShouldReturnLogoutPageUriWhenSessionExists() {
+        when(sessionService.getSession(anyString()))
+            .thenReturn(new Session(null, null, 0));
+        when(uriProvider.getLogoutUri(anyString()))
+            .thenReturn(DUMMY_LOGOUT_URI);
+
+        URI uri = authenticationService.logout(DUMMY_SESSION_ID);
+
+        assertEquals(DUMMY_LOGOUT_URI, uri);
     }
 
 }


### PR DESCRIPTION
## [DMP-496](https://tools.hmcts.net/jira/browse/DMP-496)

logout endpoint implementation, allowing for the first phase of logout to be initiated by Portal:
![image](https://github.com/hmcts/darts-api/assets/131763968/4798f1f5-dc0b-4f7f-b43d-0daf7defa3e2)

Azure AD B2C config also updated to reflect the frontend redirect url: `https://darts-portal.staging.platform.hmcts.net/auth/logout-callback`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
