### PR TITLE
Implement invalidate-session endpoint (external users)

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/InvalidateSessionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/InvalidateSessionIntTest.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.darts.authentication.controller.impl;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.darts.audio.repository.AudioRequestRepository;
+import uk.gov.hmcts.darts.authentication.model.Session;
+import uk.gov.hmcts.darts.authentication.service.SessionService;
+import uk.gov.hmcts.darts.courthouse.CourthouseRepository;
+import uk.gov.hmcts.darts.notification.repository.NotificationRepository;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"intTest", "h2db"})
+class InvalidateSessionIntTest {
+
+    private static final String EXTERNAL_USER_INVALIDATE_SESSION_ENDPOINT = "/external-user/invalidate-session";
+
+    @MockBean
+    private NotificationRepository notificationRepository;
+
+    @MockBean
+    private AudioRequestRepository audioRequestRepository;
+
+    @MockBean
+    private CourthouseRepository courthouseRepository;
+
+    @Autowired
+    private SessionService sessionService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void invalidateSessionShouldReturn200OkWhenSessionIsInvalidated() throws Exception {
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        String id = mockHttpSession.getId();
+        sessionService.putSession(id, new Session(id, null, 0));
+
+        MockHttpServletRequestBuilder requestBuilder = post(EXTERNAL_USER_INVALIDATE_SESSION_ENDPOINT)
+            .session(mockHttpSession);
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(status().isOk());
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/SessionCache.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/SessionCache.java
@@ -8,4 +8,5 @@ public interface SessionCache {
 
     Session get(String sessionId);
 
+    Session remove(String sessionId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/SimpleInMemorySessionCacheImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/SimpleInMemorySessionCacheImpl.java
@@ -17,7 +17,9 @@ public class SimpleInMemorySessionCacheImpl implements SessionCache {
 
     @PostConstruct
     public void postConstruct() {
-        log.warn("### This implementation is intended only for test purposes, and is not intended for production ###");
+        log.warn(
+            "### This implementation is intended only for dev and test purposes, and is not intended for production ###"
+        );
     }
 
     @Override
@@ -33,6 +35,11 @@ public class SimpleInMemorySessionCacheImpl implements SessionCache {
     @Override
     public Session get(String sessionId) {
         return cache.get(sessionId);
+    }
+
+    @Override
+    public Session remove(String sessionId) {
+        return cache.remove(sessionId);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/AuthenticationController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/AuthenticationController.java
@@ -16,4 +16,8 @@ public interface AuthenticationController {
 
     @GetMapping("/logout")
     ModelAndView logout(HttpSession session);
+
+    @PostMapping("/invalidate-session")
+    void invalidateSession(HttpSession session);
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
@@ -36,4 +36,9 @@ public class AuthenticationExternalUserController implements AuthenticationContr
         return new ModelAndView("redirect:" + url.toString());
     }
 
+    @Override
+    public void invalidateSession(HttpSession session) {
+        authenticationService.invalidateSession(session.getId());
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserController.java
@@ -13,21 +13,28 @@ import uk.gov.hmcts.darts.authentication.controller.AuthenticationController;
 @RequestMapping("/internal-user")
 public class AuthenticationInternalUserController implements AuthenticationController {
 
+    private static final String INTERNAL_USERS_NOT_SUPPORTED_MESSAGE = "Internal users not yet supported";
+
     @Override
     public ModelAndView loginOrRefresh(HttpSession session) {
-        throw new NotImplementedException("Internal users not yet supported");
+        throw new NotImplementedException(INTERNAL_USERS_NOT_SUPPORTED_MESSAGE);
     }
 
     @Override
     public String handleOauthCode(HttpSession session, String code) {
         log.info("Authorization Token received successfully");
 
-        throw new NotImplementedException("Internal users not yet supported");
+        throw new NotImplementedException(INTERNAL_USERS_NOT_SUPPORTED_MESSAGE);
     }
 
     @Override
     public ModelAndView logout(HttpSession httpSession) {
-        throw new NotImplementedException("Internal users not yet supported");
+        throw new NotImplementedException(INTERNAL_USERS_NOT_SUPPORTED_MESSAGE);
+    }
+
+    @Override
+    public void invalidateSession(HttpSession session) {
+        throw new NotImplementedException(INTERNAL_USERS_NOT_SUPPORTED_MESSAGE);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
@@ -10,4 +10,7 @@ public interface AuthenticationService {
     String handleOauthCode(String sessionId, String code);
 
     URI logout(String sessionId);
+
+    void invalidateSession(String sessionId);
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/SessionService.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/SessionService.java
@@ -8,4 +8,5 @@ public interface SessionService {
 
     void putSession(String sessionId, Session session);
 
+    Session dropSession(String sessionId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
@@ -73,4 +73,17 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         return uriProvider.getLogoutUri(sessionId);
     }
 
+    @Override
+    public void invalidateSession(String sessionId) {
+        log.debug("Session {} is requesting invalidation", sessionId);
+
+        Session session = sessionService.dropSession(sessionId);
+        if (session == null) {
+            throw new AuthenticationException(
+                String.format("Session %s requested invalidation but this session is not active", sessionId));
+        }
+
+        log.debug("Session {} invalidated", sessionId);
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
@@ -77,11 +77,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     public void invalidateSession(String sessionId) {
         log.debug("Session {} is requesting invalidation", sessionId);
 
-        Session session = sessionService.dropSession(sessionId);
-        if (session == null) {
-            throw new AuthenticationException(
-                String.format("Session %s requested invalidation but this session is not active", sessionId));
-        }
+        sessionService.dropSession(sessionId);
 
         log.debug("Session {} invalidated", sessionId);
     }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/SessionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/SessionServiceImpl.java
@@ -1,15 +1,13 @@
 package uk.gov.hmcts.darts.authentication.service.impl;
 
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.authentication.component.SessionCache;
 import uk.gov.hmcts.darts.authentication.model.Session;
 import uk.gov.hmcts.darts.authentication.service.SessionService;
 
-@Slf4j
-@Component
-@AllArgsConstructor
+@Service
+@RequiredArgsConstructor
 public class SessionServiceImpl implements SessionService {
 
     private final SessionCache sessionCache;
@@ -22,6 +20,11 @@ public class SessionServiceImpl implements SessionService {
     @Override
     public void putSession(String sessionId, Session session) {
         sessionCache.put(sessionId, session);
+    }
+
+    @Override
+    public Session dropSession(String sessionId) {
+        return sessionCache.remove(sessionId);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/SimpleInMemorySessionCacheImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/SimpleInMemorySessionCacheImplTest.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.darts.authentication.component.SessionCache;
 import uk.gov.hmcts.darts.authentication.model.Session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class SimpleInMemorySessionCacheImplTest {
@@ -43,6 +44,26 @@ class SimpleInMemorySessionCacheImplTest {
     @SuppressWarnings("PMD.LinguisticNaming")
     void getShouldThrowExceptionWhenProvidedWithNullKey() {
         assertThrows(NullPointerException.class, () -> sessionCache.get(null));
+    }
+
+    @Test
+    void removeShouldRemoveAndReturnExistingSession() {
+        Session existingSession = createSession();
+        sessionCache.put(DUMMY_SESSION_ID, existingSession);
+
+        Session removedSession = sessionCache.remove(DUMMY_SESSION_ID);
+
+        assertEquals(existingSession, removedSession);
+
+        Session session = sessionCache.get(DUMMY_SESSION_ID);
+        assertNull(session);
+    }
+
+    @Test
+    void removeShouldReturnNullWhenNoSessionExists() {
+        Session removedSession = sessionCache.remove(DUMMY_SESSION_ID);
+
+        assertNull(removedSession);
     }
 
     private Session createSession() {

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
@@ -11,10 +11,12 @@ import uk.gov.hmcts.darts.authentication.service.AuthenticationService;
 
 import java.net.URI;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -66,6 +68,15 @@ class AuthenticationExternalUserControllerTest {
 
         assertNotNull(modelAndView);
         assertEquals("redirect:https://www.example.com/logout?param=value", modelAndView.getViewName());
+    }
+
+    @Test
+    void invalidateSessionShouldCompleteWithoutExceptionWhenSessionIsInvalidated() {
+        doNothing().when(authenticationService).invalidateSession(anyString());
+
+        MockHttpSession session = new MockHttpSession();
+
+        assertDoesNotThrow(() -> controller.invalidateSession(session));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
@@ -29,4 +29,9 @@ class AuthenticationInternalUserControllerTest {
         assertThrows(NotImplementedException.class, () -> controller.logout(null));
     }
 
+    @Test
+    void invalidateSessionShouldCompleteWithoutExceptionWhenSessionIsInvalidated() {
+        assertThrows(NotImplementedException.class, () -> controller.invalidateSession(null));
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.darts.authentication.service.SessionService;
 
 import java.net.URI;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -135,6 +136,28 @@ class AuthenticationServiceImplTest {
         URI uri = authenticationService.logout(DUMMY_SESSION_ID);
 
         assertEquals(DUMMY_LOGOUT_URI, uri);
+    }
+
+    @Test
+    void invalidateSessionShouldThrowExceptionWhenSessionDoesNotExist() {
+        when(sessionService.dropSession(anyString()))
+            .thenReturn(null);
+
+        AuthenticationException exception = assertThrows(
+            AuthenticationException.class,
+            () -> authenticationService.invalidateSession(DUMMY_SESSION_ID)
+        );
+
+        assertEquals("Session 9D65049E1787A924E269747222F60CAA requested invalidation but this session is not active",
+                     exception.getMessage());
+    }
+
+    @Test
+    void invalidateSessionShouldCompleteWithoutExceptionWhenSessionExists() {
+        when(sessionService.dropSession(anyString()))
+            .thenReturn(new Session(null, null, 0));
+
+        assertDoesNotThrow(() -> authenticationService.invalidateSession(DUMMY_SESSION_ID));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
@@ -139,17 +139,11 @@ class AuthenticationServiceImplTest {
     }
 
     @Test
-    void invalidateSessionShouldThrowExceptionWhenSessionDoesNotExist() {
+    void invalidateSessionShouldShouldCompleteWithoutExceptionWhenSessionDoesNotExist() {
         when(sessionService.dropSession(anyString()))
             .thenReturn(null);
 
-        AuthenticationException exception = assertThrows(
-            AuthenticationException.class,
-            () -> authenticationService.invalidateSession(DUMMY_SESSION_ID)
-        );
-
-        assertEquals("Session 9D65049E1787A924E269747222F60CAA requested invalidation but this session is not active",
-                     exception.getMessage());
+        assertDoesNotThrow(() -> authenticationService.invalidateSession(DUMMY_SESSION_ID));
     }
 
     @Test


### PR DESCRIPTION
## [DMP-497](https://tools.hmcts.net/jira/browse/DMP-497)

invalidate-session endpoint implementation, allowing for the second phase of logout to be initiated by Portal:
![image](https://github.com/hmcts/darts-api/assets/131763968/4798f1f5-dc0b-4f7f-b43d-0daf7defa3e2)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
