### PR TITLE
DMP-405 initial data management service to save and get binary blob data

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -21,7 +21,8 @@ def secrets = [
     secret('api-FUNC-TEST-ROPC-PASSWORD', 'FUNC_TEST_ROPC_PASSWORD'),
     secret('AzureAdB2CFuncTestROPCClientIdKey', 'AAD_B2C_ROPC_CLIENT_ID_KEY'),
     secret('AzureAdB2CFuncTestROPCClientSecretKey', 'AAD_B2C_ROPC_CLIENT_SECRET_KEY'),
-    secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA')
+    secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
+    secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING')
   ],
 ]
 
@@ -98,5 +99,9 @@ withPipeline(type, product, component) {
       reportFiles          : "main.html",
       reportName           : "PMD Report"
     ]
+  }
+
+  afterFailure('test') {
+    junit '**/test-results/integration/*.xml'
   }
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -22,7 +22,8 @@ def secrets = [
     secret('api-FUNC-TEST-ROPC-PASSWORD', 'FUNC_TEST_ROPC_PASSWORD'),
     secret('AzureAdB2CFuncTestROPCClientIdKey', 'AAD_B2C_ROPC_CLIENT_ID_KEY'),
     secret('AzureAdB2CFuncTestROPCClientSecretKey', 'AAD_B2C_ROPC_CLIENT_SECRET_KEY'),
-    secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA')
+    secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
+    secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING')
   ],
 ]
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -18,7 +18,8 @@ def secrets = [
     secret('api-FUNC-TEST-ROPC-PASSWORD', 'FUNC_TEST_ROPC_PASSWORD'),
     secret('AzureAdB2CFuncTestROPCClientIdKey', 'AAD_B2C_ROPC_CLIENT_ID_KEY'),
     secret('AzureAdB2CFuncTestROPCClientSecretKey', 'AAD_B2C_ROPC_CLIENT_SECRET_KEY'),
-    secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA')
+    secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
+    secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING')
   ],
 ]
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ launchctl setenv <<env var name>> <<secret value>>
 ```
 You will then need to restart intellij/terminal windows for it to take effect.
 
+### Storage Account
+Some functional tests require a storage account to complete. Locally, this can be achieved by installing and running the Azurite open-source emulator which provides a free local environment for testing any Azure Blob, Queue or Table storage.
+
+#### Install Azurite
+Use DockerHub to pull the latest Azurite image by using the following command:
+```
+docker pull mcr.microsoft.com/azure-storage/azurite
+```
+#### Run Azurite
+The following command runs the Azurite Docker image. The -p 10000:10000 parameter redirects requests from host machine's port 10000 to the Docker instance.
+```
+docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+    mcr.microsoft.com/azure-storage/azurite
+```
+
+#### Connection String Configuration
+The application obtains the connection string from the key vault. However, locally the default Azurite account details are required. Therefore, you will need to add its connection string as an environment variable .
+
+Environment Variable Name: AZURE_STORAGE_CONNECTION_STRING
+
+Environment Variable Value:
+```
+DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={DEFAULT_ACCOUNT_KEY};BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
+```
+Replace the {DEFAULT_ACCOUNT_KEY} with the value provided in the following link: https://github.com/Azure/Azurite#default-storage-account
+
 ## Building the application
 
 The project uses [Gradle](https://gradle.org) as a build tool. It already contains

--- a/build.gradle
+++ b/build.gradle
@@ -327,6 +327,9 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
   implementation group: 'org.apache.commons', name: 'commons-exec', version: '1.3'
 
+  implementation platform('com.azure:azure-sdk-bom:1.2.13')
+  implementation 'com.azure:azure-storage-blob'
+
   implementation group: 'io.rest-assured', name: 'rest-assured'
   implementation group: 'org.flywaydb', name: 'flyway-core', version: '9.19.4'
   implementation group: 'io.hypersistence', name: 'hypersistence-utils-hibernate-60', version: '3.5.1'
@@ -343,6 +346,7 @@ dependencies {
   testImplementation(platform('org.junit:junit-bom:5.9.3'))
   testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  testImplementation 'org.mockito:mockito-inline:2.13.0'
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.22
+version: 0.0.23
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -30,6 +30,8 @@ java:
           alias: AAD_B2C_ROPC_CLIENT_ID_KEY
         - name: AzureAdB2CFuncTestROPCClientSecretKey
           alias: AAD_B2C_ROPC_CLIENT_SECRET_KEY
+        - name: AzureStorageConnectionString
+          alias: AZURE_STORAGE_CONNECTION_STRING
 
   environment:
     NOTIFICATION_SCHEDULER_CRON: "3 */2 * * * MON-FRI"

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -18,6 +18,7 @@ services:
       - GOVUK_NOTIFY_API_KEY
       - AAD_B2C_ROPC_CLIENT_ID_KEY
       - AAD_B2C_ROPC_CLIENT_SECRET_KEY
+      - AZURE_STORAGE_CONNECTION_STRING
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/functionalTest/java/uk/gov/hmcts/darts/datamanagement/DataManagementServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/datamanagement/DataManagementServiceTest.java
@@ -40,7 +40,7 @@ class DataManagementServiceTest {
         byte[] testStringInBytes = TEST_BINARY_STRING.getBytes(StandardCharsets.UTF_8);
         BinaryData data = BinaryData.fromBytes(testStringInBytes);
 
-        var uniqueBlobName = dataManagementService.saveAudioBlobData(unstructuredStorageContainerName, data);
+        var uniqueBlobName = dataManagementService.saveBlobData(unstructuredStorageContainerName, data);
 
         assertTrue(uniqueBlobName instanceof UUID);
     }
@@ -51,9 +51,9 @@ class DataManagementServiceTest {
         byte[] testStringInBytes = TEST_BINARY_STRING.getBytes(StandardCharsets.UTF_8);
         BinaryData data = BinaryData.fromBytes(testStringInBytes);
 
-        var uniqueBlobName = dataManagementService.saveAudioBlobData(unstructuredStorageContainerName, data);
+        var uniqueBlobName = dataManagementService.saveBlobData(unstructuredStorageContainerName, data);
 
-        var blobData = dataManagementService.getAudioBlobData(
+        var blobData = dataManagementService.getBlobData(
                  unstructuredStorageContainerName,
                  uniqueBlobName);
 
@@ -63,7 +63,7 @@ class DataManagementServiceTest {
     @Test
     void whenGetShouldThrowExceptionWhenProvidedWithInvalidContainerName() {
         assertThrows(BlobStorageException.class, () ->
-            dataManagementService.getAudioBlobData(
+            dataManagementService.getBlobData(
                 "INVALID_CONTAINER_NAME",
                 UUID.fromString(TEST_BLOB_ID)));
     }

--- a/src/functionalTest/java/uk/gov/hmcts/darts/datamanagement/DataManagementServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/datamanagement/DataManagementServiceTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.darts.datamanagement;
+
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.models.BlobStorageException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@ActiveProfiles({"dev","h2db"})
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@ExtendWith(MockitoExtension.class)
+class DataManagementServiceTest {
+
+    private static final String TEST_BINARY_STRING = "Test String to be converted to binary!";
+
+    private static final String TEST_BLOB_ID = "b0f23c62-8dd3-4e4e-ae6a-321ff6eb61d8";
+
+    @Value("${darts.storage.blob.container-name.unstructured}")
+    String unstructuredStorageContainerName;
+
+    @Autowired
+    DataManagementService dataManagementService;
+
+    @Test
+    void saveBinaryDataToBlobStorage() {
+
+        byte[] testStringInBytes = TEST_BINARY_STRING.getBytes(StandardCharsets.UTF_8);
+        BinaryData data = BinaryData.fromBytes(testStringInBytes);
+
+        var uniqueBlobName = dataManagementService.saveAudioBlobData(unstructuredStorageContainerName, data);
+
+        assertTrue(uniqueBlobName instanceof UUID);
+    }
+
+    @Test
+    void fetchBinaryDataFromBlobStorage() {
+
+        byte[] testStringInBytes = TEST_BINARY_STRING.getBytes(StandardCharsets.UTF_8);
+        BinaryData data = BinaryData.fromBytes(testStringInBytes);
+
+        var uniqueBlobName = dataManagementService.saveAudioBlobData(unstructuredStorageContainerName, data);
+
+        var blobData = dataManagementService.getAudioBlobData(
+                 unstructuredStorageContainerName,
+                 uniqueBlobName);
+
+        assertEquals(TEST_BINARY_STRING, blobData.toString());
+    }
+
+    @Test
+    void whenGetShouldThrowExceptionWhenProvidedWithInvalidContainerName() {
+        assertThrows(BlobStorageException.class, () ->
+            dataManagementService.getAudioBlobData(
+                "INVALID_CONTAINER_NAME",
+                UUID.fromString(TEST_BLOB_ID)));
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/config/DataManagementConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/config/DataManagementConfiguration.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.darts.datamanagement.config;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+@Getter
+public class DataManagementConfiguration {
+
+    @Value("${darts.storage.blob.connection-string}")
+    private String blobStorageAccountConnectionString;
+
+    @Value("${darts.storage.blob.container-name.unstructured}")
+    private String unstructuredContainerName;
+
+    @Value("${darts.storage.blob.container-name.inbound}")
+    private String inboundContainerName;
+
+    @Value("${darts.storage.blob.container-name.outbound}")
+    private String outboundContainerName;
+}

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/dao/DataManagementDao.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/dao/DataManagementDao.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.darts.datamanagement.dao;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+
+import java.util.UUID;
+
+public interface DataManagementDao {
+    BlobContainerClient getBlobContainerClient(String containerName);
+
+    BlobClient getBlobClient(BlobContainerClient containerClient, UUID blobName);
+}

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/dao/impl/DataManagementDaoImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/dao/impl/DataManagementDaoImpl.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.darts.datamanagement.dao.impl;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
+import uk.gov.hmcts.darts.datamanagement.dao.DataManagementDao;
+
+import java.util.UUID;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class DataManagementDaoImpl implements DataManagementDao {
+
+    private final DataManagementConfiguration dataManagementConfiguration;
+    private BlobServiceClient blobServiceClient;
+
+    @Override
+    public BlobContainerClient getBlobContainerClient(String containerName) {
+        if (blobServiceClient == null) {
+            blobServiceClient = getBlobServiceClient();
+        }
+        return blobServiceClient.getBlobContainerClient(containerName);
+    }
+
+    @Override
+    public BlobClient getBlobClient(BlobContainerClient containerClient, UUID blobId) {
+        return containerClient.getBlobClient(String.valueOf(blobId));
+    }
+
+    public BlobServiceClient getBlobServiceClient() {
+        return getBlobServiceClientBuilder()
+            .connectionString(dataManagementConfiguration.getBlobStorageAccountConnectionString())
+            .buildClient();
+    }
+
+    public BlobServiceClientBuilder getBlobServiceClientBuilder() {
+        return new BlobServiceClientBuilder();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/dao/impl/DataManagementDaoImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/dao/impl/DataManagementDaoImpl.java
@@ -33,13 +33,9 @@ public class DataManagementDaoImpl implements DataManagementDao {
         return containerClient.getBlobClient(String.valueOf(blobId));
     }
 
-    public BlobServiceClient getBlobServiceClient() {
-        return getBlobServiceClientBuilder()
+    private BlobServiceClient getBlobServiceClient() {
+        return new BlobServiceClientBuilder()
             .connectionString(dataManagementConfiguration.getBlobStorageAccountConnectionString())
             .buildClient();
-    }
-
-    public BlobServiceClientBuilder getBlobServiceClientBuilder() {
-        return new BlobServiceClientBuilder();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.darts.datamanagement.service;
+
+import com.azure.core.util.BinaryData;
+
+import java.util.UUID;
+
+public interface DataManagementService {
+    BinaryData getAudioBlobData(String containerName, UUID uniqueBlobName);
+
+    UUID saveAudioBlobData(String containerName, BinaryData audioData);
+}

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
@@ -5,7 +5,7 @@ import com.azure.core.util.BinaryData;
 import java.util.UUID;
 
 public interface DataManagementService {
-    BinaryData getBlobData(String containerName, UUID uniqueBlobName);
+    BinaryData getBlobData(String containerName, UUID blobId);
 
-    UUID saveBlobData(String containerName, BinaryData audioData);
+    UUID saveBlobData(String containerName, BinaryData binaryData);
 }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
@@ -5,7 +5,7 @@ import com.azure.core.util.BinaryData;
 import java.util.UUID;
 
 public interface DataManagementService {
-    BinaryData getAudioBlobData(String containerName, UUID uniqueBlobName);
+    BinaryData getBlobData(String containerName, UUID uniqueBlobName);
 
-    UUID saveAudioBlobData(String containerName, BinaryData audioData);
+    UUID saveBlobData(String containerName, BinaryData audioData);
 }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -19,7 +19,7 @@ public class DataManagementServiceImpl implements DataManagementService {
     private DataManagementDao dataManagementDao;
 
     @Override
-    public BinaryData getAudioBlobData(String containerName, UUID blobId) {
+    public BinaryData getBlobData(String containerName, UUID blobId) {
 
         BlobContainerClient containerClient = dataManagementDao.getBlobContainerClient(containerName);
         BlobClient blobClient = dataManagementDao.getBlobClient(containerClient, blobId);
@@ -27,7 +27,7 @@ public class DataManagementServiceImpl implements DataManagementService {
     }
 
     @Override
-    public UUID saveAudioBlobData(String containerName, BinaryData audioData) {
+    public UUID saveBlobData(String containerName, BinaryData audioData) {
 
         UUID uniqueBlobId = UUID.randomUUID();
         BlobContainerClient containerClient = dataManagementDao.getBlobContainerClient(containerName);

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -27,12 +27,12 @@ public class DataManagementServiceImpl implements DataManagementService {
     }
 
     @Override
-    public UUID saveBlobData(String containerName, BinaryData audioData) {
+    public UUID saveBlobData(String containerName, BinaryData binaryData) {
 
         UUID uniqueBlobId = UUID.randomUUID();
         BlobContainerClient containerClient = dataManagementDao.getBlobContainerClient(containerName);
         BlobClient client = dataManagementDao.getBlobClient(containerClient, uniqueBlobId);
-        client.upload(audioData);
+        client.upload(binaryData);
 
         return uniqueBlobId;
     }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.darts.datamanagement.service.impl;
+
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.datamanagement.dao.DataManagementDao;
+import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
+
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class DataManagementServiceImpl implements DataManagementService {
+
+    @Autowired
+    private DataManagementDao dataManagementDao;
+
+    @Override
+    public BinaryData getAudioBlobData(String containerName, UUID blobId) {
+
+        BlobContainerClient containerClient = dataManagementDao.getBlobContainerClient(containerName);
+        BlobClient blobClient = dataManagementDao.getBlobClient(containerClient, blobId);
+        return blobClient.downloadContent();
+    }
+
+    @Override
+    public UUID saveAudioBlobData(String containerName, BinaryData audioData) {
+
+        UUID uniqueBlobId = UUID.randomUUID();
+        BlobContainerClient containerClient = dataManagementDao.getBlobContainerClient(containerName);
+        BlobClient client = dataManagementDao.getBlobClient(containerClient, uniqueBlobId);
+        client.upload(audioData);
+
+        return uniqueBlobId;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -121,6 +121,15 @@ darts:
         transcription_available: a928742c-5eb7-46f0-9f61-d89d5394785c
         transcription_request_approved: 29c26992-df77-4ba6-8ba7-03324eb5ae37
         transcription_request_rejected: 739a31cf-13a1-49bc-bcf9-0794f4670dbb
+  storage:
+    blob:
+      connection-string: ${AZURE_STORAGE_CONNECTION_STRING:}
+      container-name:
+        unstructured: darts-unstructured
+        inbound: darts-inbound-container
+        outbound: darts-outbound
+
+
 
 dbMigration:
   # When true, the app will run DB migration on startup.

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/dao/DataManagementDaoImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/dao/DataManagementDaoImplTest.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.darts.datamanagement.dao;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
+import uk.gov.hmcts.darts.datamanagement.dao.impl.DataManagementDaoImpl;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+class DataManagementDaoImplTest {
+
+    @InjectMocks
+    private DataManagementDaoImpl dataManagementDaoImpl;
+    @Mock
+    private DataManagementConfiguration dataManagementConfiguration;
+
+    public static final String BLOB_CONTAINER_NAME = "dummy_container";
+    public static final UUID BLOB_ID = UUID.randomUUID();
+    private static final String CONNECTION_STRING = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;" +
+        "AccountKey=KBHBeksoGMGw;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+    private BlobContainerClient blobContainerClient;
+    private BlobClient blobClient;
+
+    @BeforeEach
+    void beforeEach() {
+        blobContainerClient = Mockito.mock(BlobContainerClient.class);
+        blobClient = Mockito.mock(BlobClient.class);
+    }
+
+    @Test
+    void testGetBlobContainerClient() {
+        Mockito.when(dataManagementConfiguration.getBlobStorageAccountConnectionString()).thenReturn(CONNECTION_STRING);
+        BlobContainerClient blobContainerClient = dataManagementDaoImpl.getBlobContainerClient(BLOB_CONTAINER_NAME);
+        assertNotNull(blobContainerClient);
+    }
+
+    @Test
+    void testGetBlobClient() {
+        Mockito.when(blobContainerClient.getBlobClient(String.valueOf(BLOB_ID))).thenReturn(blobClient);
+        BlobClient blobClient = dataManagementDaoImpl.getBlobClient(blobContainerClient, BLOB_ID);
+        assertNotNull(blobClient);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.darts.datamanagement.service;
+
+import com.azure.core.util.BinaryData;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.datamanagement.dao.DataManagementDao;
+import uk.gov.hmcts.darts.datamanagement.service.impl.DataManagementServiceImpl;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class DataManagementServiceImplTest {
+
+    @InjectMocks
+    private DataManagementServiceImpl dataManagementService;
+    @Mock
+    private DataManagementDao dataManagementDao;
+    public static final String BLOB_CONTAINER_NAME = "dummy_container";
+    public static final UUID BLOB_ID = UUID.randomUUID();
+    private static final String TEST_BINARY_STRING = "Test String to be converted to binary!";
+    private static final BinaryData BINARY_DATA = BinaryData.fromBytes(TEST_BINARY_STRING.getBytes());
+    private BlobContainerClient blobContainerClient;
+    private BlobClient blobClient;
+
+    @BeforeEach
+    void beforeEach() {
+        blobContainerClient = Mockito.mock(BlobContainerClient.class);
+        blobClient = Mockito.mock(BlobClient.class);
+    }
+
+    @Test
+    void testGetAudioBlobData() {
+        Mockito.when(dataManagementDao.getBlobContainerClient(BLOB_CONTAINER_NAME)).thenReturn(blobContainerClient);
+        Mockito.when(dataManagementDao.getBlobClient(blobContainerClient, BLOB_ID)).thenReturn(blobClient);
+        Mockito.when(blobClient.downloadContent()).thenReturn(BINARY_DATA);
+        BinaryData blobData = dataManagementService.getAudioBlobData(BLOB_CONTAINER_NAME, BLOB_ID);
+        assertNotNull(blobData);
+        assertEquals(BINARY_DATA, blobData);
+    }
+
+    @Test
+    void testSaveAudioBlobData() {
+        Mockito.when(dataManagementDao.getBlobContainerClient(BLOB_CONTAINER_NAME)).thenReturn(blobContainerClient);
+        Mockito.when(dataManagementDao.getBlobClient(any(), any())).thenReturn(blobClient);
+        UUID blobId = dataManagementService.saveAudioBlobData(BLOB_CONTAINER_NAME, BINARY_DATA);
+        assertNotNull(blobId);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
@@ -40,20 +40,20 @@ class DataManagementServiceImplTest {
     }
 
     @Test
-    void testGetAudioBlobData() {
+    void testGetBlobData() {
         Mockito.when(dataManagementDao.getBlobContainerClient(BLOB_CONTAINER_NAME)).thenReturn(blobContainerClient);
         Mockito.when(dataManagementDao.getBlobClient(blobContainerClient, BLOB_ID)).thenReturn(blobClient);
         Mockito.when(blobClient.downloadContent()).thenReturn(BINARY_DATA);
-        BinaryData blobData = dataManagementService.getAudioBlobData(BLOB_CONTAINER_NAME, BLOB_ID);
+        BinaryData blobData = dataManagementService.getBlobData(BLOB_CONTAINER_NAME, BLOB_ID);
         assertNotNull(blobData);
         assertEquals(BINARY_DATA, blobData);
     }
 
     @Test
-    void testSaveAudioBlobData() {
+    void testSaveBlobData() {
         Mockito.when(dataManagementDao.getBlobContainerClient(BLOB_CONTAINER_NAME)).thenReturn(blobContainerClient);
         Mockito.when(dataManagementDao.getBlobClient(any(), any())).thenReturn(blobClient);
-        UUID blobId = dataManagementService.saveAudioBlobData(BLOB_CONTAINER_NAME, BINARY_DATA);
+        UUID blobId = dataManagementService.saveBlobData(BLOB_CONTAINER_NAME, BINARY_DATA);
         assertNotNull(blobId);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-405 


### Change description ###
Introduced a data management service that initially has two methods. One to save binary data to blob storage for a passed in container name which returns the stored unique id and a get method to fetch binary data for a particular container name and blob id.

The connection string is fetched from the key vault and passed in the services constructor.

Local this will need the Azurite emulator. The read me file has been updated with instructions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
