### PR TITLE
Uplift Spring Boot to 3.1.1 and resolve resultant JPARepository @Quer…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.0'
-  id 'org.springframework.boot' version '3.0.7'
+  id 'org.springframework.boot' version '3.1.1'
   id 'org.owasp.dependencycheck' version '8.2.1'
   id 'com.github.ben-manes.versions' version '0.47.0'
   id 'org.sonarqube' version '4.2.1.3168'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -21,7 +21,7 @@
 
   <suppress until="2023-09-14">
     <notes>Looks like a new security issue which involves DOS attacks</notes>
-    <packageUrl regex="true">pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.14.3</packageUrl>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
     <vulnerabilityName>CVE-2023-35116</vulnerabilityName>
   </suppress>
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CourtroomRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CourtroomRepository.java
@@ -13,7 +13,7 @@ public interface CourtroomRepository extends JpaRepository<CourtroomEntity, Inte
     @Query("SELECT cr FROM CourthouseEntity ch, CourtroomEntity cr " +
         "WHERE upper(ch.courthouseName) = upper(:courthouse) " +
         "AND upper(cr.name) = upper(:courtroom) " +
-        "AND cr.courthouse = ch.id "
+        "AND cr.courthouse = ch"
     )
     CourtroomEntity findByNames(String courthouse, String courtroom);
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
@@ -15,8 +15,8 @@ public interface HearingRepository extends JpaRepository<HearingEntity, Integer>
         "WHERE upper(ch.courthouseName) = upper(:courthouse) " +
         "AND upper(cr.name) = upper(:courtroom) " +
         "AND h.hearingDate = :date " +
-        "AND h.courtroom = cr.id " +
-        "AND cr.courthouse = ch.id "
+        "AND h.courtroom = cr " +
+        "AND cr.courthouse = ch"
     )
     List<HearingEntity> findByCourthouseCourtroomAndDate(String courthouse, String courtroom, LocalDate date);
 


### PR DESCRIPTION
Uplift to latest Spring Boot (3.1.1).

This is a minor version uplift from our previous 3.0.7, and comes with the following release notes:
- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.1-Release-Notes

Of specific note is that Hibernate is uplifted from 6.1 to 6.2. Related migration guide for info:
- https://docs.jboss.org/hibernate/orm/6.2/migration-guide/migration-guide.html

Updates to repository `@Query`s were required as runtime validation (type checks) appear to now be more stringent with this new release.

This MR replaces failed automatic uplift https://github.com/hmcts/darts-api/pull/135.

```
[ ] Yes
[x] No
```
