### PR TITLE
DMP-531: Tidy up config, remove repetition of properties across profiles

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -3,49 +3,10 @@ spring:
     azure:
       active-directory:
         enabled: false
-
   autoconfigure:
     exclude:
       - "org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration"
       - "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
-      client:
-        registration:
-          external-azure-ad:
-            client-id: ${AAD_B2C_CLIENT_ID_KEY:00000000-0000-0000-0000-000000000000}
-            client-secret: ${AAD_B2C_CLIENT_SECRET_KEY:}
-            scope: openid
-            redirect-uri: https://darts-api.staging.platform.hmcts.net/external-user/handle-oauth-code
-            authorization-grant-type: authorization_code
-            response-type: code
-            response-mode: form_post
-            prompt: login
-            issuer-uri: https://hmctsdartsb2csbox.b2clogin.com/89b8de2e-eb1b-42fb-a59c-813ea2b82a56/v2.0/
-            provider: external-azure-ad-provider
-          internal-azure-ad:
-            client-id: ${AAD_B2C_CLIENT_ID_KEY:00000000-0000-0000-0000-000000000000}
-            client-secret: ${AAD_B2C_CLIENT_SECRET_KEY:}
-            scope: openid
-            redirect-uri: http://localhost:4550/external-user/handle-oauth-code
-            authorization-grant-type: authorization_code
-            response-type: code
-            response-mode: form_post
-            prompt: login
-            issuer-uri: https://hmctsdartsb2csbox.b2clogin.com/${AAD_B2C_TENANT_ID_KEY:00000000-0000-0000-0000-000000000000}/v2.0/
-            provider: internal-azure-ad-provider
-        provider:
-          external-azure-ad-provider:
-            authorization-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/authorize
-            token-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/token
-            jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
-          internal-azure-ad-provider:
-            authorization-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/authorize
-            token-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/token
-            jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
 
 logging:
   level:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -2,51 +2,12 @@ spring:
   datasource:
     username: postgres
     password: postgres
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
-      client:
-        registration:
-          external-azure-ad:
-            client-id: ${AAD_B2C_CLIENT_ID_KEY:00000000-0000-0000-0000-000000000000}
-            client-secret: ${AAD_B2C_CLIENT_SECRET_KEY:}
-            scope: openid
-            redirect-uri: https://darts-portal.staging.platform.hmcts.net/auth/callback
-            authorization-grant-type: authorization_code
-            response-type: code
-            response-mode: form_post
-            prompt: login
-            issuer-uri: https://hmctsdartsb2csbox.b2clogin.com/${AAD_B2C_TENANT_ID_KEY:00000000-0000-0000-0000-000000000000}/v2.0/
-            provider: external-azure-ad-provider
-          internal-azure-ad:
-            client-id: ${AAD_B2C_CLIENT_ID_KEY:00000000-0000-0000-0000-000000000000}
-            client-secret: ${AAD_B2C_CLIENT_SECRET_KEY:}
-            scope: openid
-            redirect-uri: http://localhost:4550/external-user/handle-oauth-code
-            authorization-grant-type: authorization_code
-            response-type: code
-            response-mode: form_post
-            prompt: login
-            issuer-uri: https://hmctsdartsb2csbox.b2clogin.com/${AAD_B2C_TENANT_ID_KEY:00000000-0000-0000-0000-000000000000}/v2.0/
-            provider: internal-azure-ad-provider
-        provider:
-          external-azure-ad-provider:
-            authorization-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/authorize
-            token-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/token
-            jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
-          internal-azure-ad-provider:
-            authorization-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/authorize
-            token-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/token
-            jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
   jpa:
     show-sql: true
-    hibernate:
-      ddl-auto: none
     properties:
       hibernate:
         format_sql: true
+
 logging:
   level:
     uk.gov.hmcts.darts: DEBUG

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,43 +24,46 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
+          jwk-set-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/discovery/v2.0/keys
       client:
         registration:
           external-azure-ad:
             client-id: ${AAD_B2C_CLIENT_ID_KEY:00000000-0000-0000-0000-000000000000}
             client-secret: ${AAD_B2C_CLIENT_SECRET_KEY:}
             scope: openid
-            redirect-uri: https://darts-portal.staging.platform.hmcts.net/auth/callback
-            logout-redirect-uri: https://darts-portal.staging.platform.hmcts.net/auth/logout-callback
+            redirect-uri: ${darts.portal.url}/auth/callback
+            logout-redirect-uri: ${darts.portal.url}/auth/logout-callback
             authorization-grant-type: authorization_code
             response-type: code
             response-mode: form_post
             prompt: login
-            issuer-uri: "https://hmctsdartsb2csbox.b2clogin.com/${AAD_B2C_TENANT_ID_KEY:00000000-0000-0000-0000-000000000000}/v2.0/"
+            issuer-uri: ${darts.azure.active-directory-b2c-base-uri}/${AAD_B2C_TENANT_ID_KEY:00000000-0000-0000-0000-000000000000}/v2.0/"
             provider: external-azure-ad-provider
           internal-azure-ad:
             client-id: ${AAD_B2C_CLIENT_ID_KEY:00000000-0000-0000-0000-000000000000}
             client-secret: ${AAD_B2C_CLIENT_SECRET_KEY:}
             scope: openid
-            redirect-uri: http://localhost:4550/external-user/handle-oauth-code
+            redirect-uri: ${darts.portal.url}/auth/callback
+            logout-redirect-uri: ${darts.portal.url}/auth/logout-callback
             authorization-grant-type: authorization_code
             response-type: code
             response-mode: form_post
             prompt: login
-            issuer-uri: https://hmctsdartsb2csbox.b2clogin.com/${AAD_B2C_TENANT_ID_KEY:00000000-0000-0000-0000-000000000000}/v2.0/
+            issuer-uri: ${darts.azure.active-directory-b2c-base-uri}/${AAD_B2C_TENANT_ID_KEY:00000000-0000-0000-0000-000000000000}/v2.0/"
             provider: internal-azure-ad-provider
         provider:
           external-azure-ad-provider:
-            authorization-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/authorize
-            token-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/token
-            jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
-            logout-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/logout
-            reset-password-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_password_reset/oauth2/v2.0/authorize
+            authorization-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/oauth2/v2.0/authorize
+            token-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/oauth2/v2.0/token
+            jwk-set-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/discovery/v2.0/keys
+            logout-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/oauth2/v2.0/logout
+            reset-password-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-passwordreset-policy}/oauth2/v2.0/authorize
           internal-azure-ad-provider:
-            authorization-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/authorize
-            token-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/oauth2/v2.0/token
-            jwk-set-uri: https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/B2C_1_darts_externaluser_signin/discovery/v2.0/keys
+            authorization-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/oauth2/v2.0/authorize
+            token-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/oauth2/v2.0/token
+            jwk-set-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/discovery/v2.0/keys
+            logout-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-signin-policy}/oauth2/v2.0/logout
+            reset-password-uri: ${darts.azure.active-directory-b2c-auth-uri}/${darts.azure.active-directory-b2c-external-user-passwordreset-policy}/oauth2/v2.0/authorize
 
   datasource:
     driver-class-name: org.postgresql.Driver
@@ -103,6 +106,11 @@ darts:
     merge-workspace: ${user.home}/audiotransform/merge
     trim-workspace: ${user.home}/audiotransform/trim
     re-encode-workspace: ${user.home}/audiotransform/encode
+  azure:
+    active-directory-b2c-base-uri: https://hmctsdartsb2csbox.b2clogin.com
+    active-directory-b2c-auth-uri: ${darts.azure.active-directory-b2c-base-uri}/hmctsdartsb2csbox.onmicrosoft.com
+    active-directory-b2c-external-user-signin-policy: "B2C_1_darts_externaluser_signin"
+    active-directory-b2c-external-user-passwordreset-policy: "B2C_1_darts_externaluser_password_reset"
   gateway:
     url: ${DARTS_GATEWAY_URL:http://localhost:8070}
     events-dar-notify-path: /events/dar-notify
@@ -128,7 +136,8 @@ darts:
         unstructured: darts-unstructured
         inbound: darts-inbound-container
         outbound: darts-outbound
-
+  portal:
+    url: https://darts-portal.staging.platform.hmcts.net
 
 
 dbMigration:


### PR DESCRIPTION
### [DMP-531](https://tools.hmcts.net/jira/browse/DMP-531)

Spring configuration for the `dev` and `local` profiles currently duplicates config that already exists in `application.yaml`, leading to unncessary complexity and maintainence overhead.

Further, `application.yaml` itself contains duplicated values between properties (generally common elements such as azure hostnames for auth).

This PR removes the duplicate config that exists between profiles, and refactors `application.yaml` to reduce duplication of values by introducing Spring expressions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
