### PR TITLE
DMP-548 Update object directory schema data (v29) to add external_location_type table and transfer_attempts columns

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
@@ -45,52 +45,6 @@ class MediaRequestServiceTest {
 
     @Test
     @Order(1)
-    void shouldGetMediaRequestByIdWhenStartAndEndTimesInsertedWithZuluTime() {
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(-1);
-        assertNotNull(mediaRequestEntity);
-        assertEquals(-1, mediaRequestEntity.getRequestId());
-        assertEquals(-2, mediaRequestEntity.getHearingId());
-        assertEquals(-3, mediaRequestEntity.getRequestor());
-        assertEquals(OPEN, mediaRequestEntity.getStatus());
-        assertEquals(DOWNLOAD, mediaRequestEntity.getRequestType());
-        assertEquals(OffsetDateTime.parse("2023-06-26T13:00:00Z"), mediaRequestEntity.getStartTime());
-        assertEquals(OffsetDateTime.parse("2023-06-26T13:45:00Z"), mediaRequestEntity.getEndTime());
-        assertNotNull(mediaRequestEntity.getCreatedDateTime());
-        assertNotNull(mediaRequestEntity.getLastUpdatedDateTime());
-    }
-
-    @Test
-    @Order(2)
-    void shouldGetMediaRequestByIdWhenStartAndEndTimesInsertedWithOffsetTime() {
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(-2);
-        assertNotNull(mediaRequestEntity);
-        assertEquals(-2, mediaRequestEntity.getRequestId());
-        assertEquals(-2, mediaRequestEntity.getHearingId());
-        assertEquals(-3, mediaRequestEntity.getRequestor());
-        assertEquals(OPEN, mediaRequestEntity.getStatus());
-        assertEquals(DOWNLOAD, mediaRequestEntity.getRequestType());
-        assertEquals(OffsetDateTime.parse("2023-06-26T13:00:00Z"), mediaRequestEntity.getStartTime());
-        assertEquals(OffsetDateTime.parse("2023-06-26T13:45:00Z"), mediaRequestEntity.getEndTime());
-        assertNotNull(mediaRequestEntity.getCreatedDateTime());
-        assertNotNull(mediaRequestEntity.getLastUpdatedDateTime());
-    }
-
-    @Test
-    @Order(3)
-    void shouldThrowExceptionWhenGetMediaRequestByIdInvalid() {
-        assertThrows(NoSuchElementException.class, () -> mediaRequestService.getMediaRequestById(-3));
-    }
-
-    @Test
-    @Order(4)
-    void shouldUpdateStatusToProcessing() {
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestStatus(-1, PROCESSING);
-
-        assertEquals(PROCESSING, mediaRequestEntity.getStatus());
-    }
-
-    @Test
-    @Order(5)
     void shouldSaveAudioRequestWithZuluTimeOk() {
         requestDetails.setStartTime(OffsetDateTime.parse(T_09_00_00_Z));
         requestDetails.setEndTime(OffsetDateTime.parse(T_12_00_00_Z));
@@ -98,9 +52,9 @@ class MediaRequestServiceTest {
         var requestId = mediaRequestService.saveAudioRequest(requestDetails);
 
         MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(requestId);
-        assertTrue(mediaRequestEntity.getRequestId() > 0);
+        assertTrue(mediaRequestEntity.getId() > 0);
         assertEquals(OPEN, mediaRequestEntity.getStatus());
-        assertEquals(requestDetails.getHearingId(), mediaRequestEntity.getHearingId());
+        assertEquals(requestDetails.getHearingId(), mediaRequestEntity.getHearing().getId());
         assertEquals(requestDetails.getStartTime(), mediaRequestEntity.getStartTime());
         assertEquals(requestDetails.getEndTime(), mediaRequestEntity.getEndTime());
         assertNotNull(mediaRequestEntity.getCreatedDateTime());
@@ -108,7 +62,7 @@ class MediaRequestServiceTest {
     }
 
     @Test
-    @Order(6)
+    @Order(2)
     void shouldSaveAudioRequestWithOffsetTimeOk() {
         requestDetails.setStartTime(OffsetDateTime.parse("2023-05-31T10:00:00+01:00"));
         requestDetails.setEndTime(OffsetDateTime.parse("2023-05-31T13:00:00+01:00"));
@@ -116,9 +70,9 @@ class MediaRequestServiceTest {
         var requestId = mediaRequestService.saveAudioRequest(requestDetails);
 
         MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(requestId);
-        assertTrue(mediaRequestEntity.getRequestId() > 0);
+        assertTrue(mediaRequestEntity.getId() > 0);
         assertEquals(OPEN, mediaRequestEntity.getStatus());
-        assertEquals(requestDetails.getHearingId(), mediaRequestEntity.getHearingId());
+        assertEquals(requestDetails.getHearingId(), mediaRequestEntity.getHearing().getId());
         assertEquals(OffsetDateTime.parse(T_09_00_00_Z), mediaRequestEntity.getStartTime());
         assertEquals(OffsetDateTime.parse(T_12_00_00_Z), mediaRequestEntity.getEndTime());
         assertNotNull(mediaRequestEntity.getCreatedDateTime());
@@ -126,7 +80,7 @@ class MediaRequestServiceTest {
     }
 
     @Test
-    @Order(7)
+    @Order(3)
     void shouldSaveAudioRequestWithZuluTimeOkWhenDaylightSavingTimeStarts() {
         // In the UK the clocks go forward 1 hour at 1am on the last Sunday in March.
         // The period when the clocks are 1 hour ahead is called British Summer Time (BST).
@@ -136,9 +90,9 @@ class MediaRequestServiceTest {
         var requestId = mediaRequestService.saveAudioRequest(requestDetails);
 
         MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(requestId);
-        assertTrue(mediaRequestEntity.getRequestId() > 0);
+        assertTrue(mediaRequestEntity.getId() > 0);
         assertEquals(OPEN, mediaRequestEntity.getStatus());
-        assertEquals(requestDetails.getHearingId(), mediaRequestEntity.getHearingId());
+        assertEquals(requestDetails.getHearingId(), mediaRequestEntity.getHearing().getId());
         assertEquals(requestDetails.getStartTime(), mediaRequestEntity.getStartTime());
         assertEquals(requestDetails.getEndTime(), mediaRequestEntity.getEndTime());
         assertNotNull(mediaRequestEntity.getCreatedDateTime());
@@ -146,7 +100,7 @@ class MediaRequestServiceTest {
     }
 
     @Test
-    @Order(8)
+    @Order(4)
     void shouldSaveAudioRequestWithZuluTimeOkWhenDaylightSavingTimeEnds() {
         // In the UK the clocks go back 1 hour at 2am on the last Sunday in October.
         requestDetails.setStartTime(OffsetDateTime.parse("2023-10-29T00:30:00Z"));
@@ -155,13 +109,27 @@ class MediaRequestServiceTest {
         var requestId = mediaRequestService.saveAudioRequest(requestDetails);
 
         MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(requestId);
-        assertTrue(mediaRequestEntity.getRequestId() > 0);
+        assertTrue(mediaRequestEntity.getId() > 0);
         assertEquals(OPEN, mediaRequestEntity.getStatus());
-        assertEquals(requestDetails.getHearingId(), mediaRequestEntity.getHearingId());
+        assertEquals(requestDetails.getHearingId(), mediaRequestEntity.getHearing().getId());
         assertEquals(requestDetails.getStartTime(), mediaRequestEntity.getStartTime());
         assertEquals(requestDetails.getEndTime(), mediaRequestEntity.getEndTime());
         assertNotNull(mediaRequestEntity.getCreatedDateTime());
         assertNotNull(mediaRequestEntity.getLastUpdatedDateTime());
+    }
+
+    @Test
+    @Order(5)
+    void shouldUpdateStatusToProcessing() {
+        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestStatus(1, PROCESSING);
+
+        assertEquals(PROCESSING, mediaRequestEntity.getStatus());
+    }
+
+    @Test
+    @Order(6)
+    void shouldThrowExceptionWhenGetMediaRequestByIdInvalid() {
+        assertThrows(NoSuchElementException.class, () -> mediaRequestService.getMediaRequestById(-3));
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/TransientObjectDirectoryServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/TransientObjectDirectoryServiceTest.java
@@ -6,12 +6,17 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
-import uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEntity;
+import uk.gov.hmcts.darts.audio.repository.MediaRequestRepository;
+import uk.gov.hmcts.darts.audio.util.AudioTestDataUtil;
+import uk.gov.hmcts.darts.cases.repository.CaseRepository;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
+import uk.gov.hmcts.darts.common.repository.CourtroomRepository;
+import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.service.TransientObjectDirectoryService;
+import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
+import uk.gov.hmcts.darts.courthouse.CourthouseRepository;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,39 +27,33 @@ import static uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEnum.NEW;
 
 @SpringBootTest
 @ActiveProfiles({"intTest", "h2db"})
-@Transactional
 class TransientObjectDirectoryServiceTest {
+
+    @Autowired
+    private CaseRepository caseRepository;
+    @Autowired
+    private CourthouseRepository courthouseRepository;
+    @Autowired
+    private CourtroomRepository courtroomRepository;
+    @Autowired
+    private HearingRepository hearingRepository;
+    @Autowired
+    private MediaRequestRepository mediaRequestRepository;
 
     @Autowired
     private MediaRequestService mediaRequestService;
     @Autowired
     private TransientObjectDirectoryService transientObjectDirectoryService;
 
-    @Test
-    void shouldGetTransientObjectDirectoryListByMediaRequest() {
-
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(-1);
-
-        List<TransientObjectDirectoryEntity> transientObjectDirectoryList = mediaRequestEntity.getTransientObjectDirectoryList();
-
-        assertNotNull(transientObjectDirectoryList);
-        assertEquals(1, transientObjectDirectoryList.size());
-        TransientObjectDirectoryEntity transientObjectDirectoryEntity = transientObjectDirectoryList.get(0);
-        assertEquals(-1, transientObjectDirectoryEntity.getId());
-        ObjectDirectoryStatusEntity objectDirectoryStatusEntity = transientObjectDirectoryEntity.getStatus();
-        assertNotNull(objectDirectoryStatusEntity);
-        assertEquals(NEW.getId(), objectDirectoryStatusEntity.getId());
-        assertEquals(
-            UUID.fromString("f744a74f-83c0-47e4-8bb2-2fd4d2b68647"),
-            transientObjectDirectoryEntity.getExternalLocation()
-        );
-    }
+    private MediaRequestEntity mediaRequestEntity1;
 
     @Test
+    @Transactional
     void shouldSaveTransientDataLocation() {
+        createAndLoadMediaRequestEntity();
 
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(-1);
-        UUID externalLocation = UUID.randomUUID();
+        MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestById(mediaRequestEntity1.getId());
+        UUID externalLocation = UUID.fromString("f744a74f-83c0-47e4-8bb2-2fd4d2b68647");
 
         TransientObjectDirectoryEntity transientObjectDirectoryEntity = transientObjectDirectoryService.saveTransientDataLocation(
             mediaRequestEntity,
@@ -63,15 +62,40 @@ class TransientObjectDirectoryServiceTest {
 
         assertNotNull(transientObjectDirectoryEntity);
         assertTrue(transientObjectDirectoryEntity.getId() > 0);
-        assertEquals(-1, transientObjectDirectoryEntity.getMediaRequest().getRequestId());
+        assertEquals(mediaRequestEntity1.getId(), transientObjectDirectoryEntity.getMediaRequest().getId());
         assertEquals(NEW.getId(), transientObjectDirectoryEntity.getStatus().getId());
         assertEquals(externalLocation, transientObjectDirectoryEntity.getExternalLocation());
         assertNull(transientObjectDirectoryEntity.getChecksum());
         assertTrue(transientObjectDirectoryEntity.getCreatedTimestamp()
-                       .isAfter(OffsetDateTime.parse("2023-06-30T17:00:00.000Z")));
+                       .isAfter(OffsetDateTime.parse("2023-07-06T16:00:00.000Z")));
         assertTrue(transientObjectDirectoryEntity.getModifiedTimestamp()
-                       .isAfter(OffsetDateTime.parse("2023-06-30T17:05:00.000Z")));
+                       .isAfter(OffsetDateTime.parse("2023-07-06T16:05:00.000Z")));
         assertNull(transientObjectDirectoryEntity.getModifiedBy());
+    }
+
+    private void createAndLoadMediaRequestEntity() {
+
+        var caseEntity = CommonTestDataUtil.createCase(UUID.randomUUID().toString());
+        caseRepository.saveAndFlush(caseEntity);
+
+        var courthouseEntity = CommonTestDataUtil.createCourthouse("C1");
+        courthouseEntity = courthouseRepository.saveAndFlush(courthouseEntity);
+
+        var courtroomEntity = CommonTestDataUtil.createCourtroom(courthouseEntity, "R1");
+        courtroomRepository.saveAndFlush(courtroomEntity);
+
+        var hearingEntityWithMediaRequest1 = CommonTestDataUtil.createHearing(caseEntity, courtroomEntity);
+        hearingEntityWithMediaRequest1 = hearingRepository.saveAndFlush(hearingEntityWithMediaRequest1);
+
+        mediaRequestEntity1 = AudioTestDataUtil.createMediaRequest(
+            hearingEntityWithMediaRequest1,
+            -2,
+            OffsetDateTime.parse("2023-06-26T13:00:00Z"),
+            OffsetDateTime.parse("2023-06-26T13:45:00Z")
+        );
+
+        mediaRequestEntity1 = mediaRequestRepository.saveAndFlush(mediaRequestEntity1);
+        assertNotNull(mediaRequestEntity1);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/util/AudioTestDataUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/util/AudioTestDataUtil.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.darts.audio.util;
+
+import lombok.experimental.UtilityClass;
+import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
+
+import java.time.OffsetDateTime;
+
+import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.OPEN;
+import static uk.gov.hmcts.darts.audiorequest.model.AudioRequestType.DOWNLOAD;
+
+@UtilityClass
+public class AudioTestDataUtil {
+
+    public MediaRequestEntity createMediaRequest(HearingEntity hearingEntity, Integer requestor,
+                                                 OffsetDateTime startTime, OffsetDateTime endTime) {
+        MediaRequestEntity mediaRequestEntity = new MediaRequestEntity();
+        mediaRequestEntity.setHearing(hearingEntity);
+        mediaRequestEntity.setRequestor(requestor);
+        mediaRequestEntity.setStatus(OPEN);
+        mediaRequestEntity.setRequestType(DOWNLOAD);
+        mediaRequestEntity.setAttempts(0);
+        mediaRequestEntity.setStartTime(startTime);
+        mediaRequestEntity.setEndTime(endTime);
+        mediaRequestEntity.setOutputFormat(null);
+        mediaRequestEntity.setOutputFilename(null);
+        mediaRequestEntity.setLastAccessedDateTime(null);
+        return mediaRequestEntity;
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/service/TransientObjectDirectoryServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/service/TransientObjectDirectoryServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.darts.audio.service;
+package uk.gov.hmcts.darts.common.service;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,12 +7,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.repository.MediaRequestRepository;
+import uk.gov.hmcts.darts.audio.service.MediaRequestService;
 import uk.gov.hmcts.darts.audio.util.AudioTestDataUtil;
 import uk.gov.hmcts.darts.cases.repository.CaseRepository;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.repository.CourtroomRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
-import uk.gov.hmcts.darts.common.service.TransientObjectDirectoryService;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
 import uk.gov.hmcts.darts.courthouse.CourthouseRepository;
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -1,14 +1,17 @@
 package uk.gov.hmcts.darts.common.util;
 
 import lombok.experimental.UtilityClass;
+import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.common.entity.CaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
+import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.HearingMediaEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEntity;
+import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -96,15 +99,31 @@ public class CommonTestDataUtil {
 
     public ExternalObjectDirectoryEntity createExternalObjectDirectory(MediaEntity mediaEntity,
                                                                        ObjectDirectoryStatusEntity objectDirectoryStatusEntity,
-                                                                       String externalLocationType,
+                                                                       ExternalLocationTypeEntity externalLocationTypeEntity,
                                                                        UUID externalLocation) {
         var externalObjectDirectory = new ExternalObjectDirectoryEntity();
         externalObjectDirectory.setMedia(mediaEntity);
         externalObjectDirectory.setStatus(objectDirectoryStatusEntity);
-        externalObjectDirectory.setExternalLocationType(externalLocationType);
+        externalObjectDirectory.setExternalLocationType(externalLocationTypeEntity);
         externalObjectDirectory.setExternalLocation(externalLocation);
+        externalObjectDirectory.setChecksum(null);
+        externalObjectDirectory.setTransferAttempts(null);
 
         return externalObjectDirectory;
+    }
+
+    public TransientObjectDirectoryEntity createTransientObjectDirectory(MediaRequestEntity mediaRequestEntity,
+                                                                         ObjectDirectoryStatusEntity objectDirectoryStatusEntity,
+                                                                         UUID externalLocation) {
+
+        var transientObjectDirectory = new TransientObjectDirectoryEntity();
+        transientObjectDirectory.setMediaRequest(mediaRequestEntity);
+        transientObjectDirectory.setStatus(objectDirectoryStatusEntity);
+        transientObjectDirectory.setExternalLocation(externalLocation);
+        transientObjectDirectory.setChecksum(null);
+        transientObjectDirectory.setTransferAttempts(null);
+
+        return transientObjectDirectory;
     }
 
 }

--- a/src/integrationTest/resources/db/migration/V1_9999__integrationTestData.sql
+++ b/src/integrationTest/resources/db/migration/V1_9999__integrationTestData.sql
@@ -226,19 +226,3 @@ INSERT INTO moj_hearing VALUES (159,31,4,'{Judge4}','2023-06-24','15:00:00',TRUE
 INSERT INTO moj_hearing VALUES (160,32,4,'{Judge4}','2023-06-24','16:00:00',TRUE, NULL);
 ALTER SEQUENCE moj_hea_seq RESTART WITH 200;
 
-
-
-INSERT INTO moj_media_request (moj_mer_id, moj_hea_id, requestor, request_status, request_type, start_ts, end_ts, created_ts, last_updated_ts)
-VALUES (-1, -2, -3, 'OPEN', 'DOWNLOAD', TIMESTAMP WITH TIME ZONE '2023-06-26 13:00:00+00:00', TIMESTAMP WITH TIME ZONE '2023-06-26 13:45:00+00:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO moj_media_request (moj_mer_id, moj_hea_id, requestor, request_status, request_type, start_ts, end_ts, created_ts, last_updated_ts)
-VALUES (-2, -2, -3, 'OPEN', 'DOWNLOAD', TIMESTAMP WITH TIME ZONE '2023-06-26 14:00:00+01:00', TIMESTAMP WITH TIME ZONE '2023-06-26 14:45:00+01:00', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-
-INSERT INTO transient_object_directory (tod_id, moj_mer_id, moj_ods_id, external_location, checksum, created_ts, modified_ts)
-VALUES (-1, -1, 1, 'f744a74f-83c0-47e4-8bb2-2fd4d2b68647', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-
-INSERT INTO moj_media (moj_med_id, moj_ctr_id, c_channel, c_total_channels, c_start, c_end, i_version)
-VALUES (-1, 1, 1, 4, TIMESTAMP WITH TIME ZONE '2023-07-03 17:00:00+00:00', TIMESTAMP WITH TIME ZONE '2023-07-03 17:30:00+00:00', 0);
-
-INSERT INTO external_object_directory (eod_id, moj_med_id, moj_ods_id, external_location, external_location_type, created_ts, modified_ts)
-VALUES(-1, -1, 2, 'a7ad5828-6a20-4bd0-adb1-bf1496a2622a', 'unstructured', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-

--- a/src/main/java/uk/gov/hmcts/darts/audio/entity/MediaRequestEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/entity/MediaRequestEntity.java
@@ -4,31 +4,29 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import uk.gov.hmcts.darts.audio.enums.AudioRequestOutputFormat;
 import uk.gov.hmcts.darts.audio.enums.AudioRequestStatus;
 import uk.gov.hmcts.darts.audiorequest.model.AudioRequestType;
-import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = MediaRequestEntity.TABLE_NAME)
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
+@Getter
+@Setter
 public class MediaRequestEntity {
 
     public static final String REQUEST_ID = "moj_mer_id";
@@ -50,10 +48,11 @@ public class MediaRequestEntity {
     @Column(name = REQUEST_ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "media_request_gen")
     @SequenceGenerator(name = "media_request_gen", sequenceName = "moj_mer_seq", allocationSize = 1)
-    private Integer requestId;
+    private Integer id;
 
-    @Column(name = HEARING_ID)
-    private Integer hearingId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = HEARING_ID)
+    private HearingEntity hearing;
 
     @Column(name = REQUESTOR)
     private Integer requestor;
@@ -91,9 +90,6 @@ public class MediaRequestEntity {
     @UpdateTimestamp
     @Column(name = LAST_UPDATED_DATE_TIME)
     private OffsetDateTime lastUpdatedDateTime;
-
-    @OneToMany(mappedBy = "mediaRequest")
-    private List<TransientObjectDirectoryEntity> transientObjectDirectoryList = new ArrayList<>();
 
 }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -8,11 +8,13 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.service.AudioTransformationService;
 import uk.gov.hmcts.darts.audio.service.MediaRequestService;
+import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEnum;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
+import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
@@ -25,13 +27,14 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.PROCESSING;
+import static uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEnum.UNSTRUCTURED;
+import static uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEnum.STORED;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AudioTransformationServiceImpl implements AudioTransformationService {
 
-    public static final int ONE = 1;
     private final MediaRequestService mediaRequestService;
     private final DataManagementService dataManagementService;
     private final DataManagementConfiguration dataManagementConfiguration;
@@ -40,6 +43,9 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     private final MediaRepository mediaRepository;
     private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
+    private final ExternalLocationTypeRepository externalLocationTypeRepository;
+
+    private static final int ONE = 1;
 
     @Transactional
     @Override
@@ -75,9 +81,9 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     public Optional<UUID> getMediaLocation(MediaEntity media) {
         Optional<UUID> externalLocation = Optional.empty();
 
-        ObjectDirectoryStatusEnum statusEnum = ObjectDirectoryStatusEnum.STORED;
-        ObjectDirectoryStatusEntity objectDirectoryStatus = objectDirectoryStatusRepository.getReferenceById(statusEnum.getId());
-        String externalLocationType = "unstructured";
+        ObjectDirectoryStatusEnum statusEnum = STORED;
+        ObjectDirectoryStatusEntity objectDirectoryStatus = objectDirectoryStatusRepository.getReferenceById(STORED.getId());
+        ExternalLocationTypeEntity externalLocationType = externalLocationTypeRepository.getReferenceById(UNSTRUCTURED.getId());
         List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntityList = externalObjectDirectoryRepository.findByMediaStatusAndType(
             media, objectDirectoryStatus, externalLocationType
         );
@@ -85,11 +91,11 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
         if (!externalObjectDirectoryEntityList.isEmpty()) {
             if (externalObjectDirectoryEntityList.size() != ONE) {
                 log.warn(
-                    "Only one External Object Directory expected, but found {} for mediaId={}, statusEnum={}, externalLocationType={}",
+                    "Only one External Object Directory expected, but found {} for mediaId={}, statusEnum={}, externalLocationTypeId={}",
                     externalObjectDirectoryEntityList.size(),
                     media.getId(),
                     statusEnum,
-                    externalLocationType
+                    externalLocationType.getId()
                 );
             }
             externalLocation = Optional.ofNullable(externalObjectDirectoryEntityList.get(0).getExternalLocation());

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalLocationTypeEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalLocationTypeEntity.java
@@ -7,20 +7,22 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
-@Table(name = "object_directory_status")
-@Data
-public class ObjectDirectoryStatusEntity {
+@Table(name = "external_location_type")
+@Getter
+@Setter
+public class ExternalLocationTypeEntity {
 
     @Id
-    @Column(name = "ods_id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ods_gen")
-    @SequenceGenerator(name = "ods_gen", sequenceName = "ods_seq", allocationSize = 1)
+    @Column(name = "elt_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "elt_gen")
+    @SequenceGenerator(name = "elt_gen", sequenceName = "elt_seq", allocationSize = 1)
     private Integer id;
 
-    @Column(name = "ods_description")
+    @Column(name = "elt_description")
     private String description;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalLocationTypeEnum.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalLocationTypeEnum.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.darts.common.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExternalLocationTypeEnum {
+
+    INBOUND(1),
+    UNSTRUCTURED(2),
+    ARM(3),
+    TEMPSTORE(4),
+    VODAFONE(5);
+
+    private final Integer id;
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalObjectDirectoryEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalObjectDirectoryEntity.java
@@ -11,9 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.NaturalId;
@@ -23,69 +21,54 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Entity
-@Table(name = ExternalObjectDirectoryEntity.TABLE_NAME)
-@AllArgsConstructor
-@NoArgsConstructor
+@Table(name = "external_object_directory")
 @Getter
 @Setter
 public class ExternalObjectDirectoryEntity implements JpaAuditing {
 
-    public static final String ID = "eod_id";
-    public static final String MEDIA_ID = "moj_med_id";
-    public static final String TRANSCRIPTION_ID = "moj_tra_id";
-    public static final String ANNOTATION_ID = "moj_ann_id";
-    public static final String EXTERNAL_LOCATION = "external_location";
-    public static final String EXTERNAL_LOCATION_TYPE = "external_location_type";
-    public static final String CREATED_TIMESTAMP = "created_ts";
-    public static final String MODIFIED_TIMESTAMP = "modified_ts";
-    public static final String MODIFIED_BY = "modified_by";
-    public static final String STATUS_ID = "moj_ods_id";
-    public static final String CHECKSUM = "checksum";
-    public static final String ATTEMPTS = "attempts";
-    public static final String TABLE_NAME = "external_object_directory";
-
     @Id
-    @Column(name = ID)
+    @Column(name = "eod_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eod_gen")
     @SequenceGenerator(name = "eod_gen", sequenceName = "eod_seq", allocationSize = 1)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = MEDIA_ID, foreignKey = @ForeignKey(name = "eod_media_fk"))
+    @JoinColumn(name = "med_id", foreignKey = @ForeignKey(name = "eod_media_fk"))
     private MediaEntity media;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = STATUS_ID, foreignKey = @ForeignKey(name = "eod_object_directory_status_fk"))
-    private ObjectDirectoryStatusEntity status;
-
-    @Column(name = TRANSCRIPTION_ID)
+    @Column(name = "tra_id")
     private Integer transcriptionId;
 
-    @Column(name = ANNOTATION_ID)
+    @Column(name = "ann_id")
     private Integer annotationId;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ods_id", foreignKey = @ForeignKey(name = "eod_object_directory_status_fk"), nullable = false)
+    private ObjectDirectoryStatusEntity status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "elt_id", foreignKey = @ForeignKey(name = "eod_external_location_type_fk"), nullable = false)
+    private ExternalLocationTypeEntity externalLocationType;
+
     @NaturalId
-    @Column(name = EXTERNAL_LOCATION, unique = true, nullable = false)
+    @Column(name = "external_location", unique = true, nullable = false)
     private UUID externalLocation;
 
-    @Column(name = EXTERNAL_LOCATION_TYPE)
-    private String externalLocationType;
+    @Column(name = "checksum")
+    private String checksum;
+
+    @Column(name = "transfer_attempts")
+    private Integer transferAttempts;
 
     @CreationTimestamp
-    @Column(name = CREATED_TIMESTAMP)
+    @Column(name = "created_ts")
     private OffsetDateTime createdTimestamp;
 
     @UpdateTimestamp
-    @Column(name = MODIFIED_TIMESTAMP)
+    @Column(name = "modified_ts")
     private OffsetDateTime modifiedTimestamp;
 
-    @Column(name = MODIFIED_BY)
+    @Column(name = "modified_by")
     private Integer modifiedBy;
-
-    @Column(name = CHECKSUM)
-    private String checksum;
-
-    @Column(name = ATTEMPTS)
-    private Integer attempts;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
@@ -38,9 +37,6 @@ public class MediaEntity extends VersionedEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "moj_ctr_id", foreignKey = @ForeignKey(name = "moj_media_courtroom_fk"))
     private CourtroomEntity courtroom;
-
-    @OneToMany(mappedBy = "media")
-    private List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntityList = new ArrayList<>();
 
     @Column(name = "r_media_object_id", length = 16)
     private String legacyObjectId;

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TransientObjectDirectoryEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TransientObjectDirectoryEntity.java
@@ -32,11 +32,11 @@ public class TransientObjectDirectoryEntity implements JpaAuditing {
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "moj_mer_id", foreignKey = @ForeignKey(name = "tod_media_request_fk"))
+    @JoinColumn(name = "mer_id", foreignKey = @ForeignKey(name = "tod_media_request_fk"), nullable = false)
     private MediaRequestEntity mediaRequest;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "moj_ods_id", foreignKey = @ForeignKey(name = "tod_object_directory_status_fk"))
+    @JoinColumn(name = "ods_id", foreignKey = @ForeignKey(name = "tod_object_directory_status_fk"), nullable = false)
     private ObjectDirectoryStatusEntity status;
 
     @NaturalId
@@ -45,6 +45,9 @@ public class TransientObjectDirectoryEntity implements JpaAuditing {
 
     @Column(name = "checksum")
     private String checksum;
+
+    @Column(name = "transfer_attempts")
+    private Integer transferAttempts;
 
     @CreationTimestamp
     @Column(name = "created_ts")

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalLocationTypeRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalLocationTypeRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.darts.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
+
+@Repository
+public interface ExternalLocationTypeRepository extends JpaRepository<ExternalLocationTypeEntity, Integer> {
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.common.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEntity;
@@ -17,6 +18,6 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             "WHERE eod.media = :media AND eod.status = :status AND eod.externalLocationType = :externalLocationType"
     )
     List<ExternalObjectDirectoryEntity> findByMediaStatusAndType(MediaEntity media, ObjectDirectoryStatusEntity status,
-                                                                 String externalLocationType);
+                                                                 ExternalLocationTypeEntity externalLocationType);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/TransientObjectDirectoryServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/TransientObjectDirectoryServiceImpl.java
@@ -28,6 +28,7 @@ public class TransientObjectDirectoryServiceImpl implements TransientObjectDirec
         transientObjectDirectoryEntity.setStatus(objectDirectoryStatusRepository.getReferenceById(NEW.getId()));
         transientObjectDirectoryEntity.setExternalLocation(externalLocation);
         transientObjectDirectoryEntity.setChecksum(null);
+        transientObjectDirectoryEntity.setTransferAttempts(null);
 
         return transientObjectDirectoryRepository.saveAndFlush(transientObjectDirectoryEntity);
     }

--- a/src/main/resources/db/migration/V1_12__object_directory_schema_data.sql
+++ b/src/main/resources/db/migration/V1_12__object_directory_schema_data.sql
@@ -1,56 +1,79 @@
-CREATE SEQUENCE IF NOT EXISTS moj_ods_seq CACHE 20;
-CREATE SEQUENCE IF NOT EXISTS eod_seq CACHE 20;
+CREATE SEQUENCE IF NOT EXISTS ods_seq CACHE 20;
 CREATE SEQUENCE IF NOT EXISTS tod_seq CACHE 20;
+CREATE SEQUENCE IF NOT EXISTS elt_seq CACHE 20;
+CREATE SEQUENCE IF NOT EXISTS eod_seq CACHE 20;
 
-CREATE TABLE IF NOT EXISTS moj_object_directory_status (
-  moj_ods_id                    INTEGER                     NOT NULL
+
+CREATE TABLE IF NOT EXISTS object_directory_status (
+  ods_id                        INTEGER                     NOT NULL
 , ods_description               CHARACTER VARYING
-, CONSTRAINT moj_object_directory_status_pk PRIMARY KEY (moj_ods_id)
+, CONSTRAINT object_directory_status_pk PRIMARY KEY (ods_id)
 );
 
 CREATE TABLE IF NOT EXISTS transient_object_directory (
   tod_id                        INTEGER                     NOT NULL
-, moj_mer_id                    INTEGER                     NOT NULL
-, moj_ods_id                    INTEGER                     NOT NULL
+, mer_id                        INTEGER                     NOT NULL
+, ods_id                        INTEGER                     NOT NULL
 , external_location             UUID                        NOT NULL
 , checksum                      CHARACTER VARYING
+, transfer_attempts             INTEGER
 , created_ts                    TIMESTAMP WITH TIME ZONE    NOT NULL
 , modified_ts                   TIMESTAMP WITH TIME ZONE    NOT NULL
 , modified_by                   INTEGER                     --NOT NULL
 , CONSTRAINT transient_object_directory_pk PRIMARY KEY (tod_id)
-, CONSTRAINT tod_media_request_fk FOREIGN KEY (moj_mer_id) REFERENCES moj_media_request (moj_mer_id)
---,CONSTRAINT tod_modified_by_fk FOREIGN KEY (modified_by) REFERENCES moj_user (moj_usr_id)
-, CONSTRAINT tod_object_directory_status_fk FOREIGN KEY (moj_ods_id) REFERENCES moj_object_directory_status (moj_ods_id)
+, CONSTRAINT tod_media_request_fk FOREIGN KEY (mer_id) REFERENCES moj_media_request (moj_mer_id) --, CONSTRAINT tod_media_request_fk FOREIGN KEY (mer_id) REFERENCES media_request (mer_id)
+--, CONSTRAINT tod_modified_by_fk FOREIGN KEY (modified_by) REFERENCES user_account (usr_id)
+, CONSTRAINT tod_object_directory_status_fk FOREIGN KEY (ods_id) REFERENCES object_directory_status (ods_id)
+);
+
+CREATE TABLE IF NOT EXISTS external_location_type (
+  elt_id                        INTEGER                     NOT NULL
+, elt_description               CHARACTER VARYING
+, CONSTRAINT external_location_type_pk PRIMARY KEY (elt_id)
 );
 
 CREATE TABLE IF NOT EXISTS external_object_directory (
   eod_id                        INTEGER                     NOT NULL
-, moj_med_id                    INTEGER
-, moj_tra_id                    INTEGER
-, moj_ann_id                    INTEGER
-, moj_ods_id                    INTEGER                     NOT NULL
+, med_id                        INTEGER
+, tra_id                        INTEGER
+, ann_id                        INTEGER
+, ods_id                        INTEGER                     NOT NULL
+, elt_id                        INTEGER                     NOT NULL
 , external_location             UUID                        NOT NULL
-, external_location_type        CHARACTER VARYING           NOT NULL
+, checksum                      CHARACTER VARYING
+, transfer_attempts             INTEGER
 , created_ts                    TIMESTAMP WITH TIME ZONE    NOT NULL
 , modified_ts                   TIMESTAMP WITH TIME ZONE    NOT NULL
 , modified_by                   INTEGER                     --NOT NULL
-, checksum                      CHARACTER VARYING
-, attempts                      INTEGER
-, CONSTRAINT external_object_directory_pkey PRIMARY KEY (eod_id)
-, CONSTRAINT eod_media_fk FOREIGN KEY (moj_med_id) REFERENCES moj_media (moj_med_id)
-, CONSTRAINT eod_object_directory_status_fk FOREIGN KEY (moj_ods_id) REFERENCES moj_object_directory_status (moj_ods_id)
+, CONSTRAINT external_object_directory_pk PRIMARY KEY (eod_id)
+--, CONSTRAINT eod_annotation_fk FOREIGN KEY (ann_id) REFERENCES annotation (ann_id)
+, CONSTRAINT eod_external_location_type_fk FOREIGN KEY (elt_id) REFERENCES external_location_type (elt_id)
+, CONSTRAINT eod_media_fk FOREIGN KEY (med_id) REFERENCES moj_media (moj_med_id) --, CONSTRAINT eod_media_fk FOREIGN KEY (med_id) REFERENCES media (med_id)
+--, CONSTRAINT eod_modified_by_fk FOREIGN KEY (modified_by) REFERENCES user_account (usr_id)
+, CONSTRAINT eod_object_directory_status_fk FOREIGN KEY (ods_id) REFERENCES object_directory_status (ods_id)
+--, CONSTRAINT eod_transcription_fk FOREIGN KEY (tra_id) REFERENCES transcription (tra_id)
 );
 
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (1,'New');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (2,'Stored');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (3,'Failure');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (4,'Failure - File not found');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (5,'Failure - File size check failed');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (6,'Failure - File type check failed');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (7,'Failure - Checksum failed');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (8,'Failure - ARM ingestion failed');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (9,'Awaiting Verification');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (10,'Marked for Deletion');
-INSERT INTO moj_object_directory_status (moj_ods_id,ods_description) VALUES (11,'Deleted');
 
-ALTER SEQUENCE moj_ods_seq RESTART WITH 12;
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (1,'New');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (2,'Stored');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (3,'Failure');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (4,'Failure - File not found');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (5,'Failure - File size check failed');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (6,'Failure - File type check failed');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (7,'Failure - Checksum failed');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (8,'Failure - ARM ingestion failed');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (9,'Awaiting Verification');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (10,'Marked for Deletion');
+INSERT INTO object_directory_status (ods_id,ods_description) VALUES (11,'Deleted');
+
+ALTER SEQUENCE ods_seq RESTART WITH 12;
+
+INSERT INTO external_location_type (elt_id,elt_description) VALUES (1,'inbound');
+INSERT INTO external_location_type (elt_id,elt_description) VALUES (2,'unstructured');
+INSERT INTO external_location_type (elt_id,elt_description) VALUES (3,'arm');
+INSERT INTO external_location_type (elt_id,elt_description) VALUES (4,'tempstore');
+INSERT INTO external_location_type (elt_id,elt_description) VALUES (5,'vodafone');
+
+ALTER SEQUENCE elt_seq RESTART WITH 6;
+


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-548

### Change description ###

Update object directory schema data (v29) to add external_location_type table and transfer_attempts columns

* Also remove integrationTest dependency on V1_9999__integrationTestData.sql

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
