### PR TITLE
DMP-401: Implement Generate Outbound File and integration with lower …

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -40,6 +40,7 @@
   </rule>
   <rule ref="category/java/design.xml">
     <exclude name="AvoidCatchingGenericException"/>
+<!--    <exclude name="AvoidThrowingRawExceptionTypes"/>-->
     <exclude name="UseUtilityClass"/>
     <exclude name="LoosePackageCoupling"/>
     <exclude name="DataClass"/>
@@ -69,7 +70,14 @@
     <exclude name="NonSerializableClass"/>
     <exclude name="MissingSerialVersionUID"/>
   </rule>
-  <rule ref="category/java/multithreading.xml"/>
+  <rule ref="category/java/errorprone.xml/AvoidLiteralsInIfCondition">
+    <properties>
+      <property name="ignoreMagicNumbers" value="-1,0,1"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/multithreading.xml">
+    <exclude name="UseConcurrentHashMap"/>
+  </rule>
   <rule ref="category/java/performance.xml"/>
   <rule ref="category/java/security.xml"/>
   <exclude-pattern>.*/generated.*</exclude-pattern>

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceProcessAudioRequestTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceProcessAudioRequestTest.java
@@ -1,0 +1,126 @@
+package uk.gov.hmcts.darts.audio.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
+import uk.gov.hmcts.darts.audio.service.impl.AudioTransformationServiceImpl;
+import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEnum;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.entity.HearingMediaEntity;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.testutils.SystemCommandExecutorStubImpl;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.COMPLETED;
+import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.FAILED;
+import static uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEnum.STORED;
+
+@SpringBootTest
+@ActiveProfiles({"intTest", "h2db"})
+@Import(SystemCommandExecutorStubImpl.class)
+@AutoConfigureWireMock
+@ExtendWith(MockitoExtension.class)
+class AudioTransformationServiceProcessAudioRequestTest extends IntegrationBase {
+
+    private static final int SOME_REQUESTOR = 666;
+    public static final OffsetDateTime TIME_12_00 = OffsetDateTime.parse("2023-01-01T12:00Z");
+    public static final OffsetDateTime TIME_12_10 = OffsetDateTime.parse("2023-01-01T12:10Z");
+    public static final OffsetDateTime TIME_13_00 = OffsetDateTime.parse("2023-01-01T13:00Z");
+
+    @Autowired
+    private AudioTransformationServiceImpl audioTransformationService;
+
+    private MediaRequestEntity mediaRequestEntity;
+    private HearingEntity hearingEntity;
+
+    @BeforeEach
+    void setUp() {
+        hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
+            "1",
+            "some-courthouse",
+            "some-courtroom",
+            LocalDate.now()
+        );
+
+        var mediaRequestEntity = new MediaRequestEntity();
+        mediaRequestEntity.setHearing(hearingEntity);
+        mediaRequestEntity.setRequestor(SOME_REQUESTOR);
+        mediaRequestEntity.setStartTime(TIME_12_00);
+        mediaRequestEntity.setEndTime(TIME_13_00);
+        this.mediaRequestEntity = dartsDatabase.getMediaRequestRepository()
+            .saveAndFlush(mediaRequestEntity);
+    }
+
+    @Test
+    void processAudioRequestShouldSucceedAndUpdateRequestStatusToCompleted() {
+        provisionDatabaseForHappyPath();
+
+        UUID blobId = audioTransformationService.processAudioRequest(mediaRequestEntity.getId());
+
+        assertNotNull(blobId);
+
+        mediaRequestEntity = dartsDatabase.getMediaRequestRepository()
+            .findById(mediaRequestEntity.getId())
+            .orElseThrow();
+        assertEquals(COMPLETED, mediaRequestEntity.getStatus());
+    }
+
+    @Test
+    void processAudioRequestShouldFailAndUpdateRequestStatusToFailed() {
+        var exception = assertThrows(
+            DartsApiException.class,
+            () -> audioTransformationService.processAudioRequest(mediaRequestEntity.getId())
+        );
+
+        assertEquals("Failed to process audio request", exception.getMessage());
+
+        mediaRequestEntity = dartsDatabase.getMediaRequestRepository()
+            .findById(mediaRequestEntity.getId())
+            .orElseThrow();
+        assertEquals(FAILED, mediaRequestEntity.getStatus());
+    }
+
+    private void provisionDatabaseForHappyPath() {
+        var mediaEntity = dartsDatabase.createMediaEntity(
+            TIME_12_00,
+            TIME_12_10,
+            1
+        );
+
+        var hearingMediaEntity = new HearingMediaEntity();
+        hearingMediaEntity.setMedia(mediaEntity);
+        hearingMediaEntity.setHearing(hearingEntity);
+
+        dartsDatabase.getHearingMediaRepository()
+            .saveAndFlush(hearingMediaEntity);
+
+        var externalLocationTypeEntity = dartsDatabase.getExternalLocationTypeEntity(
+            ExternalLocationTypeEnum.UNSTRUCTURED);
+        var objectDirectoryStatusEntity = dartsDatabase.getObjectDirectoryStatusEntity(STORED);
+
+        var externalObjectDirectoryEntity = CommonTestDataUtil.createExternalObjectDirectory(
+            mediaEntity,
+            objectDirectoryStatusEntity,
+            externalLocationTypeEntity,
+            UUID.randomUUID()
+        );
+        dartsDatabase.getExternalObjectDirectoryRepository()
+            .saveAndFlush(externalObjectDirectoryEntity);
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
@@ -54,7 +54,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.PROCESSING;
 import static uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEnum.UNSTRUCTURED;
 import static uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEnum.STORED;
 
@@ -123,17 +122,6 @@ class AudioTransformationServiceTest {
 
     @Mock
     private TransientObjectDirectoryEntity mockTransientObjectDirectoryEntity;
-
-    @Test
-    @Transactional
-    void shouldProcessAudioRequest() {
-        createAndLoadMediaRequestEntity();
-
-        MediaRequestEntity processingMediaRequestEntity = audioTransformationService.processAudioRequest(
-            mediaRequestEntity1.getId());
-
-        assertEquals(PROCESSING, processingMediaRequestEntity.getStatus());
-    }
 
     @Test
     void shouldGetAudioBlobDataUsingLocation() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/DartsDatabaseStub.java
@@ -1,26 +1,39 @@
 package uk.gov.hmcts.darts.testutils;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.darts.audio.repository.MediaRequestRepository;
 import uk.gov.hmcts.darts.cases.repository.CaseRepository;
 import uk.gov.hmcts.darts.cases.repository.ReportingRestrictionsRepository;
 import uk.gov.hmcts.darts.common.entity.CaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
+import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
+import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+import uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEntity;
+import uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEnum;
 import uk.gov.hmcts.darts.common.repository.CourtroomRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
+import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
+import uk.gov.hmcts.darts.common.repository.HearingMediaRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.courthouse.CourthouseRepository;
 import uk.gov.hmcts.darts.dailylist.repository.DailyListRepository;
 import uk.gov.hmcts.darts.notification.entity.NotificationEntity;
 import uk.gov.hmcts.darts.notification.repository.NotificationRepository;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,10 +44,13 @@ import static uk.gov.hmcts.darts.common.util.CommonTestDataUtil.createCourtroom;
 import static uk.gov.hmcts.darts.common.util.CommonTestDataUtil.createHearing;
 import static uk.gov.hmcts.darts.testutils.MinimalEntities.aCase;
 import static uk.gov.hmcts.darts.testutils.MinimalEntities.aCourtHouseWithName;
+import static uk.gov.hmcts.darts.testutils.MinimalEntities.aMediaEntity;
 
 @Service
 @AllArgsConstructor
-@SuppressWarnings("PMD.TooManyMethods")
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessiveImports"})
+@Getter
+@Slf4j
 public class DartsDatabaseStub {
 
     private final CaseRepository caseRepository;
@@ -44,16 +60,24 @@ public class DartsDatabaseStub {
     private final HearingRepository hearingRepository;
     private final CourtroomRepository courtroomRepository;
     private final MediaRepository mediaRepository;
+    private final MediaRequestRepository mediaRequestRepository;
+    private final HearingMediaRepository hearingMediaRepository;
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
+    private final ExternalLocationTypeRepository externalLocationTypeRepository;
     private final NotificationRepository notificationRepository;
+    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
     private final DailyListRepository dailyListRepository;
+    private final TransientObjectDirectoryRepository transientObjectDirectoryRepository;
 
     public void clearDatabase() {
-        notificationRepository.deleteAll();
-        hearingRepository.deleteAll();
-        eventRepository.deleteAll();
         externalObjectDirectoryRepository.deleteAll();
+        hearingMediaRepository.deleteAll();
         mediaRepository.deleteAll();
+        transientObjectDirectoryRepository.deleteAll();
+        mediaRequestRepository.deleteAll();
+        hearingRepository.deleteAll();
+        notificationRepository.deleteAll();
+        eventRepository.deleteAll();
         courtroomRepository.deleteAll();
         caseRepository.deleteAll();
         dailyListRepository.deleteAll();
@@ -142,6 +166,10 @@ public class DartsDatabaseStub {
         return courthouseRepository.save(courthouse);
     }
 
+    public MediaEntity createMediaEntity(OffsetDateTime startTime, OffsetDateTime endTime, int channel) {
+        return mediaRepository.saveAndFlush(aMediaEntity(startTime, endTime, channel));
+    }
+
 
     public CourtroomEntity findCourtroomBy(String courthouseName, String courtroomName) {
         return courtroomRepository.findByNames(courthouseName, courtroomName);
@@ -158,4 +186,13 @@ public class DartsDatabaseStub {
     public CourthouseEntity findCourthouseWithName(String name) {
         return courthouseRepository.findByCourthouseName(name).get();
     }
+
+    public ExternalLocationTypeEntity getExternalLocationTypeEntity(ExternalLocationTypeEnum externalLocationTypeEnum) {
+        return externalLocationTypeRepository.getReferenceById(externalLocationTypeEnum.getId());
+    }
+
+    public ObjectDirectoryStatusEntity getObjectDirectoryStatusEntity(ObjectDirectoryStatusEnum objectDirectoryStatusEnum) {
+        return objectDirectoryStatusRepository.getReferenceById(objectDirectoryStatusEnum.getId());
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/DataManagementServiceStubImpl.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/DataManagementServiceStubImpl.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.darts.testutils;
+
+import com.azure.core.util.BinaryData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
+
+import java.util.UUID;
+
+/**
+ * This class is a test implementation of DataManagementService, intended to mimic the basic behaviour of Azure
+ * Blob Storage. TODO: Hopefully this will be replaced by a more functional implementation (see DMP-597).
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@Profile("intTest")
+public class DataManagementServiceStubImpl implements DataManagementService {
+
+    @Override
+    public BinaryData getBlobData(String containerName, UUID blobId) {
+        logStubUsageWarning();
+
+        log.warn("Returning dummy file to mimic Blob storage download");
+        return BinaryData.fromBytes(new byte[1024]);
+    }
+
+    @Override
+    public UUID saveBlobData(String containerName, BinaryData binaryData) {
+        logStubUsageWarning();
+
+        UUID uuid = UUID.randomUUID();
+        log.warn("Returning random UUID to mimic successful upload: {}", uuid);
+        return uuid;
+    }
+
+    private void logStubUsageWarning() {
+        log.warn("### This implementation is intended only for integration tests. If you see this log message elsewhere"
+                     + " you should ask questions! ###");
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/MinimalEntities.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/MinimalEntities.java
@@ -4,6 +4,9 @@ import uk.gov.hmcts.darts.common.entity.CaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+
+import java.time.OffsetDateTime;
 
 import static java.time.LocalDate.now;
 
@@ -70,4 +73,14 @@ public class MinimalEntities {
         hearing.setHearingDate(now());
         return hearing;
     }
+
+    public static MediaEntity aMediaEntity(OffsetDateTime startTime, OffsetDateTime endTime, int channel) {
+        MediaEntity mediaEntity = new MediaEntity();
+        mediaEntity.setStart(startTime);
+        mediaEntity.setEnd(endTime);
+        mediaEntity.setChannel(channel);
+
+        return mediaEntity;
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/SystemCommandExecutorStubImpl.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/SystemCommandExecutorStubImpl.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.darts.testutils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.exec.CommandLine;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.audio.component.SystemCommandExecutor;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class is a test implementation of SystemCommandExecutor, intended to mimic the side effects of specified system
+ * commands without actually executing those commands. This is useful for scenarios where the executable is not present
+ * on the host system but the side effects of the command are required by subsequent test steps.
+ */
+@Component
+@Slf4j
+@Profile("intTest")
+public class SystemCommandExecutorStubImpl implements SystemCommandExecutor {
+
+    public static final int DUMMY_FILE_SIZE_BYTES = 10_240;
+
+    @Override
+    public Boolean execute(CommandLine command) {
+        log.warn("### This implementation is intended only for integration tests. If you see this log message elsewhere"
+                     + " you should ask questions! ###");
+
+        String executable = command.getExecutable();
+        List<String> arguments = Arrays.asList(command.getArguments());
+        if (executable.contains("ffmpeg")) {
+            // The output path is assumed to always be the final argument
+            var fileOutputPath = Path.of(arguments.get(arguments.size() - 1));
+            if (isFfmpegConcatOperation(arguments)) {
+                log.debug("Stubbing ffmpeg concat operation");
+            } else if (isFfmpegTrimOperation(arguments)) {
+                log.debug("Stubbing ffmpeg trim operation");
+            }
+            writeDummyFile(fileOutputPath);
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isFfmpegConcatOperation(List<String> arguments) {
+        return arguments.stream()
+            .anyMatch(argument -> argument.contains("concat="));
+    }
+
+    private boolean isFfmpegTrimOperation(List<String> arguments) {
+        return arguments.contains("-ss") && arguments.contains("-to");
+    }
+
+    @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
+    private void writeDummyFile(Path path) {
+        log.debug("Writing dummy file to: {}", path);
+        try {
+            Files.createDirectories(path.getParent());
+            Files.write(path, new byte[DUMMY_FILE_SIZE_BYTES]);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/integrationTest/resources/application-intTest.yaml
+++ b/src/integrationTest/resources/application-intTest.yaml
@@ -27,9 +27,19 @@ spring:
     - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
     - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
     - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
+
+darts:
+  audio:
+    concat-workspace: ${java.io.tmpdir}/audiotransform/concatenate
+    merge-workspace: ${java.io.tmpdir}/audiotransform/merge
+    trim-workspace: ${java.io.tmpdir}/audiotransform/trim
+    re-encode-workspace: ${java.io.tmpdir}/audiotransform/encode
+    temp-blob-workspace: ${java.io.tmpdir}/audiotransform/tempworkspace
+
 logging:
   level:
     uk:
       gov:
         hmcts:
           darts: DEBUG
+

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/OutboundFileProcessor.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/OutboundFileProcessor.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.darts.audio.component;
+
+import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+public interface OutboundFileProcessor {
+
+    List<List<AudioFileInfo>> processAudio(Map<MediaEntity, Path> mediaEntityToDownloadLocation,
+                                           OffsetDateTime overallStartTime,
+                                           OffsetDateTime overallEndTime)
+        throws ExecutionException, InterruptedException;
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/OutboundFileZipGenerator.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/OutboundFileZipGenerator.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.darts.audio.component;
+
+import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public interface OutboundFileZipGenerator {
+
+    Path generateAndWriteZip(List<List<AudioFileInfo>> audioSessions);
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/SystemCommandExecutor.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/SystemCommandExecutor.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.darts.audio.component;
+
+import org.apache.commons.exec.CommandLine;
+
+import java.util.concurrent.ExecutionException;
+
+public interface SystemCommandExecutor {
+
+    Boolean execute(CommandLine command) throws ExecutionException, InterruptedException;
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
@@ -1,0 +1,155 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.audio.component.OutboundFileProcessor;
+import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
+import uk.gov.hmcts.darts.audio.service.AudioOperationService;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OutboundFileProcessorImpl implements OutboundFileProcessor {
+
+    private final AudioOperationService audioOperationService;
+
+    /**
+     * Group the provided media/audio into logical groups in preparation for zipping with OutboundFileZipGenerator.
+     *
+     * @param mediaEntityToDownloadLocation Map relating each mediaEntity to the local filepath of its associated
+     *                                      downloaded audio file.
+     * @param overallStartTime              The time at which the audio start should be trimmed to.
+     * @param overallEndTime                The time at which the audio end should be trimmed to.
+     * @return A grouping of trimmed and concatenated multichannel audio files, whereby each group is a collection of
+     *     audio files that belong to a continuous recording session.
+     */
+    @Override
+    public List<List<AudioFileInfo>> processAudio(Map<MediaEntity, Path> mediaEntityToDownloadLocation,
+                                                  OffsetDateTime overallStartTime,
+                                                  OffsetDateTime overallEndTime)
+        throws ExecutionException, InterruptedException {
+        List<AudioFileInfo> audioFileInfos = mapToAudioFileInfos(mediaEntityToDownloadLocation);
+
+        List<List<AudioFileInfo>> groupedAudioSessions = new ArrayList<>();
+        for (AudioFileInfo audioFileInfo : audioFileInfos) {
+            groupBySession(audioFileInfo, groupedAudioSessions);
+        }
+
+        List<List<AudioFileInfo>> finalisedAudioSessions = new ArrayList<>();
+        for (List<AudioFileInfo> audioSession : groupedAudioSessions) {
+            List<AudioFileInfo> concatenatedAudios = concatenateByChannel(audioSession);
+            List<AudioFileInfo> trimmedAudios = trimToPeriod(
+                concatenatedAudios,
+                overallStartTime,
+                overallEndTime
+            );
+            finalisedAudioSessions.add(trimmedAudios);
+        }
+
+        return finalisedAudioSessions;
+    }
+
+    private List<AudioFileInfo> mapToAudioFileInfos(Map<MediaEntity, Path> mediaEntityPathMap) {
+        List<AudioFileInfo> audioFileInfos = new ArrayList<>();
+        for (Entry<MediaEntity, Path> mediaEntityPathEntry : mediaEntityPathMap.entrySet()) {
+            audioFileInfos.add(mapToAudioFileInfo(mediaEntityPathEntry));
+        }
+        return audioFileInfos;
+    }
+
+    private AudioFileInfo mapToAudioFileInfo(Entry<MediaEntity, Path> mediaEntityPathEntry) {
+        MediaEntity mediaEntity = mediaEntityPathEntry.getKey();
+        Path path = mediaEntityPathEntry.getValue();
+
+        return new AudioFileInfo(
+            mediaEntity.getStart().toInstant(),
+            mediaEntity.getEnd().toInstant(),
+            path.toString(),
+            mediaEntity.getChannel()
+        );
+    }
+
+    private void groupBySession(AudioFileInfo ungroupedAudioFileInfo, List<List<AudioFileInfo>> groupings) {
+        for (List<AudioFileInfo> groupedAudioFileInfos : groupings) {
+            for (AudioFileInfo groupedAudioFileInfo : groupedAudioFileInfos) {
+                if (isSameSession(groupedAudioFileInfo, ungroupedAudioFileInfo)) {
+                    groupedAudioFileInfos.add(ungroupedAudioFileInfo);
+                    return;
+                }
+            }
+        }
+        groupings.add(new ArrayList<>(Collections.singletonList(ungroupedAudioFileInfo)));
+    }
+
+    /**
+     * A discriminator used to establish whether the ungroupedAudioFileInfo belongs in the same logical "session" as the
+     * groupedAudioFileInfo.
+     */
+    private boolean isSameSession(AudioFileInfo groupedAudioFileInfo, AudioFileInfo ungroupedAudioFileInfo) {
+        boolean hasEqualTimestamps = groupedAudioFileInfo.getStartTime().equals(ungroupedAudioFileInfo.getStartTime())
+            && groupedAudioFileInfo.getEndTime().equals(ungroupedAudioFileInfo.getEndTime());
+
+        boolean hasContinuity = ungroupedAudioFileInfo.getChannel().equals(groupedAudioFileInfo.getChannel())
+            && (ungroupedAudioFileInfo.getStartTime().equals(groupedAudioFileInfo.getEndTime())
+            || ungroupedAudioFileInfo.getEndTime().equals(groupedAudioFileInfo.getStartTime()));
+
+        return hasEqualTimestamps || hasContinuity;
+    }
+
+    private List<AudioFileInfo> concatenateByChannel(List<AudioFileInfo> audioFileInfos)
+        throws ExecutionException, InterruptedException {
+        Map<Integer, List<AudioFileInfo>> audioFileInfosByChannel = audioFileInfos.stream()
+            .collect(Collectors.groupingBy(AudioFileInfo::getChannel));
+
+        List<AudioFileInfo> processedAudios = new ArrayList<>();
+
+        for (List<AudioFileInfo> audioFileInfosForChannel : audioFileInfosByChannel.values()) {
+            if (audioFileInfosForChannel.size() == 1) {
+                // If there is only one file then there is nothing to concatenate
+                processedAudios.add(audioFileInfosForChannel.get(0));
+                continue;
+            }
+
+            // Sort to be sure concatenation occurs in chronological order
+            audioFileInfosForChannel.sort(Comparator.comparing(AudioFileInfo::getStartTime));
+            AudioFileInfo concatenatedAudio = audioOperationService.concatenate(
+                StringUtils.EMPTY,
+                audioFileInfosForChannel
+            );
+            processedAudios.add(concatenatedAudio);
+        }
+
+        return processedAudios;
+    }
+
+    private List<AudioFileInfo> trimToPeriod(List<AudioFileInfo> audioFileInfos, OffsetDateTime start,
+                                             OffsetDateTime end) throws ExecutionException, InterruptedException {
+        List<AudioFileInfo> processedAudios = new ArrayList<>();
+        for (AudioFileInfo audioFileInfo : audioFileInfos) {
+            AudioFileInfo trimmedAudio = audioOperationService.trim(
+                StringUtils.EMPTY,
+                audioFileInfo,
+                start.toLocalTime().toString(),
+                end.toLocalTime().toString()
+            );
+            processedAudios.add(trimmedAudio);
+        }
+
+        return processedAudios;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileZipGeneratorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileZipGeneratorImpl.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.audio.component.OutboundFileZipGenerator;
+import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
+import uk.gov.hmcts.darts.audio.exception.AudioError;
+import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OutboundFileZipGeneratorImpl implements OutboundFileZipGenerator {
+
+    private final AudioConfigurationProperties audioConfigurationProperties;
+
+    /**
+     * Produce a structured zip file containing audio files.
+     *
+     * @param audioSessions A grouping of audio sessions, as produced by OutboundFileProcessor.
+     * @return The local filepath of the produced zip file containing the provided audioSessions.
+     */
+    @Override
+    public Path generateAndWriteZip(List<List<AudioFileInfo>> audioSessions) {
+
+        Map<Path, Path> sourceToDestinationPaths = generateZipStructure(audioSessions);
+        try {
+            var outputPath = Path.of(
+                audioConfigurationProperties.getTempBlobWorkspace(),
+                String.format("%s.zip", UUID.randomUUID())
+            );
+            writeZip(sourceToDestinationPaths, outputPath);
+
+            return outputPath;
+        } catch (IOException e) {
+            throw new DartsApiException(AudioError.FAILED_TO_PROCESS_AUDIO_REQUEST, e);
+        }
+    }
+
+    private Map<Path, Path> generateZipStructure(List<List<AudioFileInfo>> audioSessions) {
+        Map<Path, Path> sourceToDestinationPaths = new HashMap<>();
+        for (int i = 0; i < audioSessions.size(); i++) {
+            List<AudioFileInfo> audioSession = audioSessions.get(i);
+            for (AudioFileInfo audioFileInfo : audioSession) {
+                Path path = generateZipPath(i, audioFileInfo);
+                sourceToDestinationPaths.put(Path.of(audioFileInfo.getFileName()), path);
+            }
+        }
+
+        log.debug("Generated zip structure: {}", sourceToDestinationPaths);
+        return sourceToDestinationPaths;
+    }
+
+    private Path generateZipPath(int directoryIndex, AudioFileInfo audioFileInfo) {
+        var directoryName = String.format("%04d", directoryIndex + 1);
+
+        var filename = String.format("%s.a%02d", directoryName, audioFileInfo.getChannel() - 1);
+
+        return Path.of(directoryName, filename);
+    }
+
+    @SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops", "PMD.AssignmentInOperand"})
+    private void writeZip(Map<Path, Path> sourceToDestinationPaths, Path outputPath) throws IOException {
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(Files.newOutputStream(outputPath))) {
+            for (Entry<Path, Path> paths : sourceToDestinationPaths.entrySet()) {
+                Path sourcePath = paths.getKey();
+                Path destinationPath = paths.getValue();
+
+                try (InputStream fileInputStream = Files.newInputStream(sourcePath)) {
+                    var zipEntry = new ZipEntry(destinationPath.toString());
+                    zipOutputStream.putNextEntry(zipEntry);
+
+                    byte[] readBuffer = new byte[1024];
+                    int length;
+                    while ((length = fileInputStream.read(readBuffer)) >= 0) {
+                        zipOutputStream.write(readBuffer, 0, length);
+                    }
+                }
+            }
+        }
+
+        log.debug("Produced zip file: {}", outputPath);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/SystemCommandExecutorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/SystemCommandExecutorImpl.java
@@ -1,8 +1,10 @@
-package uk.gov.hmcts.darts.audio.util;
+package uk.gov.hmcts.darts.audio.component.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.exec.CommandLine;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.audio.component.SystemCommandExecutor;
 import uk.gov.hmcts.darts.common.util.CommandRunner;
 
 import java.util.concurrent.ExecutionException;
@@ -12,9 +14,11 @@ import java.util.concurrent.Future;
 
 @Slf4j
 @Component
-public class AudioUtil {
+@Profile("!intTest")
+public class SystemCommandExecutorImpl implements SystemCommandExecutor {
 
     @SuppressWarnings("PMD.DoNotUseThreads")
+    @Override
     public Boolean execute(CommandLine command) throws ExecutionException, InterruptedException {
         try {
             ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioError.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioError.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.darts.audio.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.darts.common.exception.DartsApiError;
+
+@Getter
+@RequiredArgsConstructor
+public enum AudioError implements DartsApiError {
+
+    FAILED_TO_PROCESS_AUDIO_REQUEST("100",
+                                  null,
+                                  "Failed to process audio request");
+
+    private static final String ERROR_TYPE_PREFIX = "AUDIO";
+
+    private final String errorTypeNumeric;
+    private final HttpStatus httpStatus;
+    private final String title;
+
+    @Override
+    public String getErrorTypePrefix() {
+        return ERROR_TYPE_PREFIX;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/AudioTransformationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/AudioTransformationService.java
@@ -10,10 +10,11 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
 public interface AudioTransformationService {
 
-    MediaRequestEntity processAudioRequest(Integer requestId);
+    UUID processAudioRequest(Integer requestId) throws ExecutionException, InterruptedException;
 
     BinaryData getAudioBlobData(UUID location);
 
@@ -27,6 +28,6 @@ public interface AudioTransformationService {
 
     Path saveBlobDataToTempWorkspace(BinaryData mediaFile, String fileName) throws IOException;
 
-    void saveProcessedData(MediaRequestEntity mediaRequest, BinaryData binaryData);
+    UUID saveProcessedData(MediaRequestEntity mediaRequest, BinaryData binaryData);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioOperationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioOperationServiceImpl.java
@@ -4,12 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.exec.CommandLine;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.audio.component.SystemCommandExecutor;
 import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
 import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
 import uk.gov.hmcts.darts.audio.service.AudioOperationService;
 import uk.gov.hmcts.darts.audio.util.AudioConstants;
 import uk.gov.hmcts.darts.audio.util.AudioConstants.AudioOperationTypes;
-import uk.gov.hmcts.darts.audio.util.AudioUtil;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -29,7 +29,7 @@ public class AudioOperationServiceImpl implements AudioOperationService {
     private static final String STRING_SLASH_STRING_FORMAT = "%s/%s";
 
     private final AudioConfigurationProperties audioConfigurationProperties;
-    private final AudioUtil audioUtil;
+    private final SystemCommandExecutor systemCommandExecutor;
 
     CommandLine generateConcatenateCommand(final Integer channel, final List<AudioFileInfo> audioFileInfos,
                                            final String outputFilename) {
@@ -67,7 +67,7 @@ public class AudioOperationServiceImpl implements AudioOperationService {
                                                        channel, AudioConstants.AudioFileFormats.MP2
         );
         CommandLine command = generateConcatenateCommand(channel, audioFileInfos, outputFilename);
-        audioUtil.execute(command);
+        systemCommandExecutor.execute(command);
 
         return new AudioFileInfo(
             getEarliestStartTime(audioFileInfos),
@@ -100,7 +100,7 @@ public class AudioOperationServiceImpl implements AudioOperationService {
             .addArgument(String.format("amix=inputs=%d:duration=longest", numberOfChannels))
             .addArgument(outputFilename);
 
-        audioUtil.execute(command);
+        systemCommandExecutor.execute(command);
 
         return new AudioFileInfo(
             getEarliestStartTime(audioFilesInfo),
@@ -130,7 +130,7 @@ public class AudioOperationServiceImpl implements AudioOperationService {
         command.addArgument("-to").addArgument(endTime);
         command.addArgument("-c").addArgument("copy").addArgument(outputFilename);
 
-        audioUtil.execute(command);
+        systemCommandExecutor.execute(command);
 
         return new AudioFileInfo(
             adjustTimeDuration(audioFileInfo.getStartTime(), startTime),
@@ -158,7 +158,7 @@ public class AudioOperationServiceImpl implements AudioOperationService {
         command.addArgument("-i").addArgument(audioFileInfo.getFileName());
         command.addArgument(outputFilename);
 
-        audioUtil.execute(command);
+        systemCommandExecutor.execute(command);
 
         return new AudioFileInfo(
             audioFileInfo.getStartTime(),

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiException.java
@@ -26,14 +26,14 @@ public class DartsApiException extends RuntimeException {
     }
 
     public DartsApiException(DartsApiError error, String detail) {
-        super(error.getTitle());
+        super(String.format("%s. %s", error.getTitle(), detail));
 
         this.error = error;
         this.detail = detail;
     }
 
     public DartsApiException(DartsApiError error, String detail, Throwable throwable) {
-        super(error.getTitle(), throwable);
+        super(String.format("%s. %s", error.getTitle(), detail), throwable);
 
         this.error = error;
         this.detail = detail;

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/FileOperationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/FileOperationServiceImpl.java
@@ -38,4 +38,5 @@ public class FileOperationServiceImpl implements FileOperationService {
 
         return targetTempFile;
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -5,6 +5,7 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.datamanagement.dao.DataManagementDao;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
@@ -13,6 +14,7 @@ import java.util.UUID;
 
 @Service
 @Slf4j
+@Profile("!intTest")
 public class DataManagementServiceImpl implements DataManagementService {
 
     @Autowired

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImplTest.java
@@ -1,0 +1,211 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
+import uk.gov.hmcts.darts.audio.service.impl.AudioOperationServiceImpl;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OutboundFileProcessorImplTest {
+
+    private static final Path SOME_DOWNLOAD_PATH = Path.of("/some-download-dir/some-downloaded-file");
+    private static final OffsetDateTime TIME_12_00 = OffsetDateTime.parse("2023-01-01T12:00Z");
+    private static final OffsetDateTime TIME_12_10 = OffsetDateTime.parse("2023-01-01T12:10Z");
+    private static final OffsetDateTime TIME_12_20 = OffsetDateTime.parse("2023-01-01T12:20Z");
+    private static final OffsetDateTime TIME_12_30 = OffsetDateTime.parse("2023-01-01T12:30Z");
+    private static final OffsetDateTime TIME_13_00 = OffsetDateTime.parse("2023-01-01T13:00Z");
+
+    private OutboundFileProcessorImpl outboundFileProcessor;
+
+    @Mock
+    private AudioOperationServiceImpl audioOperationService;
+
+    @BeforeEach
+    void setUp() {
+        outboundFileProcessor = new OutboundFileProcessorImpl(audioOperationService);
+    }
+
+    @Test
+    void processAudioShouldReturnOneSessionWithOneAudioWhenProvidedWithOneAudio()
+        throws ExecutionException, InterruptedException {
+
+        AudioFileInfo trimmedAudioFileInfo = new AudioFileInfo();
+        when(audioOperationService.trim(any(), any(), any(), any()))
+            .thenReturn(trimmedAudioFileInfo);
+
+        var mediaEntity = createMediaEntity(TIME_12_00,
+                                            TIME_12_10,
+                                            1
+        );
+        var mediaEntityToDownloadLocation = Map.of(mediaEntity, SOME_DOWNLOAD_PATH);
+
+        List<List<AudioFileInfo>> sessions = outboundFileProcessor.processAudio(
+            mediaEntityToDownloadLocation,
+            TIME_12_00,
+            TIME_13_00
+        );
+
+        assertEquals(1, sessions.size());
+        List<AudioFileInfo> session = sessions.get(0);
+
+        assertEquals(1, session.size());
+        assertEquals(trimmedAudioFileInfo, session.get(0));
+
+        verify(audioOperationService, never()).concatenate(any(), any());
+        verify(audioOperationService, times(1)).trim(any(), any(), any(), any());
+    }
+
+    @Test
+    void processAudioShouldReturnOneSessionWithOneAudioWhenProvidedWithTwoContinuousAudios()
+        throws ExecutionException, InterruptedException {
+
+        var concatenatedAudioFileInfo = new AudioFileInfo();
+        when(audioOperationService.concatenate(any(), any()))
+            .thenReturn(concatenatedAudioFileInfo);
+
+        var trimmedAudioFileInfo = new AudioFileInfo();
+        when(audioOperationService.trim(any(), any(), any(), any()))
+            .thenReturn(trimmedAudioFileInfo);
+
+        var mediaEntity1 = createMediaEntity(
+            TIME_12_00,
+            TIME_12_10,
+            1
+        );
+        var mediaEntity2 = createMediaEntity(
+            TIME_12_10,
+            TIME_12_20,
+            1
+        );
+        var mediaEntityToDownloadLocation = Map.of(mediaEntity1, SOME_DOWNLOAD_PATH,
+                                                   mediaEntity2, SOME_DOWNLOAD_PATH
+        );
+
+        List<List<AudioFileInfo>> sessions = outboundFileProcessor.processAudio(
+            mediaEntityToDownloadLocation,
+            TIME_12_00,
+            TIME_13_00
+        );
+
+        assertEquals(1, sessions.size());
+        List<AudioFileInfo> session = sessions.get(0);
+
+        assertEquals(1, session.size());
+        assertEquals(trimmedAudioFileInfo, session.get(0));
+
+        verify(audioOperationService, times(1)).concatenate(any(), any());
+        verify(audioOperationService, times(1)).trim(any(), any(), any(), any());
+    }
+
+    @Test
+    void processAudioShouldReturnOneSessionWithTwoAudioWhenProvidedWithTwoNonContinuousAudiosWithDifferentChannelsAndSameTimestamp()
+        throws ExecutionException, InterruptedException {
+
+        var firstTrimmedAudioFileInfo = new AudioFileInfo();
+        var secondTrimmedAudioFileInfo = new AudioFileInfo();
+        when(audioOperationService.trim(any(), any(), any(), any()))
+            .thenReturn(firstTrimmedAudioFileInfo)
+            .thenReturn(secondTrimmedAudioFileInfo);
+
+        var mediaEntity1 = createMediaEntity(
+            TIME_12_00,
+            TIME_12_10,
+            1
+        );
+        var mediaEntity2 = createMediaEntity(
+            TIME_12_00,
+            TIME_12_10,
+            2
+        );
+        var mediaEntityToDownloadLocation = Map.of(mediaEntity1, SOME_DOWNLOAD_PATH,
+                                                   mediaEntity2, SOME_DOWNLOAD_PATH
+        );
+
+        List<List<AudioFileInfo>> sessions = outboundFileProcessor.processAudio(
+            mediaEntityToDownloadLocation,
+            TIME_12_00,
+            TIME_13_00
+        );
+
+        assertEquals(1, sessions.size());
+        List<AudioFileInfo> session = sessions.get(0);
+
+        assertEquals(2, session.size());
+        assertEquals(firstTrimmedAudioFileInfo, session.get(0));
+        assertEquals(secondTrimmedAudioFileInfo, session.get(1));
+
+        verify(audioOperationService, never()).concatenate(any(), any());
+        verify(audioOperationService, times(2)).trim(any(), any(), any(), any());
+    }
+
+    @Test
+    void processAudioShouldReturnTwoSessionsEachWithOneAudioWhenProvidedWithTwoNonContinuousAudios()
+        throws ExecutionException, InterruptedException {
+
+        var firstTrimmedAudioFileInfo = new AudioFileInfo();
+        var secondTrimmedAudioFileInfo = new AudioFileInfo();
+        when(audioOperationService.trim(any(), any(), any(), any()))
+            .thenReturn(firstTrimmedAudioFileInfo)
+            .thenReturn(secondTrimmedAudioFileInfo);
+
+        var mediaEntity1 = createMediaEntity(
+            TIME_12_00,
+            TIME_12_10,
+            1
+        );
+        var mediaEntity2 = createMediaEntity(
+            TIME_12_20,
+            TIME_12_30,
+            1
+        );
+        var mediaEntityToDownloadLocation = Map.of(mediaEntity1, SOME_DOWNLOAD_PATH,
+                                                   mediaEntity2, SOME_DOWNLOAD_PATH
+        );
+
+        List<List<AudioFileInfo>> sessions = outboundFileProcessor.processAudio(
+            mediaEntityToDownloadLocation,
+            TIME_12_00,
+            TIME_13_00
+        );
+
+        assertEquals(2, sessions.size());
+        List<AudioFileInfo> firstSession = sessions.get(0);
+        List<AudioFileInfo> secondSession = sessions.get(1);
+
+        assertEquals(1, firstSession.size());
+        assertEquals(firstTrimmedAudioFileInfo, firstSession.get(0));
+
+        assertEquals(1, secondSession.size());
+        assertEquals(secondTrimmedAudioFileInfo, secondSession.get(0));
+
+        verify(audioOperationService, never()).concatenate(any(), any());
+        verify(audioOperationService, times(2)).trim(any(), any(), any(), any());
+    }
+
+    private MediaEntity createMediaEntity(OffsetDateTime startTime, OffsetDateTime endTime, int channel) {
+        var mediaEntity = new MediaEntity();
+        mediaEntity.setStart(startTime);
+        mediaEntity.setEnd(endTime);
+        mediaEntity.setChannel(channel);
+
+        return mediaEntity;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileZipGeneratorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileZipGeneratorImplTest.java
@@ -1,0 +1,107 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
+import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
+@ExtendWith(MockitoExtension.class)
+class OutboundFileZipGeneratorImplTest {
+
+    // Any value that exceeds the size of the read buffer of the tested impl
+    private static final int DUMMY_FILE_SIZE = 2048;
+    private static final Instant SOME_INSTANT = Instant.now();
+
+    private OutboundFileZipGeneratorImpl outboundFileZipGenerator;
+    private Path tempDirectory;
+
+    @Mock
+    private AudioConfigurationProperties audioConfigurationProperties;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        outboundFileZipGenerator = new OutboundFileZipGeneratorImpl(audioConfigurationProperties);
+
+        var tempDirectoryName = UUID.randomUUID().toString();
+        tempDirectory = Files.createTempDirectory(tempDirectoryName);
+
+        when(audioConfigurationProperties.getTempBlobWorkspace())
+            .thenReturn(tempDirectory.toString());
+    }
+
+    @Test
+    void generateAndWriteZipShouldProduceZipWithTheExpectedFileStructure() {
+        var audioWithSession1AndChannel1 = createDummyFileAndAudioFileInfo(1);
+        var audioWithSession1AndChannel2 = createDummyFileAndAudioFileInfo(2);
+        List<AudioFileInfo> session1 = List.of(
+            audioWithSession1AndChannel1,
+            audioWithSession1AndChannel2
+        );
+
+        var audioWithSession2AndChannel1 = createDummyFileAndAudioFileInfo(1);
+        List<AudioFileInfo> session2 = List.of(
+            audioWithSession2AndChannel1
+        );
+
+        Path path = outboundFileZipGenerator.generateAndWriteZip(List.of(session1, session2));
+
+        assertTrue(Files.exists(path));
+
+        List<String> paths = readZipStructure(path);
+
+        assertEquals(3, paths.size());
+        assertThat(paths, hasItem("0001/0001.a00"));
+        assertThat(paths, hasItem("0001/0001.a01"));
+        assertThat(paths, hasItem("0002/0002.a00"));
+    }
+
+    private AudioFileInfo createDummyFileAndAudioFileInfo(int channel) {
+        Path path = createDummyFile();
+        return new AudioFileInfo(SOME_INSTANT, SOME_INSTANT, path.toString(), channel);
+    }
+
+    private Path createDummyFile() {
+        var tempFilename = UUID.randomUUID()
+            .toString();
+        try {
+            return Files.write(tempDirectory.resolve(tempFilename), new byte[DUMMY_FILE_SIZE]);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    private List<String> readZipStructure(Path path) {
+        List<String> paths = new ArrayList<>();
+        try (ZipInputStream zipInputStream = new ZipInputStream(Files.newInputStream(path))) {
+            ZipEntry entry;
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                paths.add(entry.getName());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return paths;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/SystemCommandExecutorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/SystemCommandExecutorImplTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.darts.audio.util;
+package uk.gov.hmcts.darts.audio.component.impl;
 
 import org.apache.commons.exec.CommandLine;
 import org.junit.jupiter.api.Test;
@@ -10,18 +10,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
-class AudioUtilTest {
+class SystemCommandExecutorImplTest {
 
     @InjectMocks
-    private AudioUtil audioUtil;
+    private SystemCommandExecutorImpl systemCommandExecutor;
 
     @Test
     void shouldExecuteCommandsWhenCommandIsValid() throws Exception {
-        assertTrue(audioUtil.execute(new CommandLine("hostname")));
+        assertTrue(systemCommandExecutor.execute(new CommandLine("hostname")));
     }
 
     @Test
     void shouldThrowExceptionWhenCommandIsInValid() {
-        assertThrows(Exception.class, () -> audioUtil.execute(new CommandLine("Dummy Command")));
+        assertThrows(Exception.class, () -> systemCommandExecutor.execute(new CommandLine("Dummy Command")));
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioOperationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioOperationServiceImplTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.audio.component.impl.SystemCommandExecutorImpl;
 import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
 import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
-import uk.gov.hmcts.darts.audio.util.AudioUtil;
 
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
@@ -42,7 +42,7 @@ class AudioOperationServiceImplTest {
     private AudioConfigurationProperties audioConfigurationProperties;
 
     @Mock
-    private AudioUtil audioUtil;
+    private SystemCommandExecutorImpl systemCommandExecutor;
 
     @BeforeEach
     void beforeEach() {
@@ -85,7 +85,7 @@ class AudioOperationServiceImplTest {
     void shouldReturnConcatenatedAudioFileInfoWhenValidInputAudioFiles() throws Exception {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
         when(audioConfigurationProperties.getConcatWorkspace()).thenReturn("/tempDir/concatenate");
-        when(audioUtil.execute(any())).thenReturn(Boolean.TRUE);
+        when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
 
         AudioFileInfo expectedAudio = new AudioFileInfo(
             Instant.parse(T_09_00_00_Z),
@@ -106,7 +106,7 @@ class AudioOperationServiceImplTest {
     void shouldReturnMergedAudioFileInfoWhenValidInputAudioFiles() throws Exception {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
         when(audioConfigurationProperties.getMergeWorkspace()).thenReturn("/tempDir/merge");
-        when(audioUtil.execute(any())).thenReturn(Boolean.TRUE);
+        when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
 
         AudioFileInfo expectedAudio = new AudioFileInfo(
             Instant.parse(T_09_00_00_Z),
@@ -127,7 +127,7 @@ class AudioOperationServiceImplTest {
     void shouldReturnTrimmedAudioFileWhenValidInputAudioFile() throws ExecutionException, InterruptedException {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
         when(audioConfigurationProperties.getTrimWorkspace()).thenReturn("/tempDir/trim");
-        when(audioUtil.execute(any())).thenReturn(Boolean.TRUE);
+        when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
 
         AudioFileInfo expectedAudio = new AudioFileInfo(
             Instant.parse("2023-04-28T09:45:00Z"),
@@ -199,7 +199,7 @@ class AudioOperationServiceImplTest {
     void shouldReturnReEncodedAudioFileInfoWhenValidInputAudioFile() throws ExecutionException, InterruptedException {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
         when(audioConfigurationProperties.getReEncodeWorkspace()).thenReturn("/tempDir/encode");
-        when(audioUtil.execute(any())).thenReturn(Boolean.TRUE);
+        when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
 
         AudioFileInfo expectedAudio = new AudioFileInfo(
             Instant.parse(T_09_00_00_Z),


### PR DESCRIPTION
[DMP-401](https://tools.hmcts.net/jira/browse/DMP-401)

This PR integrates multiple existing components to complete the overall "Process AudioRequest" functionality.

This entails:

- Downloading all audio related to the given AudioRequest
- Performing audio transformations to concatentate audio files that share the same channel and have continous start/end times, and to trim the audio to the desired overall start and end times
- Producing a zip file containing these files, in the structure defined by DMP-401
- Uploading the zip to Azure blob storage

Whilst existing components are used where possible, new components were also written to correctly structure the data/files, and to produce the zip file.

The main classes involved in this work are:

- `src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java`
- `src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java`
- `src/main/java/uk/gov/hmcts/darts/audio/component/OutboundFileZipGenerator.java`

Other changes are related to:

- Creating error code to enable error handling
- Stub creation to enable adequate integration testing


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
