### PR TITLE
DMP-624: Openapi additions for events POST /courtlogs

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerCourtLogsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerCourtLogsTest.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.darts.event.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.darts.event.model.CourtLogsPostRequestBody;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles({"intTest", "h2db"})
+@AutoConfigureMockMvc
+@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+class EventsControllerCourtLogsTest extends IntegrationBase {
+
+    private static final URI ENDPOINT = URI.create("/courtlogs");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void courtLogsPostShouldReturnNotImplementedError() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = post(ENDPOINT)
+            .header("Content-Type", "application/json")
+            .content(objectMapper.writeValueAsBytes(createRequestBody()));
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(status().isNotImplemented());
+    }
+
+    @Test
+    void courtLogsPostShouldReturnBadRequestWhenNoRequestBodyIsProvided() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = post(ENDPOINT)
+            .header("Content-Type", "application/json");
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(status().isBadRequest())
+            .andExpect(header().string("Content-Type", "application/problem+json"));
+    }
+
+    private CourtLogsPostRequestBody createRequestBody() {
+        return new CourtLogsPostRequestBody(OffsetDateTime.now(),
+                                            "some-courthouse",
+                                            "some-courtroom",
+                                            Collections.singletonList("some-case-number"),
+                                            "some-text");
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -15,10 +15,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.event.api.EventApi;
-import uk.gov.hmcts.darts.event.model.AddDocumentResponse;
 import uk.gov.hmcts.darts.event.model.CourtLogsPostRequestBody;
-import uk.gov.hmcts.darts.event.model.CourtLogsPostResponseBody;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
+import uk.gov.hmcts.darts.event.model.EventsResponse;
 import uk.gov.hmcts.darts.event.service.EventDispatcher;
 
 import javax.validation.Valid;
@@ -37,7 +36,7 @@ public class EventsController implements EventApi {
         tags = {"Event"},
         responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = {
-                @Content(mediaType = "application/json", schema = @Schema(implementation = AddDocumentResponse.class))
+                @Content(mediaType = "application/json", schema = @Schema(implementation = EventsResponse.class))
             }),
             @ApiResponse(responseCode = "500", description = "Internal Server Error")
         }
@@ -49,12 +48,12 @@ public class EventsController implements EventApi {
         consumes = {"application/json"}
     )
     @Override
-    public ResponseEntity<AddDocumentResponse> eventsPost(
+    public ResponseEntity<EventsResponse> eventsPost(
         @Parameter(name = "DartsEvent") @Valid @RequestBody DartsEvent dartsEvent
     ) {
         eventDispatcher.receive(dartsEvent);
 
-        var addDocumentResponse = new AddDocumentResponse();
+        var addDocumentResponse = new EventsResponse();
         addDocumentResponse.setCode("200");
         addDocumentResponse.setMessage("OK");
 
@@ -62,7 +61,7 @@ public class EventsController implements EventApi {
     }
 
     @Override
-    public ResponseEntity<CourtLogsPostResponseBody> courtlogsPost(CourtLogsPostRequestBody courtLogsPostRequestBody) {
+    public ResponseEntity<EventsResponse> courtlogsPost(CourtLogsPostRequestBody courtLogsPostRequestBody) {
         return EventApi.super.courtlogsPost(courtLogsPostRequestBody);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.event.api.EventApi;
 import uk.gov.hmcts.darts.event.model.AddDocumentResponse;
+import uk.gov.hmcts.darts.event.model.CourtLogsPostRequestBody;
+import uk.gov.hmcts.darts.event.model.CourtLogsPostResponseBody;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.service.EventDispatcher;
 
@@ -48,7 +50,7 @@ public class EventsController implements EventApi {
     )
     @Override
     public ResponseEntity<AddDocumentResponse> eventsPost(
-          @Parameter(name = "DartsEvent") @Valid @RequestBody DartsEvent dartsEvent
+        @Parameter(name = "DartsEvent") @Valid @RequestBody DartsEvent dartsEvent
     ) {
         eventDispatcher.receive(dartsEvent);
 
@@ -57,6 +59,11 @@ public class EventsController implements EventApi {
         addDocumentResponse.setMessage("OK");
 
         return new ResponseEntity<>(addDocumentResponse, HttpStatus.CREATED);
+    }
+
+    @Override
+    public ResponseEntity<CourtLogsPostResponseBody> courtlogsPost(CourtLogsPostRequestBody courtLogsPostRequestBody) {
+        return EventApi.super.courtlogsPost(courtLogsPostRequestBody);
     }
 
 }

--- a/src/main/resources/openapi/events.yaml
+++ b/src/main/resources/openapi/events.yaml
@@ -73,7 +73,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AddDocumentResponse'
+                $ref: '#/components/schemas/EventsResponse'
 
         '500':
           description: Internal Server Error
@@ -119,11 +119,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CourtLogsPostResponseBody'
-              example:
-                log_entry_date_time: '2023-05-23T09:15:25Z'
-                courthouse: CARDIFF
-                case_number: CASE1001
+                $ref: '#/components/schemas/EventsResponse'
 
 components:
   schemas:
@@ -131,14 +127,6 @@ components:
     ###################################################################################################################
     # TOP-LEVEL MODELS
     ###################################################################################################################
-
-    AddDocumentResponse:
-      type: object
-      properties:
-        code:
-          type: string
-        message:
-          type: string
 
     CourtLogsPostRequestBody:
       type: object
@@ -164,21 +152,6 @@ components:
         - courtroom
         - case_numbers
         - text
-
-    CourtLogsPostResponseBody:
-      type: object
-      properties:
-        log_entry_date_time:
-          type: string
-          format: date-time
-        courthouse:
-          $ref: '#/components/schemas/Courthouse'
-        case_number:
-          $ref: '#/components/schemas/CaseNumber'
-      required:
-        - log_entry_date_time
-        - courthouse
-        - case_number
 
     DartsEvent:
       type: object
@@ -211,6 +184,14 @@ components:
               type: string
             case_total_sentence:
               type: string
+
+    EventsResponse:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
 
     ###################################################################################################################
     # PRIMITIVES

--- a/src/main/resources/openapi/events.yaml
+++ b/src/main/resources/openapi/events.yaml
@@ -67,7 +67,6 @@ paths:
                     CaseRetentionFixedPolicy: 4
                     CaseTotalSentence: 26Y0M0D
 
-
       responses:
         '200':
           description: OK
@@ -78,14 +77,109 @@ paths:
 
         '500':
           description: Internal Server Error
+          content:
+            application/json+problem:
+              schema:
+                $ref: './problem.yaml'
+
+  /courtlogs:
+    post:
+      tags:
+        - Event
+      summary: An Endpoint which allows users to create a court log event.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CourtLogsPostRequestBody'
+            examples:
+              example1:
+                summary: Request with single case
+                value:
+                  log_entry_date_time: '2023-05-23T09:15:25Z'
+                  courthouse: CARDIFF
+                  courtroom: '1'
+                  case_numbers:
+                    - CASE1001
+                  text: 'System : Start Recording : Record: Case Code:0008, New Case'
+              example2:
+                summary: Request with multiple cases
+                value:
+                  log_entry_date_time: '2023-05-23T09:15:25Z'
+                  courthouse: CARDIFF
+                  courtroom: '1'
+                  case_numbers:
+                    - CASE1001
+                    - CASE1002
+                  text: 'System : Start Recording : Record: Case Code:0008, New Case'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourtLogsPostResponseBody'
+              example:
+                log_entry_date_time: '2023-05-23T09:15:25Z'
+                courthouse: CARDIFF
+                case_number: CASE1001
 
 components:
-
-  #-----------------#
-  #----------------------------------#
-  #-----------------#
-
   schemas:
+
+    ###################################################################################################################
+    # TOP-LEVEL MODELS
+    ###################################################################################################################
+
+    AddDocumentResponse:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+
+    CourtLogsPostRequestBody:
+      type: object
+      properties:
+        log_entry_date_time:
+          type: string
+          format: date-time
+        courthouse:
+          $ref: '#/components/schemas/Courthouse'
+        courtroom:
+          $ref: '#/components/schemas/Courtroom'
+        case_numbers:
+          type: array
+          items:
+            $ref: '#/components/schemas/CaseNumber'
+          minItems: 1
+        text:
+          type: string
+          maxLength: 250
+      required:
+        - log_entry_date_time
+        - courthouse
+        - courtroom
+        - case_numbers
+        - text
+
+    CourtLogsPostResponseBody:
+      type: object
+      properties:
+        log_entry_date_time:
+          type: string
+          format: date-time
+        courthouse:
+          $ref: '#/components/schemas/Courthouse'
+        case_number:
+          $ref: '#/components/schemas/CaseNumber'
+      required:
+        - log_entry_date_time
+        - courthouse
+        - case_number
+
     DartsEvent:
       type: object
       properties:
@@ -98,13 +192,13 @@ components:
         event_id:
           type: string
         courthouse:
-          type: string
+          $ref: '#/components/schemas/Courthouse'
         courtroom:
-          type: string
+          $ref: '#/components/schemas/Courtroom'
         case_numbers:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/CaseNumber'
         event_text:
           type: string
         date_time:
@@ -118,11 +212,18 @@ components:
             case_total_sentence:
               type: string
 
+    ###################################################################################################################
+    # PRIMITIVES
+    ###################################################################################################################
 
-    AddDocumentResponse:
-      type: object
-      properties:
-        code:
-          type: string
-        message:
-          type: string
+    CaseNumber:
+      type: string
+      maxLength: 25
+
+    Courthouse:
+      type: string
+      maxLength: 50
+
+    Courtroom:
+      type: string
+      maxLength: 25

--- a/src/main/resources/openapi/problem.yaml
+++ b/src/main/resources/openapi/problem.yaml
@@ -6,15 +6,12 @@ properties:
     description: |
       A URI that identifies the unique error code representing this problem. Consumers can rely on this value to be
       stable.
-    example: 'COURTHOUSE_100'
   title:
     type: string
     description: |
       A short summary of the problem type. Written in english and readable
       for engineers (usually not suited for non technical stakeholders and
       not localized)
-    example:
-      - "Courthouse could not be found"
   status:
     type: integer
     format: int32
@@ -24,10 +21,8 @@ properties:
     minimum: 100
     maximum: 600
     exclusiveMaximum: true
-    example: 503
   detail:
     type: string
     description: |
       A human readable explanation specific to this occurrence of the
       problem. May be dynamic.
-    example: "Courthouse 'Swansea' is unknown"


### PR DESCRIPTION
[624](https://tools.hmcts.net/jira/browse/DMP-624)

Openapi changes required for [DMP-462](https://tools.hmcts.net/jira/browse/DMP-462) (POST /courtlogs), and initial no-op implementation for `@Controller` layer.