### PR TITLE
DMP-549: Schedule notification when audio processing is complete

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceProcessAudioRequestGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceProcessAudioRequestGivenBuilder.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.model.AudioRequestType;
 import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.testutils.data.ExternalObjectDirectoryTestData;
 import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
 
@@ -29,17 +30,18 @@ import static uk.gov.hmcts.darts.common.entity.ObjectDirectoryStatusEnum.STORED;
 @SuppressWarnings("MethodName")
 public class AudioTransformationServiceProcessAudioRequestGivenBuilder {
 
-    public static final int SOME_REQUESTOR = 666;
-    public static final OffsetDateTime TIME_12_00 = OffsetDateTime.parse("2023-01-01T12:00Z");
-    public static final OffsetDateTime TIME_12_10 = OffsetDateTime.parse("2023-01-01T12:10Z");
-    public static final OffsetDateTime TIME_13_00 = OffsetDateTime.parse("2023-01-01T13:00Z");
+    private static final OffsetDateTime TIME_12_00 = OffsetDateTime.parse("2023-01-01T12:00Z");
+    private static final OffsetDateTime TIME_12_10 = OffsetDateTime.parse("2023-01-01T12:10Z");
+    private static final OffsetDateTime TIME_13_00 = OffsetDateTime.parse("2023-01-01T13:00Z");
+
 
     private final DartsDatabaseStub dartsDatabase;
 
     private MediaRequestEntity mediaRequestEntity;
     private HearingEntity hearingEntity;
+    private UserAccountEntity userAccountEntity;
 
-    public void databaseIsProvisionedForHappyPath() {
+    public void aMediaEntityGraph() {
         var mediaEntity = dartsDatabase.createMediaEntity(
               TIME_12_00,
               TIME_12_10,
@@ -63,6 +65,16 @@ public class AudioTransformationServiceProcessAudioRequestGivenBuilder {
               .saveAndFlush(externalObjectDirectoryEntity);
     }
 
+    public UserAccountEntity aUserAccount(String emailAddress) {
+        userAccountEntity = new UserAccountEntity();
+        userAccountEntity.setEmailAddress(emailAddress);
+
+        dartsDatabase.getUserAccountRepository()
+            .saveAndFlush(userAccountEntity);
+
+        return userAccountEntity;
+    }
+
     public HearingEntity aHearingWith(String caseNumber, String courthouseName, String courtroomName) {
         hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
               caseNumber,
@@ -74,15 +86,16 @@ public class AudioTransformationServiceProcessAudioRequestGivenBuilder {
         return hearingEntity;
     }
 
-    public void aMediaRequestEntityForHearingWithRequestType(HearingEntity hearing, AudioRequestType audioRequestType) {
+    public void aMediaRequestEntityForHearingWithRequestType(HearingEntity hearing, AudioRequestType audioRequestType, UserAccountEntity userAccountEntity) {
         mediaRequestEntity = new MediaRequestEntity();
         mediaRequestEntity.setHearing(hearing);
         mediaRequestEntity.setRequestType(audioRequestType);
-        mediaRequestEntity.setRequestor(SOME_REQUESTOR);
+        mediaRequestEntity.setRequestor(userAccountEntity.getId());
         mediaRequestEntity.setStartTime(TIME_12_00);
         mediaRequestEntity.setEndTime(TIME_13_00);
 
-        dartsDatabase.getMediaRequestRepository().saveAndFlush(mediaRequestEntity);
+        dartsDatabase.getMediaRequestRepository()
+            .saveAndFlush(mediaRequestEntity);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceProcessAudioRequestTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceProcessAudioRequestTest.java
@@ -1,8 +1,9 @@
 package uk.gov.hmcts.darts.audio.service;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -10,13 +11,16 @@ import uk.gov.hmcts.darts.audio.model.AudioRequestType;
 import uk.gov.hmcts.darts.audio.service.impl.AudioTransformationServiceImpl;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.notification.entity.NotificationEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.SystemCommandExecutorStubImpl;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.COMPLETED;
 import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.FAILED;
@@ -25,6 +29,10 @@ import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.FAILED;
 @Import(SystemCommandExecutorStubImpl.class)
 @ExtendWith(MockitoExtension.class)
 class AudioTransformationServiceProcessAudioRequestTest extends IntegrationBase {
+
+    private static final String NOTIFICATION_TEMPLATE_ID_SUCCESS = "66a1864f-24a6-469a-ac55-66bc57c7e4f6";
+    private static final String NOTIFICATION_TEMPLATE_ID_FAILURE = "cb5bc3f6-ae1f-4346-845a-622cf6ad2632";
+    private static final String EMAIL_ADDRESS = "test@test.com";
 
     @Autowired
     private AudioTransformationServiceProcessAudioRequestGivenBuilder given;
@@ -39,10 +47,14 @@ class AudioTransformationServiceProcessAudioRequestTest extends IntegrationBase 
         hearing = given.aHearingWith("1", "some-courthouse", "some-courtroom");
     }
 
-    @Test
-    void processAudioRequestShouldSucceedAndUpdateRequestStatusToCompletedForDownloadRequestType() {
-        given.databaseIsProvisionedForHappyPath();
-        given.aMediaRequestEntityForHearingWithRequestType(hearing, AudioRequestType.DOWNLOAD);
+    @ParameterizedTest
+    @EnumSource(names = {"DOWNLOAD", "PLAYBACK"})
+    void processAudioRequestShouldSucceedAndUpdateRequestStatusToCompletedAndScheduleSuccessNotificationFor(AudioRequestType audioRequestType) {
+        given.aMediaEntityGraph();
+        var userAccountEntity = given.aUserAccount(EMAIL_ADDRESS);
+        given.aMediaRequestEntityForHearingWithRequestType(hearing,
+                                                           audioRequestType,
+                                                           userAccountEntity);
 
         Integer mediaRequestId = given.getMediaRequestEntity().getId();
 
@@ -52,30 +64,26 @@ class AudioTransformationServiceProcessAudioRequestTest extends IntegrationBase 
         var mediaRequestEntity = dartsDatabase.getMediaRequestRepository()
             .findById(mediaRequestId)
             .orElseThrow();
-
         assertEquals(COMPLETED, mediaRequestEntity.getStatus());
+
+        List<NotificationEntity> scheduledNotifications = dartsDatabase.getNotificationRepository()
+            .findAll();
+        assertEquals(1, scheduledNotifications.size());
+
+        var notificationEntity = scheduledNotifications.get(0);
+        assertEquals(NOTIFICATION_TEMPLATE_ID_SUCCESS, notificationEntity.getEventId());
+        assertNull(notificationEntity.getTemplateValues());
+        assertEquals("OPEN", notificationEntity.getStatus());
+        assertEquals(EMAIL_ADDRESS, notificationEntity.getEmailAddress());
     }
 
-    @Test
-    void processAudioRequestShouldSucceedAndUpdateRequestStatusToCompletedForPlaybackRequestType() {
-        given.databaseIsProvisionedForHappyPath();
-        given.aMediaRequestEntityForHearingWithRequestType(hearing, AudioRequestType.PLAYBACK);
-
-        Integer mediaRequestId = given.getMediaRequestEntity().getId();
-
-        UUID blobId = audioTransformationService.processAudioRequest(mediaRequestId);
-        assertNotNull(blobId);
-
-        var mediaRequestEntity = dartsDatabase.getMediaRequestRepository()
-            .findById(mediaRequestId)
-            .orElseThrow();
-
-        assertEquals(COMPLETED, mediaRequestEntity.getStatus());
-    }
-
-    @Test
-    void processAudioRequestShouldFailAndUpdateRequestStatusToFailed() {
-        given.aMediaRequestEntityForHearingWithRequestType(hearing, AudioRequestType.DOWNLOAD);
+    @ParameterizedTest
+    @EnumSource(names = {"DOWNLOAD", "PLAYBACK"})
+    void processAudioRequestShouldFailAndUpdateRequestStatusToFailedAndScheduleFailureNotificationFor(AudioRequestType audioRequestType) {
+        var userAccountEntity = given.aUserAccount(EMAIL_ADDRESS);
+        given.aMediaRequestEntityForHearingWithRequestType(hearing,
+                                                           audioRequestType,
+                                                           userAccountEntity);
 
         Integer mediaRequestId = given.getMediaRequestEntity().getId();
         var exception = assertThrows(
@@ -89,5 +97,16 @@ class AudioTransformationServiceProcessAudioRequestTest extends IntegrationBase 
             .findById(mediaRequestId)
             .orElseThrow();
         assertEquals(FAILED, mediaRequestEntity.getStatus());
+
+        List<NotificationEntity> scheduledNotifications = dartsDatabase.getNotificationRepository()
+            .findAll();
+        assertEquals(1, scheduledNotifications.size());
+
+        var notificationEntity = scheduledNotifications.get(0);
+        assertEquals(NOTIFICATION_TEMPLATE_ID_FAILURE, notificationEntity.getEventId());
+        assertNull(notificationEntity.getTemplateValues());
+        assertEquals("OPEN", notificationEntity.getStatus());
+        assertEquals(EMAIL_ADDRESS, notificationEntity.getEmailAddress());
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/entity/MediaRequestEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/entity/MediaRequestEntity.java
@@ -50,7 +50,7 @@ public class MediaRequestEntity {
     @SequenceGenerator(name = "media_request_gen", sequenceName = "mer_seq", allocationSize = 1)
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
     @JoinColumn(name = HEARING_ID)
     private HearingEntity hearing;
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -288,7 +288,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
         log.debug("Scheduling notification for templateId: {}...", notificationTemplateId);
 
         Integer requester = mediaRequestEntity.getRequestor();
-        var userAccountEntity = userAccountRepository.getUserAccountEntityById(requester)
+        var userAccountEntity = userAccountRepository.findById(requester)
             .orElseThrow(() -> new DartsApiException(
                 AudioError.FAILED_TO_PROCESS_AUDIO_REQUEST,
                 String.format("User record for id %s could not be obtained", requester)

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
@@ -4,7 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
+import java.util.Optional;
+
 @Repository
 public interface UserAccountRepository extends JpaRepository<UserAccountEntity, Integer> {
+
+    Optional<UserAccountEntity> getUserAccountEntityById(Integer id);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
@@ -4,11 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
-import java.util.Optional;
-
 @Repository
 public interface UserAccountRepository extends JpaRepository<UserAccountEntity, Integer> {
-
-    Optional<UserAccountEntity> getUserAccountEntityById(Integer id);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/api/DataManagementApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/api/DataManagementApi.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.darts.datamanagement.api;
+
+import com.azure.core.util.BinaryData;
+
+import java.util.UUID;
+
+public interface DataManagementApi {
+
+    BinaryData getBlobDataFromUnstructuredContainer(UUID blobId);
+
+    UUID saveBlobDataToOutboundContainer(BinaryData binaryData);
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/api/impl/DataManagementApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/api/impl/DataManagementApiImpl.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.darts.datamanagement.api.impl;
+
+import com.azure.core.util.BinaryData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
+import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
+import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DataManagementApiImpl implements DataManagementApi {
+
+    private final DataManagementService dataManagementService;
+    private final DataManagementConfiguration dataManagementConfiguration;
+
+    @Override
+    public BinaryData getBlobDataFromUnstructuredContainer(UUID blobId) {
+        return dataManagementService.getBlobData(dataManagementConfiguration.getUnstructuredContainerName(), blobId);
+    }
+
+    @Override
+    public UUID saveBlobDataToOutboundContainer(BinaryData binaryData) {
+        return dataManagementService.saveBlobData(dataManagementConfiguration.getOutboundContainerName(), binaryData);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/notification/api/NotificationApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/api/NotificationApi.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.darts.notification.api;
+
+import uk.gov.hmcts.darts.notification.dto.SaveNotificationToDbRequest;
+import uk.gov.hmcts.darts.notification.exception.TemplateNotFoundException;
+
+public interface NotificationApi {
+
+    String getNotificationTemplateIdByName(String templateName) throws TemplateNotFoundException;
+
+    void scheduleNotification(SaveNotificationToDbRequest saveNotificationToDbRequest);
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/notification/api/impl/NotificationApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/api/impl/NotificationApiImpl.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.darts.notification.api.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.notification.api.NotificationApi;
+import uk.gov.hmcts.darts.notification.dto.SaveNotificationToDbRequest;
+import uk.gov.hmcts.darts.notification.exception.TemplateNotFoundException;
+import uk.gov.hmcts.darts.notification.helper.TemplateIdHelper;
+import uk.gov.hmcts.darts.notification.service.NotificationService;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationApiImpl implements NotificationApi {
+
+    private final TemplateIdHelper templateIdHelper;
+    private final NotificationService notificationService;
+
+    @Override
+    public String getNotificationTemplateIdByName(String templateName) throws TemplateNotFoundException {
+        return templateIdHelper.findTemplateId(templateName);
+    }
+
+    @Override
+    public void scheduleNotification(SaveNotificationToDbRequest saveNotificationToDbRequest) {
+        notificationService.scheduleNotification(saveNotificationToDbRequest);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.COMPLETED;
@@ -99,14 +98,9 @@ class AudioTransformationServiceImplTest {
             BINARY_DATA
         );
 
-        verify(mockDataManagementApi).saveBlobDataToOutboundContainer(
-            eq(BINARY_DATA)
-        );
+        verify(mockDataManagementApi).saveBlobDataToOutboundContainer(BINARY_DATA);
 
-        verify(mockTransientObjectDirectoryService).saveTransientDataLocation(
-            eq(mediaRequestEntity),
-            eq(BLOB_LOCATION)
-        );
+        verify(mockTransientObjectDirectoryService).saveTransientDataLocation(mediaRequestEntity, BLOB_LOCATION);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
@@ -7,13 +7,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
-import uk.gov.hmcts.darts.audio.service.MediaRequestService;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
 import uk.gov.hmcts.darts.common.service.TransientObjectDirectoryService;
-import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
-import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
+import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 
 import java.util.Collections;
 import java.util.List;
@@ -34,21 +32,13 @@ class AudioTransformationServiceImplTest {
     private static final BinaryData BINARY_DATA = BinaryData.fromBytes(TEST_BINARY_STRING.getBytes());
 
     @Mock
-    private DataManagementService mockDataManagementService;
+    private DataManagementApi mockDataManagementApi;
 
     @Mock
     private TransientObjectDirectoryService mockTransientObjectDirectoryService;
 
     @Mock
-    private MediaRequestService mockMediaRequestService;
-
-    @Mock
-    private DataManagementConfiguration mockDataManagementConfiguration;
-
-
-    @Mock
     private TransientObjectDirectoryEntity mockTransientObjectDirectoryEntity;
-
 
     @Mock
     private MediaRepository mediaRepository;
@@ -59,9 +49,7 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void testGetAudioBlobData() {
-        when(mockDataManagementService.getBlobData(
-                mockDataManagementConfiguration.getUnstructuredContainerName(),
-                BLOB_LOCATION))
+        when(mockDataManagementApi.getBlobDataFromUnstructuredContainer(BLOB_LOCATION))
             .thenReturn(BINARY_DATA);
 
         BinaryData binaryData = audioTransformationService.getAudioBlobData(BLOB_LOCATION);
@@ -94,36 +82,24 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void saveProcessedDataShouldSaveBlobAndSetStatus() {
-        final String containerName = "ContainerName";
-
         final MediaRequestEntity mediaRequestEntity = new MediaRequestEntity();
         final MediaRequestEntity mediaRequestEntityUpdated = new MediaRequestEntity();
         mediaRequestEntityUpdated.setStatus(COMPLETED);
 
-        when(mockDataManagementConfiguration.getOutboundContainerName()).thenReturn(containerName);
-
-        when(mockDataManagementService.saveBlobData(
-            any(),
-            any()
-        )).thenReturn(BLOB_LOCATION);
+        when(mockDataManagementApi.saveBlobDataToOutboundContainer(any()))
+            .thenReturn(BLOB_LOCATION);
 
         when(mockTransientObjectDirectoryService.saveTransientDataLocation(
             any(),
             any()
         )).thenReturn(mockTransientObjectDirectoryEntity);
 
-        when(mockMediaRequestService.updateAudioRequestStatus(
-             any(),
-             any()
-         )).thenReturn(mediaRequestEntityUpdated);
-
         audioTransformationService.saveProcessedData(
             mediaRequestEntity,
             BINARY_DATA
         );
 
-        verify(mockDataManagementService).saveBlobData(
-            eq(containerName),
+        verify(mockDataManagementApi).saveBlobDataToOutboundContainer(
             eq(BINARY_DATA)
         );
 
@@ -131,12 +107,6 @@ class AudioTransformationServiceImplTest {
             eq(mediaRequestEntity),
             eq(BLOB_LOCATION)
         );
-
-        verify(mockMediaRequestService).updateAudioRequestStatus(
-            eq(mediaRequestEntity.getId()),
-            eq(COMPLETED)
-        );
     }
-
 
 }


### PR DESCRIPTION
### [DMP-549](https://tools.hmcts.net/jira/browse/DMP-549)

Schedule a success or failure notification upon success/failure of audio processing.

This change also takes the opporunity to fix direct access of datamanagement classes from the audio feature, in favour of going through a new api interface in the datamanagement feature.

Finally, complexity of `AudioTransformationServiceImpl` has reached a stage where refactoring would be beneficial. For now, PMD/Checkstyle warnings are suppressed, and ticket DMP-715 is created to later tackle this refactoring.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
