### PR TITLE
Refactor NotificationEntity to utilise NotificationStatus enum

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceProcessAudioRequestTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceProcessAudioRequestTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.audio.service.impl.AudioTransformationServiceImpl;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.notification.entity.NotificationEntity;
+import uk.gov.hmcts.darts.notification.enums.NotificationStatus;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.SystemCommandExecutorStubImpl;
 
@@ -73,7 +74,7 @@ class AudioTransformationServiceProcessAudioRequestTest extends IntegrationBase 
         var notificationEntity = scheduledNotifications.get(0);
         assertEquals(NOTIFICATION_TEMPLATE_ID_SUCCESS, notificationEntity.getEventId());
         assertNull(notificationEntity.getTemplateValues());
-        assertEquals("OPEN", notificationEntity.getStatus());
+        assertEquals(NotificationStatus.OPEN, notificationEntity.getStatus());
         assertEquals(EMAIL_ADDRESS, notificationEntity.getEmailAddress());
     }
 
@@ -105,7 +106,7 @@ class AudioTransformationServiceProcessAudioRequestTest extends IntegrationBase 
         var notificationEntity = scheduledNotifications.get(0);
         assertEquals(NOTIFICATION_TEMPLATE_ID_FAILURE, notificationEntity.getEventId());
         assertNull(notificationEntity.getTemplateValues());
-        assertEquals("OPEN", notificationEntity.getStatus());
+        assertEquals(NotificationStatus.OPEN, notificationEntity.getStatus());
         assertEquals(EMAIL_ADDRESS, notificationEntity.getEmailAddress());
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/notification/service/NotificationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/notification/service/NotificationServiceTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.darts.notification.dto.GovNotifyRequest;
 import uk.gov.hmcts.darts.notification.dto.SaveNotificationToDbRequest;
 import uk.gov.hmcts.darts.notification.entity.NotificationEntity;
+import uk.gov.hmcts.darts.notification.enums.NotificationStatus;
 import uk.gov.hmcts.darts.notification.exception.TemplateNotFoundException;
 import uk.gov.hmcts.darts.notification.helper.TemplateIdHelper;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
@@ -47,7 +48,7 @@ class NotificationServiceTest extends IntegrationBase {
         List<NotificationEntity> resultList = dartsDatabase.getNotificationsForCase(caseId);
         NotificationEntity notification = resultList.get(0);
         assertTrue(notification.getId() > 0);
-        assertEquals("OPEN", notification.getStatus());
+        assertEquals(NotificationStatus.OPEN, notification.getStatus());
         assertEquals(caseId, notification.getCourtCase().getId());
     }
 
@@ -111,7 +112,7 @@ class NotificationServiceTest extends IntegrationBase {
 
         List<NotificationEntity> resultList = dartsDatabase.getNotificationsForCase(caseId);
         NotificationEntity result = resultList.get(0);
-        assertEquals("SENT", result.getStatus(), "Object may not have sent");
+        assertEquals(NotificationStatus.SENT, result.getStatus(), "Object may not have sent");
     }
 
     @Test
@@ -133,7 +134,7 @@ class NotificationServiceTest extends IntegrationBase {
 
         List<NotificationEntity> resultList = dartsDatabase.getNotificationsForCase(caseId);
         NotificationEntity result = resultList.get(0);
-        assertEquals("PROCESSING", result.getStatus());
+        assertEquals(NotificationStatus.PROCESSING, result.getStatus());
         assertEquals(1, result.getAttempts());
     }
 
@@ -159,7 +160,7 @@ class NotificationServiceTest extends IntegrationBase {
 
         List<NotificationEntity> resultList = dartsDatabase.getNotificationsForCase(caseId);
         NotificationEntity result = resultList.get(0);
-        assertEquals("FAILED", result.getStatus());
+        assertEquals(NotificationStatus.FAILED, result.getStatus());
         assertEquals(3, result.getAttempts());
     }
 
@@ -180,7 +181,7 @@ class NotificationServiceTest extends IntegrationBase {
 
         List<NotificationEntity> resultList = dartsDatabase.getNotificationsForCase(caseId);
         NotificationEntity result = resultList.get(0);
-        assertEquals("FAILED", result.getStatus());
+        assertEquals(NotificationStatus.FAILED, result.getStatus());
         assertEquals(0, result.getAttempts());
     }
 
@@ -201,7 +202,7 @@ class NotificationServiceTest extends IntegrationBase {
 
         List<NotificationEntity> resultList = dartsDatabase.getNotificationsForCase(caseId);
         NotificationEntity result = resultList.get(0);
-        assertEquals("FAILED", result.getStatus());
+        assertEquals(NotificationStatus.FAILED, result.getStatus());
         assertEquals(0, result.getAttempts());
         verify(templateIdHelper).findTemplateId(anyString());
     }

--- a/src/main/java/uk/gov/hmcts/darts/notification/entity/NotificationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/entity/NotificationEntity.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.darts.notification.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.notification.enums.NotificationStatus;
 
 import java.time.OffsetDateTime;
 
@@ -57,7 +60,8 @@ public class NotificationEntity {
     private String emailAddress;
 
     @Column(name = STATUS)
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private NotificationStatus status;
 
     @Column(name = ATTEMPTS)
     private int attempts;

--- a/src/main/java/uk/gov/hmcts/darts/notification/repository/NotificationRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/repository/NotificationRepository.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.notification.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.notification.entity.NotificationEntity;
+import uk.gov.hmcts.darts.notification.enums.NotificationStatus;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<NotificationEntity, Integer> {
     List<NotificationEntity> findByCourtCase_Id(Integer caseId);
 
-    List<NotificationEntity> findByStatusIn(List<String> status);
+    List<NotificationEntity> findByStatusIn(List<NotificationStatus> status);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/service/impl/NotificationServiceImpl.java
@@ -38,9 +38,9 @@ public class NotificationServiceImpl implements NotificationService {
     private final GovNotifyService govNotifyService;
     private final TemplateIdHelper templateIdHelper;
     private final EmailValidator emailValidator = EmailValidator.getInstance();
-    private static final List<String> STATUS_ELIGIBLE_TO_SEND = Arrays.asList(
-          String.valueOf(NotificationStatus.OPEN),
-          String.valueOf(NotificationStatus.PROCESSING)
+    private static final List<NotificationStatus> STATUS_ELIGIBLE_TO_SEND = Arrays.asList(
+          NotificationStatus.OPEN,
+          NotificationStatus.PROCESSING
     );
 
     @Value("${darts.notification.max_retry_attempts}")
@@ -70,7 +70,7 @@ public class NotificationServiceImpl implements NotificationService {
         dbNotification.setEventId(eventId);
         dbNotification.setCourtCase(caseRepository.getReferenceById(caseId));
         dbNotification.setEmailAddress(emailAddress);
-        dbNotification.setStatus(String.valueOf(NotificationStatus.OPEN));
+        dbNotification.setStatus(NotificationStatus.OPEN);
         dbNotification.setAttempts(0);
         dbNotification.setTemplateValues(templateValues);
 
@@ -116,7 +116,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private void updateNotificationStatus(NotificationEntity notification, NotificationStatus status) {
-        notification.setStatus(String.valueOf(status));
+        notification.setStatus(status);
         notificationRepo.saveAndFlush(notification);
     }
 
@@ -125,7 +125,7 @@ public class NotificationServiceImpl implements NotificationService {
         attempts++;
         if (attempts <= maxRetry) {
             notification.setAttempts(attempts);
-            notification.setStatus(String.valueOf(NotificationStatus.PROCESSING));
+            notification.setStatus(NotificationStatus.PROCESSING);
             log.info("Notification has failed to send, retrying ID: {}", notification.getId());
         } else {
             updateNotificationStatus(notification, NotificationStatus.FAILED);


### PR DESCRIPTION
Update the `NotificationEntity.status` field to utilise existing enum `NotificationStatus`. The benefit is a more expressive entity, and elimination of string conversion at various points in the codebase.

This addresses review comment https://github.com/hmcts/darts-api/pull/301#discussion_r1282984091.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
