### PR TITLE
Optionally override redirect URI in authentication flows

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LoginOrRefreshIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LoginOrRefreshIntTest.java
@@ -19,6 +19,8 @@ class LoginOrRefreshIntTest extends IntegrationBase {
 
     private static final String EXPECTED_LOGIN_REDIRECT_URL = "http://localhost:8080/oauth2/v2.0/authorize?client_id=dummy_client_id&redirect_uri=https%3A%2F%2Fexample.com%2Fhandle-oauth-code&scope=openid&prompt=login&response_mode=form_post&response_type=code";
     private static final String EXTERNAL_USER_LOGIN_OR_REFRESH_ENDPOINT = "/external-user/login-or-refresh";
+    private static final String EXTERNAL_USER_LOGIN_OR_REFRESH_ENDPOINT_WITH_OVERRIDE = "/external-user/login-or-refresh?redirect_uri=https://darts-portal.com/auth/callback";
+    private static final String EXPECTED_LOGIN_REDIRECT_URL_WITH_OVERRIDE = "http://localhost:8080/oauth2/v2.0/authorize?client_id=dummy_client_id&redirect_uri=https%3A%2F%2Fdarts-portal.com%2Fauth%2Fcallback&scope=openid&prompt=login&response_mode=form_post&response_type=code";
 
     @Autowired
     private MockMvc mockMvc;
@@ -33,6 +35,19 @@ class LoginOrRefreshIntTest extends IntegrationBase {
             .andExpect(header().string(
                 HttpHeaders.LOCATION,
                 EXPECTED_LOGIN_REDIRECT_URL
+            ));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void loginOrRefreshShouldReturnRedirectWithOverriddenRedirectUri() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = get(EXTERNAL_USER_LOGIN_OR_REFRESH_ENDPOINT_WITH_OVERRIDE);
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(status().isFound())
+            .andExpect(header().string(
+                HttpHeaders.LOCATION,
+                EXPECTED_LOGIN_REDIRECT_URL_WITH_OVERRIDE
             ));
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class LogoutIntTest extends IntegrationBase {
 
     private static final String EXTERNAL_USER_LOGOUT_ENDPOINT = "/external-user/logout";
+    private static final String EXTERNAL_USER_LOGOUT_ENDPOINT_WITH_OVERRIDE = "/external-user/logout?redirect_uri=https://darts-portal.com/auth/logout-callback";
 
     @Autowired
     private MockMvc mockMvc;
@@ -31,6 +32,27 @@ class LogoutIntTest extends IntegrationBase {
             "&post_logout_redirect_uri=https%3A%2F%2Fdarts-portal.staging.platform.hmcts.net%2Fauth%2Flogout-callback";
 
         MockHttpServletRequestBuilder requestBuilder = get(EXTERNAL_USER_LOGOUT_ENDPOINT)
+            .header("Authorization", "Bearer " + accessToken);
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(status().isFound())
+            .andExpect(header().string(
+                HttpHeaders.LOCATION,
+                expectedUri
+            ));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void logoutShouldReturnRedirectWithOverriddenRedirectUri() throws Exception {
+        String accessToken = "DummyAccessToken";
+
+        String expectedUri = "https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com" +
+            "/B2C_1_darts_externaluser_signin/oauth2/v2.0/logout?id_token_hint=" +
+            accessToken +
+            "&post_logout_redirect_uri=https%3A%2F%2Fdarts-portal.com%2Fauth%2Flogout-callback";
+
+        MockHttpServletRequestBuilder requestBuilder = get(EXTERNAL_USER_LOGOUT_ENDPOINT_WITH_OVERRIDE)
             .header("Authorization", "Bearer " + accessToken);
 
         mockMvc.perform(requestBuilder)

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/ResetPasswordIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/ResetPasswordIntTest.java
@@ -22,7 +22,12 @@ class ResetPasswordIntTest {
         "B2C_1_darts_externaluser_password_reset/oauth2/v2.0/authorize?" +
         "client_id=dummy_client_id&redirect_uri=https%3A%2F%2Fexample.com%2Fhandle-oauth-code&" +
         "scope=openid&prompt=login&response_type=id_token";
+    private static final String EXPECTED_REDIRECT_URL_WITH_OVERRIDE = "https://hmctsdartsb2csbox.b2clogin.com/hmctsdartsb2csbox.onmicrosoft.com/" +
+        "B2C_1_darts_externaluser_password_reset/oauth2/v2.0/authorize?" +
+        "client_id=dummy_client_id&redirect_uri=https%3A%2F%2Fdarts-portal.com%2Fauth%2Fcallback&" +
+        "scope=openid&prompt=login&response_type=id_token";
     private static final String EXTERNAL_USER_RESET_PASSWORD_ENDPOINT = "/external-user/reset-password";
+    private static final String EXTERNAL_USER_RESET_PASSWORD_ENDPOINT_WITH_OVERRIDE = "/external-user/reset-password?redirect_uri=https://darts-portal.com/auth/callback";
 
 
     @Autowired
@@ -38,6 +43,19 @@ class ResetPasswordIntTest {
             .andExpect(header().string(
                 HttpHeaders.LOCATION,
                 EXPECTED_REDIRECT_URL
+            ));
+    }
+    
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    void resetPasswordShouldReturnRedirectWithOverriddenRedirectUri() throws Exception {
+        MockHttpServletRequestBuilder requestBuilder = get(EXTERNAL_USER_RESET_PASSWORD_ENDPOINT_WITH_OVERRIDE);
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(status().isFound())
+            .andExpect(header().string(
+                HttpHeaders.LOCATION,
+                EXPECTED_REDIRECT_URL_WITH_OVERRIDE
             ));
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/UriProvider.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/UriProvider.java
@@ -4,12 +4,12 @@ import java.net.URI;
 
 public interface UriProvider {
 
-    URI getLoginUri();
+    URI getLoginUri(String redirectUri);
 
     URI getLandingPageUri();
 
-    URI getLogoutUri(String accessToken);
+    URI getLogoutUri(String accessToken, String redirectUri);
 
-    URI getResetPasswordUri();
+    URI getResetPasswordUri(String redirectUri);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImpl.java
@@ -18,8 +18,8 @@ public class UriProviderImpl implements UriProvider {
 
     @Override
     @SneakyThrows(URISyntaxException.class)
-    public URI getLoginUri() {
-        return buildCommonAuthUri(authConfig.getExternalADauthorizationUri())
+    public URI getLoginUri(String redirectUri) {
+        return buildCommonAuthUri(authConfig.getExternalADauthorizationUri(), redirectUri)
             .addParameter("response_mode", authConfig.getExternalADresponseMode())
             .addParameter("response_type", authConfig.getExternalADresponseType())
             .build();
@@ -32,27 +32,35 @@ public class UriProviderImpl implements UriProvider {
 
     @Override
     @SneakyThrows(URISyntaxException.class)
-    public URI getLogoutUri(String accessToken) {
+    public URI getLogoutUri(String accessToken, String redirectUriOverride) {
+        var redirectUri = authConfig.getExternalADlogoutRedirectUri();
+        if (redirectUriOverride != null) {
+            redirectUri = redirectUriOverride;
+        }
         return new URIBuilder(
             authConfig.getExternalADlogoutUri())
             .addParameter("id_token_hint", accessToken)
-            .addParameter("post_logout_redirect_uri", authConfig.getExternalADlogoutRedirectUri())
+            .addParameter("post_logout_redirect_uri", redirectUri)
             .build();
     }
 
     @Override
     @SneakyThrows(URISyntaxException.class)
-    public URI getResetPasswordUri() {
-        return buildCommonAuthUri(authConfig.getExternalADresetPasswordUri())
+    public URI getResetPasswordUri(String redirectUri) {
+        return buildCommonAuthUri(authConfig.getExternalADresetPasswordUri(), redirectUri)
             .addParameter("response_type", "id_token")
             .build();
     }
 
     @SneakyThrows(URISyntaxException.class)
-    private URIBuilder buildCommonAuthUri(String uri) {
+    private URIBuilder buildCommonAuthUri(String uri, String redirectUriOverride) {
+        var redirectUri = authConfig.getExternalADredirectUri();
+        if (redirectUriOverride != null) {
+            redirectUri = redirectUriOverride;
+        }
         return new URIBuilder(uri)
             .addParameter("client_id", authConfig.getExternalADclientId())
-            .addParameter("redirect_uri", authConfig.getExternalADredirectUri())
+            .addParameter("redirect_uri", redirectUri)
             .addParameter("scope", authConfig.getExternalADscope())
             .addParameter("prompt", authConfig.getExternalADprompt());
     }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/AuthenticationController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/AuthenticationController.java
@@ -10,14 +10,20 @@ import uk.gov.hmcts.darts.authentication.model.SecurityToken;
 public interface AuthenticationController {
 
     @GetMapping("/login-or-refresh")
-    ModelAndView loginOrRefresh(@RequestHeader(value = "Authorization", required = false) String authHeaderValue);
+    ModelAndView loginOrRefresh(
+        @RequestHeader(value = "Authorization", required = false) String authHeaderValue, 
+        @RequestParam(value = "redirect_uri", required = false) String redirectUri
+    );
 
     @PostMapping("/handle-oauth-code")
     SecurityToken handleOauthCode(@RequestParam("code") String code);
 
     @GetMapping("/logout")
-    ModelAndView logout(@RequestHeader("Authorization") String authHeaderValue);
+    ModelAndView logout(
+        @RequestHeader("Authorization") String authHeaderValue, 
+        @RequestParam(value = "redirect_uri", required = false) String redirectUri
+    );
 
     @GetMapping("/reset-password")
-    ModelAndView resetPassword();
+    ModelAndView resetPassword(@RequestParam(value = "redirect_uri", required = false) String redirectUri);
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserController.java
@@ -31,12 +31,12 @@ public class AuthenticationExternalUserController implements AuthenticationContr
     private final AuthorisationApi authorisationApi;
 
     @Override
-    public ModelAndView loginOrRefresh(String authHeaderValue) {
+    public ModelAndView loginOrRefresh(String authHeaderValue, String redirectUri) {
         String accessToken = null;
         if (authHeaderValue != null) {
             accessToken = authHeaderValue.replace("Bearer ", "");
         }
-        URI url = authenticationService.loginOrRefresh(accessToken);
+        URI url = authenticationService.loginOrRefresh(accessToken, redirectUri);
         return new ModelAndView("redirect:" + url.toString());
     }
 
@@ -60,15 +60,15 @@ public class AuthenticationExternalUserController implements AuthenticationContr
     }
 
     @Override
-    public ModelAndView logout(String authHeaderValue) {
+    public ModelAndView logout(String authHeaderValue, String redirectUri) {
         String accessToken = authHeaderValue.replace("Bearer ", "");
-        URI url = authenticationService.logout(accessToken);
+        URI url = authenticationService.logout(accessToken, redirectUri);
         return new ModelAndView("redirect:" + url.toString());
     }
 
     @Override
-    public ModelAndView resetPassword() {
-        URI url = authenticationService.resetPassword();
+    public ModelAndView resetPassword(String redirectUri) {
+        URI url = authenticationService.resetPassword(redirectUri);
         return new ModelAndView("redirect:" + url.toString());
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserController.java
@@ -16,7 +16,7 @@ public class AuthenticationInternalUserController implements AuthenticationContr
     private static final String INTERNAL_USERS_NOT_SUPPORTED_MESSAGE = "Internal users not yet supported";
 
     @Override
-    public ModelAndView loginOrRefresh(String authHeaderValue) {
+    public ModelAndView loginOrRefresh(String authHeaderValue, String redirectUri) {
         throw new NotImplementedException(INTERNAL_USERS_NOT_SUPPORTED_MESSAGE);
     }
 
@@ -27,12 +27,12 @@ public class AuthenticationInternalUserController implements AuthenticationContr
     }
 
     @Override
-    public ModelAndView logout(String authHeaderValue) {
+    public ModelAndView logout(String authHeaderValue, String redirectUri) {
         throw new NotImplementedException(INTERNAL_USERS_NOT_SUPPORTED_MESSAGE);
     }
 
     @Override
-    public ModelAndView resetPassword() {
+    public ModelAndView resetPassword(String redirectUri) {
         throw new NotImplementedException(INTERNAL_USERS_NOT_SUPPORTED_MESSAGE);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/AuthenticationService.java
@@ -4,12 +4,12 @@ import java.net.URI;
 
 public interface AuthenticationService {
 
-    URI loginOrRefresh(String accessToken);
+    URI loginOrRefresh(String accessToken, String redirectUri);
 
     String handleOauthCode(String code);
 
-    URI logout(String accessToken);
+    URI logout(String accessToken, String redirectUri);
 
-    URI resetPassword();
+    URI resetPassword(String redirectUri);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImpl.java
@@ -24,16 +24,16 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     private final UriProvider uriProvider;
 
     @Override
-    public URI loginOrRefresh(String accessToken) {
+    public URI loginOrRefresh(String accessToken, String redirectUri) {
         log.debug("Initiated login or refresh flow with access token {}", accessToken);
 
         if (accessToken == null) {
-            return uriProvider.getLoginUri();
+            return uriProvider.getLoginUri(redirectUri);
         }
 
         var validationResult = tokenValidator.validate(accessToken);
         if (!validationResult.valid()) {
-            return uriProvider.getLoginUri();
+            return uriProvider.getLoginUri(redirectUri);
         }
 
         return uriProvider.getLandingPageUri();
@@ -60,15 +60,15 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     }
 
     @Override
-    public URI logout(String accessToken) {
-        log.debug("Initiated logout flow with access token {}", accessToken);
-        return uriProvider.getLogoutUri(accessToken);
+    public URI logout(String accessToken, String redirectUri) {
+        log.debug("Initiated logout flow with access token {} and redirectUri {}", accessToken, redirectUri);
+        return uriProvider.getLogoutUri(accessToken, redirectUri);
     }
 
     @Override
-    public URI resetPassword() {
-        log.debug("Requesting password reset");
-        return uriProvider.getResetPasswordUri();
+    public URI resetPassword(String redirectUri) {
+        log.debug("Requesting password reset, with redirectUri {}", redirectUri);
+        return uriProvider.getResetPasswordUri(redirectUri);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
                 filterChain.doFilter(request, response);
                 return;
             }
-            response.sendRedirect(uriProvider.getLoginUri().toString());
+            response.sendRedirect(uriProvider.getLoginUri(null).toString());
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/component/impl/UriProviderImplTest.java
@@ -28,9 +28,23 @@ class UriProviderImplTest {
         when(authConfig.getExternalADresponseMode()).thenReturn("ResponseMode");
         when(authConfig.getExternalADresponseType()).thenReturn("ResponseType");
 
-        URI authUrl = uriProvider.getLoginUri();
+        URI authUrl = uriProvider.getLoginUri(null);
 
         assertEquals("AuthUrl?client_id=ClientId&redirect_uri=RedirectId&scope=Scope&prompt=Prompt" +
+                         "&response_mode=ResponseMode&response_type=ResponseType",
+                     authUrl.toString());
+    }
+
+    @Test
+    void getLoginUriShouldReturnExpectedUriWithOverriddenRedirectUri() {
+        commonMocksForAuthorisation();
+        when(authConfig.getExternalADauthorizationUri()).thenReturn("AuthUrl");
+        when(authConfig.getExternalADresponseMode()).thenReturn("ResponseMode");
+        when(authConfig.getExternalADresponseType()).thenReturn("ResponseType");
+
+        URI authUrl = uriProvider.getLoginUri("OverriddenRedirectUri");
+
+        assertEquals("AuthUrl?client_id=ClientId&redirect_uri=OverriddenRedirectUri&scope=Scope&prompt=Prompt" +
                          "&response_mode=ResponseMode&response_type=ResponseType",
                      authUrl.toString());
     }
@@ -47,9 +61,20 @@ class UriProviderImplTest {
         when(authConfig.getExternalADlogoutUri()).thenReturn("LogoutUrl");
         when(authConfig.getExternalADlogoutRedirectUri()).thenReturn("LogoutRedirectUrl");
 
-        URI logoutUri = uriProvider.getLogoutUri("DUMMY_SESSION_ID");
+        URI logoutUri = uriProvider.getLogoutUri("DUMMY_SESSION_ID", null);
 
         assertEquals("LogoutUrl?id_token_hint=DUMMY_SESSION_ID&post_logout_redirect_uri=LogoutRedirectUrl",
+                     logoutUri.toString());
+    }
+
+    @Test
+    void getLogoutUriShouldReturnExpectedUriWithOverriddenRedirectUri() {
+        when(authConfig.getExternalADlogoutUri()).thenReturn("LogoutUrl");
+        when(authConfig.getExternalADlogoutRedirectUri()).thenReturn("LogoutRedirectUrl");
+
+        URI logoutUri = uriProvider.getLogoutUri("DUMMY_SESSION_ID", "OverriddenRedirectUri");
+
+        assertEquals("LogoutUrl?id_token_hint=DUMMY_SESSION_ID&post_logout_redirect_uri=OverriddenRedirectUri",
                      logoutUri.toString());
     }
 
@@ -58,9 +83,21 @@ class UriProviderImplTest {
         commonMocksForAuthorisation();
         when(authConfig.getExternalADresetPasswordUri()).thenReturn("ResetUrl");
 
-        URI logoutUri = uriProvider.getResetPasswordUri();
+        URI logoutUri = uriProvider.getResetPasswordUri(null);
 
         assertEquals("ResetUrl?client_id=ClientId&redirect_uri=RedirectId&scope=Scope&prompt=Prompt" +
+                         "&response_type=id_token",
+                     logoutUri.toString());
+    }
+
+    @Test
+    void getResetPasswordUriShouldReturnExpectedUriWithOverriddenRedirectUri() {
+        commonMocksForAuthorisation();
+        when(authConfig.getExternalADresetPasswordUri()).thenReturn("ResetUrl");
+
+        URI logoutUri = uriProvider.getResetPasswordUri("OverriddenRedirectUri");
+
+        assertEquals("ResetUrl?client_id=ClientId&redirect_uri=OverriddenRedirectUri&scope=Scope&prompt=Prompt" +
                          "&response_type=id_token",
                      logoutUri.toString());
     }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
@@ -43,6 +43,7 @@ class AuthenticationExternalUserControllerTest {
     private static final URI DUMMY_AUTHORIZATION_URI = URI.create("https://www.example.com/authorization?param=value");
     private static final URI DUMMY_LOGOUT_URI = URI.create("https://www.example.com/logout?param=value");
     private static final String DUMMY_CODE = "code";
+    private static final String DUMMY_TOKEN = "token";
 
     @InjectMocks
     private AuthenticationExternalUserController controller;
@@ -54,10 +55,10 @@ class AuthenticationExternalUserControllerTest {
 
     @Test
     void loginAndRefreshShouldReturnLoginPageAsRedirectWhenAuthHeaderIsNotSet() {
-        when(authenticationService.loginOrRefresh(null))
+        when(authenticationService.loginOrRefresh(null, null))
             .thenReturn(DUMMY_AUTHORIZATION_URI);
 
-        ModelAndView modelAndView = controller.loginOrRefresh(null);
+        ModelAndView modelAndView = controller.loginOrRefresh(null, null);
 
         assertNotNull(modelAndView);
         assertEquals("redirect:https://www.example.com/authorization?param=value", modelAndView.getViewName());
@@ -107,10 +108,10 @@ class AuthenticationExternalUserControllerTest {
 
     @Test
     void logoutShouldReturnLogoutPageUriAsRedirectWhenTokenExistsInSession() {
-        when(authenticationService.logout(any()))
+        when(authenticationService.logout(DUMMY_TOKEN, null))
             .thenReturn(DUMMY_LOGOUT_URI);
 
-        ModelAndView modelAndView = controller.logout(anyString());
+        ModelAndView modelAndView = controller.logout("Bearer " + DUMMY_TOKEN, null);
 
         assertNotNull(modelAndView);
         assertEquals("redirect:https://www.example.com/logout?param=value", modelAndView.getViewName());
@@ -118,10 +119,10 @@ class AuthenticationExternalUserControllerTest {
 
     @Test
     void resetPasswordShouldReturnResetPageAsRedirect() {
-        when(authenticationService.resetPassword())
+        when(authenticationService.resetPassword(any()))
             .thenReturn(DUMMY_AUTHORIZATION_URI);
 
-        ModelAndView modelAndView = controller.resetPassword();
+        ModelAndView modelAndView = controller.resetPassword(null);
 
         assertNotNull(modelAndView);
         assertEquals("redirect:https://www.example.com/authorization?param=value", modelAndView.getViewName());

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
@@ -26,12 +26,12 @@ class AuthenticationInternalUserControllerTest {
 
     @Test
     void logoutWhenUserLogoutFromdarts() {
-        assertThrows(NotImplementedException.class, () -> controller.logout(null));
+        assertThrows(NotImplementedException.class, () -> controller.logout(null, null));
     }
 
     @Test
     void resetPasswordShouldCompleteWithoutExceptionWhenSessionIsInvalidated() {
-        assertThrows(NotImplementedException.class, () -> controller.resetPassword());
+        assertThrows(NotImplementedException.class, () -> controller.resetPassword(null));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/service/impl/AuthenticationServiceImplTest.java
@@ -17,6 +17,7 @@ import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -43,22 +44,22 @@ class AuthenticationServiceImplTest {
 
     @Test
     void loginOrRefreshShouldReturnAuthUriWhenNoAuthHeaderExists() {
-        when(uriProvider.getLoginUri())
+        when(uriProvider.getLoginUri(null))
             .thenReturn(DUMMY_AUTH_URI);
 
-        URI uri = authenticationService.loginOrRefresh(null);
+        URI uri = authenticationService.loginOrRefresh(null, null);
 
         assertEquals(DUMMY_AUTH_URI, uri);
     }
 
     @Test
     void loginOrRefreshShouldReturnAuthUriWhenInvalidAccessTokenExists() {
-        when(uriProvider.getLoginUri())
+        when(uriProvider.getLoginUri(null))
             .thenReturn(DUMMY_AUTH_URI);
         when(tokenValidator.validate(DUMMY_ID_TOKEN))
             .thenReturn(new JwtValidationResult(false, "Invalid token"));
 
-        URI uri = authenticationService.loginOrRefresh(DUMMY_ID_TOKEN);
+        URI uri = authenticationService.loginOrRefresh(DUMMY_ID_TOKEN, null);
 
         assertEquals(DUMMY_AUTH_URI, uri);
     }
@@ -70,7 +71,7 @@ class AuthenticationServiceImplTest {
         when(tokenValidator.validate(DUMMY_ID_TOKEN))
             .thenReturn(new JwtValidationResult(true, null));
 
-        URI uri = authenticationService.loginOrRefresh(DUMMY_ID_TOKEN);
+        URI uri = authenticationService.loginOrRefresh(DUMMY_ID_TOKEN, null);
 
         assertEquals(DUMMY_LANDING_PAGE_URI, uri);
     }
@@ -117,20 +118,20 @@ class AuthenticationServiceImplTest {
 
     @Test
     void logoutShouldReturnLogoutPageUriWhenSessionExists() {
-        when(uriProvider.getLogoutUri(anyString()))
+        when(uriProvider.getLogoutUri(anyString(), any()))
             .thenReturn(DUMMY_LOGOUT_URI);
 
-        URI uri = authenticationService.logout(DUMMY_ID_TOKEN);
+        URI uri = authenticationService.logout(DUMMY_ID_TOKEN, null);
 
         assertEquals(DUMMY_LOGOUT_URI, uri);
     }
 
     @Test
     void resetPasswordShouldReturnResetPasswordUri() {
-        when(uriProvider.getResetPasswordUri())
+        when(uriProvider.getResetPasswordUri(null))
             .thenReturn(DUMMY_AUTH_URI);
 
-        URI uri = authenticationService.resetPassword();
+        URI uri = authenticationService.resetPassword(null);
 
         assertEquals(DUMMY_AUTH_URI, uri);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- including login, logout and reset-password
- this is so that any darts-portal instance is able to authenticate with the staging API, e.g. for local development

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
