### PR TITLE
Enable postgres query logging for local development

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -27,6 +27,7 @@ services:
       - "4550:4550"
     networks:
       - darts-network
+
   darts-db:
     container_name: darts-db
     image: postgres:15.4-alpine
@@ -35,6 +36,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=darts
+    command: ["postgres", "-c", "log_statement=all"]
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
Enable postgres query logging (by the database server) for local development. This is useful to see exactly which queries are being executed against the database for debugging purposes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
