### PR TITLE
DMP-755: Implement get audio metadata API endpoint

### DIFF
--- a/ModernisedDarts.postman_collection.json
+++ b/ModernisedDarts.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "768c8675-0aec-44b3-b83d-4897031799ea",
+		"_postman_id": "7a48dccf-5630-4bb3-9409-9923c57a4b64",
 		"name": "ModernisedDarts",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -304,6 +304,39 @@
 							"response": []
 						}
 					]
+				}
+			]
+		},
+		{
+			"name": "Audio",
+			"item": [
+				{
+					"name": "GET /audio/hearings/:hearingId/audios",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:4550/audio/hearings/1/audios",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "4550",
+							"path": [
+								"audio",
+								"hearings",
+								"1",
+								"audios"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetMetadataIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetMetadataIntTest.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.darts.audio.controller;
+
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+class AudioControllerGetMetadataIntTest extends IntegrationBase {
+
+    private static final OffsetDateTime MEDIA_START_TIME = OffsetDateTime.parse("2023-01-01T12:00:00Z");
+    private static final OffsetDateTime MEDIA_END_TIME = MEDIA_START_TIME.plusHours(1);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void getAudioMetadataGetShouldReturnMetadataAssociatedWithProvidedHearing() throws Exception {
+        var mediaEntity = dartsDatabase.createMediaEntity(MEDIA_START_TIME, MEDIA_END_TIME, 999);
+
+        var hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
+            "999",
+            "test",
+            "test",
+            LocalDate.now()
+        );
+        hearingEntity.setMediaList(Collections.singletonList(mediaEntity));
+        dartsDatabase.getHearingRepository()
+            .save(hearingEntity);
+
+        var requestBuilder = get(URI.create(String.format("/audio/hearings/%d/audios", hearingEntity.getId())));
+
+        MvcResult mvcResult = mockMvc.perform(requestBuilder)
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String actualJson = mvcResult.getResponse().getContentAsString();
+        String expectedJson = """
+            [
+              {
+                "id": 1,
+                "media_start_timestamp": "2023-01-01T12:00:00Z",
+                "media_end_timestamp": "2023-01-01T13:00:00Z"
+              }
+            ]
+            """;
+        JSONAssert.assertEquals(expectedJson, actualJson, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    void getAudioMetadataGetShouldReturnEmptyListWhenNoMediaIsAssociatedWithHearing() throws Exception {
+        var hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
+            "999",
+            "test",
+            "test",
+            LocalDate.now()
+        );
+
+        var requestBuilder = get(URI.create(String.format("/audio/hearings/%d/audios", hearingEntity.getId())));
+
+        MvcResult mvcResult = mockMvc.perform(requestBuilder)
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String actualJson = mvcResult.getResponse().getContentAsString();
+        JSONAssert.assertEquals("[]", actualJson, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/AudioResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/AudioResponseMapper.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.darts.audio.component;
+
+import uk.gov.hmcts.darts.audio.model.AudioMetadata;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+
+import java.util.List;
+
+public interface AudioResponseMapper {
+
+    List<AudioMetadata> mapToAudioMetadata(List<MediaEntity> mediaEntities);
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioResponseMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioResponseMapperImpl.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.audio.component.AudioResponseMapper;
+import uk.gov.hmcts.darts.audio.model.AudioMetadata;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+
+import java.util.List;
+
+@Component
+public class AudioResponseMapperImpl implements AudioResponseMapper {
+
+    @Override
+    public List<AudioMetadata> mapToAudioMetadata(List<MediaEntity> mediaEntities) {
+        return mediaEntities.stream()
+            .map(this::mapToAudioMetadata)
+            .toList();
+    }
+
+    private AudioMetadata mapToAudioMetadata(MediaEntity mediaEntity) {
+        var audioMetadata = new AudioMetadata();
+
+        audioMetadata.setId(mediaEntity.getId());
+        audioMetadata.setMediaStartTimestamp(mediaEntity.getStart());
+        audioMetadata.setMediaEndTimestamp(mediaEntity.getEnd());
+
+        return audioMetadata;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -7,11 +7,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.audio.api.AudioApi;
+import uk.gov.hmcts.darts.audio.component.AudioResponseMapper;
+import uk.gov.hmcts.darts.audio.model.AudioMetadata;
 import uk.gov.hmcts.darts.audio.model.AudioRequestDetails;
 import uk.gov.hmcts.darts.audio.service.AudioService;
+import uk.gov.hmcts.darts.audio.service.AudioTransformationService;
 import uk.gov.hmcts.darts.audio.service.MediaRequestService;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
 
 import java.io.InputStream;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +24,8 @@ public class AudioController implements AudioApi {
 
     private final MediaRequestService mediaRequestService;
     private final AudioService audioService;
+    private final AudioTransformationService audioTransformationService;
+    private final AudioResponseMapper audioResponseMapper;
 
     @Override
     public ResponseEntity<Void> addAudioRequest(AudioRequestDetails audioRequestDetails) {
@@ -37,6 +44,14 @@ public class AudioController implements AudioApi {
 
         return new ResponseEntity<>(new InputStreamResource(audioFileStream),
                                     HttpStatus.OK);
+    }
+
+    @Override
+    public ResponseEntity<List<AudioMetadata>> getAudioMetadata(Integer hearingId) {
+        List<MediaEntity> mediaEntities = audioTransformationService.getMediaMetadata(hearingId);
+        List<AudioMetadata> audioMetadata = audioResponseMapper.mapToAudioMetadata(mediaEntities);
+
+        return new ResponseEntity<>(audioMetadata, HttpStatus.OK);
     }
 
 }

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -66,6 +66,40 @@ paths:
                 title: "The requested data cannot be located"
                 status: 500
 
+  /audio/hearings/{hearingId}/audios:
+    get:
+      tags:
+        - Audio
+      summary: Media metadata for provided hearing
+      operationId: getAudioMetadata
+      description: Media metadata for provided hearing
+      parameters:
+        - in: path
+          name: hearingId
+          schema:
+            type: integer
+          required: true
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AudioMetadata'
+              examples:
+                media-found:
+                  summary: Media metadata exists for the given hearing id
+                  value:
+                    - id: 1
+                      media_start_timestamp: '2023-07-31T14:32:24.620Z'
+                      media_end_timestamp: '2023-07-31T14:32:24.620Z'
+                media-not-found:
+                  summary: No media metadata exists for the given hearing id
+                  value:
+                    []
+
 components:
   schemas:
     AudioRequestType:
@@ -103,3 +137,16 @@ components:
     AudioRequestId:
       type: integer
       example: 12345
+
+    AudioMetadata:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        media_start_timestamp:
+          type: string
+          format: date-time
+        media_end_timestamp:
+          type: string
+          format: date-time

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/AudioResponseMapperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/AudioResponseMapperImplTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.audio.component.AudioResponseMapper;
+import uk.gov.hmcts.darts.audio.model.AudioMetadata;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AudioResponseMapperImplTest {
+
+    private static final OffsetDateTime START_TIME = OffsetDateTime.now();
+    private static final OffsetDateTime END_TIME = START_TIME.plusHours(1);
+
+    private AudioResponseMapper audioResponseMapper;
+
+    @BeforeEach
+    void setUp() {
+        audioResponseMapper = new AudioResponseMapperImpl();
+    }
+
+    @Test
+    void mapToAudioMetadataShouldMapToExpectedStructure() {
+        MediaEntity mediaEntity = new MediaEntity();
+        mediaEntity.setId(1);
+        mediaEntity.setStart(START_TIME);
+        mediaEntity.setEnd(END_TIME);
+
+        List<AudioMetadata> mappedAudioMetadatas = audioResponseMapper.mapToAudioMetadata(Collections.singletonList(mediaEntity));
+
+        assertEquals(mappedAudioMetadatas.size(), 1);
+        AudioMetadata mappedAudioMetaData = mappedAudioMetadatas.get(0);
+
+        assertEquals(1, mappedAudioMetaData.getId());
+        assertEquals(START_TIME, mappedAudioMetaData.getMediaStartTimestamp());
+        assertEquals(END_TIME, mappedAudioMetaData.getMediaEndTimestamp());
+    }
+
+}


### PR DESCRIPTION
# [DMP-755](https://tools.hmcts.net/jira/browse/DMP-755)

Implement an endpoint to get all media metadata associated with the provided hearingId.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
