### PR TITLE
DMP-753_Add_error_response_to_GET_case_hearings_endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
@@ -77,15 +77,6 @@ class CaseControllerGetCaseByIdTest extends IntegrationBase {
 
     }
 
-    @Test
-    void casesSearchEmptyHearingListCaseIdExists() throws Exception {
-
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId("25","test"));
-
-        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk());
-
-    }
-
     private Integer getCaseId(String caseNumber, String courthouse) {
 
         CourtCaseEntity courtCase = dartsDatabase.createCaseUnlessExists(caseNumber, courthouse);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
@@ -43,7 +43,7 @@ class CaseControllerGetCaseByIdTest extends IntegrationBase {
     @Test
     void casesSearchGetEndpoint() throws Exception {
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId());
+        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE));
 
         mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk());
 
@@ -52,11 +52,11 @@ class CaseControllerGetCaseByIdTest extends IntegrationBase {
     @Test
     void casesSearchGetEndpointCheckListsAreCorrectSize() throws Exception {
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId());
+        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE));
 
         mockMvc.perform(requestBuilder)
             .andExpect(MockMvcResultMatchers.status().isOk())
-            .andExpect(MockMvcResultMatchers.jsonPath("$.case_id", Matchers.is(getCaseId())))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.case_id", Matchers.is(getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE))))
             .andExpect(MockMvcResultMatchers.jsonPath("$.judges", Matchers.hasSize(1)))
             .andExpect(MockMvcResultMatchers.jsonPath("$.judges[0]", Matchers.is("1judge1")))
             .andExpect(MockMvcResultMatchers.jsonPath("$.prosecutors", Matchers.hasSize(1)))
@@ -77,9 +77,18 @@ class CaseControllerGetCaseByIdTest extends IntegrationBase {
 
     }
 
-    private Integer getCaseId() {
+    @Test
+    void casesSearchEmptyHearingListCaseIdExists() throws Exception {
 
-        CourtCaseEntity courtCase = dartsDatabase.createCaseUnlessExists(SOME_CASE_NUMBER, SOME_COURTHOUSE);
+        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId("25","test"));
+
+        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+
+    private Integer getCaseId(String caseNumber, String courthouse) {
+
+        CourtCaseEntity courtCase = dartsDatabase.createCaseUnlessExists(caseNumber, courthouse);
 
         return courtCase.getId();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
@@ -98,6 +99,17 @@ class CaseControllerGetCaseHearingsTest extends IntegrationBase {
 
         mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isNotFound()).andExpect(MockMvcResultMatchers.jsonPath(
             "$[0]").doesNotExist());
+
+    }
+
+    @Test
+    void casesSearchEmptyHearingListCaseIdExists() throws Exception {
+
+        CourtCaseEntity courtCase = dartsDatabase.createCaseUnlessExists("25", "Test");
+
+        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, courtCase.getId());
+
+        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andExpect(MockMvcResultMatchers.jsonPath("$.case_id").doesNotExist());
 
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
@@ -44,7 +44,7 @@ class CaseControllerGetCaseHearingsTest extends IntegrationBase {
 
         MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, "25");
 
-        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk());
+        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isNotFound());
 
     }
 
@@ -96,7 +96,7 @@ class CaseControllerGetCaseHearingsTest extends IntegrationBase {
 
         MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, "25");
 
-        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andExpect(MockMvcResultMatchers.jsonPath(
+        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isNotFound()).andExpect(MockMvcResultMatchers.jsonPath(
             "$[0]").doesNotExist());
 
     }

--- a/src/main/java/uk/gov/hmcts/darts/cases/exception/CaseApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/exception/CaseApiError.java
@@ -33,6 +33,11 @@ public enum CaseApiError implements DartsApiError {
         "104",
         HttpStatus.NOT_FOUND,
         "The requested case cannot be found"
+    ),
+    HEARING_DATA_NOT_FOUND(
+        "105",
+        HttpStatus.NOT_FOUND,
+        "The requested hearing data cannot be found"
     );
 
     private static final String ERROR_TYPE_PREFIX = "CASE";

--- a/src/main/java/uk/gov/hmcts/darts/cases/exception/CaseApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/exception/CaseApiError.java
@@ -33,11 +33,6 @@ public enum CaseApiError implements DartsApiError {
         "104",
         HttpStatus.NOT_FOUND,
         "The requested case cannot be found"
-    ),
-    HEARING_DATA_NOT_FOUND(
-        "105",
-        HttpStatus.NOT_FOUND,
-        "The requested hearing data cannot be found"
     );
 
     private static final String ERROR_TYPE_PREFIX = "CASE";

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearing.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearing.java
@@ -21,6 +21,7 @@ public class HearingEntityToCaseHearing {
             }
 
         }
+
         return hearings;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -64,6 +64,10 @@ public class CaseServiceImpl implements CaseService {
 
         List<HearingEntity> hearingList = hearingRepository.findByCaseIds(List.of(caseId));
 
+        if (hearingList.isEmpty()) {
+            throw new DartsApiException(CaseApiError.HEARING_DATA_NOT_FOUND);
+        }
+
         return HearingEntityToCaseHearing.mapToHearingList(hearingList);
 
     }

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -65,7 +65,13 @@ public class CaseServiceImpl implements CaseService {
         List<HearingEntity> hearingList = hearingRepository.findByCaseIds(List.of(caseId));
 
         if (hearingList.isEmpty()) {
-            throw new DartsApiException(CaseApiError.HEARING_DATA_NOT_FOUND);
+
+            Optional<CourtCaseEntity> caseEntity = caseRepository.findById(caseId);
+
+            if (caseEntity.isEmpty()) {
+                throw new DartsApiException(CaseApiError.CASE_NOT_FOUND);
+            }
+
         }
 
         return HearingEntityToCaseHearing.mapToHearingList(hearingList);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-753

### Change description ###
updated CaseApiError.java with another Enum for Hearing data not found. added error handling within service class for an empty array from repository and throws a DartsAPIException

also updated tests to reflect changes - these pass

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
