### PR TITLE
BUGFIX media_request created_by / last_modified_by columns

### DIFF
--- a/src/main/resources/db/migration/common/V1_206__update_media_request_expiry_ts.sql
+++ b/src/main/resources/db/migration/common/V1_206__update_media_request_expiry_ts.sql
@@ -4,9 +4,7 @@ ALTER TABLE media_request ALTER COLUMN request_type SET NOT NULL;
 ALTER TABLE media_request ALTER COLUMN start_ts SET NOT NULL;
 ALTER TABLE media_request ALTER COLUMN end_ts SET NOT NULL;
 ALTER TABLE media_request ALTER COLUMN created_ts SET NOT NULL;
-ALTER TABLE media_request ALTER COLUMN created_by SET NOT NULL;
 ALTER TABLE media_request ALTER COLUMN last_modified_ts SET NOT NULL;
-ALTER TABLE media_request ALTER COLUMN last_modified_by SET NOT NULL;
 
 ALTER TABLE media_request DROP CONSTRAINT media_hearing_fk;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-759](https://tools.hmcts.net/jira/browse/DMP-759)

### Change description ###

FIX darts-api/job/master/331 ERROR: column "created_by" of relation "media_request" contains null values

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
