### PR TITLE
BUGFIX (DMP-829): Fix path usage for audio operations

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/component/OutboundFileProcessor.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/OutboundFileProcessor.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.audio.component;
 import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -14,10 +15,10 @@ public interface OutboundFileProcessor {
     List<List<AudioFileInfo>> processAudioForDownload(Map<MediaEntity, Path> mediaEntityToDownloadLocation,
                                                       OffsetDateTime overallStartTime,
                                                       OffsetDateTime overallEndTime)
-        throws ExecutionException, InterruptedException;
+        throws ExecutionException, InterruptedException, IOException;
 
     AudioFileInfo processAudioForPlayback(Map<MediaEntity, Path> mediaEntityToDownloadLocation, OffsetDateTime startTime,
                                           OffsetDateTime endTime)
-        throws ExecutionException, InterruptedException;
+        throws ExecutionException, InterruptedException, IOException;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/AudioOperationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/AudioOperationService.java
@@ -2,21 +2,22 @@ package uk.gov.hmcts.darts.audio.service;
 
 import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 public interface AudioOperationService {
 
     AudioFileInfo concatenate(String workspaceDir, List<AudioFileInfo> audioFileInfos)
-        throws ExecutionException, InterruptedException;
+        throws ExecutionException, InterruptedException, IOException;
 
     AudioFileInfo merge(List<AudioFileInfo> audioFilesInfo, String workspaceDir)
-        throws ExecutionException, InterruptedException;
+        throws ExecutionException, InterruptedException, IOException;
 
     AudioFileInfo trim(String workspaceDir, AudioFileInfo audioFileInfo, String startTime, String endTime)
-        throws ExecutionException, InterruptedException;
+        throws ExecutionException, InterruptedException, IOException;
 
     AudioFileInfo reEncode(String workspaceDir, AudioFileInfo audioFileInfo)
-        throws ExecutionException, InterruptedException;
+        throws ExecutionException, InterruptedException, IOException;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
@@ -54,12 +54,10 @@ public class AudioServiceImpl implements AudioService {
             Path downloadPath = audioTransformationService.saveMediaToWorkspace(mediaEntity);
 
             AudioFileInfo audioFileInfo = createAudioFileInfo(mediaEntity, downloadPath);
-            String workspaceDir = downloadPath.toFile().getParent();
 
             AudioFileInfo encodedAudioFileInfo;
-
             try {
-                encodedAudioFileInfo = audioOperationService.reEncode(workspaceDir, audioFileInfo);
+                encodedAudioFileInfo = audioOperationService.reEncode(UUID.randomUUID().toString(), audioFileInfo);
             } catch (ExecutionException | InterruptedException e) {
                 // For Sonar rule S2142
                 throw e;

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -251,7 +251,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     @SuppressWarnings("PMD.LawOfDemeter")
     private Path generateFileForRequestType(MediaRequestEntity mediaRequestEntity,
                                             Map<MediaEntity, Path> downloadedMedias)
-        throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException, IOException {
 
         var requestType = mediaRequestEntity.getRequestType();
 
@@ -266,7 +266,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     }
 
     private Path handleDownload(Map<MediaEntity, Path> downloadedMedias, MediaRequestEntity mediaRequestEntity)
-        throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException, IOException {
 
         List<List<AudioFileInfo>> processedAudio = outboundFileProcessor.processAudioForDownload(
             downloadedMedias,
@@ -278,7 +278,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     }
 
     public Path handlePlayback(Map<MediaEntity, Path> downloadedMedias, OffsetDateTime startTime, OffsetDateTime endTime)
-        throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException, IOException {
 
         AudioFileInfo audioFileInfo = outboundFileProcessor.processAudioForPlayback(
             downloadedMedias,
@@ -290,7 +290,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     }
 
     private Path handlePlayback(Map<MediaEntity, Path> downloadedMedias, MediaRequestEntity mediaRequestEntity)
-        throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException, IOException {
         return handlePlayback(downloadedMedias, mediaRequestEntity.getStartTime(), mediaRequestEntity.getEndTime());
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/FileOperationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/FileOperationServiceImpl.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +24,8 @@ public class FileOperationServiceImpl implements FileOperationService {
     @Override
     public Path saveFileToTempWorkspace(BinaryData mediaFile, String fileName) throws IOException {
 
-        Path targetTempDirectory = Path.of(audioConfigurationProperties.getTempBlobWorkspace());
+        Path targetTempDirectory = Path.of(audioConfigurationProperties.getTempBlobWorkspace())
+            .resolve(UUID.randomUUID().toString());
         Path targetTempFile = targetTempDirectory.resolve(fileName);
 
         try (InputStream audioInputStream = mediaFile.toStream()) {

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImplTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
 import uk.gov.hmcts.darts.audio.service.impl.AudioOperationServiceImpl;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -46,7 +47,7 @@ class OutboundFileProcessorImplTest {
 
     @Test
     void processAudioForDownloadShouldReturnOneSessionWithOneAudioWhenProvidedWithOneAudio()
-        throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException, IOException {
 
         AudioFileInfo trimmedAudioFileInfo = new AudioFileInfo();
         when(audioOperationService.trim(any(), any(), any(), any()))
@@ -77,7 +78,7 @@ class OutboundFileProcessorImplTest {
 
     @Test
     void processAudioForDownloadShouldReturnOneSessionWithOneAudioWhenProvidedWithTwoContinuousAudios()
-        throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException, IOException {
 
         var concatenatedAudioFileInfo = new AudioFileInfo(TIME_12_00.toInstant(),
                                                           TIME_12_20.toInstant(),
@@ -122,7 +123,7 @@ class OutboundFileProcessorImplTest {
 
     @Test
     void processAudioForDownloadShouldReturnOneSessionWithTwoAudioWhenProvidedWithTwoNonContinuousAudiosWithDifferentChannelsAndSameTimestamp()
-        throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException, IOException {
 
         var firstTrimmedAudioFileInfo = new AudioFileInfo();
         var secondTrimmedAudioFileInfo = new AudioFileInfo();
@@ -163,7 +164,7 @@ class OutboundFileProcessorImplTest {
 
     @Test
     void processAudioForDownloadShouldReturnTwoSessionsEachWithOneAudioWhenProvidedWithTwoNonContinuousAudios()
-        throws ExecutionException, InterruptedException {
+        throws ExecutionException, InterruptedException, IOException {
 
         var firstTrimmedAudioFileInfo = new AudioFileInfo();
         var secondTrimmedAudioFileInfo = new AudioFileInfo();
@@ -206,7 +207,8 @@ class OutboundFileProcessorImplTest {
     }
 
     @Test
-    void processAudioForPlaybackShouldPerformExpectedAudioOperations() throws ExecutionException, InterruptedException {
+    void processAudioForPlaybackShouldPerformExpectedAudioOperations()
+        throws ExecutionException, InterruptedException, IOException {
         var concatenatedAudioFileInfo = new AudioFileInfo();
         when(audioOperationService.concatenate(any(), any()))
             .thenReturn(concatenatedAudioFileInfo);
@@ -263,7 +265,8 @@ class OutboundFileProcessorImplTest {
     }
 
     @Test
-    void processAudioShouldCallTrimWithExpectedArgumentsWhenDurationsIsPositive() throws ExecutionException, InterruptedException {
+    void processAudioShouldCallTrimWithExpectedArgumentsWhenDurationsIsPositive()
+        throws ExecutionException, InterruptedException, IOException {
         var concatenatedAudioFileInfo = new AudioFileInfo();
         when(audioOperationService.concatenate(any(), any()))
             .thenReturn(concatenatedAudioFileInfo);
@@ -300,7 +303,8 @@ class OutboundFileProcessorImplTest {
     }
 
     @Test
-    void processAudioShouldCallTrimWithExpectedArgumentsWhenDurationIsNegative() throws ExecutionException, InterruptedException {
+    void processAudioShouldCallTrimWithExpectedArgumentsWhenDurationIsNegative()
+        throws ExecutionException, InterruptedException, IOException {
         var concatenatedAudioFileInfo = new AudioFileInfo();
         when(audioOperationService.concatenate(any(), any()))
             .thenReturn(concatenatedAudioFileInfo);

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioOperationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioOperationServiceImplTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class AudioOperationServiceImplTest {
 
-    private static final String WORKSPACE_DIR = "requestId";
+    private static final String WORKSPACE_DIR = "44887a8c-d918-4907-b9e8-38d5b1bf9c9c";
     private static final String T_09_00_00_Z = "2023-04-28T09:00:00Z";
     private static final String T_10_30_00_Z = "2023-04-28T10:30:00Z";
     private static final String T_11_00_00_Z = "2023-04-28T11:00:00Z";
@@ -110,7 +110,7 @@ class AudioOperationServiceImplTest {
             inputAudioFileInfos
         );
 
-        assertTrue(audioFileInfo.getFileName().matches(".*/requestId/C[1-4]-concatenate-[0-9]*.mp2"));
+        assertTrue(audioFileInfo.getFileName().matches(".*/44887a8c-d918-4907-b9e8-38d5b1bf9c9c/C[1-4]-concatenate-[0-9]*.mp2"));
         assertEquals(1, audioFileInfo.getChannel());
         assertEquals(Instant.parse(T_09_00_00_Z), audioFileInfo.getStartTime());
         assertEquals(Instant.parse(T_11_00_00_Z), audioFileInfo.getEndTime());
@@ -127,7 +127,7 @@ class AudioOperationServiceImplTest {
             WORKSPACE_DIR
         );
 
-        assertTrue(audioFileInfo.getFileName().matches(".*/requestId/C0-merge-[0-9]*.mp2"));
+        assertTrue(audioFileInfo.getFileName().matches(".*/44887a8c-d918-4907-b9e8-38d5b1bf9c9c/C0-merge-[0-9]*.mp2"));
         assertEquals(0, audioFileInfo.getChannel());
         assertEquals(Instant.parse(T_09_00_00_Z), audioFileInfo.getStartTime());
         assertEquals(Instant.parse(T_11_00_00_Z), audioFileInfo.getEndTime());
@@ -156,7 +156,7 @@ class AudioOperationServiceImplTest {
             "01:15:00"
         );
 
-        assertTrue(audioFileInfo.getFileName().matches(".*/requestId/C[1-4]-trim-[0-9]*.mp2"));
+        assertTrue(audioFileInfo.getFileName().matches(".*/44887a8c-d918-4907-b9e8-38d5b1bf9c9c/C[1-4]-trim-[0-9]*.mp2"));
         assertEquals(1, audioFileInfo.getChannel());
         assertEquals(Instant.parse("2023-04-28T09:45:00Z"), audioFileInfo.getStartTime());
         assertEquals(Instant.parse("2023-04-28T10:15:00Z"), audioFileInfo.getEndTime());
@@ -220,7 +220,7 @@ class AudioOperationServiceImplTest {
             inputAudioFileInfos.get(0)
         );
 
-        assertTrue(audioFileInfo.getFileName().matches(".*/requestId/C[0-4]-encode-[0-9]*.mp3"));
+        assertTrue(audioFileInfo.getFileName().matches(".*/44887a8c-d918-4907-b9e8-38d5b1bf9c9c/C[0-4]-encode-[0-9]*.mp3"));
         assertEquals(1, audioFileInfo.getChannel());
         assertEquals(Instant.parse(T_09_00_00_Z), audioFileInfo.getStartTime());
         assertEquals(Instant.parse(T_10_30_00_Z), audioFileInfo.getEndTime());

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioOperationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioOperationServiceImplTest.java
@@ -11,9 +11,11 @@ import uk.gov.hmcts.darts.audio.component.impl.SystemCommandExecutorImpl;
 import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
 import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -33,7 +35,8 @@ class AudioOperationServiceImplTest {
     private static final String T_11_00_00_Z = "2023-04-28T11:00:00Z";
     private static final String FFMPEG = "/usr/bin/ffmpeg";
 
-    private List<AudioFileInfo> audioFileInfos;
+    private List<AudioFileInfo> inputAudioFileInfos;
+    private Path tempDirectory;
 
     @InjectMocks
     private AudioOperationServiceImpl audioOperationService;
@@ -45,113 +48,123 @@ class AudioOperationServiceImplTest {
     private SystemCommandExecutorImpl systemCommandExecutor;
 
     @BeforeEach
-    void beforeEach() {
-        audioFileInfos = new ArrayList<>();
-        audioFileInfos.add(new AudioFileInfo(
-            Instant.parse(T_09_00_00_Z),
-            Instant.parse(T_10_30_00_Z),
-            "/path/to/audio/requestId/sample1-5secs.mp2",
-            1
-        ));
-        audioFileInfos.add(new AudioFileInfo(
-            Instant.parse(T_10_30_00_Z),
-            Instant.parse(T_11_00_00_Z),
-            "/path/to/audio/requestId/sample2-5secs.mp2",
-            1
-        ));
+    void beforeEach() throws IOException {
+        tempDirectory = Files.createTempDirectory("darts_api_unit_test");
+
+        inputAudioFileInfos = List.of(
+            new AudioFileInfo(
+                Instant.parse(T_09_00_00_Z),
+                Instant.parse(T_10_30_00_Z),
+                createFile(tempDirectory, "original0.mp3").toString(),
+                1
+            ),
+            new AudioFileInfo(
+                Instant.parse(T_10_30_00_Z),
+                Instant.parse(T_11_00_00_Z),
+                createFile(tempDirectory, "original1.mp3").toString(),
+                1
+            )
+        );
     }
 
     @Test
     void shouldGenerateConcatenateCommandWhenValidAudioFilesAreReceived() {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
 
-        CommandLine expectedCommand = CommandLine.parse(
-            "/usr/bin/ffmpeg -i /path/to/audio/requestId/sample1-5secs.mp2 -i /path/to/audio/requestId/sample2-5secs.mp2"
-                + " -filter_complex \"[0:a][1:a]concat=n=2:v=0:a=1\" /tempDir/concatenate/requestId/C1-concatenate-20230510145233697.mp2");
-
-        CommandLine concatenateCommand = audioOperationService.generateConcatenateCommand(
-            1,
-            audioFileInfos,
-            "/tempDir/concatenate/requestId/C1-concatenate-20230510145233697.mp2"
+        List<AudioFileInfo> inputAudioFileInfos = List.of(
+            new AudioFileInfo(
+                Instant.parse(T_09_00_00_Z),
+                Instant.parse(T_10_30_00_Z),
+                "/path/to/audio/original0.mp3",
+                1
+            ),
+            new AudioFileInfo(
+                Instant.parse(T_10_30_00_Z),
+                Instant.parse(T_11_00_00_Z),
+                "/path/to/audio/original1.mp3",
+                1
+            )
         );
 
-        assertNotNull(concatenateCommand);
-        assertEquals(expectedCommand.getArguments().length, concatenateCommand.getArguments().length);
-        assertEquals(expectedCommand.getExecutable(), concatenateCommand.getExecutable());
-        assertEquals(expectedCommand.toString(), concatenateCommand.toString());
+        CommandLine actualCommand = audioOperationService.generateConcatenateCommand(
+            inputAudioFileInfos,
+            Path.of("/path/to/output/audio.mp2")
+        );
+
+        CommandLine expectedCommand = CommandLine.parse(
+            "/usr/bin/ffmpeg -i /path/to/audio/original0.mp3 -i /path/to/audio/original1.mp3"
+                + " -filter_complex [0:a][1:a]concat=n=2:v=0:a=1 /path/to/output/audio.mp2");
+
+        assertNotNull(actualCommand);
+        assertEquals(expectedCommand.toString(), actualCommand.toString());
     }
 
     @Test
     void shouldReturnConcatenatedAudioFileInfoWhenValidInputAudioFiles() throws Exception {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
-        when(audioConfigurationProperties.getConcatWorkspace()).thenReturn("/tempDir/concatenate");
+        when(audioConfigurationProperties.getConcatWorkspace()).thenReturn(tempDirectory.toString());
         when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
 
-        AudioFileInfo expectedAudio = new AudioFileInfo(
-            Instant.parse(T_09_00_00_Z),
-            Instant.parse(T_11_00_00_Z),
-            "/tempDir/concatenate/requestId/C1-concatenate-20230510145233697.mp2",
-            1
+        AudioFileInfo audioFileInfo = audioOperationService.concatenate(
+            WORKSPACE_DIR,
+            inputAudioFileInfos
         );
 
-        AudioFileInfo audioFileInfo = audioOperationService.concatenate(WORKSPACE_DIR, audioFileInfos);
-
-        assertTrue(audioFileInfo.getFileName().matches("/tempDir/concatenate/requestId/C[1-4]-concatenate-[0-9]*.mp2"));
-        assertEquals(expectedAudio.getChannel(), audioFileInfo.getChannel());
-        assertEquals(expectedAudio.getStartTime(), audioFileInfo.getStartTime());
-        assertEquals(expectedAudio.getEndTime(), audioFileInfo.getEndTime());
+        assertTrue(audioFileInfo.getFileName().matches(".*/requestId/C[1-4]-concatenate-[0-9]*.mp2"));
+        assertEquals(1, audioFileInfo.getChannel());
+        assertEquals(Instant.parse(T_09_00_00_Z), audioFileInfo.getStartTime());
+        assertEquals(Instant.parse(T_11_00_00_Z), audioFileInfo.getEndTime());
     }
 
     @Test
     void shouldReturnMergedAudioFileInfoWhenValidInputAudioFiles() throws Exception {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
-        when(audioConfigurationProperties.getMergeWorkspace()).thenReturn("/tempDir/merge");
+        when(audioConfigurationProperties.getMergeWorkspace()).thenReturn(tempDirectory.toString());
         when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
 
-        AudioFileInfo expectedAudio = new AudioFileInfo(
-            Instant.parse(T_09_00_00_Z),
-            Instant.parse(T_11_00_00_Z),
-            "/tempDir/merge/requestId/C0-merge-20230510145233697.mp2",
-            0
+        AudioFileInfo audioFileInfo = audioOperationService.merge(
+            inputAudioFileInfos,
+            WORKSPACE_DIR
         );
 
-        AudioFileInfo audioFileInfo = audioOperationService.merge(audioFileInfos, WORKSPACE_DIR);
-
-        assertTrue(audioFileInfo.getFileName().matches("/tempDir/merge/requestId/C0-merge-[0-9]*.mp2"));
-        assertEquals(expectedAudio.getChannel(), audioFileInfo.getChannel());
-        assertEquals(expectedAudio.getStartTime(), audioFileInfo.getStartTime());
-        assertEquals(expectedAudio.getEndTime(), audioFileInfo.getEndTime());
+        assertTrue(audioFileInfo.getFileName().matches(".*/requestId/C0-merge-[0-9]*.mp2"));
+        assertEquals(0, audioFileInfo.getChannel());
+        assertEquals(Instant.parse(T_09_00_00_Z), audioFileInfo.getStartTime());
+        assertEquals(Instant.parse(T_11_00_00_Z), audioFileInfo.getEndTime());
     }
 
     @Test
-    void shouldReturnTrimmedAudioFileWhenValidInputAudioFile() throws ExecutionException, InterruptedException {
+    void shouldReturnTrimmedAudioFileWhenValidInputAudioFile()
+        throws ExecutionException, InterruptedException, IOException {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
-        when(audioConfigurationProperties.getTrimWorkspace()).thenReturn("/tempDir/trim");
-        when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
 
-        AudioFileInfo expectedAudio = new AudioFileInfo(
-            Instant.parse("2023-04-28T09:45:00Z"),
-            Instant.parse("2023-04-28T10:15:00Z"),
-            "/tempDir/trim/requestId/C1-trim-20230510123741468.mp2",
-            1
-        );
+        Path tempDirectory = createTempDirectory();
+        when(audioConfigurationProperties.getTrimWorkspace()).thenReturn(tempDirectory.toString());
+
+        when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
+        Path file = Files.createFile(tempDirectory.resolve("original.mp3"));
 
         AudioFileInfo audioFileInfo = audioOperationService.trim(
             WORKSPACE_DIR,
-            audioFileInfos.get(0),
+            new AudioFileInfo(
+                Instant.parse(T_09_00_00_Z),
+                Instant.parse(T_10_30_00_Z),
+                file.toString(),
+                1
+            ),
             "00:45:00",
             "01:15:00"
         );
 
-        assertTrue(audioFileInfo.getFileName().matches("/tempDir/trim/requestId/C[1-4]-trim-[0-9]*.mp2"));
-        assertEquals(expectedAudio.getChannel(), audioFileInfo.getChannel());
-        assertEquals(expectedAudio.getStartTime(), audioFileInfo.getStartTime());
-        assertEquals(expectedAudio.getEndTime(), audioFileInfo.getEndTime());
+        assertTrue(audioFileInfo.getFileName().matches(".*/requestId/C[1-4]-trim-[0-9]*.mp2"));
+        assertEquals(1, audioFileInfo.getChannel());
+        assertEquals(Instant.parse("2023-04-28T09:45:00Z"), audioFileInfo.getStartTime());
+        assertEquals(Instant.parse("2023-04-28T10:15:00Z"), audioFileInfo.getEndTime());
     }
 
     @Test
     void shouldAdjustTimeDurationWhenValid() {
-        AudioFileInfo audioFileInfo = audioFileInfos.get(0);
+        AudioFileInfo audioFileInfo = inputAudioFileInfos.get(0);
         assertEquals(
             Instant.parse(T_09_00_00_Z),
             audioOperationService.adjustTimeDuration(audioFileInfo.getStartTime(), "00:00:00")
@@ -196,32 +209,29 @@ class AudioOperationServiceImplTest {
     }
 
     @Test
-    void shouldReturnReEncodedAudioFileInfoWhenValidInputAudioFile() throws ExecutionException, InterruptedException {
+    void shouldReturnReEncodedAudioFileInfoWhenValidInputAudioFile()
+        throws ExecutionException, InterruptedException, IOException {
         when(audioConfigurationProperties.getFfmpegExecutable()).thenReturn(FFMPEG);
-        when(audioConfigurationProperties.getReEncodeWorkspace()).thenReturn("/tempDir/encode");
+        when(audioConfigurationProperties.getReEncodeWorkspace()).thenReturn(tempDirectory.toString());
         when(systemCommandExecutor.execute(any())).thenReturn(Boolean.TRUE);
-
-        AudioFileInfo expectedAudio = new AudioFileInfo(
-            Instant.parse(T_09_00_00_Z),
-            Instant.parse(T_10_30_00_Z),
-            "/tempDir/encode/requestId/C0-encode-20230512163422198.mp3",
-            0
-        );
 
         AudioFileInfo audioFileInfo = audioOperationService.reEncode(
             WORKSPACE_DIR,
-            new AudioFileInfo(
-                Instant.parse(T_09_00_00_Z),
-                Instant.parse(T_10_30_00_Z),
-                "/tempDir/merge/requestId/C0-merge-20230510145233697.mp2",
-                0
-            )
+            inputAudioFileInfos.get(0)
         );
 
-        assertTrue(audioFileInfo.getFileName().matches("/tempDir/encode/requestId/C[0-4]-encode-[0-9]*.mp3"));
-        assertEquals(expectedAudio.getChannel(), audioFileInfo.getChannel());
-        assertEquals(expectedAudio.getStartTime(), audioFileInfo.getStartTime());
-        assertEquals(expectedAudio.getEndTime(), audioFileInfo.getEndTime());
+        assertTrue(audioFileInfo.getFileName().matches(".*/requestId/C[0-4]-encode-[0-9]*.mp3"));
+        assertEquals(1, audioFileInfo.getChannel());
+        assertEquals(Instant.parse(T_09_00_00_Z), audioFileInfo.getStartTime());
+        assertEquals(Instant.parse(T_10_30_00_Z), audioFileInfo.getEndTime());
+    }
+
+    private Path createTempDirectory() throws IOException {
+        return Files.createTempDirectory("darts_api_unit_test");
+    }
+
+    private Path createFile(Path path, String name) throws IOException {
+        return Files.createFile(path.resolve(name));
     }
 
 }


### PR DESCRIPTION
These changes fix two feature-breaking bugs with the preview audio flow:

- Update `AudioServiceImpl.preview()` to call `AudioOperationService.reEncode()` with a directory name as the `workspaceDir` rather than a full absolute path. This directory is also explicitly created, as this is the expectation of the `ffmpeg` executable.
- Update `FileOperationService.saveFileToTempWorkspace()` to create a subdirectory within the temp workspace directory.

For both items above, the directory name is randomised on each call to ensure each request has a clean/empty location in which to write any output files. This avoids potential naming conflicts with existing files in the directory.

In genreal, method signatures are updated to favour use of `Path` rather than `String` to avoid future ambiguity around whether a filename or path is expected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
