### PR TITLE
Proof of concept around problem  codes

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/exception/AuditApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/AuditApiError.java
@@ -3,8 +3,8 @@ package uk.gov.hmcts.darts.common.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import uk.gov.hmcts.darts.audio.model.AuditErrorCode;
-import uk.gov.hmcts.darts.audio.model.AuditTitleErrors;
+import uk.gov.hmcts.darts.audit.model.AuditErrorCode;
+import uk.gov.hmcts.darts.audit.model.AuditTitleErrors;
 
 import java.net.URI;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/AuditApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/AuditApiError.java
@@ -3,20 +3,21 @@ package uk.gov.hmcts.darts.common.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.darts.audio.model.AuditErrorCode;
+import uk.gov.hmcts.darts.audio.model.AuditTitleErrors;
 
 @Getter
 @RequiredArgsConstructor
 public enum AuditApiError implements DartsApiError {
 
-    FILTERS_WERE_EMPTY(
-        "100",
+    FILTERS_WERE_EMPTY(AuditErrorCode.AUDIT_FILTERS_WERE_EMPTY.getValue(),
         HttpStatus.BAD_REQUEST,
-        "All filters were empty."
+        AuditTitleErrors.FILTER_WAS_EMPTY.getValue()
     ),
     DATE_EMPTY(
-        "101",
+        AuditErrorCode.AUDIT_DATE_EMPTY.getValue(),
         HttpStatus.BAD_REQUEST,
-        "When using date filters, both must be provided."
+        AuditErrorCode.AUDIT_DATE_EMPTY.getValue()
     );
 
     private static final String ERROR_TYPE_PREFIX = "AUDIT";

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/AuditApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/AuditApiError.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.darts.audio.model.AuditErrorCode;
 import uk.gov.hmcts.darts.audio.model.AuditTitleErrors;
 
+import java.net.URI;
+
 @Getter
 @RequiredArgsConstructor
 public enum AuditApiError implements DartsApiError {
@@ -17,7 +19,7 @@ public enum AuditApiError implements DartsApiError {
     DATE_EMPTY(
         AuditErrorCode.AUDIT_DATE_EMPTY.getValue(),
         HttpStatus.BAD_REQUEST,
-        AuditErrorCode.AUDIT_DATE_EMPTY.getValue()
+        AuditTitleErrors.DATE_FILTER_BOTH_MUST_BE_PROVIDED.getValue()
     );
 
     private static final String ERROR_TYPE_PREFIX = "AUDIT";
@@ -31,4 +33,9 @@ public enum AuditApiError implements DartsApiError {
         return ERROR_TYPE_PREFIX;
     }
 
+    @Override
+    public URI getType() {
+        return URI.create(
+            getErrorTypePrefix());
+    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiError.java
@@ -16,7 +16,8 @@ public interface DartsApiError {
 
     default URI getType() {
         return URI.create(
-            getErrorTypePrefix());
+            String.format("%s_%s", getErrorTypePrefix(), getErrorTypeNumeric())
+        );
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiError.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import java.net.URI;
 
 public interface DartsApiError {
-    
+
     String getErrorTypePrefix();
 
     String getErrorTypeNumeric();
@@ -16,8 +16,7 @@ public interface DartsApiError {
 
     default URI getType() {
         return URI.create(
-            String.format("%s_%s", getErrorTypePrefix(), getErrorTypeNumeric())
-        );
+            getErrorTypePrefix());
     }
 
 }

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -189,3 +189,27 @@ components:
         media_end_timestamp:
           type: string
           format: date-time
+
+    AuditErrorCode:
+      type: string
+      enum:
+        - "AUDIT_100"
+        - "AUDIT_200"
+      x-enum-varnames: [AUDIT_FILTERS_WERE_EMPTY, AUDIT_DATE_EMPTY]
+
+    AuditTitleErrors:
+      type: string
+      enum:
+        - "All filters were empty."
+        - "When using date filters, both must be provided."
+      x-enum-varnames:
+        - FILTER_WAS_EMPTY
+        - DATE_FILTER_BOTH_MUST_BE_PROVIDED
+
+    AuditResponse:
+      type: object
+      properties:
+        errorType:
+          type: AuditErrorCode
+        title:
+          type: AuditTitle

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -189,27 +189,3 @@ components:
         media_end_timestamp:
           type: string
           format: date-time
-
-    AuditErrorCode:
-      type: string
-      enum:
-        - "AUDIT_100"
-        - "AUDIT_200"
-      x-enum-varnames: [AUDIT_FILTERS_WERE_EMPTY, AUDIT_DATE_EMPTY]
-
-    AuditTitleErrors:
-      type: string
-      enum:
-        - "All filters were empty."
-        - "When using date filters, both must be provided."
-      x-enum-varnames:
-        - FILTER_WAS_EMPTY
-        - DATE_FILTER_BOTH_MUST_BE_PROVIDED
-
-    AuditResponse:
-      type: object
-      properties:
-        errorType:
-          type: AuditErrorCode
-        title:
-          type: AuditTitle

--- a/src/main/resources/openapi/audit.yaml
+++ b/src/main/resources/openapi/audit.yaml
@@ -85,3 +85,19 @@ components:
           example: '2023-05-31T09:00:00Z'
         audit_activity_id:
           type: integer
+
+    AuditErrorCode:
+      type: string
+      enum:
+        - "AUDIT_100"
+        - "AUDIT_101"
+      x-enum-varnames: [AUDIT_FILTERS_WERE_EMPTY, AUDIT_DATE_EMPTY]
+
+    AuditTitleErrors:
+      type: string
+      enum:
+        - "All filters were empty."
+        - "When using date filters, both must be provided."
+      x-enum-varnames:
+        - FILTER_WAS_EMPTY
+        - DATE_FILTER_BOTH_MUST_BE_PROVIDED


### PR DESCRIPTION
### JIRA link (if applicable) ###

THIS IS A PROOF OF CONCEPT

### Change description ###

This idea will probably not go anywhere but thought i'd put the idea out there to get feedback. Its great that we have a common problem structure in out HTTP responses. The use of RFC 7807 is amazing.

To take this further we could bake enums error codes into the open api spec. This would allow clients to easily work out the nature of the responses without having to know the specific error integers. 

This PR ONLY converts the AuditApiError code.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
