### PR TITLE
DMP-962 - When the daillylist is created, the status of the Dailylist in the database is null which is not expected.

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListServiceTest.java
@@ -161,9 +161,7 @@ class DailyListServiceTest extends IntegrationBase {
         DailyListJsonObject dailyList = MAPPER.readValue(requestBody, DailyListJsonObject.class);
 
         DailyListPostRequest request = new DailyListPostRequest(CPP, null, null, null, null, null, dailyList);
-        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
-            service.saveDailyListToDatabase(request);
-        });
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> service.saveDailyListToDatabase(request));
 
         assertThat(exception.getMessage(), containsString("invalid courthouse 'test'"));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/data/DailyListTestData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/data/DailyListTestData.java
@@ -19,7 +19,7 @@ import static uk.gov.hmcts.darts.testutils.TestUtils.getContentsFromFile;
 public class DailyListTestData {
     public DailyListEntity createDailyList(LocalTime time, String source, CourthouseEntity courthouse, String fileLocation) throws IOException {
         DailyListEntity dailyListEntity = new DailyListEntity();
-        dailyListEntity.setStatus(String.valueOf(JobStatusType.NEW));
+        dailyListEntity.setStatus(JobStatusType.NEW);
         dailyListEntity.setStartDate(LocalDate.now());
         dailyListEntity.setEndDate(LocalDate.now());
         dailyListEntity.setCourthouse(courthouse);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DailyListStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DailyListStub.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.DailyListEntity;
+import uk.gov.hmcts.darts.dailylist.enums.JobStatusType;
 import uk.gov.hmcts.darts.dailylist.repository.DailyListRepository;
 
 import java.time.LocalDate;
@@ -17,6 +18,7 @@ public class DailyListStub {
         DailyListEntity dailyListEntity = new DailyListEntity();
         dailyListEntity.setStartDate(date);
         dailyListEntity.setCourthouse(courthouse);
+        dailyListEntity.setStatus(JobStatusType.NEW);
         dailyListRepository.saveAndFlush(dailyListEntity);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DailyListEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DailyListEntity.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.darts.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +15,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.dailylist.enums.JobStatusType;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -59,7 +62,8 @@ public class DailyListEntity extends CreatedModifiedBaseEntity {
     private String uniqueId;
 
     @Column(name = JOB_STATUS)
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private JobStatusType status;
 
     @Column(name = TIMESTAMP)
     private OffsetDateTime publishedTimestamp;

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/mapper/DailyListMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/mapper/DailyListMapper.java
@@ -40,7 +40,7 @@ public class DailyListMapper {
         dailyListEntity.setPublishedTimestamp(documentId.getTimeStamp());
         dailyListEntity.setStartDate(dailyList.getListHeader().getStartDate());
         dailyListEntity.setEndDate(dailyList.getListHeader().getEndDate());
-        dailyListEntity.setStatus(String.valueOf(JobStatusType.NEW));
+        dailyListEntity.setStatus(JobStatusType.NEW);
         try {
             dailyListEntity.setContent(objectMapper.writeValueAsString(dailyList));
         } catch (JsonProcessingException e) {

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/repository/DailyListRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/repository/DailyListRepository.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.dailylist.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.DailyListEntity;
+import uk.gov.hmcts.darts.dailylist.enums.JobStatusType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -14,7 +15,7 @@ public interface DailyListRepository extends JpaRepository<DailyListEntity, Inte
     Optional<DailyListEntity> findByUniqueId(String uniqueId);
 
     List<DailyListEntity> findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-            Integer id, String status, LocalDate date, String source);
+        Integer id, JobStatusType status, LocalDate date, String source);
 
     List<DailyListEntity> deleteByStartDateBefore(LocalDate startDate);
 }

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListProcessorImpl.java
@@ -77,7 +77,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
                 if (!dailyLists.isEmpty()) {
                     try {
                         processDailyList(dailyLists.get(0));
-                    } catch (JsonProcessingException e) {
+                    } catch (JsonProcessingException | IllegalArgumentException e) {
                         dailyLists.get(0).setStatus(String.valueOf(JobStatusType.FAILED));
                         log.error("Failed to process dailylist for courthouse: {} with dailylist id: {}",
                                   courthouse.getCourthouseName(), dailyLists.get(0).getId(), e
@@ -101,7 +101,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
     }
 
     @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
-    private void processDailyList(DailyListEntity dailyListEntity) throws JsonProcessingException {
+    private void processDailyList(DailyListEntity dailyListEntity) throws JsonProcessingException, IllegalArgumentException {
         DailyListJsonObject dailyList = objectMapper.readValue(dailyListEntity.getContent(), DailyListJsonObject.class);
         JobStatusType statusType = JobStatusType.PROCESSED;
 
@@ -136,7 +136,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
             } else {
                 statusType = JobStatusType.PARTIALLY_PROCESSED;
                 log.error("Unregistered courthouse " + courtHouseName + " daily list entry with id "
-                          + dailyListEntity.getId() + " has not been processed");
+                              + dailyListEntity.getId() + " has not been processed");
             }
         }
         dailyListEntity.setStatus(statusType.name());
@@ -150,7 +150,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
                 return getTimeFromTimeMarkingNote(timeMarkingNoteText);
             } catch (DateTimeException dateTimeException) {
                 log.warn("Ignore error and continue, Parsing failed for field TimeMarkingNote with value: "
-                         + timeMarkingNoteText, dateTimeException);
+                             + timeMarkingNoteText, dateTimeException);
             }
         }
 
@@ -159,7 +159,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
                 return getTimeFromSittingAt(sitting);
             } catch (DateTimeException dateTimeException) {
                 log.warn("Ignore error and continue, Parsing failed for field SittingAt with value: "
-                         + sitting.getSittingAt(), dateTimeException);
+                             + sitting.getSittingAt(), dateTimeException);
             }
         }
         return null;

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListProcessorImpl.java
@@ -70,7 +70,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
             for (SourceType source : SourceType.values()) {
                 List<DailyListEntity> dailyLists = dailyListRepository.findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
                     courthouse.getId(),
-                    String.valueOf(JobStatusType.NEW),
+                    JobStatusType.NEW,
                     date, String.valueOf(source)
                 );
                 // Daily lists are being ordered descending by date so first item will be the most recent version
@@ -78,7 +78,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
                     try {
                         processDailyList(dailyLists.get(0));
                     } catch (JsonProcessingException | IllegalArgumentException e) {
-                        dailyLists.get(0).setStatus(String.valueOf(JobStatusType.FAILED));
+                        dailyLists.get(0).setStatus(JobStatusType.FAILED);
                         log.error("Failed to process dailylist for courthouse: {} with dailylist id: {}",
                                   courthouse.getCourthouseName(), dailyLists.get(0).getId(), e
                         );
@@ -96,7 +96,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
 
     private void ignoreOldDailyList(List<DailyListEntity> dailyLists) {
         for (DailyListEntity dailyList : dailyLists) {
-            dailyList.setStatus(String.valueOf(JobStatusType.IGNORED));
+            dailyList.setStatus(JobStatusType.IGNORED);
         }
     }
 
@@ -139,7 +139,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
                           + dailyListEntity.getId() + " has not been processed");
             }
         }
-        dailyListEntity.setStatus(statusType.name());
+        dailyListEntity.setStatus(statusType);
     }
 
 
@@ -204,7 +204,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
             } else {
                 String urn = hearing.getDefendants().get(0).getUrn();
                 if (StringUtils.isBlank(urn)) {
-                    dailyListEntity.setStatus(String.valueOf(JobStatusType.PARTIALLY_PROCESSED));
+                    dailyListEntity.setStatus(JobStatusType.PARTIALLY_PROCESSED);
                     log.error("Hearing not added - HearingInfo does not contain a URN value");
                 } else {
                     return urn;

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListProcessorImpl.java
@@ -136,7 +136,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
             } else {
                 statusType = JobStatusType.PARTIALLY_PROCESSED;
                 log.error("Unregistered courthouse " + courtHouseName + " daily list entry with id "
-                              + dailyListEntity.getId() + " has not been processed");
+                          + dailyListEntity.getId() + " has not been processed");
             }
         }
         dailyListEntity.setStatus(statusType.name());
@@ -150,7 +150,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
                 return getTimeFromTimeMarkingNote(timeMarkingNoteText);
             } catch (DateTimeException dateTimeException) {
                 log.warn("Ignore error and continue, Parsing failed for field TimeMarkingNote with value: "
-                             + timeMarkingNoteText, dateTimeException);
+                         + timeMarkingNoteText, dateTimeException);
             }
         }
 
@@ -159,7 +159,7 @@ public class DailyListProcessorImpl implements DailyListProcessor {
                 return getTimeFromSittingAt(sitting);
             } catch (DateTimeException dateTimeException) {
                 log.warn("Ignore error and continue, Parsing failed for field SittingAt with value: "
-                             + sitting.getSittingAt(), dateTimeException);
+                         + sitting.getSittingAt(), dateTimeException);
             }
         }
         return null;

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListServiceImpl.java
@@ -91,7 +91,7 @@ public class DailyListServiceImpl implements DailyListService {
         dailyListEntity.setCourthouse(courthouse);
         dailyListEntity.setXmlContent(postRequest.getDailyListXml());
         dailyListEntity.setSource(postRequest.getSourceSystem());
-        dailyListEntity.setStatus(JobStatusType.NEW.name());
+        dailyListEntity.setStatus(JobStatusType.NEW);
         dailyListEntity.setStartDate(postRequest.getHearingDate());
         dailyListEntity.setUniqueId(postRequest.getUniqueId());
         dailyListEntity.setPublishedTimestamp(postRequest.getPublishedDateTime());

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListServiceImpl.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.courthouse.api.CourthouseApi;
 import uk.gov.hmcts.darts.courthouse.exception.CourthouseCodeNotMatchException;
 import uk.gov.hmcts.darts.courthouse.exception.CourthouseNameNotFoundException;
+import uk.gov.hmcts.darts.dailylist.enums.JobStatusType;
 import uk.gov.hmcts.darts.dailylist.exception.DailyListError;
 import uk.gov.hmcts.darts.dailylist.mapper.DailyListMapper;
 import uk.gov.hmcts.darts.dailylist.model.CourtHouse;
@@ -90,6 +91,7 @@ public class DailyListServiceImpl implements DailyListService {
         dailyListEntity.setCourthouse(courthouse);
         dailyListEntity.setXmlContent(postRequest.getDailyListXml());
         dailyListEntity.setSource(postRequest.getSourceSystem());
+        dailyListEntity.setStatus(JobStatusType.NEW.name());
         dailyListEntity.setStartDate(postRequest.getHearingDate());
         dailyListEntity.setUniqueId(postRequest.getUniqueId());
         dailyListEntity.setPublishedTimestamp(postRequest.getPublishedDateTime());

--- a/src/main/resources/db/migration/common/V1_213__dailylist_job_status_not_null.sql
+++ b/src/main/resources/db/migration/common/V1_213__dailylist_job_status_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE daily_list ALTER COLUMN job_status SET NOT NULL;

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -251,7 +251,7 @@ public class CommonTestDataUtil {
 
     public DailyListEntity createDailyList(LocalTime time, String source, String filelocation) throws IOException {
         DailyListEntity dailyListEntity = new DailyListEntity();
-        dailyListEntity.setStatus(String.valueOf(JobStatusType.NEW));
+        dailyListEntity.setStatus(JobStatusType.NEW);
         dailyListEntity.setCourthouse(createCourthouse("SWANSEA"));
         dailyListEntity.setContent(TestUtils.substituteHearingDateWithToday(getContentsFromFile(filelocation)));
         dailyListEntity.setPublishedTimestamp(OffsetDateTime.of(LocalDate.now(), time, ZoneOffset.UTC));
@@ -262,7 +262,7 @@ public class CommonTestDataUtil {
 
     public DailyListEntity createInvalidDailyList(LocalTime time) {
         DailyListEntity dailyListEntity = new DailyListEntity();
-        dailyListEntity.setStatus(String.valueOf(JobStatusType.NEW));
+        dailyListEntity.setStatus(JobStatusType.NEW);
         dailyListEntity.setCourthouse(createCourthouse("SWANSEA"));
         dailyListEntity.setContent("blah");
         dailyListEntity.setPublishedTimestamp(OffsetDateTime.of(LocalDate.now(), time, ZoneOffset.UTC));
@@ -272,7 +272,7 @@ public class CommonTestDataUtil {
 
     public DailyListEntity createInvalidXmlDailyList(LocalTime time) {
         DailyListEntity dailyListEntity = new DailyListEntity();
-        dailyListEntity.setStatus(String.valueOf(JobStatusType.NEW));
+        dailyListEntity.setStatus(JobStatusType.NEW);
         dailyListEntity.setCourthouse(createCourthouse("SWANSEA"));
         dailyListEntity.setXmlContent("blah");
         dailyListEntity.setPublishedTimestamp(OffsetDateTime.of(LocalDate.now(), time, ZoneOffset.UTC));

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -270,5 +270,15 @@ public class CommonTestDataUtil {
         return dailyListEntity;
     }
 
+    public DailyListEntity createInvalidXmlDailyList(LocalTime time) {
+        DailyListEntity dailyListEntity = new DailyListEntity();
+        dailyListEntity.setStatus(String.valueOf(JobStatusType.NEW));
+        dailyListEntity.setCourthouse(createCourthouse("SWANSEA"));
+        dailyListEntity.setXmlContent("blah");
+        dailyListEntity.setPublishedTimestamp(OffsetDateTime.of(LocalDate.now(), time, ZoneOffset.UTC));
+        dailyListEntity.setSource(String.valueOf(SourceType.XHB));
+        return dailyListEntity;
+    }
+
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorImplTest.java
@@ -121,22 +121,22 @@ class DailyListProcessorImplTest {
         ));
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(dailyListEntities);
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             2, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             2, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(Collections.emptyList());
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(Collections.emptyList());
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             2, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             2, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(Collections.emptyList());
 
         dailyListProcessor.processAllDailyLists(LocalDate.now());
@@ -159,7 +159,7 @@ class DailyListProcessorImplTest {
         assertEquals("1", savedHearing.getCourtroom().getName());
         assertEquals(swanseaCourtroom, savedHearing.getCourtroom());
 
-        assertEquals(String.valueOf(JobStatusType.PROCESSED), dailyListEntities.get(0).getStatus());
+        assertEquals(JobStatusType.PROCESSED, dailyListEntities.get(0).getStatus());
     }
 
 
@@ -206,12 +206,12 @@ class DailyListProcessorImplTest {
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(dailyListEntities);
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(Collections.emptyList());
 
         dailyListProcessor.processAllDailyLists(LocalDate.now());
@@ -232,12 +232,12 @@ class DailyListProcessorImplTest {
         assertEquals(LocalDate.now(), savedHearing.getHearingDate());
         assertEquals("1", savedHearing.getCourtroom().getName());
         assertEquals(swanseaCourtroom, savedHearing.getCourtroom());
-        assertEquals(String.valueOf(JobStatusType.IGNORED), oldDailyList.getStatus());
+        assertEquals(JobStatusType.IGNORED, oldDailyList.getStatus());
         assertEquals(1, savedHearing.getJudges().size());
         assertEquals(LocalTime.of(11, 0), savedHearing.getScheduledStartTime());
 
-        assertEquals(String.valueOf(JobStatusType.PROCESSED), dailyListEntities.get(0).getStatus());
-        assertEquals(String.valueOf(JobStatusType.IGNORED), dailyListEntities.get(1).getStatus());
+        assertEquals(JobStatusType.PROCESSED, dailyListEntities.get(0).getStatus());
+        assertEquals(JobStatusType.IGNORED, dailyListEntities.get(1).getStatus());
     }
 
     @Test
@@ -288,23 +288,23 @@ class DailyListProcessorImplTest {
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(dailyListEntities);
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             2, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             2, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(Collections.emptyList());
 
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(dailyListEntities);
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             2, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             2, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(Collections.emptyList());
 
 
@@ -325,12 +325,12 @@ class DailyListProcessorImplTest {
         assertEquals(LocalDate.now(), savedHearing.getHearingDate());
         assertEquals("1", savedHearing.getCourtroom().getName());
         assertEquals(swanseaCourtroom, savedHearing.getCourtroom());
-        assertEquals(String.valueOf(JobStatusType.IGNORED), oldDailyList.getStatus());
+        assertEquals(JobStatusType.IGNORED, oldDailyList.getStatus());
         assertEquals(1, savedHearing.getJudges().size());
         assertEquals(LocalTime.of(11, 0), savedHearing.getScheduledStartTime());
 
-        assertEquals(String.valueOf(JobStatusType.PROCESSED), dailyListEntities.get(0).getStatus());
-        assertEquals(String.valueOf(JobStatusType.IGNORED), dailyListEntities.get(1).getStatus());
+        assertEquals(JobStatusType.PROCESSED, dailyListEntities.get(0).getStatus());
+        assertEquals(JobStatusType.IGNORED, dailyListEntities.get(1).getStatus());
     }
 
 
@@ -373,8 +373,7 @@ class DailyListProcessorImplTest {
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
                              1,
-                             String.valueOf(
-                                 JobStatusType.NEW),
+                             JobStatusType.NEW,
                              LocalDate.now(),
                              String.valueOf(
                                  SourceType.XHB)
@@ -383,7 +382,7 @@ class DailyListProcessorImplTest {
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(Collections.emptyList());
 
         dailyListProcessor.processAllDailyLists(LocalDate.now());
@@ -406,7 +405,7 @@ class DailyListProcessorImplTest {
         assertEquals("1", savedHearing.getCourtroom().getName());
         assertEquals(swanseaCourtroom, savedHearing.getCourtroom());
 
-        assertEquals(String.valueOf(JobStatusType.PROCESSED), dailyListEntities.get(0).getStatus());
+        assertEquals(JobStatusType.PROCESSED, dailyListEntities.get(0).getStatus());
     }
 
 
@@ -435,19 +434,19 @@ class DailyListProcessorImplTest {
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(dailyListEntities);
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(dailyListEntities);
 
         dailyListProcessor.processAllDailyLists(LocalDate.now());
 
         Mockito.verify(hearingRepository, Mockito.never()).saveAndFlush(any());
 
-        assertEquals(String.valueOf(JobStatusType.PARTIALLY_PROCESSED), dailyListEntities.get(0).getStatus());
+        assertEquals(JobStatusType.PARTIALLY_PROCESSED, dailyListEntities.get(0).getStatus());
     }
 
 
@@ -467,18 +466,18 @@ class DailyListProcessorImplTest {
         DailyListEntity invalidDailyList = CommonTestDataUtil.createInvalidDailyList(LocalTime.now());
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(List.of(invalidDailyList));
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(Collections.emptyList());
 
         dailyListProcessor.processAllDailyLists(LocalDate.now());
 
         Mockito.verify(hearingRepository, Mockito.never()).saveAndFlush(hearingEntityArgumentCaptor.capture());
-        assertEquals(String.valueOf(JobStatusType.FAILED), invalidDailyList.getStatus());
+        assertEquals(JobStatusType.FAILED, invalidDailyList.getStatus());
     }
 
     @Test
@@ -497,18 +496,18 @@ class DailyListProcessorImplTest {
         DailyListEntity invalidDailyList = CommonTestDataUtil.createInvalidXmlDailyList(LocalTime.now());
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(List.of(invalidDailyList));
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(Collections.emptyList());
 
         dailyListProcessor.processAllDailyLists(LocalDate.now());
 
         Mockito.verify(hearingRepository, Mockito.never()).saveAndFlush(hearingEntityArgumentCaptor.capture());
-        assertEquals(String.valueOf(JobStatusType.FAILED), invalidDailyList.getStatus());
+        assertEquals(JobStatusType.FAILED, invalidDailyList.getStatus());
     }
 
     @Test
@@ -544,12 +543,12 @@ class DailyListProcessorImplTest {
         ));
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.XHB)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.XHB)))
             .thenReturn(dailyListEntities);
 
         Mockito.when(dailyListRepository
                          .findByCourthouse_IdAndStatusAndStartDateAndSourceOrderByPublishedTimestampDesc(
-                             1, String.valueOf(JobStatusType.NEW), LocalDate.now(), String.valueOf(SourceType.CPP)))
+                             1, JobStatusType.NEW, LocalDate.now(), String.valueOf(SourceType.CPP)))
             .thenReturn(Collections.emptyList());
 
         dailyListProcessor.processAllDailyListForCourthouse(swansea);
@@ -572,7 +571,7 @@ class DailyListProcessorImplTest {
         assertEquals("1", savedHearing.getCourtroom().getName());
         assertEquals(swanseaCourtroom, savedHearing.getCourtroom());
 
-        assertEquals(String.valueOf(JobStatusType.PROCESSED), dailyListEntities.get(0).getStatus());
+        assertEquals(JobStatusType.PROCESSED, dailyListEntities.get(0).getStatus());
     }
 
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-962


When an xml is only sent to the daily list post endpoint then we should set the status to NEW for that xml. When the processor handles the daily list it will fail and set the status to FAIL.