### PR TITLE
DMP-1006 Fix bug where we were returning too many audio previews for …

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceGivenBuilder.java
@@ -37,6 +37,8 @@ public class AudioTransformationServiceGivenBuilder {
 
     private HearingEntity hearingEntityWithMedia1;
     private HearingEntity hearingEntityWithMedia2;
+    private MediaEntity mediaEntity1Hearing2;
+    private MediaEntity mediaEntity2Hearing2;
     private HearingEntity hearingEntityWithoutMedia;
     private MediaEntity mediaEntity1;
     private MediaEntity mediaEntity2;
@@ -76,7 +78,11 @@ public class AudioTransformationServiceGivenBuilder {
 
         mediaEntity1 = dartsDatabase.addMediaToHearing(hearingEntityWithMedia1, createMediaWith(
             courtroomAtNewcastle, MEDIA_START_TIME, MEDIA_END_TIME, channel));
+
         mediaEntity2 = dartsDatabase.addMediaToHearing(hearingEntityWithMedia1, createMediaFor(courtroomAtNewcastle));
+
+        mediaEntity1Hearing2 = dartsDatabase.addMediaToHearing(hearingEntityWithMedia2, createMediaWith(
+            courtroomAtNewcastle, MEDIA_START_TIME, MEDIA_END_TIME, channel));
 
         mediaEntity3 = createMediaFor(courtroomAtNewcastle);
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
@@ -11,11 +11,11 @@ import java.util.List;
 public interface MediaRepository extends JpaRepository<MediaEntity, Integer> {
 
     @Query("""
-           SELECT me FROM MediaEntity me, HearingEntity he
-           JOIN he.mediaList
+           SELECT me
+           FROM HearingEntity he
+           JOIN he.mediaList me
            WHERE he.id = :hearingId
         """)
     List<MediaEntity> findAllByHearingId(Integer hearingId);
 
 }
-


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-1006

### Change description ###

A small change to the hql in order to avoid returning many incorrect media records. We only want the hearing id media records

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
