### PR TITLE
DMP-1161: Return caseId and caseNumber in addAudio response

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioRequestIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioRequestIntTest.java
@@ -87,7 +87,8 @@ class AudioControllerAddAudioRequestIntTest extends IntegrationBase {
         String expectedJson = """
             {
                 "request_id": 1,
-                "case_id": "testCaseNumber",
+                "case_id": 1,
+                "case_number": "testCaseNumber",
                 "courthouse_name": "testCourthouse",
                 "defendants": ["defendant_testCaseNumber_1","defendant_testCaseNumber_2"],
                 "hearing_date": "2023-01-01",

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioResponseMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioResponseMapperImpl.java
@@ -14,12 +14,16 @@ public class AudioResponseMapperImpl implements AudioResponseMapper {
 
     @Override
     public AddAudioResponse mapToAddAudioResponse(MediaRequestEntity audioRequest) {
+        var hearing = audioRequest.getHearing();
+        var courtCase = hearing.getCourtCase();
+
         AddAudioResponse addAudioResponse = new AddAudioResponse();
         addAudioResponse.setRequestId(audioRequest.getId());
-        addAudioResponse.setCaseId(audioRequest.getHearing().getCourtCase().getCaseNumber());
-        addAudioResponse.setCourthouseName(audioRequest.getHearing().getCourtroom().getCourthouse().getCourthouseName());
-        addAudioResponse.setDefendants(audioRequest.getHearing().getCourtCase().getDefendantStringList());
-        addAudioResponse.setHearingDate(audioRequest.getHearing().getHearingDate());
+        addAudioResponse.setCaseId(courtCase.getId());
+        addAudioResponse.setCaseNumber(courtCase.getCaseNumber());
+        addAudioResponse.setCourthouseName(hearing.getCourtroom().getCourthouse().getCourthouseName());
+        addAudioResponse.setDefendants(courtCase.getDefendantStringList());
+        addAudioResponse.setHearingDate(hearing.getHearingDate());
         addAudioResponse.setStartTime(audioRequest.getStartTime());
         addAudioResponse.setEndTime(audioRequest.getEndTime());
         return addAudioResponse;

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -314,8 +314,11 @@ components:
           type: integer
           example: 1234
         case_id:
+          type: integer
+          example: 1
+        case_number:
           type: string
-          example: T4565443
+          example: 'T4565443'
         courthouse_name:
           type: string
           example: "Swansea"

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/AudioResponseMapperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/AudioResponseMapperImplTest.java
@@ -28,13 +28,12 @@ class AudioResponseMapperImplTest {
 
     private static final OffsetDateTime START_TIME = OffsetDateTime.now();
     private static final OffsetDateTime END_TIME = START_TIME.plusHours(1);
-
     private static final OffsetDateTime TIME_12_00 = OffsetDateTime.parse("2023-01-01T12:00Z");
     private static final OffsetDateTime TIME_12_10 = OffsetDateTime.parse("2023-01-01T12:10Z");
-    public static final String COURTHOUSE = "SWANSEA";
-    public static final String COURT_CASE = "T20190024";
-    public static final LocalDate HEARING_DATE = LocalDate.of(2023, 1, 1);
-
+    private static final String COURTHOUSE = "SWANSEA";
+    private static final String CASE_NUMBER = "T20190024";
+    private static final LocalDate HEARING_DATE = LocalDate.of(2023, 1, 1);
+    private static final int CASE_ID = 123;
 
     private AudioResponseMapper audioResponseMapper;
 
@@ -67,7 +66,8 @@ class AudioResponseMapperImplTest {
         AddAudioResponse addAudioResponse = audioResponseMapper.mapToAddAudioResponse(audioRequest);
 
         assertEquals(2023, addAudioResponse.getRequestId());
-        assertEquals(COURT_CASE, addAudioResponse.getCaseId());
+        assertEquals(CASE_ID, addAudioResponse.getCaseId());
+        assertEquals(CASE_NUMBER, addAudioResponse.getCaseNumber());
         assertEquals(COURTHOUSE, addAudioResponse.getCourthouseName());
         assertEquals(HEARING_DATE, addAudioResponse.getHearingDate());
         assertEquals(TIME_12_00, addAudioResponse.getStartTime());
@@ -87,8 +87,8 @@ class AudioResponseMapperImplTest {
         CourthouseEntity mockCourthouseEntity = mock(CourthouseEntity.class);
         when(mockCourtroomEntity.getCourthouse()).thenReturn(mockCourthouseEntity);
         when(mockCourthouseEntity.getCourthouseName()).thenReturn(COURTHOUSE);
-        when(mockCourtCaseEntity.getCaseNumber()).thenReturn(COURT_CASE);
-        when(mockCourtCaseEntity.getId()).thenReturn(123);
+        when(mockCourtCaseEntity.getCaseNumber()).thenReturn(CASE_NUMBER);
+        when(mockCourtCaseEntity.getId()).thenReturn(CASE_ID);
         UserAccountEntity mockUserAccountEntity = mock(UserAccountEntity.class);
 
         MediaRequestEntity mediaRequestEntity = new MediaRequestEntity();


### PR DESCRIPTION
# [DMP-1161](https://tools.hmcts.net/jira/browse/DMP-1161)

- Add new field `case_number`, mapping from the case number of the associated case
- Change value mapped to `case_id`, was the case number, now the case id of the associated case

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
