### PR TITLE
dmp-1090 | feat | Keda work

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
@@ -28,7 +28,7 @@ import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
 @Setter
 @Scope(scopeName = SCOPE_PROTOTYPE)
 @SuppressWarnings("MethodName")
-public class AudioTransformationServiceProcessAudioRequestGivenBuilder {
+public class AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder {
 
     private static final OffsetDateTime TIME_12_00 = OffsetDateTime.parse("2023-01-01T12:00Z");
     private static final OffsetDateTime TIME_12_10 = OffsetDateTime.parse("2023-01-01T12:10Z");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
@@ -10,8 +10,8 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationPerClassBase;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -140,9 +140,10 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
 
         mediaRequestService.saveAudioRequest(requestDetails);
 
-        List<MediaRequestEntity> mediaRequests = mediaRequestService.getMediaRequestsByStatus(OPEN);
+        Optional<MediaRequestEntity> mediaRequest = mediaRequestService.getOldestMediaRequestByStatus(OPEN);
 
-        assertEquals(OPEN, mediaRequests.get(0).getStatus());
+        assertTrue(mediaRequest.isPresent());
+        assertEquals(OPEN, mediaRequest.get().getStatus());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import uk.gov.hmcts.darts.audio.service.MediaRequestService;
+import uk.gov.hmcts.darts.audio.api.AudioInternalApi;
 import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.service.CourtLogsService;
@@ -36,7 +36,7 @@ class EventsControllerTest {
     private CourtLogsService courtLogsService;
 
     @MockBean
-    private MediaRequestService mediaRequestService;
+    private AudioInternalApi audioInternalApi;
 
     @MockBean
     private DartsEventMapper dartsEventMapper;

--- a/src/main/java/uk/gov/hmcts/darts/Application.java
+++ b/src/main/java/uk/gov/hmcts/darts/Application.java
@@ -1,16 +1,15 @@
 package uk.gov.hmcts.darts;
 
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-import uk.gov.hmcts.darts.audio.enums.AudioRequestStatus;
-import uk.gov.hmcts.darts.audio.service.MediaRequestService;
+import uk.gov.hmcts.darts.audio.api.AudioInternalApi;
 
 import java.util.TimeZone;
 
@@ -19,11 +18,10 @@ import static java.time.ZoneOffset.UTC;
 @SpringBootApplication(exclude = {SecurityAutoConfiguration.class, UserDetailsServiceAutoConfiguration.class})
 @EnableTransactionManagement
 @Slf4j
-@SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
+@RequiredArgsConstructor
 public class Application implements CommandLineRunner {
 
-    @Autowired
-    private MediaRequestService mediaRequestService;
+    private final AudioInternalApi audioInternalApi;
 
     @PostConstruct
     public void started() {
@@ -42,12 +40,10 @@ public class Application implements CommandLineRunner {
     }
 
     @Override
-    public void run(String... args) throws Exception {
+    public void run(String... args) {
         if (System.getenv("ATS_MODE") != null) {
             log.info("ATS_MODE activated");
-            // Temporary workaround to prevent many media requests in OPEN state
-            var openAudioRequests = mediaRequestService.getMediaRequestsByStatus(AudioRequestStatus.OPEN);
-            mediaRequestService.updateAudioRequestStatus(openAudioRequests.get(0).getId(), AudioRequestStatus.PROCESSING);
+            audioInternalApi.handleKedaInvocationForMediaRequests();
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/api/AudioInternalApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/api/AudioInternalApi.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.darts.audio.api;
+
+public interface AudioInternalApi {
+
+    void handleKedaInvocationForMediaRequests();
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/api/impl/AudioInternalApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/api/impl/AudioInternalApiImpl.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.darts.audio.api.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.audio.api.AudioInternalApi;
+import uk.gov.hmcts.darts.audio.service.AudioTransformationService;
+
+@Service
+@RequiredArgsConstructor
+public class AudioInternalApiImpl implements AudioInternalApi {
+
+    private final AudioTransformationService audioTransformationService;
+
+    @Override
+    public void handleKedaInvocationForMediaRequests() {
+        audioTransformationService.handleKedaInvocationForMediaRequests();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/repository/MediaRequestRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/repository/MediaRequestRepository.java
@@ -5,11 +5,11 @@ import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.enums.AudioRequestStatus;
 
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MediaRequestRepository extends JpaRepository<MediaRequestEntity, Integer> {
 
-    List<MediaRequestEntity> findByStatusOrderByCreatedDateTimeAsc(AudioRequestStatus status);
+    Optional<MediaRequestEntity> findTopByStatusOrderByCreatedDateTimeAsc(AudioRequestStatus status);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/AudioTransformationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/AudioTransformationService.java
@@ -10,11 +10,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 public interface AudioTransformationService {
-
-    UUID processAudioRequest(Integer requestId) throws ExecutionException, InterruptedException;
 
     BinaryData getUnstructuredAudioBlob(UUID location);
 
@@ -33,4 +30,7 @@ public interface AudioTransformationService {
     UUID saveProcessedData(MediaRequestEntity mediaRequest, BinaryData binaryData);
 
     Path saveMediaToWorkspace(MediaEntity mediaEntity) throws IOException;
+
+    void handleKedaInvocationForMediaRequests();
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
@@ -8,10 +8,9 @@ import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 
 public interface MediaRequestService {
-
-    List<MediaRequestEntity> getMediaRequestsByStatus(AudioRequestStatus status);
 
     MediaRequestEntity getMediaRequestById(Integer id);
 
@@ -24,6 +23,8 @@ public interface MediaRequestService {
     void deleteAudioRequest(Integer mediaRequestId);
 
     List<AudioRequestSummaryResult> viewAudioRequests(Integer userId, Boolean expired);
+
+    Optional<MediaRequestEntity> getOldestMediaRequestByStatus(AudioRequestStatus status);
 
     void updateAudioRequestLastAccessedTimestamp(Integer mediaRequestId);
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -44,6 +44,7 @@ import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
 
 import static uk.gov.hmcts.darts.audio.enums.AudioRequestStatus.EXPIRED;
@@ -66,8 +67,8 @@ public class MediaRequestServiceImpl implements MediaRequestService {
 
     @Override
     @Transactional(propagation = Propagation.SUPPORTS)
-    public List<MediaRequestEntity> getMediaRequestsByStatus(AudioRequestStatus status) {
-        return mediaRequestRepository.findByStatusOrderByCreatedDateTimeAsc(status);
+    public Optional<MediaRequestEntity> getOldestMediaRequestByStatus(AudioRequestStatus status) {
+        return mediaRequestRepository.findTopByStatusOrderByCreatedDateTimeAsc(status);
     }
 
     @Override
@@ -117,10 +118,11 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     @Override
     public void deleteAudioRequest(Integer mediaRequestId) {
 
-        var transientObject = transientObjectDirectoryRepository.getTransientObjectDirectoryEntityByMediaRequest_Id(mediaRequestId);
+        var transientObject = transientObjectDirectoryRepository.getTransientObjectDirectoryEntityByMediaRequest_Id(
+            mediaRequestId);
 
         if (transientObject.isPresent()) {
-            TransientObjectDirectoryEntity mediaTransientObject  = transientObject.get();
+            TransientObjectDirectoryEntity mediaTransientObject = transientObject.get();
             UUID blobId = mediaTransientObject.getExternalLocation();
 
             if (blobId != null) {


### PR DESCRIPTION
# [DMP-1090](https://tools.hmcts.net/jira/browse/DMP-1090)

Allow `processAudioRequest()` to be invoked by KEDA for the oldest `OPEN` media_request upon application startup when the `ATS_MODE` env var is assigned.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
