### PR TITLE
DMP-1177: Return last_accessed_ts in audio requests response

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerGetYourAudioIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerGetYourAudioIntTest.java
@@ -60,7 +60,8 @@ class AudioRequestsControllerGetYourAudioIntTest extends IntegrationBase {
                     "hearing_date": "2023-06-10",
                     "media_request_start_ts": "2023-06-26T13:00:00Z",
                     "media_request_end_ts": "2023-06-26T13:45:00Z",
-                    "media_request_status": "OPEN"
+                    "media_request_status": "OPEN",
+                    "last_accessed_ts": "2023-06-30T13:00:00Z"
                 }
             ]
             """;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/data/AudioTestData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/data/AudioTestData.java
@@ -16,7 +16,7 @@ import static uk.gov.hmcts.darts.audio.model.AudioRequestType.DOWNLOAD;
 public class AudioTestData {
 
     public MediaRequestEntity createCurrentMediaRequest(HearingEntity hearingEntity, UserAccountEntity requestor,
-                                                        OffsetDateTime startTime, OffsetDateTime endTime) {
+                                                        OffsetDateTime startTime, OffsetDateTime endTime, OffsetDateTime lastAccessedTime) {
         MediaRequestEntity mediaRequestEntity = new MediaRequestEntity();
         mediaRequestEntity.setHearing(hearingEntity);
         mediaRequestEntity.setRequestor(requestor);
@@ -27,7 +27,7 @@ public class AudioTestData {
         mediaRequestEntity.setEndTime(endTime);
         mediaRequestEntity.setOutputFormat(null);
         mediaRequestEntity.setOutputFilename(null);
-        mediaRequestEntity.setLastAccessedDateTime(null);
+        mediaRequestEntity.setLastAccessedDateTime(lastAccessedTime);
         mediaRequestEntity.setExpiryTime(null);
         mediaRequestEntity.setCreatedBy(requestor);
         mediaRequestEntity.setLastModifiedBy(requestor);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -304,7 +304,8 @@ public class DartsDatabaseStub {
                 hearing,
                 requestor,
                 OffsetDateTime.parse("2023-06-26T13:00:00Z"),
-                OffsetDateTime.parse("2023-06-26T13:45:00Z")
+                OffsetDateTime.parse("2023-06-26T13:45:00Z"),
+                OffsetDateTime.parse("2023-06-30T13:00:00Z")
             ));
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestSummaryMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestSummaryMapperImpl.java
@@ -30,6 +30,7 @@ public class AudioRequestSummaryMapperImpl implements AudioRequestSummaryMapper 
         audioRequestSummary.setMediaRequestEndTs(result.mediaRequestEndTs());
         audioRequestSummary.setMediaRequestExpiryTs(result.mediaRequestExpiryTs());
         audioRequestSummary.setMediaRequestStatus(MediaRequestStatus.fromValue(result.mediaRequestStatus().toString()));
+        audioRequestSummary.setLastAccessedTs(result.lastAccessedTs());
 
         return audioRequestSummary;
     }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioRequestSummaryResult.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioRequestSummaryResult.java
@@ -13,7 +13,8 @@ public record AudioRequestSummaryResult(
     OffsetDateTime mediaRequestStartTs,
     OffsetDateTime mediaRequestEndTs,
     OffsetDateTime mediaRequestExpiryTs,
-    AudioRequestStatus mediaRequestStatus
+    AudioRequestStatus mediaRequestStatus,
+    OffsetDateTime lastAccessedTs
 ) {
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -165,7 +165,8 @@ public class MediaRequestServiceImpl implements MediaRequestService {
             mediaRequest.get(MediaRequestEntity_.startTime),
             mediaRequest.get(MediaRequestEntity_.endTime),
             mediaRequest.get(MediaRequestEntity_.expiryTime),
-            mediaRequest.get(MediaRequestEntity_.status)
+            mediaRequest.get(MediaRequestEntity_.status),
+            mediaRequest.get(MediaRequestEntity_.lastAccessedDateTime)
         ));
 
         ParameterExpression<UserAccountEntity> paramRequestor = criteriaBuilder.parameter(UserAccountEntity.class);

--- a/src/main/resources/openapi/audiorequests.yaml
+++ b/src/main/resources/openapi/audiorequests.yaml
@@ -180,6 +180,10 @@ components:
           example: "2023-08-23T09:00:00Z"
         media_request_status:
           $ref: '#/components/schemas/MediaRequestStatus'
+        last_accessed_ts:
+          type: string
+          format: date-time
+          example: "2023-08-23T09:00:00Z"
 
     MediaRequestStatus:
       type: string


### PR DESCRIPTION
# [DMP-1177](https://tools.hmcts.net/jira/browse/DMP-1177)

- Add field `last_accessed_ts` to the `GET /audio-requests` response. The data is obtained from the `last_accessed_ts` field of the `media_request` record.

```
[ ] Yes
[x] No
```
