### PR TITLE
DMP-1231 Patch Media Request - Should return 204 instead 200 with emp…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerUpdateLastAccessedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerUpdateLastAccessedTest.java
@@ -45,8 +45,7 @@ class AudioRequestsControllerUpdateLastAccessedTest extends IntegrationBase {
 
     private UserAccountEntity systemUser;
     private MediaRequestEntity mediaRequestEntity;
-
-
+    
 
     @BeforeEach
     void beforeEach() {
@@ -65,7 +64,7 @@ class AudioRequestsControllerUpdateLastAccessedTest extends IntegrationBase {
             String.format("/audio-requests/%d", mediaRequestEntity.getId())));
 
         mockMvc.perform(requestBuilder)
-            .andExpect(status().isOk())
+            .andExpect(status().isNoContent())
             .andReturn();
 
     }

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -67,7 +67,7 @@ public class AudioRequestsController implements AudioRequestsApi {
         securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, LANGUAGE_SHOP_USER, RCJ_APPEALS})
     public ResponseEntity<Void> updateAudioRequestLastAccessedTimestamp(Integer mediaRequestId) {
         mediaRequestService.updateAudioRequestLastAccessedTimestamp(mediaRequestId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @Override

--- a/src/main/resources/openapi/audiorequests.yaml
+++ b/src/main/resources/openapi/audiorequests.yaml
@@ -132,8 +132,8 @@ paths:
             type: integer
           required: true
       responses:
-        '200':
-          description: OK
+        '204':
+          description: No Content
         '400':
           description: Bad Request Error
           content:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-1231

### Change description ###

Changed endpoint to return 204 instead of 200 for empty response

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
