### PR TITLE
DMP-1090: Remove redundant eager load

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -78,7 +78,7 @@ public class HearingEntity extends CreatedModifiedBaseEntity {
     @Transient
     private boolean isNew; //helper flag to indicate that the entity was just created, and so to notify DAR PC
 
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany
     @JoinTable(name = "hearing_event_ae",
         joinColumns = {@JoinColumn(name = HEA_ID)},
         inverseJoinColumns = {@JoinColumn(name = "eve_id")})


### PR DESCRIPTION
The eager load between hearing and eventList is unnecessary, reverting this change from prior https://github.com/hmcts/darts-api/pull/536.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
