### PR TITLE
increase advanced search performance

### DIFF
--- a/ModernisedDarts.postman_collection.json
+++ b/ModernisedDarts.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "f3b86088-28e9-4c59-ae47-cfeeb9a708c3",
+		"_postman_id": "87d2fa73-b40d-4535-baa4-ce37c358ca07",
 		"name": "ModernisedDarts",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "30362290"
 	},
 	"item": [
 		{
@@ -25,6 +26,33 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\n  \"message_id\": \"100\",\n  \"type\": \"1000\",\n  \"sub_type\": \"1002\",\n  \"event_id\": \"12345\",\n  \"courthouse\": \"swansea\",\n  \"courtroom\": \"1\",\n  \"case_numbers\": [\n    \"Swansea_case_1\"\n  ],\n  \"event_text\": \"some text for the event\",\n  \"date_time\": \"2023-08-08T14:01:06.085Z\"\n}"
+								},
+								"url": {
+									"raw": "{{serverUrl}}/events",
+									"host": [
+										"{{serverUrl}}"
+									],
+									"path": [
+										"events"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "TranscriptionRequestHandler",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "default"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"message_id\": \"100\",\n  \"type\": \"3010\",\n  \"event_id\": \"12345\",\n  \"courthouse\": \"swansea\",\n  \"courtroom\": \"1\",\n  \"case_numbers\": [\n    \"Swansea_case_1\"\n  ],\n  \"event_text\": \"some text for the event\",\n  \"date_time\": \"2023-08-08T14:01:06.085Z\"\n}"
 								},
 								"url": {
 									"raw": "{{serverUrl}}/events",
@@ -461,11 +489,11 @@
 										},
 										{
 											"key": "court_room_number",
-											"value": null
+											"value": ""
 										},
 										{
 											"key": "hearing_date",
-											"value": null
+											"value": ""
 										}
 									]
 								}

--- a/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
@@ -7,6 +7,7 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import org.apache.commons.collections4.CollectionUtils;
@@ -39,15 +40,18 @@ public class AdvancedSearchRequestHelper {
     @PersistenceContext
     private EntityManager entityManager;
 
-    public List<CourtCaseEntity> getMatchingCourtCases(GetCasesSearchRequest request) {
+    public List<Integer> getMatchingCourtCases(GetCasesSearchRequest request) {
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
-        CriteriaQuery<CourtCaseEntity> criteriaQuery = criteriaBuilder.createQuery(CourtCaseEntity.class);
+        CriteriaQuery<Integer> criteriaQuery = criteriaBuilder.createQuery(Integer.class);
         Root<CourtCaseEntity> caseRoot = criteriaQuery.from(CourtCaseEntity.class);
         List<Predicate> predicates = createPredicates(request, criteriaBuilder, caseRoot);
 
         Predicate finalAndPredicate = criteriaBuilder.and(predicates.toArray(new Predicate[0]));
         criteriaQuery.where(finalAndPredicate);
-        TypedQuery<CourtCaseEntity> query = entityManager.createQuery(criteriaQuery);
+        Path<Integer> namePath = caseRoot.get(CourtCaseEntity_.ID);
+        criteriaQuery.select(namePath);
+
+        TypedQuery<Integer> query = entityManager.createQuery(criteriaQuery);
         return query.getResultList();
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -23,7 +23,6 @@ import uk.gov.hmcts.darts.cases.model.SingleCase;
 import uk.gov.hmcts.darts.cases.model.Transcript;
 import uk.gov.hmcts.darts.cases.repository.CaseRepository;
 import uk.gov.hmcts.darts.cases.service.CaseService;
-import uk.gov.hmcts.darts.cases.util.CourtCaseUtil;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
@@ -123,14 +122,13 @@ public class CaseServiceImpl implements CaseService {
 
     @Override
     public List<AdvancedSearchResult> advancedSearch(GetCasesSearchRequest request) {
-        List<CourtCaseEntity> courtCaseEntities = advancedSearchRequestHelper.getMatchingCourtCases(request);
-        if (courtCaseEntities.size() > MAX_RESULTS) {
+        List<Integer> caseIds = advancedSearchRequestHelper.getMatchingCourtCases(request);
+        if (caseIds.size() > MAX_RESULTS) {
             throw new DartsApiException(CaseApiError.TOO_MANY_RESULTS);
         }
-        if (courtCaseEntities.isEmpty()) {
+        if (caseIds.isEmpty()) {
             return new ArrayList<>();
         }
-        List<Integer> caseIds = CourtCaseUtil.getCaseIdList(courtCaseEntities);
         List<HearingEntity> hearings = hearingRepository.findByCaseIds(caseIds);
         return AdvancedSearchResponseMapper.mapResponse(hearings);
     }


### PR DESCRIPTION
increase search performance by modifying the main search query to only bring back a list of caseIds, instead of a list of CourtCaseEntities, as when we were bringing back the entities, hibernate was going and fetching judges, prosecutors etc, which was not required for the functionality.