### PR TITLE
Pin postgres version to match test environments

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -42,7 +42,7 @@ services:
 
   darts-db:
     container_name: darts-db
-    image: postgres:16.0-alpine
+    image: postgres:14.8-alpine # Maintain this such that we track the version deployed in higher environments
     restart: always
     environment:
       - POSTGRES_USER=darts


### PR DESCRIPTION
To ensure local development is representative of test environments, the postgres version used for local development should match the same version as deployed in those environments.

As such, pinning to 14.8.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
