### PR TITLE
DMP 1193: Redis cache config & bank holiday caching 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -321,6 +321,8 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
+  implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis'
 
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-authorization-server', version: '1.1.3'
 
@@ -376,6 +378,7 @@ dependencies {
   }
   testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-contract-stub-runner', version: '4.0.4'
   testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+
   compileJava.dependsOn = openApiGenerateTaskList
 }
 

--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.40
+version: 0.0.41
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -21,6 +21,8 @@ java:
           alias: AAD_TENANT_ID
         - name: DartsSystemUserEmail
           alias: SYSTEM_USER_EMAIL
+        - name: redis-connection-string
+          alias: REDIS_CONNECTION_STRING
   environment:
     ENABLE_FLYWAY: true
     RUN_DB_MIGRATION_ON_STARTUP: true

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -52,6 +52,8 @@ java:
           alias: DARPC_PASSWORD
         - name: DartsSystemUserEmail
           alias: SYSTEM_USER_EMAIL
+        - name: redis-connection-string
+          alias: REDIS_CONNECTION_STRING
   environment:
     NOTIFICATION_SCHEDULER_CRON: "3 */2 * * * MON-FRI"
     POSTGRES_SSL_MODE: require

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -59,7 +59,7 @@ java:
     POSTGRES_SSL_MODE: require
     RUN_DB_MIGRATION_ON_STARTUP: false
     DARTS_GATEWAY_URL: https://darts-gateway.{{ .Values.global.environment }}.platform.hmcts.net
-    TESTING_SUPPORT_ENDPOINT_ENABLED: true
+    TESTING_SUPPORT_ENDPOINTS_ENABLED: true
 
 function:
   scaleType: Job

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -5,6 +5,7 @@ services:
     container_name: darts-api
     depends_on:
       - darts-db
+      - darts-redis
     environment:
       - DARTS_API_DB_HOST=darts-db
       - DARTS_API_DB_NAME=darts
@@ -32,6 +33,8 @@ services:
       - AZURE_AD_FUNCTIONAL_TEST_PASSWORD
       - TESTING_SUPPORT_ENDPOINTS_ENABLED=true
       - SYSTEM_USER_EMAIL
+      - REDIS_CONNECTION_STRING=redis://darts-redis:6379
+      - REDIS_SSL_ENABLED=false
     build:
       context: .
       dockerfile: Dockerfile
@@ -57,8 +60,21 @@ services:
     networks:
       - darts-network
 
+  darts-redis:
+    container_name: darts-redis
+    image: redis:6.2.14-alpine
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - darts-cache:/var/lib/redis/data
+    networks:
+      - darts-network
+
 volumes:
   darts-db:
+    driver: local
+  darts-cache:
     driver: local
 
 networks:

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidayServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidayServiceTest.java
@@ -57,4 +57,13 @@ class BankHolidayServiceTest extends IntegrationBase {
 
         assertThat(bankHolidays1.size()).isEqualTo(1);
     }
+
+    @Test
+    void returnEmptyListForNotFoundYear() {
+        bankHolidayApiStub.returns(VALID_BANK_HOLIDAY_JSON);
+
+        var bankHolidays1 = bankHolidaysService.getBankHolidaysFor(1980);
+
+        assertThat(bankHolidays1.size()).isEqualTo(0);
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidayServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidayServiceTest.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.darts.common.service.bankholidays;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.testutils.stubs.wiremock.BankHolidayApiStub;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("in-memory-caching")
+class BankHolidayServiceTest extends IntegrationBase {
+
+    public static final String VALID_BANK_HOLIDAY_JSON = """
+        {
+          "england-and-wales": {
+            "division": "england-and-wales",
+            "events": [
+              {
+                "title": "New Year’s Day",
+                "date": "2020-01-01",
+                "notes": "",
+                "bunting": true
+              },
+              {
+                "title": "Good Friday",
+                "date": "2018-03-30",
+                "notes": "",
+                "bunting": false
+              }
+            ]
+          },
+          "some-other-division": {
+            "division": "some-other-division",
+            "events": [
+              {
+                "title": "New Year’s Day",
+                "date": "2018-01-01",
+                "notes": "",
+                "bunting": true
+              }
+            ]
+          }
+        }
+        """;
+
+    @Autowired
+    private BankHolidaysService bankHolidaysService;
+
+    private final BankHolidayApiStub bankHolidayApiStub = new BankHolidayApiStub();
+
+    @Test
+    void returnsBankHolidays() {
+        bankHolidayApiStub.returns(VALID_BANK_HOLIDAY_JSON);
+
+        var bankHolidays1 = bankHolidaysService.getBankHolidaysFor(2020);
+
+        assertThat(bankHolidays1.size()).isEqualTo(1);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
@@ -6,7 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
-import uk.gov.hmcts.darts.testutils.stubs.DartsGatewayStub;
+import uk.gov.hmcts.darts.testutils.stubs.wiremock.DartsGatewayStub;
 
 @AutoConfigureWireMock
 @SpringBootTest

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationPerClassBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationPerClassBase.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
-import uk.gov.hmcts.darts.testutils.stubs.DartsGatewayStub;
+import uk.gov.hmcts.darts.testutils.stubs.wiremock.DartsGatewayStub;
 
 @AutoConfigureWireMock(port = 8070)
 @TestInstance(Lifecycle.PER_CLASS)

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/BankHolidayApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/BankHolidayApiStub.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.darts.testutils.stubs.wiremock;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+@SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
+public class BankHolidayApiStub {
+
+    public static final String BANK_HOLIDAY_API_PATH = "/bank-holidays.json";
+
+    public void returns(String bankHolidaysJson) {
+        stubFor(get(urlEqualTo(BANK_HOLIDAY_API_PATH))
+              .willReturn(aResponse()
+                              .withHeader("Content-type", "application/json")
+                              .withStatus(200)
+                              .withBody(bankHolidaysJson)));
+    }
+
+    //    public void verifyNoRequestReceived() {
+    //        verify(exactly(0), getRequestedFor(urlEqualTo(BANK_HOLIDAY_API_PATH)));
+    //    }
+    //
+    //    public void verifyRequestReceived() {
+    //        verify(exactly(1), getRequestedFor(urlEqualTo(BANK_HOLIDAY_API_PATH)));
+    //    }
+    //
+    //    public void clearStubs() {
+    //        WireMock.reset();
+    //    }
+    //
+    //    private static void wait(int millis) {
+    //        try {
+    //            Thread.sleep(millis);
+    //        } catch (InterruptedException e) {
+    //            throw new RuntimeException(e);
+    //        }
+    //    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/BankHolidayApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/BankHolidayApiStub.java
@@ -17,24 +17,4 @@ public class BankHolidayApiStub {
                               .withStatus(200)
                               .withBody(bankHolidaysJson)));
     }
-
-    //    public void verifyNoRequestReceived() {
-    //        verify(exactly(0), getRequestedFor(urlEqualTo(BANK_HOLIDAY_API_PATH)));
-    //    }
-    //
-    //    public void verifyRequestReceived() {
-    //        verify(exactly(1), getRequestedFor(urlEqualTo(BANK_HOLIDAY_API_PATH)));
-    //    }
-    //
-    //    public void clearStubs() {
-    //        WireMock.reset();
-    //    }
-    //
-    //    private static void wait(int millis) {
-    //        try {
-    //            Thread.sleep(millis);
-    //        } catch (InterruptedException e) {
-    //            throw new RuntimeException(e);
-    //        }
-    //    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/DartsGatewayStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/DartsGatewayStub.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.darts.testutils.stubs;
+package uk.gov.hmcts.darts.testutils.stubs.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 

--- a/src/integrationTest/resources/application-intTest.yaml
+++ b/src/integrationTest/resources/application-intTest.yaml
@@ -39,6 +39,9 @@ darts:
     temp-blob-workspace: ${java.io.tmpdir}/audiotransform/tempworkspace
   testing-support-endpoints:
     enabled: true
+  bank-holidays:
+    api:
+      baseurl: http://localhost:8080
 
 logging:
   level:

--- a/src/main/java/uk/gov/hmcts/darts/Application.java
+++ b/src/main/java/uk/gov/hmcts/darts/Application.java
@@ -37,6 +37,7 @@ public class Application implements CommandLineRunner {
             log.info("ATS_MODE found, closing instance");
             instance.close();
         }
+
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
@@ -8,6 +8,7 @@ import org.hibernate.SessionFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,13 +26,17 @@ import uk.gov.hmcts.darts.common.repository.CourthouseRepository;
 import uk.gov.hmcts.darts.common.repository.CourtroomRepository;
 import uk.gov.hmcts.darts.common.repository.NodeRegistrationRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.common.service.bankholidays.BankHolidaysService;
+import uk.gov.hmcts.darts.common.service.bankholidays.Event;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static java.lang.Integer.parseInt;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequestMapping(value = "/functional-tests")
@@ -51,6 +56,7 @@ public class TestSupportController {
 
     private final List<Integer> courthouseTrash = new ArrayList<>();
     private final List<Integer> courtroomTrash = new ArrayList<>();
+    private final BankHolidaysService bankHolidaysService;
 
 
     @SuppressWarnings("unchecked")
@@ -275,5 +281,11 @@ public class TestSupportController {
                                              select cas_id from darts.court_case where case_number like 'func-%'
                                              """, Integer.class)
             .getResultList();
+    }
+
+    @GetMapping(value = "/bank-holidays/{year}")
+    public ResponseEntity<List<Event>> getBankHolidaysForYear(@PathVariable(name = "year") String year) {
+        var bankHolidays = bankHolidaysService.getBankHolidaysFor(parseInt(year));
+        return new ResponseEntity<>(bankHolidays, OK);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/config/BankHolidayCacheConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/BankHolidayCacheConfig.java
@@ -28,7 +28,7 @@ public class BankHolidayCacheConfig {
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, RedisCacheConfiguration redisCacheConfiguration) {
-        log.info("Initializing Redis for caching ...");
+        log.debug("Initializing Redis for caching ...");
         return RedisCacheManager
             .builder(redisConnectionFactory)
             .cacheDefaults(redisCacheConfiguration)

--- a/src/main/java/uk/gov/hmcts/darts/common/config/BankHolidayCacheConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/BankHolidayCacheConfig.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.darts.common.config;
+
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+@Profile("!in-memory-caching")
+@Slf4j
+public class BankHolidayCacheConfig {
+
+    @Value("${darts.cache.bank-holiday.expiry-days}")
+    private int bankHolidayExpiry;
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory, RedisCacheConfiguration redisCacheConfiguration) {
+        log.info("Initializing Redis for caching ...");
+        return RedisCacheManager
+            .builder(redisConnectionFactory)
+            .cacheDefaults(redisCacheConfiguration)
+            .build();
+    }
+
+    @Bean
+    public RedisCacheConfiguration cacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofDays(bankHolidayExpiry))
+            .disableCachingNullValues()
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(redisSerializer()));
+    }
+
+    private static GenericJackson2JsonRedisSerializer redisSerializer() {
+        var serializer = new GenericJackson2JsonRedisSerializer();
+        serializer.configure(objectMapper -> {
+            objectMapper.registerModule(new JavaTimeModule());
+            objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        });
+        return serializer;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/config/RedisConnectionConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/RedisConnectionConfig.java
@@ -1,0 +1,147 @@
+package uk.gov.hmcts.darts.common.config;
+
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.ClientOptions.DisconnectedBehavior;
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.TimeoutOptions;
+import io.lettuce.core.internal.HostAndPort;
+import io.lettuce.core.resource.ClientResources;
+import io.lettuce.core.resource.DnsResolvers;
+import io.lettuce.core.resource.MappingSocketAddressResolver;
+import io.lettuce.core.resource.NettyCustomizer;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.socket.nio.NioChannelOption;
+import jdk.net.ExtendedSocketOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.net.InetAddress;
+import java.net.URLDecoder;
+import java.net.UnknownHostException;
+import java.nio.charset.Charset;
+import java.util.function.UnaryOperator;
+
+import static java.time.Duration.ofSeconds;
+
+@Configuration
+@Profile("!in-memory-caching")
+@Slf4j
+public class RedisConnectionConfig {
+
+    @Value("${darts.redis.connection-string}")
+    private String redisConnectionString;
+
+
+    @Bean
+    public LettuceConnectionFactory connectionFactory() {
+        var redisConnectionProperties = redisConnectionPropertiesFrom(redisConnectionString);
+        var mappingSocketAddressResolver = MappingSocketAddressResolver.create(
+            DnsResolvers.JVM_DEFAULT,
+            getHostAndPortMappingFunctionFor(redisConnectionProperties.host())
+        );
+
+        var clientResources = ClientResources.builder()
+            .nettyCustomizer(new CustomNettyConfig())
+            .socketAddressResolver(mappingSocketAddressResolver)
+            .build();
+
+        var socketOptions = SocketOptions.builder()
+            .connectTimeout(ofSeconds(20))
+            .build();
+
+        var clientOptions = ClientOptions.builder()
+            .timeoutOptions(TimeoutOptions.enabled(ofSeconds(20)))
+            .socketOptions(socketOptions)
+            .disconnectedBehavior(DisconnectedBehavior.REJECT_COMMANDS)
+            .build();
+
+        var clientConfig = LettuceClientConfiguration.builder()
+            .commandTimeout(ofSeconds(20))
+            .clientOptions(clientOptions)
+            .clientResources(clientResources)
+            .useSsl()
+            .build();
+
+        var redisConfig = new RedisStandaloneConfiguration(
+            redisConnectionProperties.host(),
+            redisConnectionProperties.port()
+        );
+        redisConfig.setPassword(RedisPassword.of(redisConnectionProperties.password()));
+
+        return new LettuceConnectionFactory(redisConfig, clientConfig);
+    }
+
+    private UnaryOperator<HostAndPort> getHostAndPortMappingFunctionFor(String host) {
+        return hostAndPort -> {
+            var addresses = new InetAddress[0];
+            try {
+                addresses = DnsResolvers.JVM_DEFAULT.resolve(host);
+            } catch (UnknownHostException unknownHostException) {
+                log.error("Failed to resolve: " + host, unknownHostException);
+            }
+
+            var hostIp = addresses[0].getHostAddress();
+            var finalAddress = hostAndPort;
+            if (hostAndPort.hostText.equals(hostIp)) {
+                finalAddress = HostAndPort.of(host, hostAndPort.getPort());
+            }
+
+            return finalAddress;
+        };
+    }
+
+    private static class CustomNettyConfig implements NettyCustomizer {
+
+        @Override
+        public void afterBootstrapInitialized(Bootstrap bootstrap) {
+            bootstrap.option(NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPIDLE), 15);
+            bootstrap.option(NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPINTERVAL), 5);
+            bootstrap.option(NioChannelOption.of(ExtendedSocketOptions.TCP_KEEPCOUNT), 3);
+        }
+    }
+
+    static RedisConnectionProperties redisConnectionPropertiesFrom(String redisConnectionString) {
+        String username = "";
+        String password;
+        String host;
+        String port;
+        String[] passwordAndRest;
+
+        var schemeAndRest = redisConnectionString.split("://", 2);
+        if (schemeAndRest[1].startsWith(":")) { // then empty username
+            var restWithColonRemoved = schemeAndRest[1].replaceFirst(":", "");
+            passwordAndRest = restWithColonRemoved.split("@");
+            password = passwordAndRest[0];
+        } else {
+            var usernameAnRest = schemeAndRest[1].split(":", 2);
+            username = usernameAnRest[0];
+            passwordAndRest = usernameAnRest[1].split("@", 2);
+            password = passwordAndRest[0];
+        }
+
+        var hostAndRest = passwordAndRest[1].split(":", 2);
+        host = hostAndRest[0];
+
+        var portAndRest = hostAndRest[1].split("\\?", 2);
+        port = portAndRest[0];
+
+        return new RedisConnectionProperties(
+            username,
+            URLDecoder.decode(password, Charset.defaultCharset()),
+            host,
+            Integer.valueOf(port)
+        );
+    }
+
+    public record RedisConnectionProperties(String username, String password, String host, Integer port) {
+
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/config/SimpleCacheConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/SimpleCacheConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.common.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -10,11 +11,12 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 @EnableCaching
 @Profile("in-memory-caching")
+@Slf4j
 public class SimpleCacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-        System.out.println("Using in memory caching ...");
+        log.debug("Using in memory caching ...");
         return new ConcurrentMapCacheManager();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/config/SimpleCacheConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/SimpleCacheConfig.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.darts.common.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@EnableCaching
+@Profile("in-memory-caching")
+public class SimpleCacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        System.out.println("Using in memory caching ...");
+        return new ConcurrentMapCacheManager();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidays.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidays.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.darts.common.service.bankholidays;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BankHolidays {
+    static final String ENGLAND_AND_WALES = "england-and-wales";
+
+    @JsonProperty(ENGLAND_AND_WALES)
+    public Division englandAndWales;
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidaysApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidaysApi.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.darts.common.service.bankholidays;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "bank-holidays-api", url = "${darts.bank-holidays.api.baseurl}")
+public interface BankHolidaysApi {
+
+    @GetMapping(path = "/bank-holidays.json")
+    @Cacheable(value = "bank-holidays", key = " 'ENGLAND_WALES' ")
+    BankHolidays retrieveAll();
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidaysService.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/BankHolidaysService.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.darts.common.service.bankholidays;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@RequiredArgsConstructor
+public class BankHolidaysService {
+
+    private final BankHolidaysApi bankHolidaysApi;
+
+    public List<Event> getBankHolidaysFor(int year) {
+        return bankHolidaysApi.retrieveAll().englandAndWales.events.stream()
+            .filter(eve -> eve.date.getYear() == year)
+            .collect(toList());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/Division.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/Division.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.darts.common.service.bankholidays;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Division {
+
+    @JsonProperty("events")
+    public List<Event> events;
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/Event.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/bankholidays/Event.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.darts.common.service.bankholidays;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Event {
+
+    @JsonProperty("date")
+    public LocalDate date;
+
+    @JsonProperty("title")
+    public String title;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -97,10 +97,7 @@ spring:
     locations: classpath:db/migration/common,db/migration/postgres
     default-schema: ${spring.datasource.schema}
     mixed: true
-  data:
-    redis:
-      connect-timeout: 10000
-      timeout: 10000
+
 darts:
   audio:
     ffmpeg-executable: ffmpeg
@@ -161,7 +158,8 @@ darts:
     bank-holiday:
       expiry-days: 7
   redis:
-    connection-string: ${REDIS_CONNECTION_STRING:rediss://:uS3LcL8QaZGwgkexggKW9yvuttHpd1wcLAzCaECdiVA%3D@darts-stg.redis.cache.windows.net:6380?tls=true}
+    connection-string: ${REDIS_CONNECTION_STRING:redis://localhost:6379}
+    ssl-enabled: ${REDIS_SSL_ENABLED:true}
 
 dbMigration:
   # When true, the app will run DB migration on startup.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -97,7 +97,10 @@ spring:
     locations: classpath:db/migration/common,db/migration/postgres
     default-schema: ${spring.datasource.schema}
     mixed: true
-
+  data:
+    redis:
+      connect-timeout: 10000
+      timeout: 10000
 darts:
   audio:
     ffmpeg-executable: ffmpeg
@@ -151,6 +154,14 @@ darts:
       system-user-email: ${SYSTEM_USER_EMAIL:}
   testing-support-endpoints:
     enabled: ${TESTING_SUPPORT_ENDPOINTS_ENABLED:false}
+  bank-holidays:
+    api:
+      baseurl: https://www.gov.uk
+  cache:
+    bank-holiday:
+      expiry-days: 7
+  redis:
+    connection-string: ${REDIS_CONNECTION_STRING:rediss://:uS3LcL8QaZGwgkexggKW9yvuttHpd1wcLAzCaECdiVA%3D@darts-stg.redis.cache.windows.net:6380?tls=true}
 
 dbMigration:
   # When true, the app will run DB migration on startup.

--- a/src/test/java/uk/gov/hmcts/darts/common/config/RedisConnectionConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/config/RedisConnectionConfigTest.java
@@ -7,13 +7,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RedisConnectionConfigTest {
 
     @Test
-    void createsRedisPropertiesFromConnectionStringWithUsername() {
+    void createsRedisPropertiesFromConnectionStringWithPasswordAndUsername() {
         var redisConnectionString = "redis://some-user:some-access-key@some-host:6379?key=value";
         var redisProperties = RedisConnectionConfig.redisConnectionPropertiesFrom(redisConnectionString);
 
         assertThat(redisProperties.host()).isEqualTo("some-host");
         assertThat(redisProperties.port()).isEqualTo(6379);
-        assertThat(redisProperties.password()).isEqualTo("some-access-key");
+        assertThat(redisProperties.password()).isEqualTo("some-access-key".toCharArray());
         assertThat(redisProperties.username()).isEqualTo("some-user");
     }
 
@@ -24,7 +24,31 @@ class RedisConnectionConfigTest {
 
         assertThat(redisProperties.host()).isEqualTo("some-host");
         assertThat(redisProperties.port()).isEqualTo(6379);
-        assertThat(redisProperties.password()).isEqualTo("some-access-key");
-        assertThat(redisProperties.username()).isEmpty();
+        assertThat(redisProperties.password()).isEqualTo("some-access-key".toCharArray());
+        assertThat(redisProperties.username()).isNullOrEmpty();
     }
+
+    @Test
+    void createsRedisPropertiesFromConnectionStringWithEmptyUsernameAndPassword() {
+        var redisConnectionString = "redis://some-host:6379";
+        var redisProperties = RedisConnectionConfig.redisConnectionPropertiesFrom(redisConnectionString);
+
+        assertThat(redisProperties.host()).isEqualTo("some-host");
+        assertThat(redisProperties.port()).isEqualTo(6379);
+        assertThat(redisProperties.password()).isNullOrEmpty();
+        assertThat(redisProperties.username()).isNullOrEmpty();
+    }
+
+    @Test
+    void createsRedisPropertiesFromConnectionStringWithUrlEncodedPasswordAndUsername() {
+        var redisConnectionString = "redis://some-user:some-access-key%3D@some-host:6379?key=value";
+        var redisProperties = RedisConnectionConfig.redisConnectionPropertiesFrom(redisConnectionString);
+
+        assertThat(redisProperties.host()).isEqualTo("some-host");
+        assertThat(redisProperties.port()).isEqualTo(6379);
+        assertThat(redisProperties.password()).isEqualTo("some-access-key=".toCharArray());
+        assertThat(redisProperties.username()).isEqualTo("some-user");
+    }
+
+
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/config/RedisConnectionConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/config/RedisConnectionConfigTest.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.darts.common.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisConnectionConfigTest {
+
+    @Test
+    void createsRedisPropertiesFromConnectionStringWithUsername() {
+        var redisConnectionString = "redis://some-user:some-access-key@some-host:6379?key=value";
+        var redisProperties = RedisConnectionConfig.redisConnectionPropertiesFrom(redisConnectionString);
+
+        assertThat(redisProperties.host()).isEqualTo("some-host");
+        assertThat(redisProperties.port()).isEqualTo(6379);
+        assertThat(redisProperties.password()).isEqualTo("some-access-key");
+        assertThat(redisProperties.username()).isEqualTo("some-user");
+    }
+
+    @Test
+    void createsRedisPropertiesFromConnectionStringWithEmptyUsername() {
+        var redisConnectionString = "redis://:some-access-key@some-host:6379?key=value";
+        var redisProperties = RedisConnectionConfig.redisConnectionPropertiesFrom(redisConnectionString);
+
+        assertThat(redisProperties.host()).isEqualTo("some-host");
+        assertThat(redisProperties.port()).isEqualTo(6379);
+        assertThat(redisProperties.password()).isEqualTo("some-access-key");
+        assertThat(redisProperties.username()).isEmpty();
+    }
+}


### PR DESCRIPTION
Added caching support with connections to Redis by default.  A simple in memory cache is also configured using the profile `in-memory-cache` if required for running the application without access to a Redis instance.  The Redis connection configuration required some low level configuration due to an issue with Netty, Lettuce's (Redis Client Lib) underlying http client with loading a functioning DNS resolver.  Basic cache usage has been implemented for retrieving and caching of bank holidays.  This may change as use case are implemented.  

A testing support endpoint has been added to verify the cache is working in staging. 

Redis has been added to the docker compose config for local testing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
