### PR TITLE
Dmp 1232 add controller layer authorisation to hearing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ launchctl setenv <<env var name>> <<secret value>>
 ```
 You will then need to restart intellij/terminal windows for it to take effect.
 
-to make the changes permanent, make a `.zshrc` file in your users folder and popualte it with this and their values:
+to make the changes permanent, make a `.zshrc` file in your users folder and populate it with this and their values:
 ```
 export GOVUK_NOTIFY_API_KEY=
 export FUNC_TEST_ROPC_USERNAME=

--- a/src/functionalTest/java/uk/gov/hmcts/darts/hearings/HearingsGetEventsFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/hearings/HearingsGetEventsFunctionalTest.java
@@ -15,6 +15,8 @@ class HearingsGetEventsFunctionalTest extends FunctionalTest {
     public static final String ADD_EVENT_URL = "/events";
     public static final String CASE_SEARCH_URL = "/cases/search";
 
+    private static final String COURTHOUSE = "Swansea";
+
     @AfterEach
     void cleanData() {
         buildRequestWithExternalAuth()
@@ -25,10 +27,9 @@ class HearingsGetEventsFunctionalTest extends FunctionalTest {
 
     @Test
     void success() {
-        String courthouseName = "func-swansea-house-" + randomAlphanumeric(7);
         String courtroomName = "func-swansea-room-" + randomAlphanumeric(7);
 
-        createCourtroomAndCourthouse(courthouseName, courtroomName);
+        createCourtroomAndCourthouse(COURTHOUSE, courtroomName);
 
         String randomCaseNumber = randomCaseNumber();
         String randomEventText1 = randomAlphanumeric(15);
@@ -47,7 +48,7 @@ class HearingsGetEventsFunctionalTest extends FunctionalTest {
               "event_text": "%s",
               "date_time": "2023-08-08T14:01:06.085Z"
             }""",
-            courthouseName, courtroomName, randomCaseNumber, randomEventText1);
+            COURTHOUSE, courtroomName, randomCaseNumber, randomEventText1);
 
         buildRequestWithExternalAuth()
             .contentType(ContentType.JSON)
@@ -74,7 +75,7 @@ class HearingsGetEventsFunctionalTest extends FunctionalTest {
               "event_text": "%s",
               "date_time": "2023-08-08T14:01:06.085Z"
             }""",
-            courthouseName, courtroomName, randomCaseNumber, randomEventText2);
+            COURTHOUSE, courtroomName, randomCaseNumber, randomEventText2);
 
         buildRequestWithExternalAuth()
             .contentType(ContentType.JSON)

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
@@ -34,7 +34,7 @@ class HearingsGetControllerTest extends IntegrationBase {
     @Autowired
     private transient MockMvc mockMvc;
 
-    private static final String endpointUrl = "/hearings/{hearingId}";
+    public static final String ENDPOINT_URL = "/hearings/{hearingId}";
 
     @MockBean
     private UserIdentity mockUserIdentity;
@@ -69,7 +69,7 @@ class HearingsGetControllerTest extends IntegrationBase {
     @Test
     void okGet() throws Exception {
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingEntity.getId());
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, hearingEntity.getId());
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
         String actualJson = mvcResult.getResponse().getContentAsString();
@@ -99,7 +99,7 @@ class HearingsGetControllerTest extends IntegrationBase {
     void errorGetNotFound() throws Exception {
         int hearingId = -1;
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingId);
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, hearingId);
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isNotFound()).andReturn();
 
         String actualJson = mvcResult.getResponse().getContentAsString();
@@ -131,7 +131,7 @@ class HearingsGetControllerTest extends IntegrationBase {
 
         when(mockUserIdentity.getEmailAddress()).thenReturn("forbidden.user@example.com");
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearing.getId());
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, hearing.getId());
 
         MvcResult response = mockMvc.perform(requestBuilder)
             .andExpect(MockMvcResultMatchers.status().isForbidden())

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.hearings.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -13,13 +14,13 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
-import uk.gov.hmcts.darts.common.entity.JudgeEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -37,26 +38,41 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
     @MockBean
     private UserIdentity mockUserIdentity;
 
+    private HearingEntity hearingEntity;
+    private EventEntity event;
+
+    private static final OffsetDateTime SOME_DATE_TIME = OffsetDateTime.parse("2023-01-01T12:00Z");
+    private static final String SOME_COURTHOUSE = "some-courthouse";
+    private static final String SOME_COURTROOM = "some-courtroom";
+    private static final String SOME_CASE_NUMBER = "1";
+
+    @BeforeEach
+    void setUp() {
+
+        HearingEntity hearing = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
+            SOME_CASE_NUMBER,
+            SOME_COURTHOUSE,
+            SOME_COURTROOM,
+            SOME_DATE_TIME.toLocalDate()
+        );
+        CourtCaseEntity courtCase = hearingEntity.getCourtCase();
+        courtCase.addProsecutor("aProsecutor");
+        courtCase.addDefendant("aDefendant");
+        courtCase.addDefence("aDefence");
+        dartsDatabase.save(courtCase);
+
+        event = dartsDatabase.createEvent(hearingEntity);
+
+        hearingEntity = dartsDatabase.getHearingRepository().findById(hearing.getId()).orElseThrow();
+        UserAccountEntity testUser = dartsDatabase.getUserAccountStub()
+            .createAuthorisedIntegrationTestUser(hearingEntity.getCourtroom().getCourthouse());
+        when(mockUserIdentity.getEmailAddress()).thenReturn(testUser.getEmailAddress());
+    }
 
     @Test
     void okGet() throws Exception {
-        HearingEntity hearing = dartsDatabase.createHearing(
-            "testCourthouse",
-            "testCourtroom",
-            "testCaseNumber",
-            LocalDate.of(2020, 6, 20)
-        );
-        JudgeEntity testJudge = dartsDatabase.createSimpleJudge("testJudge");
-        hearing.addJudge(testJudge);
-        dartsDatabase.save(hearing);
 
-        UserAccountEntity testUser = dartsDatabase.getUserAccountStub()
-            .createAuthorisedIntegrationTestUser(hearing.getCourtroom().getCourthouse());
-        when(mockUserIdentity.getEmailAddress()).thenReturn(testUser.getEmailAddress());
-
-        EventEntity event = dartsDatabase.createEvent(hearing);
-
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearing.getId());
+        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingEntity.getId());
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
         String actualJson = mvcResult.getResponse().getContentAsString();
@@ -91,21 +107,9 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
     @Test
     void hearingEventsGetEndpointShouldReturnForbiddenError() throws Exception {
 
-        HearingEntity hearing = dartsDatabase.createHearing(
-            "testCourthouse",
-            "testCourtroom",
-            "testCaseNumber",
-            LocalDate.of(2020, 6, 20)
-        );
-        JudgeEntity testJudge = dartsDatabase.createSimpleJudge("testJudge");
-        hearing.addJudge(testJudge);
-        dartsDatabase.save(hearing);
-
-        EventEntity event = dartsDatabase.createEvent(hearing);
-
         when(mockUserIdentity.getEmailAddress()).thenReturn("forbidden.user@example.com");
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearing.getId());
+        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingEntity.getId());
         MvcResult response = mockMvc.perform(requestBuilder)
             .andExpect(MockMvcResultMatchers.status().isForbidden())
             .andReturn();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
@@ -33,7 +33,7 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
     @Autowired
     private transient MockMvc mockMvc;
 
-    private static final String endpointUrl = "/hearings/{hearingId}/events";
+    private static final String ENDPOINT_URL = "/hearings/{hearingId}/events";
 
     @MockBean
     private UserIdentity mockUserIdentity;
@@ -72,7 +72,7 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
     @Test
     void okGet() throws Exception {
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingEntity.getId());
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, hearingEntity.getId());
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
         String actualJson = mvcResult.getResponse().getContentAsString();
@@ -89,7 +89,7 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
     void errorGetNotFound() throws Exception {
         int hearingId = -1;
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingId);
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, hearingId);
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isNotFound()).andReturn();
 
         String actualJson = mvcResult.getResponse().getContentAsString();
@@ -109,7 +109,7 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
 
         when(mockUserIdentity.getEmailAddress()).thenReturn("forbidden.user@example.com");
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingEntity.getId());
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, hearingEntity.getId());
         MvcResult response = mockMvc.perform(requestBuilder)
             .andExpect(MockMvcResultMatchers.status().isForbidden())
             .andReturn();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
@@ -55,13 +55,13 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
             SOME_COURTROOM,
             SOME_DATE_TIME.toLocalDate()
         );
-        CourtCaseEntity courtCase = hearingEntity.getCourtCase();
+        CourtCaseEntity courtCase = hearing.getCourtCase();
         courtCase.addProsecutor("aProsecutor");
         courtCase.addDefendant("aDefendant");
         courtCase.addDefence("aDefence");
         dartsDatabase.save(courtCase);
 
-        event = dartsDatabase.createEvent(hearingEntity);
+        event = dartsDatabase.createEvent(hearing);
 
         hearingEntity = dartsDatabase.getHearingRepository().findById(hearing.getId()).orElseThrow();
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub()

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
@@ -55,7 +55,6 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
         when(mockUserIdentity.getEmailAddress()).thenReturn(testUser.getEmailAddress());
 
         EventEntity event = dartsDatabase.createEvent(hearing);
-        
 
         MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearing.getId());
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/EventStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/EventStub.java
@@ -30,4 +30,5 @@ public class EventStub {
         eventRepository.saveAndFlush(eventEntity);
         return eventEntity;
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -78,6 +78,8 @@ public class HearingEntity extends CreatedModifiedBaseEntity {
     @Transient
     private boolean isNew; //helper flag to indicate that the entity was just created, and so to notify DAR PC
 
+    //TODO look to remove this
+    @Deprecated()
     @ManyToMany
     @JoinTable(name = "hearing_event_ae",
         joinColumns = {@JoinColumn(name = HEA_ID)},

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -1,10 +1,20 @@
 package uk.gov.hmcts.darts.common.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
+
+import java.util.List;
 
 @Repository
 public interface EventRepository extends JpaRepository<EventEntity, Integer> {
 
+    @Query("""
+           SELECT ee
+           FROM EventEntity ee
+           JOIN ee.hearingEntities he
+           WHERE he.id = :hearingId
+        """)
+    List<EventEntity> findAllByHearingId(Integer hearingId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/hearings/controller/HearingsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/controller/HearingsController.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.darts.hearings.controller;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.hearings.api.HearingsApi;
 import uk.gov.hmcts.darts.hearings.model.EventResponse;
 import uk.gov.hmcts.darts.hearings.model.GetHearingResponse;
@@ -11,17 +13,32 @@ import uk.gov.hmcts.darts.hearings.service.HearingsService;
 
 import java.util.List;
 
+import static uk.gov.hmcts.darts.authorisation.constants.AuthorisationConstants.SECURITY_SCHEMES_BEARER_AUTH;
+import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.HEARING_ID;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.LANGUAGE_SHOP_USER;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
+
 @RestController
 @RequiredArgsConstructor
 public class HearingsController implements HearingsApi {
 
     private final HearingsService hearingsService;
 
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = HEARING_ID,
+        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, LANGUAGE_SHOP_USER, RCJ_APPEALS})
     @Override
     public ResponseEntity<GetHearingResponse> getHearing(Integer hearingId) {
         return new ResponseEntity<>(hearingsService.getHearings(hearingId), HttpStatus.OK);
     }
 
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = HEARING_ID,
+        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, LANGUAGE_SHOP_USER, RCJ_APPEALS})
     @Override
     public ResponseEntity<List<EventResponse>> getEvents(Integer hearingId) {
         return new ResponseEntity<>(hearingsService.getEvents(hearingId), HttpStatus.OK);

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
@@ -3,8 +3,10 @@ package uk.gov.hmcts.darts.hearings.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.hearings.exception.HearingApiError;
 import uk.gov.hmcts.darts.hearings.mapper.GetEventsResponseMapper;
@@ -22,6 +24,7 @@ import java.util.Optional;
 public class HearingsServiceImpl implements HearingsService {
 
     private final HearingRepository hearingRepository;
+    private final EventRepository eventRepository;
 
     @Override
     public GetHearingResponse getHearings(Integer hearingId) {
@@ -39,8 +42,8 @@ public class HearingsServiceImpl implements HearingsService {
 
     @Override
     public List<EventResponse> getEvents(Integer hearingId) {
-        HearingEntity foundHearing = getHearingById(hearingId);
-        return GetEventsResponseMapper.mapToEvents(foundHearing.getEventList());
+        List<EventEntity> eventEntities = eventRepository.findAllByHearingId(hearingId);
+        return GetEventsResponseMapper.mapToEvents(eventEntities);
     }
 
 }

--- a/src/main/resources/openapi/hearings.yaml
+++ b/src/main/resources/openapi/hearings.yaml
@@ -32,6 +32,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/get_hearing_response'
+        '401':
+          description: Unauthorised Error
+        '403':
+          description: Forbidden Error
+          content:
+            application/json+problem:
+              schema:
+                allOf:
+                  - $ref: './problem.yaml'
+                  - type: object
+                    required:
+                      - type
+                    properties:
+                      type:
+                        $ref: '#/components/schemas/HearingAuthorisation403ErrorCode'
+              example:
+                type: "AUTHORISATION_100"
+                title: "User is not authorised for the associated courthouse"
+                status: 403
         '500':
           description: Internal Server Error
           content:
@@ -127,3 +146,9 @@ components:
         text:
           type: string
           example: Record:New Case
+
+    HearingAuthorisation403ErrorCode:
+      type: string
+      enum:
+        - "AUTHORISATION_100"
+      x-enum-varnames: [ USER_NOT_AUTHORISED_FOR_COURTHOUSE ]

--- a/src/main/resources/openapi/hearings.yaml
+++ b/src/main/resources/openapi/hearings.yaml
@@ -86,8 +86,6 @@ paths:
               schema:
                 $ref: './problem.yaml'
 
-
-
 components:
   schemas:
     get_hearing_response:
@@ -123,7 +121,6 @@ components:
     judge:
       type: string
       example: Mr Judge
-
 
     events_response:
       type: array

--- a/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
 import uk.gov.hmcts.darts.hearings.model.EventResponse;
@@ -29,6 +30,9 @@ class HearingsServiceImplTest {
 
     @Mock
     HearingRepository hearingRepository;
+    @Mock
+    EventRepository eventRepository;
+
 
     HearingsServiceImpl service;
 
@@ -36,7 +40,8 @@ class HearingsServiceImplTest {
     @BeforeEach
     void setUp() {
         service = new HearingsServiceImpl(
-            hearingRepository
+            hearingRepository,
+            eventRepository
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.darts.hearings.model.EventResponse;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -57,14 +56,13 @@ class HearingsServiceImplTest {
             courtroomEntity,
             LocalDate.now()
         );
-        Mockito.when(hearingRepository.findById(hearingEntity.getId())).thenReturn(Optional.of(hearingEntity));
 
         EventHandlerEntity eventType = mock(EventHandlerEntity.class);
         Mockito.when(eventType.getEventName()).thenReturn("TestEvent");
 
         List<EventEntity> event = List.of(
             CommonTestDataUtil.createEventWith("LOG", "Test", hearingEntity, eventType));
-        hearingEntity.setEventList(event);
+        Mockito.when(eventRepository.findAllByHearingId(hearingEntity.getId())).thenReturn(event);
 
         List<EventResponse> eventResponses = service.getEvents(hearingEntity.getId());
         assertEquals(1, eventResponses.size());
@@ -74,6 +72,5 @@ class HearingsServiceImplTest {
         assertNotNull(eventResponses.get(0).getTimestamp());
 
     }
-
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-1232

### Change description ###

Added the auth code to the hearing endpoint and had to change the way the events were retrieved due to the lazy loading not working.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
