### PR TITLE
Adding `/preview2` audio preview endpoint

### DIFF
--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -68,19 +68,20 @@ java:
         - name: redis-connection-string
           alias: REDIS_CONNECTION_STRING
   environment:
-    ENABLE_FLYWAY: true
-    RUN_DB_MIGRATION_ON_STARTUP: true
-    DARTS_API_DB_HOST: "darts-modernisation-dev.postgres.database.azure.com"
-    DARTS_API_DB_NAME: "pr-${CHANGE_ID}-darts"
-    DARTS_API_DB_USERNAME: "hmcts"
+#    ENABLE_FLYWAY: true
+#    RUN_DB_MIGRATION_ON_STARTUP: true
+#    DARTS_API_DB_HOST: "darts-modernisation-dev.postgres.database.azure.com"
+#    DARTS_API_DB_NAME: "pr-${CHANGE_ID}-darts"
+#    DARTS_API_DB_USERNAME: "hmcts"
+    POSTGRES_SSL_MODE: require
     spring.profiles.active: dev
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
     DARTS_GATEWAY_URL: https://darts-gateway.staging.platform.hmcts.net
-  secrets:
-    DARTS_API_DB_PASSWORD:
-      secretRef: "postgres"
-      key: PASSWORD
-      disabled: false
+#  secrets:
+#    DARTS_API_DB_PASSWORD:
+#      secretRef: "postgres"
+#      key: PASSWORD
+#      disabled: false
 
 postgresql:
   enabled: true

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -68,20 +68,19 @@ java:
         - name: redis-connection-string
           alias: REDIS_CONNECTION_STRING
   environment:
-#    ENABLE_FLYWAY: true
-#    RUN_DB_MIGRATION_ON_STARTUP: true
-#    DARTS_API_DB_HOST: "darts-modernisation-dev.postgres.database.azure.com"
-#    DARTS_API_DB_NAME: "pr-${CHANGE_ID}-darts"
-#    DARTS_API_DB_USERNAME: "hmcts"
-    POSTGRES_SSL_MODE: require
+    ENABLE_FLYWAY: true
+    RUN_DB_MIGRATION_ON_STARTUP: true
+    DARTS_API_DB_HOST: "darts-modernisation-dev.postgres.database.azure.com"
+    DARTS_API_DB_NAME: "pr-${CHANGE_ID}-darts"
+    DARTS_API_DB_USERNAME: "hmcts"
     spring.profiles.active: dev
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
     DARTS_GATEWAY_URL: https://darts-gateway.staging.platform.hmcts.net
-#  secrets:
-#    DARTS_API_DB_PASSWORD:
-#      secretRef: "postgres"
-#      key: PASSWORD
-#      disabled: false
+  secrets:
+    DARTS_API_DB_PASSWORD:
+      secretRef: "postgres"
+      key: PASSWORD
+      disabled: false
 
 postgresql:
   enabled: true

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreview2IntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreview2IntTest.java
@@ -20,8 +20,15 @@ import java.util.Set;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.LANGUAGE_SHOP_USER;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 
 @SpringBootTest
 @ActiveProfiles({"intTest", "h2db"})

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreview2IntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreview2IntTest.java
@@ -72,10 +72,24 @@ class AudioControllerPreview2IntTest extends IntegrationBase {
     }
 
     @Test
-    void preview2WithRangeShouldReturnSuccess() throws Exception {
+    void preview2WithRangeFromStartShouldReturnSuccess() throws Exception {
 
         MockHttpServletRequestBuilder requestBuilder = get(URI.create(
             String.format("/audio/preview2/%d", mediaEntity.getId()))).header("Range", "bytes=0-1023");
+
+        mockMvc.perform(requestBuilder).andExpect(status().isOk());
+
+        verify(authorisation).authoriseByMediaId(
+            mediaEntity.getId(),
+            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, LANGUAGE_SHOP_USER, RCJ_APPEALS)
+        );
+    }
+
+    @Test
+    void preview2WithRangeShouldReturnSuccess() throws Exception {
+
+        MockHttpServletRequestBuilder requestBuilder = get(URI.create(
+            String.format("/audio/preview2/%d", mediaEntity.getId()))).header("Range", "bytes=1024-2047");
 
         mockMvc.perform(requestBuilder).andExpect(status().isOk());
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreview2IntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreview2IntTest.java
@@ -1,0 +1,92 @@
+package uk.gov.hmcts.darts.audio.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.darts.audio.service.AudioTransformationServiceGivenBuilder;
+import uk.gov.hmcts.darts.authorisation.component.Authorisation;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+import java.net.URI;
+import java.util.Set;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.*;
+
+@SpringBootTest
+@ActiveProfiles({"intTest", "h2db"})
+@AutoConfigureMockMvc
+class AudioControllerPreview2IntTest extends IntegrationBase {
+
+    @Autowired
+    private AudioTransformationServiceGivenBuilder given;
+
+    @MockBean
+    private Authorisation authorisation;
+
+    private MediaEntity mediaEntity;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setupData() {
+        given.setupTest();
+        mediaEntity = given.getMediaEntity1();
+        given.externalObjectDirForMedia(mediaEntity);
+        doNothing().when(authorisation).authoriseByMediaId(
+            mediaEntity.getId(),
+            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, LANGUAGE_SHOP_USER, RCJ_APPEALS)
+        );
+    }
+
+    @Test
+    void preview2ShouldReturnSuccess() throws Exception {
+
+        MockHttpServletRequestBuilder requestBuilder = get(URI.create(
+            String.format("/audio/preview2/%d", mediaEntity.getId())));
+
+        mockMvc.perform(requestBuilder).andExpect(status().isOk());
+
+        verify(authorisation).authoriseByMediaId(
+            mediaEntity.getId(),
+            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, LANGUAGE_SHOP_USER, RCJ_APPEALS)
+        );
+    }
+
+    @Test
+    void preview2WithRangeShouldReturnSuccess() throws Exception {
+
+        MockHttpServletRequestBuilder requestBuilder = get(URI.create(
+            String.format("/audio/preview2/%d", mediaEntity.getId()))).header("Range", "bytes=0-1023");
+
+        mockMvc.perform(requestBuilder).andExpect(status().isOk());
+
+        verify(authorisation).authoriseByMediaId(
+            mediaEntity.getId(),
+            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, LANGUAGE_SHOP_USER, RCJ_APPEALS)
+        );
+    }
+
+    @Test
+    void preview2ShouldReturnErrorWhenNoMediaIdExistsInDatabase() throws Exception {
+
+        MockHttpServletRequestBuilder requestBuilder = get(
+            String.format("/audio/preview2/%s", "1234567"));
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(header().string("Content-Type", "application/problem+json"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.type").value("AUDIO_101"));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -119,8 +119,14 @@ public class AudioController implements AudioApi {
     }
 
     public byte[] readByteRange(byte[] wholeFile, long start, long end) {
+        int srcPos;
+        if (start > Integer.MIN_VALUE && start < Integer.MAX_VALUE)
+            srcPos = (int)start;
+        else
+            throw new IllegalArgumentException("Invalid input: start bytes truncated");
+
         byte[] result = new byte[(int) (end - start) + 1];
-        System.arraycopy(wholeFile, (int) start, result, 0, result.length);
+        System.arraycopy(wholeFile, srcPos, result, 0, result.length);
         return result;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -87,6 +88,19 @@ public class AudioController implements AudioApi {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public byte[] readByteRange(InputStream inputStream, long start, long end) throws IOException {
+        ByteArrayOutputStream bufferedOutputStream = new ByteArrayOutputStream();
+        byte[] data = new byte[BYTE_RANGE];
+        int read;
+        while ((read = inputStream.read(data, 0, data.length)) != -1) {
+            bufferedOutputStream.write(data, 0, read);
+        }
+        bufferedOutputStream.flush();
+        byte[] result = new byte[(int) (end - start) + 1];
+        System.arraycopy(bufferedOutputStream.toByteArray(), (int) start, result, 0, result.length);
+        return result;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.audio.controller;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -79,11 +80,11 @@ public class AudioController implements AudioApi {
     public ResponseEntity<byte[]> preview(Integer mediaId, @RequestHeader(value = "Range", required = false) String httpRangeList) {
         InputStream audioMediaFile = audioService.preview(mediaId);
         try {
-            int fileSize = audioMediaFile.available();
+            byte[] bytes = IOUtils.toByteArray(audioMediaFile);
             return ResponseEntity.status(HttpStatus.OK)
                 .header("Content-Type", "audio/mpeg")
-                .header("Content-Length", String.valueOf(fileSize))
-                .body(readByteRange(audioMediaFile, 0, fileSize - 1));
+                .header("Content-Length", String.valueOf(bytes.length))
+                .body(bytes);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -90,19 +90,6 @@ public class AudioController implements AudioApi {
         }
     }
 
-    public byte[] readByteRange(InputStream inputStream, long start, long end) throws IOException {
-        ByteArrayOutputStream bufferedOutputStream = new ByteArrayOutputStream();
-        byte[] data = new byte[BYTE_RANGE];
-        int read;
-        while ((read = inputStream.read(data, 0, data.length)) != -1) {
-            bufferedOutputStream.write(data, 0, read);
-        }
-        bufferedOutputStream.flush();
-        byte[] result = new byte[(int) (end - start) + 1];
-        System.arraycopy(bufferedOutputStream.toByteArray(), (int) start, result, 0, result.length);
-        return result;
-    }
-
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     public ResponseEntity<Void> addAudioMetaData(AddAudioMetadataRequest addAudioMetadataRequest) {

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -93,9 +93,9 @@ public class AudioController implements AudioApi {
     public byte[] readByteRange(InputStream inputStream, long start, long end) throws IOException {
         ByteArrayOutputStream bufferedOutputStream = new ByteArrayOutputStream();
         byte[] data = new byte[BYTE_RANGE];
-        int nRead;
-        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
-            bufferedOutputStream.write(data, 0, nRead);
+        int read;
+        while ((read = inputStream.read(data, 0, data.length)) != -1) {
+            bufferedOutputStream.write(data, 0, read);
         }
         bufferedOutputStream.flush();
         byte[] result = new byte[(int) (end - start) + 1];

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -120,10 +120,11 @@ public class AudioController implements AudioApi {
 
     public byte[] readByteRange(byte[] wholeFile, long start, long end) {
         int srcPos;
-        if (start > Integer.MIN_VALUE && start < Integer.MAX_VALUE)
-            srcPos = (int)start;
-        else
+        if (start > Integer.MIN_VALUE && start < Integer.MAX_VALUE) {
+            srcPos = (int) start;
+        } else {
             throw new IllegalArgumentException("Invalid input: start bytes truncated");
+        }
 
         byte[] result = new byte[(int) (end - start) + 1];
         System.arraycopy(wholeFile, srcPos, result, 0, result.length);

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -153,6 +153,69 @@ paths:
           required: true
           description: "Internal identifier for media"
           example: 1
+      responses:
+        200:
+          description: OK
+          content:
+            audio/mpeg:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Bad Request Error
+          content:
+            application/json+problem:
+              schema:
+                $ref: './problem.yaml'
+              example:
+                type: "AUTHORISATION_104"
+                title: "Failed to check authorisation for the media"
+                status: 400
+        '401':
+          description: Unauthorised Error
+          content:
+            application/json+problem:
+              schema:
+                $ref: './problem.yaml'
+              example:
+                type: "AUTHORISATION_100"
+                title: "User is not authorised for the associated courthouse"
+                status: 401
+        '404':
+          description: Not Found Error
+          content:
+            application/json+problem:
+              schema:
+                $ref: './problem.yaml'
+              example:
+                type: "AUDIO_102"
+                title: "The requested media cannot be found"
+                status: 404
+        500:
+          description: The requested data cannot be located
+          content:
+            application/json+problem:
+              schema:
+                $ref: './problem.yaml'
+              example:
+                type: "AUDIO_101"
+                title: "The requested data cannot be located"
+                status: 500
+  /audio/preview2/{media_id}:
+    get:
+      tags:
+        - Audio
+      summary: Preview audio (return bytes)
+      operationId: preview2
+      description: Preview audio
+      parameters:
+        - in: path
+          name: media_id
+          schema:
+            type: integer
+          required: true
+          description: "Internal identifier for media"
+          example: 1
         - in: header
           name: range
           schema:

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -153,6 +153,11 @@ paths:
           required: true
           description: "Internal identifier for media"
           example: 1
+        - in: header
+          name: range
+          schema:
+            type: string
+          description: "Range header"
       responses:
         200:
           description: OK
@@ -160,7 +165,7 @@ paths:
             audio/mpeg:
               schema:
                 type: string
-                format: binary
+                format: byte
         '400':
           description: Bad Request Error
           content:


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Introducing a second audio preview endpoint (/preview2) which returns the file in bytes and allows for a range header to be specified.

I'd like to try this on the portal to see if it makes any difference to the streaming issues we've been having.

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
