### PR TITLE
DMP-1525 DateTime Issue in Get Transcription endpoint

### DIFF
--- a/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/casesSearchGetEndpointOneObjectReturned.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/casesSearchGetEndpointOneObjectReturned.json
@@ -4,7 +4,7 @@
     "hea_id": 1,
     "hearing_date": "2023-01-01",
     "type": "SENTENCING_REMARKS",
-    "requested_on": "2023-06-20",
+    "requested_on": "2023-06-20T10:00:00Z",
     "requested_by_name": "IntegrationTest User",
     "status": "APPROVED"
   }

--- a/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/casesSearchGetEndpointTwoObjectsReturned.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/casesSearchGetEndpointTwoObjectsReturned.json
@@ -4,7 +4,7 @@
     "hea_id": 1,
     "hearing_date": "2023-01-01",
     "type": "SENTENCING_REMARKS",
-    "requested_on": "2023-06-20",
+    "requested_on": "2023-06-20T10:00:00Z",
     "requested_by_name": "IntegrationTest User",
     "status": "APPROVED"
   },
@@ -13,7 +13,7 @@
     "hea_id": 1,
     "hearing_date": "2023-01-01",
     "type": "SENTENCING_REMARKS",
-    "requested_on": "2023-06-20",
+    "requested_on": "2023-06-20T10:00:00Z",
     "requested_by_name": "IntegrationTest User",
     "status": "APPROVED"
   }

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/TranscriptionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/TranscriptionMapper.java
@@ -34,7 +34,7 @@ public class TranscriptionMapper {
             transcript.setHearingDate(hearing.getHearingDate());
         }
         transcript.setType(transcriptionEntity.getTranscriptionType().getDescription());
-        transcript.setRequestedOn(transcriptionEntity.getCreatedDateTime().toLocalDate());
+        transcript.setRequestedOn(transcriptionEntity.getCreatedDateTime());
         transcript.setRequestedByName(getRequestedBy(transcriptionEntity));
         transcript.setStatus(transcriptionEntity.getTranscriptionStatus().getStatusType());
         return transcript;

--- a/src/main/java/uk/gov/hmcts/darts/hearings/mapper/TranscriptionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/mapper/TranscriptionMapper.java
@@ -32,7 +32,7 @@ public class TranscriptionMapper {
             transcript.setHearingDate(hearing.getHearingDate());
         }
         transcript.setType(transcriptionEntity.getTranscriptionType().getDescription());
-        transcript.setRequestedOn(transcriptionEntity.getCreatedDateTime().toLocalDate());
+        transcript.setRequestedOn(transcriptionEntity.getCreatedDateTime());
         transcript.setRequestedByName(getRequestedBy(transcriptionEntity));
         transcript.setStatus(transcriptionEntity.getTranscriptionStatus().getStatusType());
         return transcript;

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -625,8 +625,8 @@ components:
           example: "Sentencing remarks"
         requested_on:
           type: string
-          format: date
-          example: 2022-05-22
+          format: date-time
+          example: 2023-06-20T10:00:00Z
         requested_by_name:
           type: string
           example: "Joe Bloggs"

--- a/src/main/resources/openapi/hearings.yaml
+++ b/src/main/resources/openapi/hearings.yaml
@@ -229,8 +229,8 @@ components:
           example: "Sentencing remarks"
         requested_on:
           type: string
-          format: date
-          example: 2022-05-22
+          format: date-time
+          example: 2023-06-20T10:00:00Z
         requested_by_name:
           type: string
           example: "Joe Bloggs"

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/TranscriptionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/TranscriptionMapperTest.java
@@ -31,7 +31,7 @@ class TranscriptionMapperTest {
         assertEquals(102, transcript.getHeaId());
         assertEquals(LocalDate.of(2023, 6, 20), transcript.getHearingDate());
         assertEquals("SENTENCING_REMARKS", transcript.getType());
-        assertEquals(LocalDate.of(2020, 6, 20), transcript.getRequestedOn());
+        assertEquals(OffsetDateTime.of(2020, 6, 20,10, 10, 0, 0,ZoneOffset.UTC), transcript.getRequestedOn());
         assertEquals("testUsername", transcript.getRequestedByName());
         assertEquals("APPROVED", transcript.getStatus());
     }
@@ -59,7 +59,7 @@ class TranscriptionMapperTest {
         assertEquals(1, transcript.getTraId());
         assertEquals(LocalDate.of(2023, 6, 20), transcript.getHearingDate());
         assertEquals("SENTENCING_REMARKS", transcript.getType());
-        assertEquals(LocalDate.of(2020, 6, 20), transcript.getRequestedOn());
+        assertEquals(OffsetDateTime.of(2020, 6, 20,10, 10, 0, 0,ZoneOffset.UTC), transcript.getRequestedOn());
         assertEquals("someLegacyRequestor", transcript.getRequestedByName());
         assertEquals("APPROVED", transcript.getStatus());
     }

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/TranscriptionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/TranscriptionMapperTest.java
@@ -31,7 +31,7 @@ class TranscriptionMapperTest {
         assertEquals(102, transcript.getHeaId());
         assertEquals(LocalDate.of(2023, 6, 20), transcript.getHearingDate());
         assertEquals("SENTENCING_REMARKS", transcript.getType());
-        assertEquals(LocalDate.of(2020, 6, 20), transcript.getRequestedOn());
+        assertEquals(OffsetDateTime.of(2020, 6, 20,10, 10, 0, 0,ZoneOffset.UTC), transcript.getRequestedOn());
         assertEquals("testUsername", transcript.getRequestedByName());
         assertEquals("APPROVED", transcript.getStatus());
     }
@@ -59,7 +59,8 @@ class TranscriptionMapperTest {
         assertEquals(1, transcript.getTraId());
         assertEquals(LocalDate.of(2023, 6, 20), transcript.getHearingDate());
         assertEquals("SENTENCING_REMARKS", transcript.getType());
-        assertEquals(LocalDate.of(2020, 6, 20), transcript.getRequestedOn());
+        assertEquals(OffsetDateTime.of(2020, 6, 20,10, 10, 0, 0,ZoneOffset.UTC), transcript.getRequestedOn());
+
         assertEquals("someLegacyRequestor", transcript.getRequestedByName());
         assertEquals("APPROVED", transcript.getStatus());
     }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-1525


### Change description ###
There are 2 Get transcriptions endpoint which returns the data using CaseId (for Case screen) and Hearing Id (for hearing screen)

The 'requested_on' parameter in cases.yaml and hearings.yaml have been updated to date-time. 
–  generated file on Transcript.java model for both hearings and cases updated from LocalDate to OffsetDateTime return types
–  the map method in TranscriptionMapper. java for both hearings and cases return requestedOn as OffsetDateTime.

All associated java and json integration test files updated from LocalDate to OffsetDateTime return types for both hearings and cases.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
