### PR TITLE
DMP-1043/DMP-1049: Implement create and modify user account

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/FunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/FunctionalTest.java
@@ -70,6 +70,13 @@ public class FunctionalTest {
         return buildRequestWithAuth(internalAccessTokenClient);
     }
 
+    public void clean() {
+        buildRequestWithExternalAuth()
+            .baseUri(getUri("/functional-tests/clean"))
+            .redirects().follow(false)
+            .delete();
+    }
+
     private RequestSpecification buildRequestWithAuth(AccessTokenClient accessTokenClient) {
         return RestAssured.given()
             .header("Authorization", String.format("Bearer %s", accessTokenClient.getAccessToken()));

--- a/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/UserManagementFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/UserManagementFunctionalTest.java
@@ -1,0 +1,102 @@
+package uk.gov.hmcts.darts.usermanagement;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.RegularExpressionValueMatcher;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
+import uk.gov.hmcts.darts.FunctionalTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserManagementFunctionalTest extends FunctionalTest {
+
+    @AfterEach
+    void tearDown() {
+        clean();
+    }
+
+    @Test
+    void shouldCreateUser() {
+        Response response = createUser();
+
+        JSONAssert.assertEquals(
+            """
+                {
+                    "id": "",
+                    "full_name": "James Smith",
+                    "email_address": "james.smith@hmcts.net",
+                    "description": "Functional test user",
+                    "state": "ENABLED",
+                    "security_groups": [ ]
+                }
+                """,
+            response.asString(),
+            new CustomComparator(
+                JSONCompareMode.NON_EXTENSIBLE,
+                new Customization("id", new RegularExpressionValueMatcher<>("\\d*"))
+            )
+        );
+    }
+
+    @Test
+    void shouldModifyUser() {
+        Response createUserResponse = createUser();
+        int userId = new JSONObject(createUserResponse.asString())
+            .getInt("id");
+
+        Response modifyUserResponse = buildRequestWithExternalAuth()
+            .baseUri(getUri("/users/" + userId))
+            .contentType(ContentType.JSON)
+            .body("""
+                      {
+                           "full_name": "Jimmy Smith"
+                      }
+                      """)
+            .patch()
+            .thenReturn();
+
+        JSONAssert.assertEquals(
+            """
+                {
+                    "id": "",
+                    "full_name": "Jimmy Smith",
+                    "email_address": "james.smith@hmcts.net",
+                    "description": "Functional test user",
+                    "state": "ENABLED",
+                    "security_groups": [ ]
+                }
+                """,
+            modifyUserResponse.asString(),
+            new CustomComparator(
+                JSONCompareMode.NON_EXTENSIBLE,
+                new Customization("id", new RegularExpressionValueMatcher<>("^" + userId + "$"))
+            )
+        );
+    }
+
+    private Response createUser() {
+        Response response = buildRequestWithExternalAuth()
+            .baseUri(getUri("/users"))
+            .contentType(ContentType.JSON)
+            .body("""
+                      {
+                           "full_name": "James Smith",
+                           "email_address": "james.smith@hmcts.net",
+                           "description": "Functional test user"
+                      }
+                      """)
+            .post()
+            .thenReturn();
+
+        assertEquals(201, response.getStatusCode());
+
+        return response;
+    }
+
+}

--- a/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/UserManagementFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/UserManagementFunctionalTest.java
@@ -39,7 +39,7 @@ class UserManagementFunctionalTest extends FunctionalTest {
             response.asString(),
             new CustomComparator(
                 JSONCompareMode.NON_EXTENSIBLE,
-                new Customization("id", new RegularExpressionValueMatcher<>("\\d*"))
+                new Customization("id", new RegularExpressionValueMatcher<>("\\d+"))
             )
         );
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
@@ -1,0 +1,370 @@
+package uk.gov.hmcts.darts.usermanagement.controller;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+class PatchUserIntTest extends IntegrationBase {
+
+    private static final String ORIGINAL_USERNAME = "James Smith";
+    private static final String ORIGINAL_EMAIL_ADDRESS = "james.smith@hmcts.net";
+    private static final String ORIGINAL_DESCRIPTION = "A test user";
+    private static final int ORIGINAL_SECURITY_GROUP_ID_1 = -1;
+    private static final int ORIGINAL_SECURITY_GROUP_ID_2 = -2;
+    private static final boolean ORIGINAL_SYSTEM_USER_FLAG = false;
+    private static final OffsetDateTime ORIGINAL_LAST_LOGIN_TIME = OffsetDateTime.parse("2023-04-11T15:37:59Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockBean
+    private AuthorisationApi authorisationApi;
+
+    private TransactionTemplate transactionTemplate;
+    private UserAccountEntity integrationTestUser;
+
+    @BeforeEach
+    void setUp() {
+        transactionTemplate = new TransactionTemplate(transactionManager);
+
+        integrationTestUser = dartsDatabase.getUserAccountStub()
+            .getIntegrationTestUserAccountEntity();
+        Mockito.when(authorisationApi.getCurrentUser())
+            .thenReturn(integrationTestUser);
+    }
+
+    @Test
+    void patchUserShouldSucceedWhenProvidedWithValidValueForSubsetOfAllowableFields() throws Exception {
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        Integer userId = existingAccount.getId();
+
+        MockHttpServletRequestBuilder request = buildRequest(userId)
+            .content("""
+                         {
+                           "full_name": "Jimmy Smith"
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.full_name").value("Jimmy Smith"))
+            .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
+            .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
+            .andExpect(jsonPath("$.state").value("ENABLED"))
+            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.security_groups", Matchers.containsInAnyOrder(
+                ORIGINAL_SECURITY_GROUP_ID_1,
+                ORIGINAL_SECURITY_GROUP_ID_2
+            )));
+
+        transactionTemplate.execute(status -> {
+            UserAccountEntity latestUserAccountEntity = dartsDatabase.getUserAccountRepository()
+                .findById(userId)
+                .orElseThrow();
+            assertEquals("Jimmy Smith", latestUserAccountEntity.getUsername());
+            assertEquals(ORIGINAL_EMAIL_ADDRESS, latestUserAccountEntity.getEmailAddress());
+            assertEquals(ORIGINAL_DESCRIPTION, latestUserAccountEntity.getUserDescription());
+            assertEquals(0, latestUserAccountEntity.getState());
+            assertThat(
+                getSecurityGroupIds(latestUserAccountEntity),
+                hasItems(ORIGINAL_SECURITY_GROUP_ID_1, ORIGINAL_SECURITY_GROUP_ID_2)
+            );
+            assertEquals(ORIGINAL_SYSTEM_USER_FLAG, latestUserAccountEntity.getIsSystemUser());
+
+            assertEquals(existingAccount.getCreatedDateTime(), latestUserAccountEntity.getCreatedDateTime());
+            assertThat(latestUserAccountEntity.getLastModifiedDateTime(), greaterThan(existingAccount.getLastModifiedDateTime()));
+            assertEquals(ORIGINAL_LAST_LOGIN_TIME, latestUserAccountEntity.getLastLoginTime());
+            assertEquals(integrationTestUser.getId(), latestUserAccountEntity.getLastModifiedBy().getId());
+            assertEquals(integrationTestUser.getId(), latestUserAccountEntity.getCreatedBy().getId());
+
+            return null;
+        });
+    }
+
+    @Test
+    void patchUserShouldSucceedWhenProvidedWithValidValuesForAllAllowableFields() throws Exception {
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        Integer userId = existingAccount.getId();
+
+        MockHttpServletRequestBuilder request = buildRequest(userId)
+            .content("""
+                         {
+                           "full_name": "Jimmy Smith",
+                           "description": "An updated description",
+                           "state": "DISABLED",
+                           "security_groups": [ ]
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.full_name").value("Jimmy Smith"))
+            .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
+            .andExpect(jsonPath("$.description").value("An updated description"))
+            .andExpect(jsonPath("$.state").value("DISABLED"))
+            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.security_groups").isEmpty());
+
+        transactionTemplate.execute(status -> {
+            UserAccountEntity latestUserAccountEntity = dartsDatabase.getUserAccountRepository()
+                .findById(userId)
+                .orElseThrow();
+            assertEquals("Jimmy Smith", latestUserAccountEntity.getUsername());
+            assertEquals(ORIGINAL_EMAIL_ADDRESS, latestUserAccountEntity.getEmailAddress());
+            assertEquals("An updated description", latestUserAccountEntity.getUserDescription());
+            assertEquals(1, latestUserAccountEntity.getState());
+            assertThat(getSecurityGroupIds(latestUserAccountEntity), empty()
+            );
+            assertEquals(ORIGINAL_SYSTEM_USER_FLAG, latestUserAccountEntity.getIsSystemUser());
+
+            assertEquals(existingAccount.getCreatedDateTime(), latestUserAccountEntity.getCreatedDateTime());
+            assertThat(latestUserAccountEntity.getLastModifiedDateTime(), greaterThan(existingAccount.getLastModifiedDateTime()));
+            assertEquals(ORIGINAL_LAST_LOGIN_TIME, latestUserAccountEntity.getLastLoginTime());
+            assertEquals(integrationTestUser.getId(), latestUserAccountEntity.getLastModifiedBy().getId());
+            assertEquals(integrationTestUser.getId(), latestUserAccountEntity.getCreatedBy().getId());
+
+            return null;
+        });
+    }
+
+    @Test
+    void patchUserShouldFailIfChangeWithInvalidDataIsAttempted() throws Exception {
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        Integer userId = existingAccount.getId();
+
+        MockHttpServletRequestBuilder request = buildRequest(userId)
+            .content("""
+                         {
+                           "full_name": " ",
+                           "description": ""
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.title").value("Constraint Violation"))
+            .andExpect(jsonPath("$.violations[*].field", hasItems("fullName", "description")));
+    }
+
+    @Test
+    void patchUserShouldFailIfProvidedUserIdDoesNotExistInDB() throws Exception {
+        MockHttpServletRequestBuilder request = buildRequest(818_231)
+            .content("""
+                         {
+                           "full_name": "Jimmy Smith"
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.type").value("USER_MANAGEMENT_100"));
+    }
+
+    @Test
+    void patchUserShouldSucceedAndClearSecurityGroupsWhenAccountGetsDisabledAndNoSecurityGroupsAreExplicitlyProvided() throws Exception {
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        Integer userId = existingAccount.getId();
+
+        MockHttpServletRequestBuilder request = buildRequest(userId)
+            .content("""
+                         {
+                           "state": "DISABLED"
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.full_name").value(ORIGINAL_USERNAME))
+            .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
+            .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
+            .andExpect(jsonPath("$.state").value("DISABLED"))
+            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.security_groups").isEmpty());
+
+        transactionTemplate.execute(status -> {
+            UserAccountEntity latestUserAccountEntity = dartsDatabase.getUserAccountRepository()
+                .findById(userId)
+                .orElseThrow();
+
+            assertEquals(1, latestUserAccountEntity.getState());
+            assertThat(getSecurityGroupIds(latestUserAccountEntity), empty());
+
+            return null;
+        });
+    }
+
+    @Test
+    void patchUserShouldSucceedWhenAccountGetsEnabled() throws Exception {
+        UserAccountEntity existingAccount = createDisabledUserAccountEntity();
+        Integer userId = existingAccount.getId();
+
+        MockHttpServletRequestBuilder request = buildRequest(userId)
+            .content("""
+                         {
+                           "state": "ENABLED"
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.full_name").value(ORIGINAL_USERNAME))
+            .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
+            .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
+            .andExpect(jsonPath("$.state").value("ENABLED"))
+            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.security_groups").isEmpty());
+
+        transactionTemplate.execute(status -> {
+            UserAccountEntity latestUserAccountEntity = dartsDatabase.getUserAccountRepository()
+                .findById(userId)
+                .orElseThrow();
+
+            assertEquals(0, latestUserAccountEntity.getState());
+            assertThat(getSecurityGroupIds(latestUserAccountEntity), empty());
+
+            return null;
+        });
+    }
+
+    @Test
+    void patchUserShouldSucceedWhenSecurityGroupsAreUpdated() throws Exception {
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        Integer userId = existingAccount.getId();
+
+        MockHttpServletRequestBuilder request = buildRequest(userId)
+            .content("""
+                         {
+                           "security_groups": [ -3, -4 ]
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.full_name").value(ORIGINAL_USERNAME))
+            .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
+            .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
+            .andExpect(jsonPath("$.state").value("ENABLED"))
+            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.security_groups", not(Matchers.containsInAnyOrder(
+                ORIGINAL_SECURITY_GROUP_ID_1,
+                ORIGINAL_SECURITY_GROUP_ID_2
+            ))))
+            .andExpect(jsonPath("$.security_groups", Matchers.containsInAnyOrder(-3, -4)));
+
+        transactionTemplate.execute(status -> {
+            UserAccountEntity latestUserAccountEntity = dartsDatabase.getUserAccountRepository()
+                .findById(userId)
+                .orElseThrow();
+
+            assertThat(getSecurityGroupIds(latestUserAccountEntity),
+                not(hasItems(ORIGINAL_SECURITY_GROUP_ID_1, ORIGINAL_SECURITY_GROUP_ID_2)));
+            assertThat(getSecurityGroupIds(latestUserAccountEntity),
+                hasItems(-3, -4));
+
+            return null;
+        });
+    }
+
+    @Test
+    void patchUserShouldFailIfEmailAddressChangeIsAttemptedAndDataShouldRemainUnchanged() throws Exception {
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        Integer userId = existingAccount.getId();
+
+        MockHttpServletRequestBuilder request = buildRequest(userId)
+            .content("""
+                         {
+                           "email_address": "jimmy.smith@hmcts.net"
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.detail", containsString("Unrecognized field \"email_address\"")));
+
+        UserAccountEntity latestUserAccountEntity = dartsDatabase.getUserAccountRepository()
+            .findById(userId)
+            .orElseThrow();
+        assertEquals(ORIGINAL_SYSTEM_USER_FLAG, latestUserAccountEntity.getIsSystemUser());
+        assertEquals(ORIGINAL_USERNAME, latestUserAccountEntity.getUsername());
+        assertEquals(ORIGINAL_EMAIL_ADDRESS, latestUserAccountEntity.getEmailAddress());
+        assertEquals(ORIGINAL_DESCRIPTION, latestUserAccountEntity.getUserDescription());
+        assertEquals(0, latestUserAccountEntity.getState());
+        assertEquals(ORIGINAL_LAST_LOGIN_TIME, latestUserAccountEntity.getLastLoginTime());
+    }
+
+    private UserAccountEntity createEnabledUserAccountEntity() {
+        UserAccountEntity userAccountEntity = new UserAccountEntity();
+        userAccountEntity.setUsername(ORIGINAL_USERNAME);
+        userAccountEntity.setEmailAddress(ORIGINAL_EMAIL_ADDRESS);
+        userAccountEntity.setUserDescription(ORIGINAL_DESCRIPTION);
+        userAccountEntity.setState(0);
+        userAccountEntity.setLastLoginTime(ORIGINAL_LAST_LOGIN_TIME);
+
+        userAccountEntity.setIsSystemUser(ORIGINAL_SYSTEM_USER_FLAG);
+        userAccountEntity.setCreatedBy(integrationTestUser);
+        userAccountEntity.setLastModifiedBy(integrationTestUser);
+
+        SecurityGroupEntity securityGroupEntity1 = dartsDatabase.getSecurityGroupRepository()
+            .getReferenceById(ORIGINAL_SECURITY_GROUP_ID_1);
+        SecurityGroupEntity securityGroupEntity2 = dartsDatabase.getSecurityGroupRepository()
+            .getReferenceById(ORIGINAL_SECURITY_GROUP_ID_2);
+        userAccountEntity.setSecurityGroupEntities(Set.of(securityGroupEntity1, securityGroupEntity2));
+
+        return dartsDatabase.getUserAccountRepository()
+            .save(userAccountEntity);
+    }
+
+    private UserAccountEntity createDisabledUserAccountEntity() {
+        UserAccountEntity userAccountEntity = new UserAccountEntity();
+        userAccountEntity.setUsername(ORIGINAL_USERNAME);
+        userAccountEntity.setEmailAddress(ORIGINAL_EMAIL_ADDRESS);
+        userAccountEntity.setUserDescription(ORIGINAL_DESCRIPTION);
+        userAccountEntity.setState(1);
+        userAccountEntity.setLastLoginTime(ORIGINAL_LAST_LOGIN_TIME);
+
+        userAccountEntity.setIsSystemUser(ORIGINAL_SYSTEM_USER_FLAG);
+        userAccountEntity.setCreatedBy(integrationTestUser);
+        userAccountEntity.setLastModifiedBy(integrationTestUser);
+
+        userAccountEntity.setSecurityGroupEntities(Collections.emptySet());
+
+        return dartsDatabase.getUserAccountRepository()
+            .save(userAccountEntity);
+    }
+
+    private MockHttpServletRequestBuilder buildRequest(int userId) {
+        return patch("/users/" + userId)
+            .header("Content-Type", "application/json");
+    }
+
+    private static List<Integer> getSecurityGroupIds(UserAccountEntity createdUserAccountEntity) {
+        return createdUserAccountEntity.getSecurityGroupEntities().stream()
+            .map(SecurityGroupEntity::getId)
+            .toList();
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostUserIntTest.java
@@ -1,0 +1,235 @@
+package uk.gov.hmcts.darts.usermanagement.controller;
+
+import org.hamcrest.Matchers;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+class PostUserIntTest extends IntegrationBase {
+
+    private static final String USERNAME = "James Smith";
+    private static final String EMAIL_ADDRESS = "james.smith@hmcts.net";
+    private static final String DESCRIPTION = "A test user";
+    private static final int SECURITY_GROUP_ID_1 = -1;
+    private static final int SECURITY_GROUP_ID_2 = -2;
+    private static final boolean SYSTEM_USER_FLAG = false;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @MockBean
+    private AuthorisationApi authorisationApi;
+
+    private TransactionTemplate transactionTemplate;
+    private UserAccountEntity integrationTestUser;
+
+    @BeforeEach
+    void setUp() {
+        transactionTemplate = new TransactionTemplate(transactionManager);
+
+        integrationTestUser = dartsDatabase.getUserAccountStub()
+            .getIntegrationTestUserAccountEntity();
+        Mockito.when(authorisationApi.getCurrentUser())
+            .thenReturn(integrationTestUser);
+    }
+
+    @Test
+    void createUserShouldSucceedWhenProvidedWithValidValuesForMinimumRequiredFields() throws Exception {
+        MockHttpServletRequestBuilder request = buildRequest()
+            .content("""
+                         {
+                           "full_name": "James Smith",
+                           "email_address": "james.smith@hmcts.net"
+                         }
+                         """);
+
+        MvcResult result = mockMvc.perform(request)
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.full_name").value(USERNAME))
+            .andExpect(jsonPath("$.email_address").value(EMAIL_ADDRESS))
+            .andExpect(jsonPath("$.description").doesNotExist())
+            .andExpect(jsonPath("$.state").value("ENABLED"))
+            .andExpect(jsonPath("$.last_login").doesNotExist())
+            .andExpect(jsonPath("$.security_groups").isEmpty())
+            .andReturn();
+
+        int userId = getUserId(result);
+
+        transactionTemplate.execute(status -> {
+            UserAccountEntity createdUserAccountEntity = dartsDatabase.getUserAccountRepository()
+                .findById(userId)
+                .orElseThrow();
+            assertEquals(USERNAME, createdUserAccountEntity.getUsername());
+            assertEquals(EMAIL_ADDRESS, createdUserAccountEntity.getEmailAddress());
+            assertNull(createdUserAccountEntity.getUserDescription());
+            assertEquals(0, createdUserAccountEntity.getState());
+            assertTrue(createdUserAccountEntity.getSecurityGroupEntities().isEmpty());
+            assertEquals(SYSTEM_USER_FLAG, createdUserAccountEntity.getIsSystemUser());
+
+            assertNotNull(createdUserAccountEntity.getCreatedDateTime());
+            assertNotNull(createdUserAccountEntity.getLastModifiedDateTime());
+            assertNull(createdUserAccountEntity.getLastLoginTime());
+            assertEquals(integrationTestUser.getId(), createdUserAccountEntity.getLastModifiedBy().getId());
+            assertEquals(integrationTestUser.getId(), createdUserAccountEntity.getCreatedBy().getId());
+
+            return null;
+        });
+    }
+
+    @Test
+    void createUserShouldSucceedWhenProvidedWithValidValuesForAllFields() throws Exception {
+        MockHttpServletRequestBuilder request = buildRequest()
+            .content("""
+                         {
+                           "full_name": "James Smith",
+                           "email_address": "james.smith@hmcts.net",
+                           "description": "A test user",
+                           "state": "ENABLED",
+                           "security_groups": [
+                             -1, -2
+                           ]
+                         }
+                         """);
+        MvcResult result = mockMvc.perform(request)
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.full_name").value(USERNAME))
+            .andExpect(jsonPath("$.email_address").value(EMAIL_ADDRESS))
+            .andExpect(jsonPath("$.description").value(DESCRIPTION))
+            .andExpect(jsonPath("$.state").value("ENABLED"))
+            .andExpect(jsonPath("$.last_login").doesNotExist())
+            .andExpect(jsonPath("$.security_groups", Matchers.containsInAnyOrder(
+                SECURITY_GROUP_ID_1,
+                SECURITY_GROUP_ID_2
+            )))
+            .andReturn();
+
+        int userId = getUserId(result);
+
+        transactionTemplate.execute(status -> {
+            UserAccountEntity createdUserAccountEntity = dartsDatabase.getUserAccountRepository()
+                .findById(userId)
+                .orElseThrow();
+            assertEquals(USERNAME, createdUserAccountEntity.getUsername());
+            assertEquals(EMAIL_ADDRESS, createdUserAccountEntity.getEmailAddress());
+            assertEquals(DESCRIPTION, createdUserAccountEntity.getUserDescription());
+            assertEquals(0, createdUserAccountEntity.getState());
+            assertThat(
+                getSecurityGroupIds(createdUserAccountEntity),
+                hasItems(SECURITY_GROUP_ID_1, SECURITY_GROUP_ID_2)
+            );
+            assertEquals(SYSTEM_USER_FLAG, createdUserAccountEntity.getIsSystemUser());
+
+            assertNotNull(createdUserAccountEntity.getCreatedDateTime());
+            assertNotNull(createdUserAccountEntity.getLastModifiedDateTime());
+            assertNull(createdUserAccountEntity.getLastLoginTime());
+            assertEquals(integrationTestUser.getId(), createdUserAccountEntity.getLastModifiedBy().getId());
+            assertEquals(integrationTestUser.getId(), createdUserAccountEntity.getCreatedBy().getId());
+
+            return null;
+        });
+    }
+
+    @Test
+    void createUserShouldFailWhenRequiredFieldsAreMissing() throws Exception {
+        MockHttpServletRequestBuilder request = buildRequest()
+            .header("Content-Type", "application/json")
+            .content("""
+                         {
+                           "description": "",
+                           "state": "ENABLED",
+                           "security_groups": [
+                             1
+                           ]
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createUserShouldSucceedWhenProvidedWithAUserEmailAddressThatMatchesAnExistingDisabledAccount() throws Exception {
+        UserAccountEntity userAccountEntity = new UserAccountEntity();
+        userAccountEntity.setUsername("James Smith");
+        userAccountEntity.setEmailAddress("james.smith@hmcts.net");
+        userAccountEntity.setIsSystemUser(false);
+        userAccountEntity.setState(1);
+        dartsDatabase.getUserAccountRepository()
+            .save(userAccountEntity);
+
+        MockHttpServletRequestBuilder request = buildRequest()
+            .content("""
+                         {
+                           "full_name": "James Smith",
+                           "email_address": "james.smith@hmcts.net"
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    void createUserShouldFailWhenProvidedWithASecurityGroupThatDoesntExist() throws Exception {
+        MockHttpServletRequestBuilder request = buildRequest()
+            .content("""
+                         {
+                           "full_name": "James Smith",
+                           "email_address": "james.smith@hmcts.net",
+                           "security_groups": [
+                             9999999
+                           ]
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isInternalServerError());
+    }
+
+    private MockHttpServletRequestBuilder buildRequest() {
+        return post("/users")
+            .header("Content-Type", "application/json");
+    }
+
+    private int getUserId(MvcResult result) throws UnsupportedEncodingException {
+        String contentAsString = result.getResponse().getContentAsString();
+        return new JSONObject(contentAsString)
+            .getInt("id");
+    }
+
+    private static List<Integer> getSecurityGroupIds(UserAccountEntity createdUserAccountEntity) {
+        return createdUserAccountEntity.getSecurityGroupEntities().stream()
+            .map(SecurityGroupEntity::getId)
+            .toList();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
@@ -96,6 +96,8 @@ public class TestSupportController {
 
         removeCourtHouses(session);
 
+        removeUsers(session);
+
         session.getTransaction().commit();
         session.close();
     }
@@ -318,6 +320,13 @@ public class TestSupportController {
                                              select cas_id from darts.court_case where case_number like 'func-%'
                                              """, Integer.class)
             .getResultList();
+    }
+
+    private void removeUsers(Session session) {
+        session.createNativeQuery("""
+                delete from darts.user_account where description = 'Functional test user'
+                """, Integer.class)
+            .executeUpdate();
     }
 
     @GetMapping(value = "/bank-holidays/{year}")

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/api/AuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/api/AuthorisationApi.java
@@ -17,4 +17,5 @@ public interface AuthorisationApi {
 
     List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse);
 
+    UserAccountEntity getCurrentUser();
 }

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/api/impl/AuthorisationApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/api/impl/AuthorisationApiImpl.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.authorisation.api.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
 import uk.gov.hmcts.darts.authorisation.service.AuthorisationService;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
@@ -18,6 +19,7 @@ import java.util.Set;
 public class AuthorisationApiImpl implements AuthorisationApi {
 
     private final AuthorisationService authorisationService;
+    private final UserIdentity userIdentity;
 
     @Override
     public Optional<UserState> getAuthorisation(String emailAddress) {
@@ -36,4 +38,10 @@ public class AuthorisationApiImpl implements AuthorisationApi {
     public List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse) {
         return authorisationService.getUsersWithRoleAtCourthouse(securityRole, courthouse);
     }
+
+    @Override
+    public UserAccountEntity getCurrentUser() {
+        return userIdentity.getUserAccount();
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
@@ -34,6 +34,7 @@ public class UserController implements UserApi {
     }
 
     @Override
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     public ResponseEntity<UserWithId> usersPost(User user) {
         UserWithId createdUser = userManagementService.createUser(user);
 
@@ -42,6 +43,7 @@ public class UserController implements UserApi {
     }
 
     @Override
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     public ResponseEntity<UserWithIdAndLastLogin> usersIdPatch(Integer userId, UserPatch userPatch) {
         UserWithIdAndLastLogin updatedUser = userManagementService.modifyUser(userId, userPatch);
 

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
@@ -1,11 +1,17 @@
 package uk.gov.hmcts.darts.usermanagement.controller;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.usermanagement.http.api.UserApi;
+import uk.gov.hmcts.darts.usermanagement.model.User;
+import uk.gov.hmcts.darts.usermanagement.model.UserPatch;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
 import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndLastLogin;
+import uk.gov.hmcts.darts.usermanagement.service.UserManagementService;
 
 import java.util.List;
 
@@ -14,13 +20,32 @@ import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANY_ENTITY_ID
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.ADMIN;
 
 @RestController
+@RequiredArgsConstructor
 public class UserController implements UserApi {
+
+    private final UserManagementService userManagementService;
+
 
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = ADMIN)
     public ResponseEntity<List<UserWithIdAndLastLogin>> usersGet(Integer courthouse) {
         return UserApi.super.usersGet(courthouse);
+    }
+
+    @Override
+    public ResponseEntity<UserWithId> usersPost(User user) {
+        UserWithId createdUser = userManagementService.createUser(user);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(createdUser);
+    }
+
+    @Override
+    public ResponseEntity<UserWithIdAndLastLogin> usersIdPatch(Integer userId, UserPatch userPatch) {
+        UserWithIdAndLastLogin updatedUser = userManagementService.modifyUser(userId, userPatch);
+
+        return ResponseEntity.ok(updatedUser);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/exception/UserManagementError.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/exception/UserManagementError.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.darts.usermanagement.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.darts.common.exception.DartsApiError;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserManagementError implements DartsApiError {
+
+    USER_NOT_FOUND(
+        "100",
+            HttpStatus.NOT_FOUND,
+            "The provided user does not exist"
+    );
+
+    private static final String ERROR_TYPE_PREFIX = "USER_MANAGEMENT";
+
+    private final String errorTypeNumeric;
+    private final HttpStatus httpStatus;
+    private final String title;
+
+    @Override
+    public String getErrorTypePrefix() {
+        return ERROR_TYPE_PREFIX;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/mapper/impl/UserAccountMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/mapper/impl/UserAccountMapper.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.darts.usermanagement.mapper.impl;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.usermanagement.model.User;
+import uk.gov.hmcts.darts.usermanagement.model.UserState;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndLastLogin;
+
+@Mapper(componentModel = "spring",
+    unmappedSourcePolicy = ReportingPolicy.IGNORE,
+    unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface UserAccountMapper {
+
+    @Mappings({
+        @Mapping(source = "fullName", target = "username"),
+        @Mapping(source = "emailAddress", target = "emailAddress"),
+        @Mapping(source = "description", target = "userDescription"),
+        @Mapping(source = "state", target = "state"),
+    })
+    UserAccountEntity mapToUserEntity(User user);
+
+    @Mappings({
+        @Mapping(source = "id", target = "id"),
+        @Mapping(source = "username", target = "fullName"),
+        @Mapping(source = "emailAddress", target = "emailAddress"),
+        @Mapping(source = "userDescription", target = "description"),
+        @Mapping(source = "state", target = "state")
+    })
+    UserWithId mapToUserWithIdModel(UserAccountEntity userAccountEntity);
+
+    @Mappings({
+        @Mapping(source = "id", target = "id"),
+        @Mapping(source = "username", target = "fullName"),
+        @Mapping(source = "emailAddress", target = "emailAddress"),
+        @Mapping(source = "userDescription", target = "description"),
+        @Mapping(source = "state", target = "state"),
+        @Mapping(source = "lastLoginTime", target = "lastLogin")
+    })
+    UserWithIdAndLastLogin mapToUserWithIdAndLastLoginModel(UserAccountEntity userAccountEntity);
+
+    default UserState mapToUserState(Integer stateValue) {
+        return stateValue == 0 ? UserState.ENABLED : UserState.DISABLED;
+    }
+
+    default Integer mapToUserStateValue(UserState userState) {
+        return UserState.ENABLED.equals(userState) ? 0 : 1;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementService.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.darts.usermanagement.service;
+
+import uk.gov.hmcts.darts.usermanagement.model.User;
+import uk.gov.hmcts.darts.usermanagement.model.UserPatch;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndLastLogin;
+
+public interface UserManagementService {
+
+    UserWithIdAndLastLogin modifyUser(Integer userId, UserPatch userPatch);
+
+    UserWithId createUser(User user);
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
@@ -1,0 +1,117 @@
+package uk.gov.hmcts.darts.usermanagement.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.usermanagement.exception.UserManagementError;
+import uk.gov.hmcts.darts.usermanagement.mapper.impl.UserAccountMapper;
+import uk.gov.hmcts.darts.usermanagement.model.User;
+import uk.gov.hmcts.darts.usermanagement.model.UserPatch;
+import uk.gov.hmcts.darts.usermanagement.model.UserState;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndLastLogin;
+import uk.gov.hmcts.darts.usermanagement.service.UserManagementService;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserManagementServiceImpl implements UserManagementService {
+
+    private final UserAccountMapper userAccountMapper;
+    private final UserAccountRepository userAccountRepository;
+    private final SecurityGroupRepository securityGroupRepository;
+    private final AuthorisationApi authorisationApi;
+
+    @Override
+    public UserWithId createUser(User user) {
+        var userEntity = userAccountMapper.mapToUserEntity(user);
+        userEntity.setIsSystemUser(false);
+        mapSecurityGroupsToUserEntity(user.getSecurityGroups(), userEntity);
+
+        var currentUser = authorisationApi.getCurrentUser();
+        userEntity.setCreatedBy(currentUser);
+        userEntity.setLastModifiedBy(currentUser);
+
+        var now = OffsetDateTime.now();
+        userEntity.setCreatedDateTime(now);
+        userEntity.setLastModifiedDateTime(now);
+
+        var createdUserEntity = userAccountRepository.save(userEntity);
+
+        UserWithId userWithId = userAccountMapper.mapToUserWithIdModel(createdUserEntity);
+        List<Integer> securityGroupIds = mapSecurityGroupEntitiesToIds(createdUserEntity.getSecurityGroupEntities());
+        userWithId.setSecurityGroups(securityGroupIds);
+
+        return userWithId;
+    }
+
+    @Override
+    public UserWithIdAndLastLogin modifyUser(Integer userId, UserPatch userPatch) {
+        var userEntity = userAccountRepository.findById(userId)
+            .orElseThrow(() -> new DartsApiException(UserManagementError.USER_NOT_FOUND,
+                                                     String.format("User id %d not found", userId)));
+        updateEntity(userPatch, userEntity);
+
+        UserAccountEntity updatedUserEntity = userAccountRepository.save(userEntity);
+
+        UserWithIdAndLastLogin user = userAccountMapper.mapToUserWithIdAndLastLoginModel(updatedUserEntity);
+        List<Integer> securityGroupIds = mapSecurityGroupEntitiesToIds(updatedUserEntity.getSecurityGroupEntities());
+        user.setSecurityGroups(securityGroupIds);
+
+        return user;
+    }
+
+    private void updateEntity(UserPatch user, UserAccountEntity userAccountEntity) {
+        String name = user.getFullName();
+        if (name != null) {
+            userAccountEntity.setUsername(name);
+        }
+
+        String description = user.getDescription();
+        if (description != null) {
+            userAccountEntity.setUserDescription(description);
+        }
+
+        UserState state = user.getState();
+        if (state != null) {
+            userAccountEntity.setState(userAccountMapper.mapToUserStateValue(state));
+        }
+
+        if (UserState.DISABLED.equals(user.getState())) {
+            userAccountEntity.setSecurityGroupEntities(Collections.emptySet());
+        } else {
+            mapSecurityGroupsToUserEntity(user.getSecurityGroups(), userAccountEntity);
+        }
+
+        userAccountEntity.setLastModifiedBy(authorisationApi.getCurrentUser());
+        userAccountEntity.setLastModifiedDateTime(OffsetDateTime.now());
+    }
+
+    private void mapSecurityGroupsToUserEntity(List<Integer> securityGroups, UserAccountEntity userAccountEntity) {
+        if (securityGroups != null) {
+            Set<SecurityGroupEntity> securityGroupEntities = securityGroups.stream()
+                .map(securityGroupRepository::findById)
+                .map(Optional::orElseThrow)
+                .collect(Collectors.toSet());
+            userAccountEntity.setSecurityGroupEntities(securityGroupEntities);
+        }
+    }
+
+    private List<Integer> mapSecurityGroupEntitiesToIds(Set<SecurityGroupEntity> securityGroupEntities) {
+        return securityGroupEntities.stream()
+            .map(SecurityGroupEntity::getId)
+            .toList();
+    }
+    
+}

--- a/src/main/resources/openapi/usermanagement.yaml
+++ b/src/main/resources/openapi/usermanagement.yaml
@@ -196,7 +196,7 @@ components:
     UserName:
       minLength: 1
       maxLength: 256
-      pattern: '^\S.+$' # Disallow starting or ending with whitespace
+      pattern: ^[^\s][a-zA-Z\s'-]+[^\s]$
       type: string
     UserEmailAddress:
       minLength: 1

--- a/src/main/resources/openapi/usermanagement.yaml
+++ b/src/main/resources/openapi/usermanagement.yaml
@@ -196,6 +196,7 @@ components:
     UserName:
       minLength: 1
       maxLength: 256
+      pattern: '^\S.+$' # Disallow starting or ending with whitespace
       type: string
     UserEmailAddress:
       minLength: 1
@@ -225,7 +226,7 @@ components:
 
     CourthouseId:
       type: integer
-    
+
     GenericSearchField:
       minLength: 3
       maxLength: 256
@@ -280,11 +281,13 @@ components:
     UserWithIdAndLastLogin:
       type: object
       properties:
+        id:
+          $ref: '#/components/schemas/UserId'
         last_login:
           type: string
           format: date-time
       allOf:
-        - $ref: '#/components/schemas/UserWithId'
+        - $ref: '#/components/schemas/User'
 
     SecurityGroup:
       type: object


### PR DESCRIPTION
# DMP-1043 & DMP-1049

Implement POST (create) and PATCH (modify) user operations.

Note the implementation does not apply any auth restrictions to these endpoints, this will be handled in a future task.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
