### PR TITLE
Updated transcription rejection notification template.

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -6,6 +6,13 @@
     <cve>CVE-2023-4586</cve>
   </suppress>
 
+  <suppress until="2024-01-14">
+    <notes>Suppression for netty. Pulled in by azure-bom latest version</notes>
+    <cve>CVE-2023-36052</cve>
+  </suppress>
+
+  CVE-2023-36052
+
   <!--Please add all the false positives under the below section-->
   <suppress>
     <notes>False Positive

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,11 +7,9 @@
   </suppress>
 
   <suppress until="2024-01-14">
-    <notes>Suppression for netty. Pulled in by azure-bom latest version</notes>
+    <notes>Suppression for azure deps. Pulled in by azure-bom latest version</notes>
     <cve>CVE-2023-36052</cve>
   </suppress>
-
-  CVE-2023-36052
 
   <!--Please add all the false positives under the below section-->
   <suppress>

--- a/src/functionalTest/java/uk/gov/hmcts/darts/notification/service/GovNotifyServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/notification/service/GovNotifyServiceTest.java
@@ -160,5 +160,4 @@ class GovNotifyServiceTest {
                     DARTS""", emailResponse);
 
     }
-
 }

--- a/src/functionalTest/java/uk/gov/hmcts/darts/notification/service/GovNotifyServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/notification/service/GovNotifyServiceTest.java
@@ -129,12 +129,10 @@ class GovNotifyServiceTest {
             parameterMap
         );
         assertEquals("Your transcript request was rejected", emailResponse.getSubject());
-        compare(
-            """
-                Your transcript request for case ID TheCaseId has been rejected due to TheRejectionReason.
+        compare("""
+                 Your transcript request for case ID TheCaseId has been rejected due to TheRejectionReason.
 
-                You can resubmit your request, but take into account the reason for the original request's rejection.
-            """,
+                 You can resubmit your request, but take into account the reason for the original request's rejection.""",
             emailResponse
         );
     }

--- a/src/functionalTest/java/uk/gov/hmcts/darts/notification/service/GovNotifyServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/notification/service/GovNotifyServiceTest.java
@@ -128,11 +128,13 @@ class GovNotifyServiceTest {
             NotificationApi.NotificationTemplate.TRANSCRIPTION_REQUEST_REJECTED.toString(),
             parameterMap
         );
-        assertEquals("DARTS: Transcript Request Rejected", emailResponse.getSubject());
+        assertEquals("Your transcript request was rejected", emailResponse.getSubject());
         compare(
             """
-                Your transcript request for case ID TheCaseId has been rejected due to TheRejectionReason
-                Please resubmit your request, taking into account the reason for the original request's rejection.""",
+                Your transcript request for case ID TheCaseId has been rejected due to TheRejectionReason.
+
+                You can resubmit your request, but take into account the reason for the original request's rejection.
+            """,
             emailResponse
         );
     }


### PR DESCRIPTION
Updating functional to test to reflect notification template change

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
