### PR TITLE
DMP-1660 Refactor audio request processed logic

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
@@ -173,7 +173,8 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
     @Test
     @Order(9)
     void shouldSetDownloadFileNameAndFormat() {
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(1, TEST_FILENAME, AudioRequestOutputFormat.MP3);
+        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(mediaRequestService.getMediaRequestById(1), TEST_FILENAME,
+                                                                                                AudioRequestOutputFormat.MP3);
 
         assertEquals(COMPLETED, mediaRequestEntity.getStatus());
         assertEquals(TEST_FILENAME, mediaRequestEntity.getOutputFilename());
@@ -183,7 +184,8 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
     @Test
     @Order(10)
     void shouldSetPlaybackFileNameAndFormat() {
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(1, TEST_FILENAME, AudioRequestOutputFormat.ZIP);
+        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(mediaRequestService.getMediaRequestById(1), TEST_FILENAME,
+                                                                                                AudioRequestOutputFormat.ZIP);
 
         assertEquals(COMPLETED, mediaRequestEntity.getStatus());
         assertEquals(TEST_FILENAME, mediaRequestEntity.getOutputFilename());

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
@@ -36,5 +36,5 @@ public interface MediaRequestService {
 
     InputStream playback(Integer mediaRequestId);
 
-    MediaRequestEntity updateAudioRequestCompleted(Integer id, String fileName, AudioRequestOutputFormat audioRequestOutputFormat);
+    MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity, String fileName, AudioRequestOutputFormat audioRequestOutputFormat);
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -203,7 +203,11 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
                 blobId = saveProcessedData(mediaRequestEntity, BinaryData.fromStream(inputStream));
             }
 
-            mediaRequestService.updateAudioRequestCompleted(requestId, fileName, audioRequestOutputFormat);
+            mediaRequestService.updateAudioRequestCompleted(mediaRequestEntity, fileName, audioRequestOutputFormat);
+
+            log.debug("Completed processing for requestId {}. Zip successfully uploaded with blobId: {}", requestId, blobId);
+
+            notifyUser(mediaRequestEntity, hearingEntity.getCourtCase(), NotificationApi.NotificationTemplate.REQUESTED_AUDIO_AVAILABLE.toString());
 
         } catch (Exception e) {
             log.error(
@@ -221,13 +225,8 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
             throw new DartsApiException(AudioApiError.FAILED_TO_PROCESS_AUDIO_REQUEST, e);
         }
 
-        log.debug(
-            "Completed processing for requestId {}. Zip successfully uploaded with blobId: {}",
-            requestId,
-            blobId
-        );
 
-        notifyUser(mediaRequestEntity, hearingEntity.getCourtCase(), NotificationApi.NotificationTemplate.REQUESTED_AUDIO_AVAILABLE.toString());
+
 
         return blobId;
     }
@@ -309,7 +308,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     private void notifyUser(MediaRequestEntity mediaRequestEntity,
                             CourtCaseEntity courtCase,
                             String notificationTemplateName) {
-        log.debug("Scheduling notification for template name: {}...", notificationTemplateName);
+        log.info("Scheduling notification for template name {} and case id {}", notificationTemplateName, courtCase.getId());
 
         var saveNotificationToDbRequest = SaveNotificationToDbRequest.builder()
             .eventId(notificationTemplateName)

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -283,8 +283,8 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     }
 
     @Override
-    public MediaRequestEntity updateAudioRequestCompleted(Integer id, String fileName, AudioRequestOutputFormat audioRequestOutputFormat) {
-        MediaRequestEntity mediaRequestEntity = getMediaRequestById(id);
+    public MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity, String fileName,
+                                                          AudioRequestOutputFormat audioRequestOutputFormat) {
 
         mediaRequestEntity.setStatus(AudioRequestStatus.COMPLETED);
         mediaRequestEntity.setOutputFilename(fileName);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-1660


### Change description ###
Refactor the audio request processed logic in an attempt to stop Hibernate throwing a lazy loading exception when trying to send the notification when audio request has been processed. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
