### PR TITLE
DMP-1635 added validation on creating users with same email 

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
@@ -171,6 +171,7 @@ class AuthorisationServiceTest {
         var c3Court = dartsDatabaseStub.createCourthouseUnlessExists("C3 COURT");
 
         var bristolUser = dartsDatabaseStub.getUserAccountRepository().findByEmailAddressIgnoreCase(emailAddress)
+            .stream().findFirst()
             .orElseThrow();
         final Iterator<SecurityGroupEntity> bristolUserGroupIt = bristolUser.getSecurityGroupEntities().iterator();
         bristolUserGroupIt.next().getCourthouseEntities().addAll(Set.of(a1Court, b2Court));

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -45,14 +46,11 @@ public class UserAccountStub {
     }
 
     public UserAccountEntity getIntegrationTestUserAccountEntity() {
-        Optional<UserAccountEntity> userAccountEntityOptional = userAccountRepository.findByEmailAddressIgnoreCase(
-            INTEGRATION_TEST_USER_EMAIL);
-
-        if (userAccountEntityOptional.isPresent()) {
-            return userAccountEntityOptional.get();
-        } else {
+        List<UserAccountEntity> userAccounts = userAccountRepository.findByEmailAddressIgnoreCase(INTEGRATION_TEST_USER_EMAIL);
+        if (userAccounts.isEmpty()) {
             return createIntegrationUser(UUID.randomUUID().toString());
         }
+        return userAccounts.get(0);
     }
 
     private UserAccountEntity createIntegrationUser(String guid) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.usermanagement.controller;
 
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -63,6 +64,11 @@ class PatchUserIntTest extends IntegrationBase {
             .getIntegrationTestUserAccountEntity();
         Mockito.when(authorisationApi.getCurrentUser())
             .thenReturn(integrationTestUser);
+    }
+
+    @AfterEach
+    void deleteUser() {
+        dartsDatabase.addToUserAccountTrash(ORIGINAL_EMAIL_ADDRESS);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostUserIntTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.usermanagement.controller;
 
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -61,6 +62,11 @@ class PostUserIntTest extends IntegrationBase {
             .getIntegrationTestUserAccountEntity();
         Mockito.when(authorisationApi.getCurrentUser())
             .thenReturn(integrationTestUser);
+    }
+
+    @AfterEach
+    void deleteUser() {
+        dartsDatabase.addToUserAccountTrash(EMAIL_ADDRESS);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
@@ -84,10 +84,11 @@ public class UserIdentityImpl implements UserIdentity {
         String guid = getGuidFromToken();
         if (nonNull(guid)) {
             // System users will use GUID not email address
-            userAccount = userAccountRepository.findByAccountGuid(guid).orElse(null);
+            userAccount = userAccountRepository.findByAccountGuidAndActive(guid, true).orElse(null);
         }
         if (isNull(userAccount)) {
-            userAccount = userAccountRepository.findByEmailAddressIgnoreCase(getEmailAddressFromToken())
+            userAccount = userAccountRepository.findByEmailAddressIgnoreCaseAndActive(getEmailAddressFromToken(), true).stream()
+                .findFirst()
                 .orElseThrow(() -> new DartsApiException(USER_DETAILS_INVALID));
         }
         return userAccount;

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
@@ -13,9 +13,9 @@ import java.util.Set;
 @Repository
 public interface UserAccountRepository extends JpaRepository<UserAccountEntity, Integer> {
 
-    Optional<UserAccountEntity> findByEmailAddressIgnoreCase(String emailAddress);
+    List<UserAccountEntity> findByEmailAddressIgnoreCase(String emailAddress);
 
-    Optional<UserAccountEntity> findByAccountGuid(String guid);
+    Optional<UserAccountEntity> findByAccountGuidAndActive(String guid, Boolean active);
 
     //todo find out what user states are Active
     @Query("""
@@ -60,5 +60,7 @@ public interface UserAccountRepository extends JpaRepository<UserAccountEntity, 
         AND securityRole.id = :securityRoleId
         """)
     Optional<UserAccountEntity> findByRoleAndUserId(Integer securityRoleId, Integer userId);
+
+    List<UserAccountEntity> findByEmailAddressIgnoreCaseAndActive(String emailAddress, Boolean active);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/exception/UserManagementError.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/exception/UserManagementError.java
@@ -12,8 +12,11 @@ public enum UserManagementError implements DartsApiError {
     USER_NOT_FOUND(
         "100",
         HttpStatus.NOT_FOUND,
-        "The provided user does not exist"
-    ),
+        "The provided user does not exist"),
+    DUPLICATE_EMAIL(
+        "101",
+            HttpStatus.UNPROCESSABLE_ENTITY,
+        "The provided email already exists"),
     DUPLICATE_SECURITY_GROUP_NAME_NOT_PERMITTED(
         "110",
         HttpStatus.CONFLICT,

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
@@ -1,16 +1,16 @@
 package uk.gov.hmcts.darts.usermanagement.service.impl;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.usermanagement.component.UserSearchQuery;
-import uk.gov.hmcts.darts.usermanagement.exception.UserManagementError;
+import uk.gov.hmcts.darts.usermanagement.component.validation.Validator;
 import uk.gov.hmcts.darts.usermanagement.mapper.impl.UserAccountMapper;
 import uk.gov.hmcts.darts.usermanagement.model.User;
 import uk.gov.hmcts.darts.usermanagement.model.UserPatch;
@@ -38,9 +38,14 @@ public class UserManagementServiceImpl implements UserManagementService {
     private final SecurityGroupRepository securityGroupRepository;
     private final AuthorisationApi authorisationApi;
     private final UserSearchQuery userSearchQuery;
+    private final Validator<User> duplicateEmailValidator;
+    private final Validator<Integer> userAccountExistsValidator;
 
     @Override
+    @Transactional
     public UserWithId createUser(User user) {
+        duplicateEmailValidator.validate(user);
+
         var userEntity = userAccountMapper.mapToUserEntity(user);
         if (isNull(userEntity.isActive())) {
             userEntity.setActive(true);
@@ -66,15 +71,12 @@ public class UserManagementServiceImpl implements UserManagementService {
     }
 
     @Override
+    @Transactional
     public UserWithIdAndLastLogin modifyUser(Integer userId, UserPatch userPatch) {
-        var userEntity = userAccountRepository.findById(userId)
-            .orElseThrow(() -> new DartsApiException(
-                UserManagementError.USER_NOT_FOUND,
-                String.format("User id %d not found", userId)
-            ));
-        updateEntity(userPatch, userEntity);
+        userAccountExistsValidator.validate(userId);
 
-        UserAccountEntity updatedUserEntity = userAccountRepository.save(userEntity);
+        UserAccountEntity updatedUserEntity = userAccountRepository.findById(userId)
+            .map(userEntity -> updatedUserAccount(userPatch, userEntity)).orElseThrow();
 
         UserWithIdAndLastLogin user = userAccountMapper.mapToUserWithIdAndLastLoginModel(updatedUserEntity);
         List<Integer> securityGroupIds = mapSecurityGroupEntitiesToIds(updatedUserEntity.getSecurityGroupEntities());
@@ -95,6 +97,11 @@ public class UserManagementServiceImpl implements UserManagementService {
             });
 
         return userWithIdAndLastLoginList;
+    }
+
+    private UserAccountEntity updatedUserAccount(UserPatch userPatch, UserAccountEntity userEntity) {
+        updateEntity(userPatch, userEntity);
+        return userAccountRepository.save(userEntity);
     }
 
     private void updateEntity(UserPatch userPatch, UserAccountEntity userAccountEntity) {
@@ -138,5 +145,4 @@ public class UserManagementServiceImpl implements UserManagementService {
             .map(SecurityGroupEntity::getId)
             .toList();
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/validation/DuplicateEmailValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/validation/DuplicateEmailValidator.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.darts.usermanagement.service.validation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.usermanagement.component.validation.Validator;
+import uk.gov.hmcts.darts.usermanagement.exception.UserManagementError;
+import uk.gov.hmcts.darts.usermanagement.model.User;
+
+@Component("duplicateEmailValidator")
+@RequiredArgsConstructor
+public class DuplicateEmailValidator implements Validator<User> {
+
+    private final UserAccountRepository userAccountRepository;
+
+    @Override
+    public void validate(User user) {
+        userAccountRepository.findByEmailAddressIgnoreCaseAndActive(user.getEmailAddress(), true)
+            .stream().findFirst()
+            .ifPresent(existingUser -> {
+                throw new DartsApiException(
+                    UserManagementError.DUPLICATE_EMAIL,
+                    String.format("User with email %s already exists", existingUser.getEmailAddress())
+                );
+            });
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/validation/UserAccountExistsValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/validation/UserAccountExistsValidator.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.darts.usermanagement.service.validation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.usermanagement.component.validation.Validator;
+import uk.gov.hmcts.darts.usermanagement.exception.UserManagementError;
+
+@Component("userAccountExistsValidator")
+@RequiredArgsConstructor
+public class UserAccountExistsValidator implements Validator<Integer> {
+
+    private final UserAccountRepository userAccountRepository;
+
+    @Override
+    public void validate(Integer userId) {
+        if (!userAccountRepository.existsById(userId)) {
+            throw new DartsApiException(
+                UserManagementError.USER_NOT_FOUND,
+                String.format("User id %d not found", userId));
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/DuplicateEmailValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/DuplicateEmailValidatorTest.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.darts.usermanagement.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.usermanagement.model.User;
+import uk.gov.hmcts.darts.usermanagement.service.validation.DuplicateEmailValidator;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.darts.usermanagement.exception.UserManagementError.DUPLICATE_EMAIL;
+
+@ExtendWith(MockitoExtension.class)
+class DuplicateEmailValidatorTest {
+    private static final String NEW_EMAIL_ADDRESS = "new-email@hmcts.net";
+    private static final String EXISTING_EMAIL_ADDRESS = "existing-email@hmcts.net";
+
+    @Mock
+    private UserAccountRepository userAccountRepository;
+    private DuplicateEmailValidator duplicateEmailValidator;
+
+    @BeforeEach
+    void setUp() {
+        duplicateEmailValidator = new DuplicateEmailValidator(userAccountRepository);
+    }
+
+    @Test
+    void doesNotThrowExceptionIfEmailNotCurrentlyAssociatedWithActiveUser() {
+        when(userAccountRepository.findByEmailAddressIgnoreCaseAndActive(NEW_EMAIL_ADDRESS, true))
+            .thenReturn(Collections.emptyList());
+
+        duplicateEmailValidator.validate(someUserWithEmail(NEW_EMAIL_ADDRESS));
+
+        assertThatNoException().isThrownBy(() -> duplicateEmailValidator.validate(someUserWithEmail(NEW_EMAIL_ADDRESS)));
+    }
+
+    @Test
+    void throwsExceptionIfEmailAlreadyAssociatedWithActiveUser() {
+        when(userAccountRepository.findByEmailAddressIgnoreCaseAndActive(EXISTING_EMAIL_ADDRESS, true))
+            .thenReturn(List.of(someUserAccountWithEmail(EXISTING_EMAIL_ADDRESS)));
+
+        assertThatThrownBy(() -> duplicateEmailValidator.validate(someUserWithEmail(EXISTING_EMAIL_ADDRESS)))
+            .isInstanceOf(DartsApiException.class)
+            .hasFieldOrPropertyWithValue("error", DUPLICATE_EMAIL)
+            .hasFieldOrPropertyWithValue("detail", String.format("User with email %s already exists", EXISTING_EMAIL_ADDRESS));
+    }
+
+    private UserAccountEntity someUserAccountWithEmail(String email) {
+        UserAccountEntity userAccountEntity = new UserAccountEntity();
+        userAccountEntity.setEmailAddress(email);
+        return userAccountEntity;
+    }
+
+    private User someUserWithEmail(String email) {
+        User user = new User();
+        user.setEmailAddress(email);
+        return user;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserAccountExistsValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserAccountExistsValidatorTest.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.darts.usermanagement.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.usermanagement.service.validation.UserAccountExistsValidator;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.darts.usermanagement.exception.UserManagementError.USER_NOT_FOUND;
+
+@ExtendWith(MockitoExtension.class)
+class UserAccountExistsValidatorTest {
+
+    @Mock
+    private UserAccountRepository userAccountRepository;
+    private UserAccountExistsValidator userAccountExistsValidator;
+
+    @BeforeEach
+    void setUp() {
+        userAccountExistsValidator = new UserAccountExistsValidator(userAccountRepository);
+    }
+
+    @Test
+    void throwsIfUserNotFound() {
+        when(userAccountRepository.existsById(1)).thenReturn(false);
+
+        assertThatThrownBy(() -> userAccountExistsValidator.validate(1))
+            .isInstanceOf(DartsApiException.class)
+            .hasFieldOrPropertyWithValue("error", USER_NOT_FOUND)
+            .hasFieldOrPropertyWithValue("detail", "User id 1 not found");
+    }
+
+    @Test
+    void doesntThrowIfUserPresent() {
+        when(userAccountRepository.existsById(1)).thenReturn(true);
+
+        assertDoesNotThrow(() -> userAccountExistsValidator.validate(1));
+    }
+}


### PR DESCRIPTION
Added validation on creating users with same email address that takes into account existing user state

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
