### PR TITLE
DMP-1382 - Add 2000 character restriction to transcriptions OpenAPI spec

### DIFF
--- a/src/main/resources/openapi/transcriptions.yaml
+++ b/src/main/resources/openapi/transcriptions.yaml
@@ -629,6 +629,7 @@ components:
         comment:
           type: string
           example: 'Please expedite my transcription request'
+          maxLength: 2000
         start_date_time:
           type: string
           format: date-time
@@ -666,6 +667,7 @@ components:
           example: 3
         workflow_comment:
           type: string
+          maxLength: 2000
 
     UpdateTranscriptionsItem:
       type: object


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-1382](https://tools.hmcts.net/jira/browse/DMP-1382)

### Change description ###

Introduced maxLength in Swagger YAML for both "comment" and "workflow_comment" to limit to 2000 characters. 400 will be returned if character limit is exceeded

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
