### PR TITLE
DMP-1346: replace `repository.findById` with `repository.getReferenceById`

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
@@ -198,7 +198,6 @@ public class TestSupportController {
             auditRepository.saveAndFlush(audit);
             return new ResponseEntity<>(CREATED);
         } catch (DataIntegrityViolationException e) {
-            // if I let the exception bubble up we'd get a 500 status code, I need to catch it
             throw new ResponseStatusException(BAD_REQUEST);
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -17,7 +17,7 @@ import java.util.List;
 public interface ExternalObjectDirectoryRepository extends JpaRepository<ExternalObjectDirectoryEntity, Integer> {
 
     @Query(
-        "SELECT eod FROM ExternalObjectDirectoryEntity eod, MediaEntity med " +
+        "SELECT eod FROM ExternalObjectDirectoryEntity eod " +
             "WHERE eod.media = :media AND eod.status = :status AND eod.externalLocationType = :externalLocationType"
     )
     List<ExternalObjectDirectoryEntity> findByMediaStatusAndType(MediaEntity media, ObjectRecordStatusEntity status,


### PR DESCRIPTION
Note:

I've analyzed all the production code usages of `findById`.
Apart from one case, I believe all the current usages are legit and should not be replaced by `getReferenceById`. This is because:

- in most of the cases the (non-ID) entity fields are accessed with setters/getters, which would trigger a SQL operation anyway
- in a couple of cases replacing would break the API contract by changing the error currently returned in case the entity does not exist, which should be avoided