### PR TITLE
Remove dependency check from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,3 @@ jobs:
           cache: 'gradle'
       - name: Build
         run: ./gradlew check
-      - name: Dependency check
-        run: ./gradlew dependencyCheckAggregate


### PR DESCRIPTION
### JIRA link (if applicable) ###
NA


### Change description ###
After upgrading to version 9 of the dependency check tool, which was a breaking change (documented [here](https://github.com/jeremylong/DependencyCheck#900-upgrade-notice)), the CI tool does not work with the checker. However, the dependencies are already checked as part of the Jenkins pipeline and so it is not needed in the CI run so this PR removes that check. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
