### PR TITLE
DMP-1658: Apply authorisation to admin endpoints

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/SecurityGroupFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/SecurityGroupFunctionalTest.java
@@ -22,7 +22,7 @@ class SecurityGroupFunctionalTest extends FunctionalTest {
 
     @Test
     void shouldCreateSecurityGroup() {
-        Response response = buildRequestWithExternalAuth()
+        Response response = buildRequestWithExternalGlobalAccessAuth()
             .baseUri(getUri("/security-groups"))
             .contentType(ContentType.JSON)
             .body("""

--- a/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/UserManagementFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/UserManagementFunctionalTest.java
@@ -50,7 +50,7 @@ class UserManagementFunctionalTest extends FunctionalTest {
         int userId = new JSONObject(createUserResponse.asString())
             .getInt("id");
 
-        Response modifyUserResponse = buildRequestWithExternalAuth()
+        Response modifyUserResponse = buildRequestWithExternalGlobalAccessAuth()
             .baseUri(getUri("/users/" + userId))
             .contentType(ContentType.JSON)
             .body("""
@@ -81,7 +81,7 @@ class UserManagementFunctionalTest extends FunctionalTest {
     }
 
     private Response createUser() {
-        Response response = buildRequestWithExternalAuth()
+        Response response = buildRequestWithExternalGlobalAccessAuth()
             .baseUri(getUri("/users"))
             .contentType(ContentType.JSON)
             .body("""

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AdminUserStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AdminUserStub.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.darts.testutils.stubs;
+
+import lombok.RequiredArgsConstructor;
+import org.mockito.Mockito;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+
+@Component
+@RequiredArgsConstructor
+public class AdminUserStub {
+
+    private final UserAccountStub userAccountStub;
+
+    public UserAccountEntity givenUserIsAuthorised(UserIdentity userIdentity) {
+        var user = userAccountStub.createAdminUser();
+
+        Mockito.when(userIdentity.getUserAccount())
+            .thenReturn(user);
+        Mockito.when(userIdentity.userHasGlobalAccess(any()))
+            .thenReturn(true);
+
+        return user;
+    }
+
+    public UserAccountEntity givenUserIsNotAuthorised(UserIdentity userIdentity) {
+        var user = userAccountStub.getIntegrationTestUserAccountEntity();
+        user.setSecurityGroupEntities(Collections.emptySet());
+
+        Mockito.when(userIdentity.getUserAccount())
+            .thenReturn(user);
+        Mockito.when(userIdentity.userHasGlobalAccess(any()))
+            .thenReturn(false);
+
+        return user;
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
@@ -6,9 +6,11 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -220,6 +222,16 @@ public class UserAccountStub {
         testUser.setAccountGuid(guid);
         testUser = userAccountRepository.saveAndFlush(testUser);
         return testUser;
+    }
+
+    public UserAccountEntity createAdminUser() {
+        var adminGroup = securityGroupRepository.findByGroupName(SecurityRoleEnum.ADMIN.name())
+            .orElseThrow();
+
+        var user = getIntegrationTestUserAccountEntity();
+        user.setSecurityGroupEntities(Collections.singleton(adminGroup));
+
+        return userAccountRepository.saveAndFlush(user);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
@@ -225,7 +224,7 @@ public class UserAccountStub {
     }
 
     public UserAccountEntity createAdminUser() {
-        var adminGroup = securityGroupRepository.findByGroupName(SecurityRoleEnum.ADMIN.name())
+        var adminGroup = securityGroupRepository.findByGroupName("ADMIN")
             .orElseThrow();
 
         var user = getIntegrationTestUserAccountEntity();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
@@ -4,7 +4,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -12,10 +11,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
-import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.testutils.stubs.AdminUserStub;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -50,20 +50,17 @@ class PatchUserIntTest extends IntegrationBase {
     @Autowired
     private PlatformTransactionManager transactionManager;
 
+    @Autowired
+    private AdminUserStub adminUserStub;
+
     @MockBean
-    private AuthorisationApi authorisationApi;
+    private UserIdentity userIdentity;
 
     private TransactionTemplate transactionTemplate;
-    private UserAccountEntity integrationTestUser;
 
     @BeforeEach
     void setUp() {
         transactionTemplate = new TransactionTemplate(transactionManager);
-
-        integrationTestUser = dartsDatabase.getUserAccountStub()
-            .getIntegrationTestUserAccountEntity();
-        Mockito.when(authorisationApi.getCurrentUser())
-            .thenReturn(integrationTestUser);
     }
 
     @AfterEach
@@ -73,7 +70,9 @@ class PatchUserIntTest extends IntegrationBase {
 
     @Test
     void patchUserShouldSucceedWhenProvidedWithValidValueForSubsetOfAllowableFields() throws Exception {
-        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        UserAccountEntity user = adminUserStub.givenUserIsAuthorised(userIdentity);
+
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity(user);
         Integer userId = existingAccount.getId();
 
         MockHttpServletRequestBuilder request = buildRequest(userId)
@@ -111,8 +110,8 @@ class PatchUserIntTest extends IntegrationBase {
             assertEquals(existingAccount.getCreatedDateTime(), latestUserAccountEntity.getCreatedDateTime());
             assertThat(latestUserAccountEntity.getLastModifiedDateTime(), greaterThan(existingAccount.getLastModifiedDateTime()));
             assertEquals(ORIGINAL_LAST_LOGIN_TIME, latestUserAccountEntity.getLastLoginTime());
-            assertEquals(integrationTestUser.getId(), latestUserAccountEntity.getLastModifiedBy().getId());
-            assertEquals(integrationTestUser.getId(), latestUserAccountEntity.getCreatedBy().getId());
+            assertEquals(user.getId(), latestUserAccountEntity.getLastModifiedBy().getId());
+            assertEquals(user.getId(), latestUserAccountEntity.getCreatedBy().getId());
 
             return null;
         });
@@ -120,7 +119,9 @@ class PatchUserIntTest extends IntegrationBase {
 
     @Test
     void patchUserShouldSucceedWhenProvidedWithValidValuesForAllAllowableFields() throws Exception {
-        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        UserAccountEntity user = adminUserStub.givenUserIsAuthorised(userIdentity);
+
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity(user);
         Integer userId = existingAccount.getId();
 
         MockHttpServletRequestBuilder request = buildRequest(userId)
@@ -156,8 +157,8 @@ class PatchUserIntTest extends IntegrationBase {
             assertEquals(existingAccount.getCreatedDateTime(), latestUserAccountEntity.getCreatedDateTime());
             assertThat(latestUserAccountEntity.getLastModifiedDateTime(), greaterThan(existingAccount.getLastModifiedDateTime()));
             assertEquals(ORIGINAL_LAST_LOGIN_TIME, latestUserAccountEntity.getLastLoginTime());
-            assertEquals(integrationTestUser.getId(), latestUserAccountEntity.getLastModifiedBy().getId());
-            assertEquals(integrationTestUser.getId(), latestUserAccountEntity.getCreatedBy().getId());
+            assertEquals(user.getId(), latestUserAccountEntity.getLastModifiedBy().getId());
+            assertEquals(user.getId(), latestUserAccountEntity.getCreatedBy().getId());
 
             return null;
         });
@@ -165,7 +166,9 @@ class PatchUserIntTest extends IntegrationBase {
 
     @Test
     void patchUserShouldFailIfChangeWithInvalidDataIsAttempted() throws Exception {
-        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        UserAccountEntity user = adminUserStub.givenUserIsAuthorised(userIdentity);
+
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity(user);
         Integer userId = existingAccount.getId();
 
         MockHttpServletRequestBuilder request = buildRequest(userId)
@@ -183,6 +186,8 @@ class PatchUserIntTest extends IntegrationBase {
 
     @Test
     void patchUserShouldFailIfProvidedUserIdDoesNotExistInDB() throws Exception {
+        adminUserStub.givenUserIsAuthorised(userIdentity);
+
         MockHttpServletRequestBuilder request = buildRequest(818_231)
             .content("""
                          {
@@ -196,7 +201,9 @@ class PatchUserIntTest extends IntegrationBase {
 
     @Test
     void patchUserShouldSucceedAndClearSecurityGroupsWhenAccountGetsDisabledAndNoSecurityGroupsAreExplicitlyProvided() throws Exception {
-        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        UserAccountEntity user = adminUserStub.givenUserIsAuthorised(userIdentity);
+
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity(user);
         Integer userId = existingAccount.getId();
 
         MockHttpServletRequestBuilder request = buildRequest(userId)
@@ -228,7 +235,9 @@ class PatchUserIntTest extends IntegrationBase {
 
     @Test
     void patchUserShouldSucceedWhenAccountGetsEnabled() throws Exception {
-        UserAccountEntity existingAccount = createDisabledUserAccountEntity();
+        UserAccountEntity user = adminUserStub.givenUserIsAuthorised(userIdentity);
+
+        UserAccountEntity existingAccount = createDisabledUserAccountEntity(user);
         Integer userId = existingAccount.getId();
 
         MockHttpServletRequestBuilder request = buildRequest(userId)
@@ -260,7 +269,9 @@ class PatchUserIntTest extends IntegrationBase {
 
     @Test
     void patchUserShouldSucceedWhenSecurityGroupsAreUpdated() throws Exception {
-        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        UserAccountEntity user = adminUserStub.givenUserIsAuthorised(userIdentity);
+
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity(user);
         Integer userId = existingAccount.getId();
 
         MockHttpServletRequestBuilder request = buildRequest(userId)
@@ -302,7 +313,9 @@ class PatchUserIntTest extends IntegrationBase {
 
     @Test
     void patchUserShouldFailIfEmailAddressChangeIsAttemptedAndDataShouldRemainUnchanged() throws Exception {
-        UserAccountEntity existingAccount = createEnabledUserAccountEntity();
+        UserAccountEntity user = adminUserStub.givenUserIsAuthorised(userIdentity);
+
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity(user);
         Integer userId = existingAccount.getId();
 
         MockHttpServletRequestBuilder request = buildRequest(userId)
@@ -326,7 +339,24 @@ class PatchUserIntTest extends IntegrationBase {
         assertEquals(ORIGINAL_LAST_LOGIN_TIME, latestUserAccountEntity.getLastLoginTime());
     }
 
-    private UserAccountEntity createEnabledUserAccountEntity() {
+    @Test
+    void patchUserShouldFailIfUserIsNotAuthorised() throws Exception {
+        UserAccountEntity user = adminUserStub.givenUserIsNotAuthorised(userIdentity);
+
+        UserAccountEntity existingAccount = createEnabledUserAccountEntity(user);
+        Integer userId = existingAccount.getId();
+
+        MockHttpServletRequestBuilder request = buildRequest(userId)
+            .content("""
+                         {
+                           "full_name": "Jimmy Smith"
+                         }
+                         """);
+        mockMvc.perform(request)
+            .andExpect(status().isForbidden());
+    }
+
+    private UserAccountEntity createEnabledUserAccountEntity(UserAccountEntity user) {
         UserAccountEntity userAccountEntity = new UserAccountEntity();
         userAccountEntity.setUserName(ORIGINAL_USERNAME);
         userAccountEntity.setEmailAddress(ORIGINAL_EMAIL_ADDRESS);
@@ -335,8 +365,8 @@ class PatchUserIntTest extends IntegrationBase {
         userAccountEntity.setLastLoginTime(ORIGINAL_LAST_LOGIN_TIME);
 
         userAccountEntity.setIsSystemUser(ORIGINAL_SYSTEM_USER_FLAG);
-        userAccountEntity.setCreatedBy(integrationTestUser);
-        userAccountEntity.setLastModifiedBy(integrationTestUser);
+        userAccountEntity.setCreatedBy(user);
+        userAccountEntity.setLastModifiedBy(user);
 
         SecurityGroupEntity securityGroupEntity1 = dartsDatabase.getSecurityGroupRepository()
             .getReferenceById(ORIGINAL_SECURITY_GROUP_ID_1);
@@ -348,7 +378,7 @@ class PatchUserIntTest extends IntegrationBase {
             .save(userAccountEntity);
     }
 
-    private UserAccountEntity createDisabledUserAccountEntity() {
+    private UserAccountEntity createDisabledUserAccountEntity(UserAccountEntity user) {
         UserAccountEntity userAccountEntity = new UserAccountEntity();
         userAccountEntity.setUserName(ORIGINAL_USERNAME);
         userAccountEntity.setEmailAddress(ORIGINAL_EMAIL_ADDRESS);
@@ -357,8 +387,8 @@ class PatchUserIntTest extends IntegrationBase {
         userAccountEntity.setLastLoginTime(ORIGINAL_LAST_LOGIN_TIME);
 
         userAccountEntity.setIsSystemUser(ORIGINAL_SYSTEM_USER_FLAG);
-        userAccountEntity.setCreatedBy(integrationTestUser);
-        userAccountEntity.setLastModifiedBy(integrationTestUser);
+        userAccountEntity.setCreatedBy(user);
+        userAccountEntity.setLastModifiedBy(user);
 
         userAccountEntity.setSecurityGroupEntities(Collections.emptySet());
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostUserIntTest.java
@@ -15,9 +15,11 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.testutils.stubs.AdminUserStub;
 
 import java.io.UnsupportedEncodingException;
 import java.util.List;
@@ -48,8 +50,14 @@ class PostUserIntTest extends IntegrationBase {
     @Autowired
     private PlatformTransactionManager transactionManager;
 
+    @Autowired
+    private AdminUserStub adminUserStub;
+
     @MockBean
     private AuthorisationApi authorisationApi;
+
+    @MockBean
+    private UserIdentity userIdentity;
 
     private TransactionTemplate transactionTemplate;
     private UserAccountEntity integrationTestUser;
@@ -71,6 +79,8 @@ class PostUserIntTest extends IntegrationBase {
 
     @Test
     void createUserShouldSucceedWhenProvidedWithValidValuesForMinimumRequiredFields() throws Exception {
+        adminUserStub.givenUserIsAuthorised(userIdentity);
+
         MockHttpServletRequestBuilder request = buildRequest()
             .content("""
                          {
@@ -115,6 +125,8 @@ class PostUserIntTest extends IntegrationBase {
 
     @Test
     void createUserShouldSucceedWhenProvidedWithValidValuesForAllFields() throws Exception {
+        adminUserStub.givenUserIsAuthorised(userIdentity);
+
         MockHttpServletRequestBuilder request = buildRequest()
             .content("""
                          {
@@ -169,6 +181,8 @@ class PostUserIntTest extends IntegrationBase {
 
     @Test
     void createUserShouldFailWhenRequiredFieldsAreMissing() throws Exception {
+        adminUserStub.givenUserIsAuthorised(userIdentity);
+
         MockHttpServletRequestBuilder request = buildRequest()
             .header("Content-Type", "application/json")
             .content("""
@@ -186,6 +200,8 @@ class PostUserIntTest extends IntegrationBase {
 
     @Test
     void createUserShouldSucceedWhenProvidedWithAUserEmailAddressThatMatchesAnExistingDisabledAccount() throws Exception {
+        adminUserStub.givenUserIsAuthorised(userIdentity);
+
         UserAccountEntity userAccountEntity = new UserAccountEntity();
         userAccountEntity.setUserName("James Smith");
         userAccountEntity.setEmailAddress("james.smith@hmcts.net");
@@ -207,6 +223,8 @@ class PostUserIntTest extends IntegrationBase {
 
     @Test
     void createUserShouldFailWhenProvidedWithASecurityGroupThatDoesntExist() throws Exception {
+        adminUserStub.givenUserIsAuthorised(userIdentity);
+
         MockHttpServletRequestBuilder request = buildRequest()
             .content("""
                          {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerGetUsersIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerGetUsersIntTest.java
@@ -10,12 +10,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.testutils.stubs.AdminUserStub;
 
 import java.util.Set;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.ADMIN;
@@ -27,12 +27,16 @@ class UserControllerGetUsersIntTest extends IntegrationBase {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private AdminUserStub adminUserStub;
+
     @MockBean
     private UserIdentity mockUserIdentity;
 
     @Test
     void usersGetShouldReturnForbiddenError() throws Exception {
-        when(mockUserIdentity.userHasGlobalAccess(Set.of(ADMIN))).thenReturn(false);
+        adminUserStub.givenUserIsNotAuthorised(mockUserIdentity);
 
         MvcResult mvcResult = mockMvc.perform(get(ENDPOINT_URL).queryParam("courthouse", "-1"))
             .andExpect(status().isForbidden())
@@ -53,7 +57,7 @@ class UserControllerGetUsersIntTest extends IntegrationBase {
 
     @Test
     void usersGetShouldReturnNotImplemented() throws Exception {
-        when(mockUserIdentity.userHasGlobalAccess(Set.of(ADMIN))).thenReturn(true);
+        adminUserStub.givenUserIsAuthorised(mockUserIdentity);
 
         mockMvc.perform(get(ENDPOINT_URL).queryParam("courthouse", "-1"))
             .andExpect(status().isNotImplemented());

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityGroupController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityGroupController.java
@@ -1,15 +1,21 @@
 package uk.gov.hmcts.darts.usermanagement.controller;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.usermanagement.http.api.SecurityGroupApi;
 import uk.gov.hmcts.darts.usermanagement.model.SecurityGroup;
 import uk.gov.hmcts.darts.usermanagement.model.SecurityGroupWithIdAndRole;
 import uk.gov.hmcts.darts.usermanagement.service.SecurityGroupService;
 
 import java.util.List;
+
+import static uk.gov.hmcts.darts.authorisation.constants.AuthorisationConstants.SECURITY_SCHEMES_BEARER_AUTH;
+import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANY_ENTITY_ID;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.ADMIN;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,11 +24,15 @@ public class SecurityGroupController implements SecurityGroupApi {
     private final SecurityGroupService securityGroupService;
 
     @Override
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = ADMIN)
     public ResponseEntity<List<SecurityGroupWithIdAndRole>> securityGroupsGet(Integer courthouse) {
         return SecurityGroupApi.super.securityGroupsGet(courthouse);
     }
 
     @Override
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = ADMIN)
     public ResponseEntity<SecurityGroupWithIdAndRole> securityGroupsPost(SecurityGroup securityGroup) {
         SecurityGroupWithIdAndRole response = securityGroupService.createSecurityGroup(securityGroup);
 

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
@@ -35,6 +35,7 @@ public class UserController implements UserApi {
 
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = ADMIN)
     public ResponseEntity<UserWithId> createUser(User user) {
         UserWithId createdUser = userManagementService.createUser(user);
 
@@ -44,6 +45,7 @@ public class UserController implements UserApi {
 
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = ADMIN)
     public ResponseEntity<UserWithIdAndLastLogin> modifyUser(Integer userId, UserPatch userPatch) {
         UserWithIdAndLastLogin updatedUser = userManagementService.modifyUser(userId, userPatch);
 

--- a/src/main/resources/db/migration/local/V1_249_1__global_test_user_admin.sql
+++ b/src/main/resources/db/migration/local/V1_249_1__global_test_user_admin.sql
@@ -1,0 +1,3 @@
+INSERT INTO darts.security_group_user_account_ae
+(usr_id, grp_id)
+VALUES(-46, 1);


### PR DESCRIPTION
# [DMP-1658](https://tools.hmcts.net/jira/browse/DMP-1658)

Restrict admin endpoints to users with the `ADMIN` role and update integration tests.

Assign the `darts_global_test_user` the `ADMIN` role to facilitate functional tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
