### PR TITLE
DMP-1853: 

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -39,7 +39,7 @@ def secrets = [
     secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
     secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
     secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
-    secret('ARMConnectionString', 'ARM_STORAGE_CONNECTION_STRING')
+    secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT')
   ],
 ]
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -40,7 +40,7 @@ def secrets = [
     secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
     secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
     secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
-    secret('ARMConnectionString', 'ARM_STORAGE_CONNECTION_STRING')
+    secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT')
   ],
 ]
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -36,7 +36,7 @@ def secrets = [
     secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
     secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
     secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
-    secret('ARMConnectionString', 'ARM_STORAGE_CONNECTION_STRING'),
+    secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT'),
   ],
 ]
 

--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.50
+version: 0.0.51
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -75,8 +75,8 @@ java:
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME
         - name: AzureAdB2CFuncTestROPCGlobalPassword
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
-        - name: ARMConnectionString
-          alias: ARM_STORAGE_CONNECTION_STRING
+        - name: ARMSasEndpoint
+          alias: ARM_SAS_ENDPOINT
   environment:
     ENABLE_FLYWAY: true
     RUN_DB_MIGRATION_ON_STARTUP: true

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -72,8 +72,8 @@ java:
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME
         - name: AzureAdB2CFuncTestROPCGlobalPassword
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
-        - name: ARMConnectionString
-          alias: ARM_STORAGE_CONNECTION_STRING
+        - name: ARMSasEndpoint
+          alias: ARM_SAS_ENDPOINT
   environment:
     NOTIFICATION_SCHEDULER_CRON: "3 */2 * * * MON-FRI"
     POSTGRES_SSL_MODE: require
@@ -158,8 +158,8 @@ function:
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME
         - name: AzureAdB2CFuncTestROPCGlobalPassword
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
-        - name: ARMConnectionString
-          alias: ARM_STORAGE_CONNECTION_STRING
+        - name: ARMSasEndpoint
+          alias: ARM_SAS_ENDPOINT
   environment:
     ATS_MODE: true
     POSTGRES_SSL_MODE: require

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -40,7 +40,7 @@ services:
       - DARTS_GATEWAY_URL=http://darts-gateway:8070
       - AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME
       - AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
-      - ARM_STORAGE_CONNECTION_STRING
+      - ARM_SAS_ENDPOINT
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/functionalTest/resources/application-functionalTest.yaml
+++ b/src/functionalTest/resources/application-functionalTest.yaml
@@ -35,5 +35,5 @@ deployed-application-uri: ${TEST_URL:http://localhost:4550}
 darts:
   storage:
     arm:
-      connection-string: ${ARM_STORAGE_CONNECTION_STRING:}
+      sas-endpoint: ${ARM_SAS_ENDPOINT:}
       container-name: darts-arm

--- a/src/main/java/uk/gov/hmcts/darts/arm/api/impl/ArmDataManagementApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/api/impl/ArmDataManagementApiImpl.java
@@ -20,6 +20,6 @@ public class ArmDataManagementApiImpl implements ArmDataManagementApi {
     }
 
     private String getArmContainerName() {
-        return armDataManagementConfiguration.getArmContainerName();
+        return armDataManagementConfiguration.getContainerName();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/config/ArmDataManagementConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/config/ArmDataManagementConfiguration.java
@@ -1,49 +1,27 @@
 package uk.gov.hmcts.darts.arm.config;
 
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@Slf4j
 @Configuration
+@ConfigurationProperties(prefix = "darts.storage.arm")
 @Getter
+@Setter
 public class ArmDataManagementConfiguration {
 
-    @Value("${darts.storage.arm.connection-string}")
-    private String armStorageAccountConnectionString;
-
-    @Value("${darts.storage.arm.container-name}")
-    private String armContainerName;
-
-    @Value("${darts.storage.arm.folders.submission}")
-    private String armSubmissionDropZone;
-
-    @Value("${darts.storage.arm.max-retry-attempts}")
+    private String connectionString;
+    private String containerName;
+    private String foldersSubmission;
     private Integer maxRetryAttempts;
-
-    @Value("${darts.storage.arm.publisher}")
     private String publisher;
-
-    @Value("${darts.storage.arm.region}")
     private String region;
-
-    @Value("${darts.storage.arm.media_record_class}")
     private String mediaRecordClass;
-
-    @Value("${darts.storage.arm.transcription_record_class}")
     private String transcriptionRecordClass;
-
-    @Value("${darts.storage.arm.annotation_record_class}")
     private String annotationRecordClass;
-
-    @Value("${darts.storage.arm.temp-blob-workspace}")
     private String tempBlobWorkspace;
-
-    @Value("${darts.storage.arm.date_time_format}")
     private String dateTimeFormat;
-
-    @Value("${darts.storage.arm.file_extension}")
     private String fileExtension;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/config/ArmDataManagementConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/config/ArmDataManagementConfiguration.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 @Setter
 public class ArmDataManagementConfiguration {
 
-    private String connectionString;
+    private String sasEndpoint;
     private String containerName;
     private String foldersSubmission;
     private Integer maxRetryAttempts;

--- a/src/main/java/uk/gov/hmcts/darts/arm/dao/impl/ArmDataManagementDaoImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/dao/impl/ArmDataManagementDaoImpl.java
@@ -33,7 +33,7 @@ public class ArmDataManagementDaoImpl implements ArmDataManagementDao {
 
     private BlobServiceClient getBlobServiceClient() {
         return new BlobServiceClientBuilder()
-            .connectionString(armDataManagementConfiguration.getConnectionString())
+            .endpoint(armDataManagementConfiguration.getSasEndpoint())
             .buildClient();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/dao/impl/ArmDataManagementDaoImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/dao/impl/ArmDataManagementDaoImpl.java
@@ -33,7 +33,7 @@ public class ArmDataManagementDaoImpl implements ArmDataManagementDao {
 
     private BlobServiceClient getBlobServiceClient() {
         return new BlobServiceClientBuilder()
-            .connectionString(armDataManagementConfiguration.getArmStorageAccountConnectionString())
+            .connectionString(armDataManagementConfiguration.getConnectionString())
             .buildClient();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmServiceImpl.java
@@ -23,7 +23,7 @@ public class ArmServiceImpl implements ArmService {
     @Override
     public String saveBlobData(String containerName, String filename, BinaryData binaryData) {
 
-        String blobPathAndName = armDataManagementConfiguration.getArmSubmissionDropZone() + filename;
+        String blobPathAndName = armDataManagementConfiguration.getFoldersSubmission() + filename;
         BlobContainerClient containerClient = armDataManagementDao.getBlobContainerClient(containerName);
         BlobClient client = armDataManagementDao.getBlobClient(containerClient, blobPathAndName);
         client.upload(binaryData);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -155,7 +155,7 @@ darts:
         transcription_request_rejected: 739a31cf-13a1-49bc-bcf9-0794f4670dbb
   storage:
     arm:
-      connection-string: ${ARM_STORAGE_CONNECTION_STRING:}
+      sas-endpoint: ${ARM_SAS_ENDPOINT:}
       container-name: darts-arm
       folders:
         submission: dropzone/DARTS/submission/

--- a/src/test/java/uk/gov/hmcts/darts/arm/dao/ArmDataManagementDaoImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/dao/ArmDataManagementDaoImplTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
 import uk.gov.hmcts.darts.arm.dao.impl.ArmDataManagementDaoImpl;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ArmDataManagementDaoImplTest {
@@ -23,8 +24,8 @@ class ArmDataManagementDaoImplTest {
     private ArmDataManagementConfiguration armDataManagementConfiguration;
     private static final String BLOB_FILENAME = "12_45_1";
     public static final String BLOB_CONTAINER_NAME = "arm_dummy_container";
-    private static final String CONNECTION_STRING = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;" +
-        "AccountKey=KBHBeksoGMGw;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+    private static final String SAS_ENDPOINT = "https://dartssasdummy.blob.core.windows.net/darts-arm?sp=r&st=2011-11-11T11:11:11Z&" +
+        "se=2011-11-11T11:11:21Z&spr=https&sv=2022-11-02&sr=c&sig=AAAAAAA";
 
     private static final String ARM_DROP_ZONE = "dummy/dropzone/submission/";
     private BlobContainerClient blobContainerClient;
@@ -38,7 +39,7 @@ class ArmDataManagementDaoImplTest {
 
     @Test
     void testGetBlobContainerClient() {
-        Mockito.when(armDataManagementConfiguration.getConnectionString()).thenReturn(CONNECTION_STRING);
+        when(armDataManagementConfiguration.getSasEndpoint()).thenReturn(SAS_ENDPOINT);
         BlobContainerClient blobContainerClient = armDataManagementDao.getBlobContainerClient(BLOB_CONTAINER_NAME);
         assertNotNull(blobContainerClient);
     }
@@ -47,7 +48,7 @@ class ArmDataManagementDaoImplTest {
     void testGetBlobClient() {
         String blobId = ARM_DROP_ZONE + BLOB_FILENAME;
 
-        Mockito.when(blobContainerClient.getBlobClient(blobId)).thenReturn(blobClient);
+        when(blobContainerClient.getBlobClient(blobId)).thenReturn(blobClient);
         BlobClient blobClient = armDataManagementDao.getBlobClient(blobContainerClient, blobId);
         assertNotNull(blobClient);
     }

--- a/src/test/java/uk/gov/hmcts/darts/arm/dao/ArmDataManagementDaoImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/dao/ArmDataManagementDaoImplTest.java
@@ -38,7 +38,7 @@ class ArmDataManagementDaoImplTest {
 
     @Test
     void testGetBlobContainerClient() {
-        Mockito.when(armDataManagementConfiguration.getArmStorageAccountConnectionString()).thenReturn(CONNECTION_STRING);
+        Mockito.when(armDataManagementConfiguration.getConnectionString()).thenReturn(CONNECTION_STRING);
         BlobContainerClient blobContainerClient = armDataManagementDao.getBlobContainerClient(BLOB_CONTAINER_NAME);
         assertNotNull(blobContainerClient);
     }

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/ArmServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/ArmServiceImplTest.java
@@ -44,7 +44,7 @@ class ArmServiceImplTest {
 
     @Test
     void testSaveBlobData() {
-        when(armDataManagementConfiguration.getArmSubmissionDropZone()).thenReturn(TEST_DROP_ZONE);
+        when(armDataManagementConfiguration.getFoldersSubmission()).thenReturn(TEST_DROP_ZONE);
         when(armDataManagementDao.getBlobContainerClient(ARM_BLOB_CONTAINER_NAME)).thenReturn(blobContainerClient);
         when(armDataManagementDao.getBlobClient(any(), any())).thenReturn(blobClient);
         String blobName = armService.saveBlobData(ARM_BLOB_CONTAINER_NAME, BLOB_FILENAME, BINARY_DATA);


### PR DESCRIPTION
Notes:
the ticket requests using a sas token, but the `BlobServiceClientBuilder` requires also an endpoint when the connection string is not provided (see the builder javadoc). Therefore I've used the sas endpoint, which contains both the endpoint and the sas token.

I've created a vault secret on staging for the sas endpoint: [ARMSasEndpoint](https://portal.azure.com/#@HMCTS.NET/asset/Microsoft_Azure_KeyVault/Secret/https://darts-stg.vault.azure.net/secrets/ARMSasEndpoint/6c3a45c092c441079af63ea234d8d77e), but I wasn't sure whether the secret needs to be configured on other environments too