### PR TITLE
DMP-1724 Part 1 - Schema updates: ObjectRecordStatusEnum / MediaEntity

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioMetadataIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioMetadataIntTest.java
@@ -73,13 +73,14 @@ class AudioControllerAddAudioMetadataIntTest extends IntegrationBase {
             "metadata",
             null,
             "application/json",
-            objectMapper.writeValueAsString(addAudioMetadataRequest).getBytes());
+            objectMapper.writeValueAsString(addAudioMetadataRequest).getBytes()
+        );
 
 
         mockMvc.perform(
-            multipart(ENDPOINT)
-                .file(audioFile)
-                .file(metadataJson))
+                multipart(ENDPOINT)
+                    .file(audioFile)
+                    .file(metadataJson))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -100,7 +101,7 @@ class AudioControllerAddAudioMetadataIntTest extends IntegrationBase {
             assertEquals(ENDED_AT, media.getEnd());
             assertEquals(1, media.getChannel());
             assertEquals(2, media.getTotalChannels());
-            assertEquals(3, media.getCaseIdList().size());
+            assertEquals(3, media.getCaseNumberList().size());
             assertEquals("1", media.getCourtroom().getName());
         }
     }
@@ -120,7 +121,8 @@ class AudioControllerAddAudioMetadataIntTest extends IntegrationBase {
             "metadata",
             null,
             "application/json",
-            objectMapper.writeValueAsString(addAudioMetadataRequest).getBytes());
+            objectMapper.writeValueAsString(addAudioMetadataRequest).getBytes()
+        );
 
         MvcResult mvcResult = mockMvc.perform(
                 multipart(ENDPOINT)

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDeleteAudioRequestIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDeleteAudioRequestIntTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDeleteTransformedMediaIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDeleteTransformedMediaIntTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDownloadIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDownloadIntTest.java
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.audiorequests.model.AudioRequestType.PLAYBACK;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 
 @AutoConfigureMockMvc

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerPlaybackIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerPlaybackIntTest.java
@@ -40,7 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.audiorequests.model.AudioRequestType.PLAYBACK;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceGivenBuilder.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 
 import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.testutils.data.JudgeTestData.createJudgeWithName;
 import static uk.gov.hmcts.darts.testutils.data.MediaTestData.createMediaFor;
 import static uk.gov.hmcts.darts.testutils.data.MediaTestData.createMediaWith;
@@ -90,7 +90,7 @@ public class AudioTransformationServiceGivenBuilder {
     public ExternalObjectDirectoryEntity externalObjectDirForMedia(MediaEntity mediaEntity) {
         var externalObjectDirectoryEntity1 = externalObjectDirectoryStub.createExternalObjectDirectory(
             mediaEntity,
-            dartsDatabase.getObjectDirectoryStatusRepository().getReferenceById(STORED.getId()),
+            dartsDatabase.getObjectRecordStatusRepository().getReferenceById(STORED.getId()),
             dartsDatabase.getExternalLocationTypeRepository().getReferenceById(UNSTRUCTURED.getId()),
             UUID.randomUUID()
         );

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 
 import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.OPEN;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @Transactional
 @Service

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.entity.MediaEntity.MEDIA_TYPE_DEFAULT;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @SuppressWarnings({"PMD.ExcessiveImports"})
 class AudioTransformationServiceTest extends IntegrationBase {
@@ -196,7 +196,7 @@ class AudioTransformationServiceTest extends IntegrationBase {
         ExternalLocationTypeEntity externalLocationTypeEntity =
             dartsDatabase.getExternalLocationTypeRepository().getReferenceById(UNSTRUCTURED.getId());
         ObjectRecordStatusEntity objectDirectoryStatus =
-            dartsDatabase.getObjectDirectoryStatusRepository().getReferenceById(STORED.getId());
+            dartsDatabase.getObjectRecordStatusRepository().getReferenceById(STORED.getId());
         UUID externalLocation1 = UUID.randomUUID();
         UUID externalLocation2 = UUID.randomUUID();
         ExternalObjectDirectoryEntity externalObjectDirectory1 = externalObjectDirectoryStub.createExternalObjectDirectory(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/UnstructuredAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/UnstructuredAudioDeleterProcessorTest.java
@@ -19,8 +19,8 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.MARKED_FOR_DELETION;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 class UnstructuredAudioDeleterProcessorTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/service/TransientObjectDirectoryServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/service/TransientObjectDirectoryServiceTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 class TransientObjectDirectoryServiceTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
@@ -27,7 +27,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.enums.SystemUsersAccountUUIDEnum;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.datamanagement.dao.DataManagementDao;
@@ -47,9 +47,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.COMPLETED;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.DELETED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.MARKED_FOR_DELETION;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.DELETED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @SuppressWarnings({"PMD.ExcessiveImports"})
 @Transactional
@@ -107,7 +107,7 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
 
 
         externalInboundDataStoreDeleter = new ExternalInboundDataStoreDeleter(
-            dartsDatabase.getObjectDirectoryStatusRepository(),
+            dartsDatabase.getObjectRecordStatusRepository(),
             dartsDatabase.getUserAccountRepository(),
             dartsDatabase.getExternalObjectDirectoryRepository(),
             inboundExternalObjectDirectoryDeletedFinder,
@@ -116,7 +116,7 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
         );
 
         externalUnstructuredDataStoreDeleter = new ExternalUnstructuredDataStoreDeleter(
-            dartsDatabase.getObjectDirectoryStatusRepository(),
+            dartsDatabase.getObjectRecordStatusRepository(),
             dartsDatabase.getUserAccountRepository(),
             dartsDatabase.getExternalObjectDirectoryRepository(),
             unstructuredExternalObjectDirectoryDeletedFinder,
@@ -125,7 +125,7 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
         );
 
         externalOutboundDataStoreDeleter =
-            new ExternalOutboundDataStoreDeleter(dartsDatabase.getObjectDirectoryStatusRepository(),
+            new ExternalOutboundDataStoreDeleter(dartsDatabase.getObjectRecordStatusRepository(),
                                                  dartsDatabase.getUserAccountRepository(),
                                                  dartsDatabase.getTransientObjectDirectoryRepository(),
                                                  outboundExternalObjectDirectoryDeletedFinder,
@@ -294,7 +294,7 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
 
     }
 
-    private ExternalObjectDirectoryEntity createExternalObjectDirectory(MediaEntity mediaEntity, Integer dataStoreId, ObjectDirectoryStatusEnum status) {
+    private ExternalObjectDirectoryEntity createExternalObjectDirectory(MediaEntity mediaEntity, Integer dataStoreId, ObjectRecordStatusEnum status) {
         var externalObjectDirectoryEntity = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             mediaEntity,
             dartsDatabase.getObjectDirectoryStatusEntity(status),
@@ -305,7 +305,7 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
         return dartsDatabase.save(externalObjectDirectoryEntity);
     }
 
-    private TransientObjectDirectoryEntity createTransientDirectoryAndObjectStatus(MediaRequestEntity currentMediaRequest, ObjectDirectoryStatusEnum status) {
+    private TransientObjectDirectoryEntity createTransientDirectoryAndObjectStatus(MediaRequestEntity currentMediaRequest, ObjectRecordStatusEnum status) {
         var blobId = UUID.randomUUID();
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundAudioDeleterProcessorTest.java
@@ -19,8 +19,8 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.MARKED_FOR_DELETION;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @SuppressWarnings("PMD.ExcessiveImports")
 class InboundAudioDeleterProcessorTest extends IntegrationBase {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
@@ -41,8 +41,8 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.COMPLETED;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.OPEN;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.PROCESSING;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.MARKED_FOR_DELETION;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 //Requires transactional as the object is being created manually rather than being autowired.
 // We are doing this, so we can mock out different dates to test the service.
@@ -91,7 +91,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             dartsDatabase.getMediaRequestRepository(),
             dartsDatabase.getTransientObjectDirectoryRepository(),
             userAccountRepository,
-            dartsDatabase.getObjectDirectoryStatusRepository(), lastAccessedDeletionDayCalculator,
+            dartsDatabase.getObjectRecordStatusRepository(), lastAccessedDeletionDayCalculator,
             systemUserHelper
         );
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
@@ -17,7 +17,7 @@ import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
@@ -29,9 +29,9 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_ARM_INGESTION_FAILED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.MARKED_FOR_DELETION;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_ARM_INGESTION_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @SpringBootTest
 @ActiveProfiles({"intTest", "h2db"})
@@ -46,7 +46,7 @@ class UnstructuredToArmProcessorTest extends IntegrationBase {
     @Autowired
     private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
     @Autowired
-    private ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private ObjectRecordStatusRepository objectRecordStatusRepository;
     @Autowired
     private ExternalLocationTypeRepository externalLocationTypeRepository;
     @Autowired
@@ -59,13 +59,15 @@ class UnstructuredToArmProcessorTest extends IntegrationBase {
 
     @BeforeEach
     void setupData() {
-        unstructuredToArmProcessor = new UnstructuredToArmProcessorImpl(externalObjectDirectoryRepository,
-                                                                        objectDirectoryStatusRepository,
-                                                                        externalLocationTypeRepository,
-                                                                        dataManagementApi,
-                                                                        armDataManagementApi,
-                                                                        userAccountRepository,
-                                                                        armDataManagementConfiguration);
+        unstructuredToArmProcessor = new UnstructuredToArmProcessorImpl(
+            externalObjectDirectoryRepository,
+            objectRecordStatusRepository,
+            externalLocationTypeRepository,
+            dataManagementApi,
+            armDataManagementApi,
+            userAccountRepository,
+            armDataManagementConfiguration
+        );
     }
 
     @Test
@@ -175,7 +177,7 @@ class UnstructuredToArmProcessorTest extends IntegrationBase {
             dartsDatabase.getExternalLocationTypeEntity(ExternalLocationTypeEnum.ARM),
             UUID.randomUUID()
         );
-        armEod.setStatus(dartsDatabase.getObjectDirectoryStatusRepository().getReferenceById(FAILURE_ARM_INGESTION_FAILED.getId()));
+        armEod.setStatus(dartsDatabase.getObjectRecordStatusRepository().getReferenceById(FAILURE_ARM_INGESTION_FAILED.getId()));
         armEod.setTransferAttempts(1);
         dartsDatabase.save(armEod);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -24,7 +24,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.repository.AuditRepository;
 import uk.gov.hmcts.darts.common.repository.CaseRepository;
 import uk.gov.hmcts.darts.common.repository.CourthouseRepository;
@@ -43,7 +43,7 @@ import uk.gov.hmcts.darts.common.repository.MediaRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
 import uk.gov.hmcts.darts.common.repository.NodeRegistrationRepository;
 import uk.gov.hmcts.darts.common.repository.NotificationRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.ProsecutorRepository;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
 import uk.gov.hmcts.darts.common.repository.SecurityRoleRepository;
@@ -100,7 +100,7 @@ public class DartsDatabaseStub {
     private final MediaRepository mediaRepository;
     private final MediaRequestRepository mediaRequestRepository;
     private final NotificationRepository notificationRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final ProsecutorRepository prosecutorRepository;
     private final RetrieveCoreObjectService retrieveCoreObjectService;
     private final TranscriptionRepository transcriptionRepository;
@@ -317,8 +317,8 @@ public class DartsDatabaseStub {
     }
 
     public ObjectRecordStatusEntity getObjectDirectoryStatusEntity(
-        ObjectDirectoryStatusEnum objectDirectoryStatusEnum) {
-        return objectDirectoryStatusRepository.getReferenceById(objectDirectoryStatusEnum.getId());
+        ObjectRecordStatusEnum objectDirectoryStatusEnum) {
+        return objectRecordStatusRepository.getReferenceById(objectDirectoryStatusEnum.getId());
     }
 
     @Transactional

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAttachTranscriptIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAttachTranscriptIntTest.java
@@ -44,7 +44,7 @@ import static org.springframework.util.unit.DataSize.ofMegabytes;
 import static uk.gov.hmcts.darts.audit.api.AuditActivity.COMPLETE_TRANSCRIPTION;
 import static uk.gov.hmcts.darts.audit.api.AuditActivity.IMPORT_TRANSCRIPTION;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.APPROVED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.COMPLETE;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WITH_TRANSCRIBER;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerDownloadTranscriptIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerDownloadTranscriptIntTest.java
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.audit.api.AuditActivity.DOWNLOAD_TRANSCRIPTION;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.APPROVED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.COMPLETE;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WITH_TRANSCRIBER;

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/MediaArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/MediaArchiveRecordMapperImpl.java
@@ -26,8 +26,10 @@ public class MediaArchiveRecordMapperImpl implements MediaArchiveRecordMapper {
 
     public MediaArchiveRecord mapToMediaArchiveRecord(ExternalObjectDirectoryEntity externalObjectDirectory, File archiveRecordFile) {
         MediaEntity media = externalObjectDirectory.getMedia();
-        MediaCreateArchiveRecordOperation mediaCreateArchiveRecordOperation = createArchiveRecordOperation(externalObjectDirectory,
-                                                                                                           externalObjectDirectory.getId());
+        MediaCreateArchiveRecordOperation mediaCreateArchiveRecordOperation = createArchiveRecordOperation(
+            externalObjectDirectory,
+            externalObjectDirectory.getId()
+        );
         UploadNewFileRecord uploadNewFileRecord = createUploadNewFileRecord(media, externalObjectDirectory.getId());
         return createMediaArchiveRecord(mediaCreateArchiveRecordOperation, uploadNewFileRecord);
     }
@@ -68,7 +70,7 @@ public class MediaArchiveRecordMapperImpl implements MediaArchiveRecordMapper {
             .startDateTime(media.getStart().format(formatter))
             .endDateTime(media.getEnd().format(formatter))
             .createdDateTime(media.getCreatedDateTime().format(formatter))
-            .caseNumbers(caseListToString(media.getCaseIdList()))
+            .caseNumbers(caseListToString(media.getCaseNumberList()))
             .build();
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AddAudioRequestMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AddAudioRequestMapperImpl.java
@@ -27,7 +27,7 @@ public class AddAudioRequestMapperImpl implements AddAudioRequestMapper {
             addAudioMetadataRequest.getCourtroom()
         );
         media.setCourtroom(foundCourtroom);
-        media.setCaseIdList(addAudioMetadataRequest.getCases());
+        media.setCaseNumberList(addAudioMetadataRequest.getCases());
         media.setMediaFormat(addAudioMetadataRequest.getFormat());
         media.setFileSize(addAudioMetadataRequest.getFileSize());
         media.setChecksum(addAudioMetadataRequest.getChecksum());

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/TransientObjectDirectoryDeletedFinder.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/TransientObjectDirectoryDeletedFinder.java
@@ -3,8 +3,8 @@ package uk.gov.hmcts.darts.audio.deleter;
 import lombok.RequiredArgsConstructor;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 
 import java.util.List;
@@ -12,7 +12,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TransientObjectDirectoryDeletedFinder implements ObjectDirectoryDeletedFinder<TransientObjectDirectoryEntity> {
     private final TransientObjectDirectoryRepository transientObjectDirectoryRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
 
     @Override
     public List<TransientObjectDirectoryEntity> findMarkedForDeletion() {
@@ -20,7 +20,7 @@ public class TransientObjectDirectoryDeletedFinder implements ObjectDirectoryDel
     }
 
     private ObjectRecordStatusEntity getMarkedForDeletionStatus() {
-        return objectDirectoryStatusRepository.getReferenceById(
-            ObjectDirectoryStatusEnum.MARKED_FOR_DELETION.getId());
+        return objectRecordStatusRepository.getReferenceById(
+            ObjectRecordStatusEnum.MARKED_FOR_DELETION.getId());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/ExternalDataStoreDeleterImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/ExternalDataStoreDeleterImpl.java
@@ -10,11 +10,11 @@ import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.common.entity.ObjectDirectory;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.util.List;
@@ -24,7 +24,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ExternalDataStoreDeleterImpl<T extends ObjectDirectory> implements ExternalDataStoreDeleter<T> {
 
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final UserAccountRepository userAccountRepository;
     private final JpaRepository<T, Integer> repository;
     private final ObjectDirectoryDeletedFinder<T> finder;
@@ -71,6 +71,6 @@ public class ExternalDataStoreDeleterImpl<T extends ObjectDirectory> implements 
 
 
     private ObjectRecordStatusEntity getDeletedStatus() {
-        return objectDirectoryStatusRepository.getReferenceById(ObjectDirectoryStatusEnum.DELETED.getId());
+        return objectRecordStatusRepository.getReferenceById(ObjectRecordStatusEnum.DELETED.getId());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/ExternalObjectDirectoryDeletedFinder.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/ExternalObjectDirectoryDeletedFinder.java
@@ -6,10 +6,10 @@ import uk.gov.hmcts.darts.audio.deleter.ObjectDirectoryDeletedFinder;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 
 import java.util.List;
 
@@ -19,7 +19,7 @@ public class ExternalObjectDirectoryDeletedFinder implements ObjectDirectoryDele
 
     private final ExternalLocationTypeRepository externalLocationTypeRepository;
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final ExternalLocationTypeEnum locationType;
 
     @Override
@@ -32,7 +32,7 @@ public class ExternalObjectDirectoryDeletedFinder implements ObjectDirectoryDele
     }
 
     private ObjectRecordStatusEntity getMarkedForDeletionStatus() {
-        return objectDirectoryStatusRepository.getReferenceById(
-            ObjectDirectoryStatusEnum.MARKED_FOR_DELETION.getId());
+        return objectRecordStatusRepository.getReferenceById(
+            ObjectRecordStatusEnum.MARKED_FOR_DELETION.getId());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/inbound/ExternalInboundDataStoreDeleter.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/inbound/ExternalInboundDataStoreDeleter.java
@@ -5,17 +5,17 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.audio.deleter.impl.ExternalDataStoreDeleterImpl;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 @Service
 public class ExternalInboundDataStoreDeleter extends ExternalDataStoreDeleterImpl<ExternalObjectDirectoryEntity> {
 
 
-    public ExternalInboundDataStoreDeleter(ObjectDirectoryStatusRepository objectDirectoryStatusRepository, UserAccountRepository userAccountRepository,
+    public ExternalInboundDataStoreDeleter(ObjectRecordStatusRepository objectRecordStatusRepository, UserAccountRepository userAccountRepository,
                                            JpaRepository<ExternalObjectDirectoryEntity, Integer> repository,
                                            InboundExternalObjectDirectoryDeletedFinder finder, InboundDataStoreDeleter deleter,
                                            SystemUserHelper systemUserHelper) {
-        super(objectDirectoryStatusRepository, userAccountRepository, repository, finder, deleter, systemUserHelper);
+        super(objectRecordStatusRepository, userAccountRepository, repository, finder, deleter, systemUserHelper);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/inbound/InboundExternalObjectDirectoryDeletedFinder.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/inbound/InboundExternalObjectDirectoryDeletedFinder.java
@@ -5,13 +5,13 @@ import uk.gov.hmcts.darts.audio.deleter.impl.ExternalObjectDirectoryDeletedFinde
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 
 @Service
 public class InboundExternalObjectDirectoryDeletedFinder extends ExternalObjectDirectoryDeletedFinder {
     public InboundExternalObjectDirectoryDeletedFinder(ExternalLocationTypeRepository externalLocationTypeRepository,
                                                        ExternalObjectDirectoryRepository externalObjectDirectoryRepository,
-                                                       ObjectDirectoryStatusRepository objectDirectoryStatusRepository) {
-        super(externalLocationTypeRepository, externalObjectDirectoryRepository, objectDirectoryStatusRepository, ExternalLocationTypeEnum.INBOUND);
+                                                       ObjectRecordStatusRepository objectRecordStatusRepository) {
+        super(externalLocationTypeRepository, externalObjectDirectoryRepository, objectRecordStatusRepository, ExternalLocationTypeEnum.INBOUND);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/outbound/ExternalOutboundDataStoreDeleter.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/outbound/ExternalOutboundDataStoreDeleter.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.audio.deleter.impl.ExternalDataStoreDeleterImpl;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
@@ -12,10 +12,10 @@ import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 public class ExternalOutboundDataStoreDeleter extends ExternalDataStoreDeleterImpl<TransientObjectDirectoryEntity> {
 
 
-    public ExternalOutboundDataStoreDeleter(ObjectDirectoryStatusRepository objectDirectoryStatusRepository, UserAccountRepository userAccountRepository,
+    public ExternalOutboundDataStoreDeleter(ObjectRecordStatusRepository objectRecordStatusRepository, UserAccountRepository userAccountRepository,
                                             TransientObjectDirectoryRepository repository,
                                             OutboundExternalObjectDirectoryDeletedFinder finder, OutboundDataStoreDeleter
                                                 deleter, SystemUserHelper systemUserHelper) {
-        super(objectDirectoryStatusRepository, userAccountRepository, repository, finder, deleter, systemUserHelper);
+        super(objectRecordStatusRepository, userAccountRepository, repository, finder, deleter, systemUserHelper);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/outbound/OutboundExternalObjectDirectoryDeletedFinder.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/outbound/OutboundExternalObjectDirectoryDeletedFinder.java
@@ -2,14 +2,14 @@ package uk.gov.hmcts.darts.audio.deleter.impl.outbound;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.audio.deleter.TransientObjectDirectoryDeletedFinder;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 
 @Service
 public class OutboundExternalObjectDirectoryDeletedFinder extends TransientObjectDirectoryDeletedFinder {
 
     public OutboundExternalObjectDirectoryDeletedFinder(TransientObjectDirectoryRepository transientObjectDirectoryRepository,
-                                                        ObjectDirectoryStatusRepository objectDirectoryStatusRepository) {
-        super(transientObjectDirectoryRepository, objectDirectoryStatusRepository);
+                                                        ObjectRecordStatusRepository objectRecordStatusRepository) {
+        super(transientObjectDirectoryRepository, objectRecordStatusRepository);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/unstructured/ExternalUnstructuredDataStoreDeleter.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/unstructured/ExternalUnstructuredDataStoreDeleter.java
@@ -5,16 +5,16 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.audio.deleter.impl.ExternalDataStoreDeleterImpl;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 @Service
 public class ExternalUnstructuredDataStoreDeleter extends ExternalDataStoreDeleterImpl<ExternalObjectDirectoryEntity> {
 
-    public ExternalUnstructuredDataStoreDeleter(ObjectDirectoryStatusRepository objectDirectoryStatusRepository, UserAccountRepository userAccountRepository,
+    public ExternalUnstructuredDataStoreDeleter(ObjectRecordStatusRepository objectRecordStatusRepository, UserAccountRepository userAccountRepository,
                                                 JpaRepository<ExternalObjectDirectoryEntity, Integer> repository,
                                                 UnstructuredExternalObjectDirectoryDeletedFinder finder, UnstructuredDataStoreDeleter deleter,
                                                 SystemUserHelper systemUserHelper) {
-        super(objectDirectoryStatusRepository, userAccountRepository, repository, finder, deleter, systemUserHelper);
+        super(objectRecordStatusRepository, userAccountRepository, repository, finder, deleter, systemUserHelper);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/unstructured/UnstructuredExternalObjectDirectoryDeletedFinder.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/deleter/impl/unstructured/UnstructuredExternalObjectDirectoryDeletedFinder.java
@@ -5,13 +5,13 @@ import uk.gov.hmcts.darts.audio.deleter.impl.ExternalObjectDirectoryDeletedFinde
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 
 @Service
 public class UnstructuredExternalObjectDirectoryDeletedFinder extends ExternalObjectDirectoryDeletedFinder {
     public UnstructuredExternalObjectDirectoryDeletedFinder(ExternalLocationTypeRepository externalLocationTypeRepository,
                                                             ExternalObjectDirectoryRepository externalObjectDirectoryRepository,
-                                                            ObjectDirectoryStatusRepository objectDirectoryStatusRepository) {
-        super(externalLocationTypeRepository, externalObjectDirectoryRepository, objectDirectoryStatusRepository, ExternalLocationTypeEnum.UNSTRUCTURED);
+                                                            ObjectRecordStatusRepository objectRecordStatusRepository) {
+        super(externalLocationTypeRepository, externalObjectDirectoryRepository, objectRecordStatusRepository, ExternalLocationTypeEnum.UNSTRUCTURED);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
@@ -18,13 +18,13 @@ import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.service.FileOperationService;
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.common.util.FileContentChecksum;
@@ -46,7 +46,7 @@ public class AudioServiceImpl implements AudioService {
 
     private final AudioTransformationService audioTransformationService;
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final ExternalLocationTypeRepository externalLocationTypeRepository;
     private final MediaRepository mediaRepository;
     private final AudioOperationService audioOperationService;
@@ -109,12 +109,15 @@ public class AudioServiceImpl implements AudioService {
         }
 
         MediaEntity savedMedia = mediaRepository.save(mapper.mapToMedia(addAudioMetadataRequest));
+        savedMedia.setChecksum(checksum);
         linkAudioAndHearing(addAudioMetadataRequest, savedMedia);
 
-        saveExternalObjectDirectory(externalLocation,
-                                    checksum,
-                                    userIdentity.getUserAccount(),
-                                    savedMedia);
+        saveExternalObjectDirectory(
+            externalLocation,
+            checksum,
+            userIdentity.getUserAccount(),
+            savedMedia
+        );
     }
 
     @Override
@@ -137,8 +140,8 @@ public class AudioServiceImpl implements AudioService {
                                                                       MediaEntity mediaEntity) {
         var externalObjectDirectoryEntity = new ExternalObjectDirectoryEntity();
         externalObjectDirectoryEntity.setMedia(mediaEntity);
-        externalObjectDirectoryEntity.setStatus(objectDirectoryStatusRepository.getReferenceById(
-            ObjectDirectoryStatusEnum.STORED.getId()));
+        externalObjectDirectoryEntity.setStatus(objectRecordStatusRepository.getReferenceById(
+            ObjectRecordStatusEnum.STORED.getId()));
         externalObjectDirectoryEntity.setExternalLocationType(externalLocationTypeRepository.getReferenceById(INBOUND.getId()));
         externalObjectDirectoryEntity.setExternalLocation(externalLocation);
         externalObjectDirectoryEntity.setChecksum(checksum);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -28,7 +28,7 @@ import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.common.service.FileOperationService;
 import uk.gov.hmcts.darts.common.service.TransientObjectDirectoryService;
@@ -59,7 +59,7 @@ import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.FAILED;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.PROCESSING;
 import static uk.gov.hmcts.darts.audiorequests.model.AudioRequestType.DOWNLOAD;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.AUDIO_END_TIME;
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.AUDIO_START_TIME;
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.COURTHOUSE;
@@ -83,7 +83,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     private final FileOperationService fileOperationService;
 
     private final MediaRepository mediaRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
     private final ExternalLocationTypeRepository externalLocationTypeRepository;
 
@@ -117,7 +117,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     public Optional<UUID> getMediaLocation(MediaEntity media) {
         Optional<UUID> externalLocation = Optional.empty();
 
-        ObjectRecordStatusEntity objectDirectoryStatus = objectDirectoryStatusRepository.getReferenceById(STORED.getId());
+        ObjectRecordStatusEntity objectDirectoryStatus = objectRecordStatusRepository.getReferenceById(STORED.getId());
         ExternalLocationTypeEntity externalLocationType = externalLocationTypeRepository.getReferenceById(UNSTRUCTURED.getId());
         List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntityList = externalObjectDirectoryRepository.findByMediaStatusAndType(
             media, objectDirectoryStatus, externalLocationType

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/InboundAudioDeleterProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/InboundAudioDeleterProcessorImpl.java
@@ -10,26 +10,26 @@ import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.MARKED_FOR_DELETION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class InboundAudioDeleterProcessorImpl implements InboundAudioDeleterProcessor {
     private final UserAccountRepository userAccountRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
     private final ExternalLocationTypeRepository externalLocationTypeRepository;
     private final CurrentTimeHelper currentTimeHelper;
@@ -40,8 +40,8 @@ public class InboundAudioDeleterProcessorImpl implements InboundAudioDeleterProc
 
     @Transactional
     public void markForDeletion() {
-        ObjectRecordStatusEntity storedStatus = objectDirectoryStatusRepository.getReferenceById(
-            ObjectDirectoryStatusEnum.STORED.getId());
+        ObjectRecordStatusEntity storedStatus = objectRecordStatusRepository.getReferenceById(
+            ObjectRecordStatusEnum.STORED.getId());
         ExternalLocationTypeEntity inboundLocation = externalLocationTypeRepository.getReferenceById(
             ExternalLocationTypeEnum.INBOUND.getId());
         ExternalLocationTypeEntity armLocation = externalLocationTypeRepository.getReferenceById(
@@ -64,7 +64,7 @@ public class InboundAudioDeleterProcessorImpl implements InboundAudioDeleterProc
         }
         log.debug("Marking the following ExternalObjectDirectory.Id's for deletion:- {}", audioFileIdsToBeMarked);
 
-        ObjectRecordStatusEntity deletionStatus = objectDirectoryStatusRepository.getReferenceById(
+        ObjectRecordStatusEntity deletionStatus = objectRecordStatusRepository.getReferenceById(
             MARKED_FOR_DELETION.getId());
 
         UserAccountEntity user = userAccountRepository.findSystemUser(systemUserHelper.findSystemUserGuid("housekeeping"));

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
@@ -20,27 +20,27 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.MARKED_FOR_DELETION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
 
 @Service
 public class OutboundAudioDeleterProcessorImpl implements OutboundAudioDeleterProcessor {
     private final MediaRequestRepository mediaRequestRepository;
     private final TransientObjectDirectoryRepository transientObjectDirectoryRepository;
     private final UserAccountRepository userAccountRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final LastAccessedDeletionDayCalculator deletionDayCalculator;
     private final SystemUserHelper systemUserHelper;
 
     public OutboundAudioDeleterProcessorImpl(MediaRequestRepository mediaRequestRepository,
                                              TransientObjectDirectoryRepository transientObjectDirectoryRepository,
                                              UserAccountRepository userAccountRepository,
-                                             ObjectDirectoryStatusRepository objectDirectoryStatusRepository,
+                                             ObjectRecordStatusRepository objectRecordStatusRepository,
                                              LastAccessedDeletionDayCalculator deletionDayCalculator,
                                              SystemUserHelper systemUserHelper) {
         this.mediaRequestRepository = mediaRequestRepository;
         this.transientObjectDirectoryRepository = transientObjectDirectoryRepository;
         this.userAccountRepository = userAccountRepository;
-        this.objectDirectoryStatusRepository = objectDirectoryStatusRepository;
+        this.objectRecordStatusRepository = objectRecordStatusRepository;
         this.deletionDayCalculator = deletionDayCalculator;
         this.systemUserHelper = systemUserHelper;
     }
@@ -70,7 +70,7 @@ public class OutboundAudioDeleterProcessorImpl implements OutboundAudioDeleterPr
         if (systemUser == null) {
             throw new DartsApiException(AudioApiError.MISSING_SYSTEM_USER);
         }
-        ObjectRecordStatusEntity deletionStatus = objectDirectoryStatusRepository.getReferenceById(
+        ObjectRecordStatusEntity deletionStatus = objectRecordStatusRepository.getReferenceById(
             MARKED_FOR_DELETION.getId());
 
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/UnstructuredAudioDeleterProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/UnstructuredAudioDeleterProcessorImpl.java
@@ -10,19 +10,19 @@ import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.MARKED_FOR_DELETION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
 
 @Service
 @Slf4j
@@ -34,15 +34,15 @@ public class UnstructuredAudioDeleterProcessorImpl implements UnstructuredAudioD
 
     private final ExternalLocationTypeRepository externalLocationTypeRepository;
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final CurrentTimeHelper currentTimeHelper;
     private final UserAccountRepository userAccountRepository;
     private final SystemUserHelper systemUserHelper;
 
     @Transactional
     public void markForDeletion() {
-        ObjectRecordStatusEntity storedStatus = objectDirectoryStatusRepository.getReferenceById(
-            ObjectDirectoryStatusEnum.STORED.getId());
+        ObjectRecordStatusEntity storedStatus = objectRecordStatusRepository.getReferenceById(
+            ObjectRecordStatusEnum.STORED.getId());
         ExternalLocationTypeEntity unstructuredLocation = externalLocationTypeRepository.getReferenceById(
             ExternalLocationTypeEnum.UNSTRUCTURED.getId());
         ExternalLocationTypeEntity armLocation = externalLocationTypeRepository.getReferenceById(
@@ -67,7 +67,7 @@ public class UnstructuredAudioDeleterProcessorImpl implements UnstructuredAudioD
         }
         log.debug("Marking the following Unstructured ExternalObjectDirectory.Id's for deletion:- {}", audioFileIdsToBeMarked);
 
-        ObjectRecordStatusEntity deletionStatus = objectDirectoryStatusRepository.getReferenceById(
+        ObjectRecordStatusEntity deletionStatus = objectRecordStatusRepository.getReferenceById(
             MARKED_FOR_DELETION.getId());
 
         UserAccountEntity user = userAccountRepository.findSystemUser(systemUserHelper.findSystemUserGuid("housekeeping"));

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.common.entity;
 
-import io.hypersistence.utils.hibernate.type.array.ListArrayType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,7 +14,6 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.annotations.Type;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 
 import java.time.OffsetDateTime;
@@ -58,9 +56,8 @@ public class MediaEntity extends CreatedModifiedBaseEntity {
     @Column(name = "end_ts", nullable = false)
     private OffsetDateTime end;
 
-    @Type(ListArrayType.class)
     @Column(name = "case_number")
-    private List<String> caseIdList = new ArrayList<>();
+    private List<String> caseNumberList = new ArrayList<>();
 
     @Column(name = "version_label", length = 32)
     private String legacyVersionLabel;

--- a/src/main/java/uk/gov/hmcts/darts/common/enums/ObjectRecordStatusEnum.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/enums/ObjectRecordStatusEnum.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ObjectDirectoryStatusEnum {
+public enum ObjectRecordStatusEnum {
 
     NEW(1),
     STORED(2),

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ObjectRecordStatusRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ObjectRecordStatusRepository.java
@@ -5,6 +5,6 @@ import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 
 @Repository
-public interface ObjectDirectoryStatusRepository extends JpaRepository<ObjectRecordStatusEntity, Integer> {
+public interface ObjectRecordStatusRepository extends JpaRepository<ObjectRecordStatusEntity, Integer> {
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/TransientObjectDirectoryServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/TransientObjectDirectoryServiceImpl.java
@@ -6,21 +6,21 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.enums.SystemUsersEnum;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.common.service.TransientObjectDirectoryService;
 
 import java.util.UUID;
 
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @Service
 @RequiredArgsConstructor
 public class TransientObjectDirectoryServiceImpl implements TransientObjectDirectoryService {
 
     private final TransientObjectDirectoryRepository transientObjectDirectoryRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final UserAccountRepository userAccountRepository;
 
     @Override
@@ -29,7 +29,7 @@ public class TransientObjectDirectoryServiceImpl implements TransientObjectDirec
 
         TransientObjectDirectoryEntity transientObjectDirectoryEntity = new TransientObjectDirectoryEntity();
         transientObjectDirectoryEntity.setTransformedMedia(transformedMediaEntity);
-        transientObjectDirectoryEntity.setStatus(objectDirectoryStatusRepository.getReferenceById(STORED.getId()));
+        transientObjectDirectoryEntity.setStatus(objectRecordStatusRepository.getReferenceById(STORED.getId()));
         transientObjectDirectoryEntity.setExternalLocation(UUID.fromString(blobClient.getBlobName()));
         transientObjectDirectoryEntity.setTransferAttempts(null);
         var systemUser = userAccountRepository.getReferenceById(SystemUsersEnum.DEFAULT.getId());

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorImpl.java
@@ -15,11 +15,11 @@ import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.enums.SystemUsersEnum;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
@@ -36,14 +36,14 @@ import static org.apache.commons.codec.binary.Base64.encodeBase64;
 import static org.apache.commons.codec.digest.DigestUtils.md5;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.AWAITING_VERIFICATION;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_ARM_INGESTION_FAILED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_CHECKSUM_FAILED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_FILE_NOT_FOUND;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_FILE_SIZE_CHECK_FAILED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_FILE_TYPE_CHECK_FAILED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.AWAITING_VERIFICATION;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_ARM_INGESTION_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_CHECKSUM_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_FILE_NOT_FOUND;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_FILE_SIZE_CHECK_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_FILE_TYPE_CHECK_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 
 @Service
@@ -52,7 +52,7 @@ import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
 public class InboundToUnstructuredProcessorImpl implements InboundToUnstructuredProcessor {
 
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final ExternalLocationTypeRepository externalLocationTypeRepository;
     private final DataManagementService dataManagementService;
     private final DataManagementConfiguration dataManagementConfiguration;
@@ -312,9 +312,9 @@ public class InboundToUnstructuredProcessorImpl implements InboundToUnstructured
         return dataManagementConfiguration.getUnstructuredContainerName();
     }
 
-    private ObjectRecordStatusEntity getStatus(ObjectDirectoryStatusEnum status) {
-        if (objectDirectoryStatusRepository != null) {
-            return objectDirectoryStatusRepository.getReferenceById(status.getId());
+    private ObjectRecordStatusEntity getStatus(ObjectRecordStatusEnum status) {
+        if (objectRecordStatusRepository != null) {
+            return objectRecordStatusRepository.getReferenceById(status.getId());
         }
         return null;
     }

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -23,13 +23,13 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionTypeEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionUrgencyEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.exception.PartialFailureException;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionCommentRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionStatusRepository;
@@ -129,7 +129,7 @@ public class TranscriptionServiceImpl implements TranscriptionService {
     private final TranscriptionWorkflowRepository transcriptionWorkflowRepository;
     private final TranscriptionCommentRepository transcriptionCommentRepository;
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
-    private final ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final ExternalLocationTypeRepository externalLocationTypeRepository;
     private final UserAccountRepository userAccountRepository;
 
@@ -205,7 +205,7 @@ public class TranscriptionServiceImpl implements TranscriptionService {
     @SuppressWarnings("checkstyle:MissingSwitchDefault")
     public UpdateTranscriptionResponse updateTranscription(Integer transcriptionId,
                                                            UpdateTranscription updateTranscription) {
-        return updateTranscription(transcriptionId,updateTranscription,false);
+        return updateTranscription(transcriptionId, updateTranscription, false);
     }
 
     @Override
@@ -589,8 +589,8 @@ public class TranscriptionServiceImpl implements TranscriptionService {
                                                                       TranscriptionDocumentEntity transcriptionDocumentEntity) {
         var externalObjectDirectoryEntity = new ExternalObjectDirectoryEntity();
         externalObjectDirectoryEntity.setTranscriptionDocumentEntity(transcriptionDocumentEntity);
-        externalObjectDirectoryEntity.setStatus(objectDirectoryStatusRepository.getReferenceById(
-            ObjectDirectoryStatusEnum.STORED.getId()));
+        externalObjectDirectoryEntity.setStatus(objectRecordStatusRepository.getReferenceById(
+            ObjectRecordStatusEnum.STORED.getId()));
         externalObjectDirectoryEntity.setExternalLocationType(externalLocationTypeRepository.getReferenceById(INBOUND.getId()));
         externalObjectDirectoryEntity.setExternalLocation(externalLocation);
         externalObjectDirectoryEntity.setChecksum(checksum);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -94,14 +94,12 @@ spring:
           envers:
             audit_table_suffix: _audit
             store_data_at_delete: true
-    flyway:
-      out-of-order: true
-      ignore-missing-migrations: true
   flyway:
     enabled: ${ENABLE_DB_MIGRATE:true}
     locations: classpath:db/migration/common,db/migration/postgres
     default-schema: ${spring.datasource.schema}
     mixed: true
+    out-of-order: true
 
 darts:
   audio:

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceImplTest.java
@@ -87,11 +87,12 @@ class ArchiveRecordServiceImplTest {
         TranscriptionArchiveRecordMapper transcriptionArchiveRecordMapper = new TranscriptionArchiveRecordMapperImpl(armDataManagementConfiguration);
         AnnotationArchiveRecordMapper annotationArchiveRecordMapper = new AnnotationArchiveRecordMapperImpl(armDataManagementConfiguration);
 
-        archiveRecordService = new ArchiveRecordServiceImpl(armDataManagementConfiguration,
-                                                            archiveRecordFileGenerator,
-                                                            mediaArchiveRecordMapper,
-                                                            transcriptionArchiveRecordMapper,
-                                                            annotationArchiveRecordMapper
+        archiveRecordService = new ArchiveRecordServiceImpl(
+            armDataManagementConfiguration,
+            archiveRecordFileGenerator,
+            mediaArchiveRecordMapper,
+            transcriptionArchiveRecordMapper,
+            annotationArchiveRecordMapper
         );
 
     }
@@ -121,7 +122,7 @@ class ArchiveRecordServiceImplTest {
         when(mediaEntity.getStart()).thenReturn(startedAt);
         when(mediaEntity.getEnd()).thenReturn(endedAt);
         when(mediaEntity.getCreatedDateTime()).thenReturn(startedAt);
-        when(mediaEntity.getCaseIdList()).thenReturn(List.of("Case1", "Case2", "Case3"));
+        when(mediaEntity.getCaseNumberList()).thenReturn(List.of("Case1", "Case2", "Case3"));
 
         when(externalObjectDirectoryEntity.getId()).thenReturn(EODID);
         when(externalObjectDirectoryEntity.getMedia()).thenReturn(mediaEntity);

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmProcessorImplTest.java
@@ -20,7 +20,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 
@@ -33,7 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_ARM_INGESTION_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_ARM_INGESTION_FAILED;
 
 @ExtendWith(MockitoExtension.class)
 class UnstructuredToArmProcessorImplTest {
@@ -44,7 +44,7 @@ class UnstructuredToArmProcessorImplTest {
     @Mock
     private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
     @Mock
-    private ObjectDirectoryStatusRepository objectRecordStatusRepository;
+    private ObjectRecordStatusRepository objectRecordStatusRepository;
     @Mock
     private ExternalLocationTypeRepository externalLocationTypeRepository;
     @Mock
@@ -85,7 +85,8 @@ class UnstructuredToArmProcessorImplTest {
         unstructuredToArmProcessor = new UnstructuredToArmProcessorImpl(externalObjectDirectoryRepository,
                                                                         objectRecordStatusRepository, externalLocationTypeRepository,
                                                                         dataManagementApi, armDataManagementApi, userAccountRepository,
-                                                                        armDataManagementConfiguration);
+                                                                        armDataManagementConfiguration
+        );
     }
 
     @Test
@@ -101,10 +102,12 @@ class UnstructuredToArmProcessorImplTest {
         List<ObjectRecordStatusEntity> armStatuses = getArmStatuses();
 
         List<ExternalObjectDirectoryEntity> inboundList = new ArrayList<>(Collections.singletonList(externalObjectDirectoryEntityUnstructured));
-        when(externalObjectDirectoryRepository.findExternalObjectsNotIn2StorageLocations(objectRecordStatusEntityStored,
-                                                                                         armStatuses,
-                                                                                         externalLocationTypeUnstructured,
-                                                                                         externalLocationTypeArm)).thenReturn(inboundList);
+        when(externalObjectDirectoryRepository.findExternalObjectsNotIn2StorageLocations(
+            objectRecordStatusEntityStored,
+            armStatuses,
+            externalLocationTypeUnstructured,
+            externalLocationTypeArm
+        )).thenReturn(inboundList);
 
         when(externalObjectDirectoryEntityUnstructured.getExternalLocationType()).thenReturn(externalLocationTypeUnstructured);
         when(externalLocationTypeUnstructured.getId()).thenReturn(ExternalLocationTypeEnum.UNSTRUCTURED.getId());
@@ -139,18 +142,22 @@ class UnstructuredToArmProcessorImplTest {
         List<ObjectRecordStatusEntity> armStatuses = getArmStatuses();
 
         List<ExternalObjectDirectoryEntity> pendingUnstructuredStorageItems = new ArrayList<>(Collections.emptyList());
-        when(externalObjectDirectoryRepository.findExternalObjectsNotIn2StorageLocations(objectRecordStatusEntityStored,
-                                                                                         armStatuses,
-                                                                                         externalLocationTypeUnstructured,
-                                                                                         externalLocationTypeArm)).thenReturn(pendingUnstructuredStorageItems);
+        when(externalObjectDirectoryRepository.findExternalObjectsNotIn2StorageLocations(
+            objectRecordStatusEntityStored,
+            armStatuses,
+            externalLocationTypeUnstructured,
+            externalLocationTypeArm
+        )).thenReturn(pendingUnstructuredStorageItems);
 
 
         when(objectRecordStatusRepository.getReferenceById(FAILURE_ARM_INGESTION_FAILED.getId())).thenReturn(objectRecordStatusEntityFailed);
         when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(MAX_RETRY_ATTEMPTS);
         List<ExternalObjectDirectoryEntity> pendingFailureList = new ArrayList<>(Collections.singletonList(externalObjectDirectoryEntityArm));
-        when(externalObjectDirectoryRepository.findFailedNotExceedRetryInStorageLocation(objectRecordStatusEntityFailed,
-                                                                                         externalLocationTypeRepository.getReferenceById(3),
-                                                                                         armDataManagementConfiguration.getMaxRetryAttempts()))
+        when(externalObjectDirectoryRepository.findFailedNotExceedRetryInStorageLocation(
+            objectRecordStatusEntityFailed,
+            externalLocationTypeRepository.getReferenceById(3),
+            armDataManagementConfiguration.getMaxRetryAttempts()
+        ))
             .thenReturn(pendingFailureList);
 
         when(dataManagementApi.getBlobDataFromUnstructuredContainer(any())).thenReturn(binaryData);
@@ -159,11 +166,13 @@ class UnstructuredToArmProcessorImplTest {
         when(externalObjectDirectoryEntityArm.getTranscriptionDocumentEntity()).thenReturn(transcriptionDocumentEntity);
         when(externalObjectDirectoryEntityArm.getAnnotationDocumentEntity()).thenReturn(annotationDocumentEntity);
         when(externalObjectDirectoryRepository
-                 .findMatchingExternalObjectDirectoryEntityByLocation(objectRecordStatusEntityStored,
-                                                                      externalLocationTypeUnstructured,
-                                                                      externalObjectDirectoryEntityArm.getMedia(),
-                                                                      externalObjectDirectoryEntityArm.getTranscriptionDocumentEntity(),
-                                                                      externalObjectDirectoryEntityArm.getAnnotationDocumentEntity()))
+                 .findMatchingExternalObjectDirectoryEntityByLocation(
+                     objectRecordStatusEntityStored,
+                     externalLocationTypeUnstructured,
+                     externalObjectDirectoryEntityArm.getMedia(),
+                     externalObjectDirectoryEntityArm.getTranscriptionDocumentEntity(),
+                     externalObjectDirectoryEntityArm.getAnnotationDocumentEntity()
+                 ))
             .thenReturn(Optional.ofNullable(externalObjectDirectoryEntityUnstructured));
 
         unstructuredToArmProcessor.processUnstructuredToArm();
@@ -185,18 +194,22 @@ class UnstructuredToArmProcessorImplTest {
 
         List<ObjectRecordStatusEntity> armStatuses = getArmStatuses();
 
-        when(externalObjectDirectoryRepository.findExternalObjectsNotIn2StorageLocations(objectRecordStatusEntityStored,
-                                                                                         armStatuses,
-                                                                                         externalLocationTypeUnstructured,
-                                                                                         externalLocationTypeArm)).thenReturn(pendingUnstructuredStorageItems);
+        when(externalObjectDirectoryRepository.findExternalObjectsNotIn2StorageLocations(
+            objectRecordStatusEntityStored,
+            armStatuses,
+            externalLocationTypeUnstructured,
+            externalLocationTypeArm
+        )).thenReturn(pendingUnstructuredStorageItems);
 
 
         when(objectRecordStatusRepository.getReferenceById(FAILURE_ARM_INGESTION_FAILED.getId())).thenReturn(objectRecordStatusEntityFailed);
         when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(MAX_RETRY_ATTEMPTS);
         List<ExternalObjectDirectoryEntity> pendingFailureList = new ArrayList<>(Collections.singletonList(externalObjectDirectoryEntityArm));
-        when(externalObjectDirectoryRepository.findFailedNotExceedRetryInStorageLocation(objectRecordStatusEntityFailed,
-                                                                                         externalLocationTypeRepository.getReferenceById(3),
-                                                                                         armDataManagementConfiguration.getMaxRetryAttempts()))
+        when(externalObjectDirectoryRepository.findFailedNotExceedRetryInStorageLocation(
+            objectRecordStatusEntityFailed,
+            externalLocationTypeRepository.getReferenceById(3),
+            armDataManagementConfiguration.getMaxRetryAttempts()
+        ))
             .thenReturn(pendingFailureList);
 
         when(externalObjectDirectoryEntityArm.getExternalLocationType()).thenReturn(externalLocationTypeArm);
@@ -204,11 +217,13 @@ class UnstructuredToArmProcessorImplTest {
         when(externalObjectDirectoryEntityArm.getTranscriptionDocumentEntity()).thenReturn(transcriptionDocumentEntity);
         when(externalObjectDirectoryEntityArm.getAnnotationDocumentEntity()).thenReturn(annotationDocumentEntity);
         when(externalObjectDirectoryRepository
-                 .findMatchingExternalObjectDirectoryEntityByLocation(objectRecordStatusEntityStored,
-                                                                      externalLocationTypeUnstructured,
-                                                                      externalObjectDirectoryEntityArm.getMedia(),
-                                                                      externalObjectDirectoryEntityArm.getTranscriptionDocumentEntity(),
-                                                                      externalObjectDirectoryEntityArm.getAnnotationDocumentEntity()))
+                 .findMatchingExternalObjectDirectoryEntityByLocation(
+                     objectRecordStatusEntityStored,
+                     externalLocationTypeUnstructured,
+                     externalObjectDirectoryEntityArm.getMedia(),
+                     externalObjectDirectoryEntityArm.getTranscriptionDocumentEntity(),
+                     externalObjectDirectoryEntityArm.getAnnotationDocumentEntity()
+                 ))
             .thenReturn(Optional.empty());
 
         unstructuredToArmProcessor.processUnstructuredToArm();

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/AddAudioRequestMapperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/AddAudioRequestMapperImplTest.java
@@ -48,7 +48,7 @@ class AddAudioRequestMapperImplTest {
         media.setChannel(1);
         media.setTotalChannels(2);
         media.setCourtroom(courtroomEntity);
-        media.setCaseIdList(List.of("case1", "case2"));
+        media.setCaseNumberList(List.of("case1", "case2"));
 
         MediaEntity result = addAudioRequestMapperImpl.mapToMedia(
             new AddAudioMetadataRequest(
@@ -68,7 +68,7 @@ class AddAudioRequestMapperImplTest {
         Assertions.assertEquals(media.getChannel(), result.getChannel());
         Assertions.assertEquals(media.getTotalChannels(), result.getTotalChannels());
         Assertions.assertEquals(media.getCourtroom().getName(), result.getCourtroom().getName());
-        Assertions.assertEquals(media.getCaseIdList().size(), result.getCaseIdList().size());
+        Assertions.assertEquals(media.getCaseNumberList().size(), result.getCaseNumberList().size());
     }
 }
 

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
@@ -27,7 +27,7 @@ import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.service.FileOperationService;
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
@@ -93,7 +93,7 @@ class AudioServiceImplTest {
     @Mock
     private ExternalLocationTypeRepository externalLocationTypeRepository;
     @Mock
-    private ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private ObjectRecordStatusRepository objectRecordStatusRepository;
     @Mock
     private DataManagementApi dataManagementApi;
     @Mock
@@ -108,7 +108,7 @@ class AudioServiceImplTest {
         audioService = new AudioServiceImpl(
             audioTransformationService,
             externalObjectDirectoryRepository,
-            objectDirectoryStatusRepository,
+            objectRecordStatusRepository,
             externalLocationTypeRepository,
             mediaRepository,
             audioOperationService,
@@ -197,7 +197,7 @@ class AudioServiceImplTest {
 
         verify(dataManagementApi).saveBlobDataToInboundContainer(inboundBlobStorageArgumentCaptor.capture());
         var binaryData = inboundBlobStorageArgumentCaptor.getValue();
-        assertEquals(BinaryData.fromStream(audioFile.getInputStream()).toString(),binaryData.toString());
+        assertEquals(BinaryData.fromStream(audioFile.getInputStream()).toString(), binaryData.toString());
 
 
         verify(mediaRepository).save(mediaEntityArgumentCaptor.capture());

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/ExternalInboundDataStoreDeleterImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/ExternalInboundDataStoreDeleterImplTest.java
@@ -13,11 +13,11 @@ import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ class ExternalInboundDataStoreDeleterImplTest {
     private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
 
     @Mock
-    private ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private ObjectRecordStatusRepository objectRecordStatusRepository;
 
     private ObjectRecordStatusEntity deletedStatus;
 
@@ -57,7 +57,7 @@ class ExternalInboundDataStoreDeleterImplTest {
     @BeforeEach
     public void setUp() {
         this.deleter = new ExternalInboundDataStoreDeleter(
-            objectDirectoryStatusRepository,
+            objectRecordStatusRepository,
             userAccountRepository,
             externalObjectDirectoryRepository,
             finder,
@@ -75,8 +75,8 @@ class ExternalInboundDataStoreDeleterImplTest {
 
     private void mockStatus() {
         this.deletedStatus = new ObjectRecordStatusEntity();
-        deletedStatus.setId(ObjectDirectoryStatusEnum.DELETED.getId());
-        when(objectDirectoryStatusRepository.getReferenceById(ObjectDirectoryStatusEnum.DELETED.getId())).thenReturn(
+        deletedStatus.setId(ObjectRecordStatusEnum.DELETED.getId());
+        when(objectRecordStatusRepository.getReferenceById(ObjectRecordStatusEnum.DELETED.getId())).thenReturn(
             deletedStatus);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/ExternalOutboundDataStoreDeleterImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/ExternalOutboundDataStoreDeleterImplTest.java
@@ -11,10 +11,10 @@ import uk.gov.hmcts.darts.audio.deleter.impl.outbound.OutboundExternalObjectDire
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 class ExternalOutboundDataStoreDeleterImplTest {
 
     @Mock
-    ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    ObjectRecordStatusRepository objectRecordStatusRepository;
     @Mock
     UserAccountRepository userAccountRepository;
     @Mock
@@ -58,7 +58,7 @@ class ExternalOutboundDataStoreDeleterImplTest {
     @BeforeEach
     void setUp() {
         this.deleter = new ExternalOutboundDataStoreDeleter(
-            objectDirectoryStatusRepository,
+            objectRecordStatusRepository,
             userAccountRepository,
             transientObjectDirectoryRepository,
             finder,
@@ -68,8 +68,8 @@ class ExternalOutboundDataStoreDeleterImplTest {
 
     private void mockStatus() {
         this.markedForDeletionStatus = new ObjectRecordStatusEntity();
-        markedForDeletionStatus.setId(ObjectDirectoryStatusEnum.DELETED.getId());
-        when(objectDirectoryStatusRepository.getReferenceById(ObjectDirectoryStatusEnum.DELETED.getId())).thenReturn(
+        markedForDeletionStatus.setId(ObjectRecordStatusEnum.DELETED.getId());
+        when(objectRecordStatusRepository.getReferenceById(ObjectRecordStatusEnum.DELETED.getId())).thenReturn(
             markedForDeletionStatus);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImplTest.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
@@ -33,7 +33,7 @@ class OutboundAudioDeleterProcessorImplTest {
     @Mock
     private UserAccountRepository userAccountRepository;
     @Mock
-    private ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private ObjectRecordStatusRepository objectRecordStatusRepository;
     private OutboundAudioDeleterProcessorImpl outboundAudioDeleterProcessorImpl;
 
     @Mock
@@ -45,7 +45,7 @@ class OutboundAudioDeleterProcessorImplTest {
             mediaRequestRepository,
             transientObjectDirectoryRepository,
             userAccountRepository,
-            objectDirectoryStatusRepository, lastAccessedDeletionDayCalculator,
+            objectRecordStatusRepository, lastAccessedDeletionDayCalculator,
             systemUserHelper
         );
         when(systemUserHelper.findSystemUserGuid(anyString())).thenReturn("value");

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorImplTest.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
-import uk.gov.hmcts.darts.common.repository.ObjectDirectoryStatusRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.service.impl.InboundToUnstructuredProcessorImpl;
@@ -39,11 +39,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_CHECKSUM_FAILED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_FILE_NOT_FOUND;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_FILE_SIZE_CHECK_FAILED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.FAILURE_FILE_TYPE_CHECK_FAILED;
-import static uk.gov.hmcts.darts.common.enums.ObjectDirectoryStatusEnum.STORED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_CHECKSUM_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_FILE_NOT_FOUND;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_FILE_SIZE_CHECK_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE_FILE_TYPE_CHECK_FAILED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings({"PMD.ExcessiveImports"})
@@ -58,7 +58,7 @@ class InboundToUnstructuredProcessorImplTest {
     @Mock
     private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
     @Mock
-    private ObjectDirectoryStatusRepository objectDirectoryStatusRepository;
+    private ObjectRecordStatusRepository objectRecordStatusRepository;
     @Mock
     private ExternalLocationTypeRepository externalLocationTypeRepository;
     @Mock
@@ -111,7 +111,7 @@ class InboundToUnstructuredProcessorImplTest {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         inboundToUnstructuredProcessor = new InboundToUnstructuredProcessorImpl(externalObjectDirectoryRepository,
-                                                                                objectDirectoryStatusRepository, externalLocationTypeRepository,
+                                                                                objectRecordStatusRepository, externalLocationTypeRepository,
                                                                                 dataManagementService, dataManagementConfiguration, userAccountRepository,
                                                                                 transcriptionConfigurationProperties, audioConfigurationProperties
         );
@@ -133,8 +133,8 @@ class InboundToUnstructuredProcessorImplTest {
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
         when(objectRecordStatusEntityAwaiting.getId()).thenReturn(9);
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
 
         setExpectationsForFailedStates();
 
@@ -156,12 +156,12 @@ class InboundToUnstructuredProcessorImplTest {
     }
 
     private void setExpectationsForFailedStates() {
-        when(objectDirectoryStatusRepository.getReferenceById(3)).thenReturn(objectRecordStatusEntityFailure);
-        when(objectDirectoryStatusRepository.getReferenceById(4)).thenReturn(objectRecordStatusEntityFailureFileNotFound);
-        when(objectDirectoryStatusRepository.getReferenceById(5)).thenReturn(objectRecordStatusEntityFailureFileSize);
-        when(objectDirectoryStatusRepository.getReferenceById(6)).thenReturn(objectRecordStatusEntityFailureFileType);
-        when(objectDirectoryStatusRepository.getReferenceById(7)).thenReturn(objectRecordStatusEntityFailureChecksum);
-        when(objectDirectoryStatusRepository.getReferenceById(8)).thenReturn(objectRecordStatusEntityFailureArm);
+        when(objectRecordStatusRepository.getReferenceById(3)).thenReturn(objectRecordStatusEntityFailure);
+        when(objectRecordStatusRepository.getReferenceById(4)).thenReturn(objectRecordStatusEntityFailureFileNotFound);
+        when(objectRecordStatusRepository.getReferenceById(5)).thenReturn(objectRecordStatusEntityFailureFileSize);
+        when(objectRecordStatusRepository.getReferenceById(6)).thenReturn(objectRecordStatusEntityFailureFileType);
+        when(objectRecordStatusRepository.getReferenceById(7)).thenReturn(objectRecordStatusEntityFailureChecksum);
+        when(objectRecordStatusRepository.getReferenceById(8)).thenReturn(objectRecordStatusEntityFailureArm);
     }
 
     @Test
@@ -170,9 +170,9 @@ class InboundToUnstructuredProcessorImplTest {
         when(externalObjectDirectoryEntityInbound.getMedia()).thenReturn(mediaEntity);
         when(objectRecordStatusEntityFailureFileNotFound.getId()).thenReturn(4);
         when(objectRecordStatusEntityAwaiting.getId()).thenReturn(9);
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
-        when(objectDirectoryStatusRepository.getReferenceById(4)).thenReturn(objectRecordStatusEntityFailureFileNotFound);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
+        when(objectRecordStatusRepository.getReferenceById(4)).thenReturn(objectRecordStatusEntityFailureFileNotFound);
         when(dataManagementService.getBlobData(any(), any())).thenThrow(new BlobStorageException("Blobbed it", null, null));
         setExpectationsForFailedStates();
 
@@ -212,7 +212,7 @@ class InboundToUnstructuredProcessorImplTest {
         when(mediaEntity.getFileSize()).thenReturn((long) binaryData.toString().length());
         when(mediaEntity.getChecksum()).thenReturn(calculatedChecksum);
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
         //when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectDirectoryStatusEntityAwaiting);
         when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(List.of(MP_2));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(MAX_FILE_SIZE_VALID);
@@ -249,8 +249,8 @@ class InboundToUnstructuredProcessorImplTest {
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
         when(objectRecordStatusEntityAwaiting.getId()).thenReturn(9);
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
         when(transcriptionConfigurationProperties.getAllowedExtensions()).thenReturn(Arrays.asList(DOC, DOCX));
         when(transcriptionConfigurationProperties.getMaxFileSize()).thenReturn(MAX_FILE_SIZE_VALID);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
@@ -281,8 +281,8 @@ class InboundToUnstructuredProcessorImplTest {
         when(annotationDocumentEntity.getChecksum()).thenReturn(calculatedChecksum);
         when(objectRecordStatusEntityAwaiting.getId()).thenReturn(9);
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
         when(transcriptionConfigurationProperties.getAllowedExtensions()).thenReturn(Arrays.asList(DOC, DOCX));
         when(transcriptionConfigurationProperties.getMaxFileSize()).thenReturn(MAX_FILE_SIZE_VALID);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
@@ -314,9 +314,9 @@ class InboundToUnstructuredProcessorImplTest {
 
         when(objectRecordStatusEntityFailureFileType.getId()).thenReturn(6);
         when(objectRecordStatusEntityAwaiting.getId()).thenReturn(9);
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        when(objectDirectoryStatusRepository.getReferenceById(6)).thenReturn(objectRecordStatusEntityFailureFileType);
-        when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(6)).thenReturn(objectRecordStatusEntityFailureFileType);
+        when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
 
 
         when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(Arrays.asList("doc", "docx"));
@@ -349,9 +349,9 @@ class InboundToUnstructuredProcessorImplTest {
         when(mediaEntity.getChecksum()).thenReturn("invalid-checksum");
         when(objectRecordStatusEntityFailureChecksum.getId()).thenReturn(7);
         when(objectRecordStatusEntityAwaiting.getId()).thenReturn(9);
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        when(objectDirectoryStatusRepository.getReferenceById(7)).thenReturn(objectRecordStatusEntityFailureChecksum);
-        when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(7)).thenReturn(objectRecordStatusEntityFailureChecksum);
+        when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
         when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(Arrays.asList("mp2"));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(MAX_FILE_SIZE_VALID);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
@@ -383,9 +383,9 @@ class InboundToUnstructuredProcessorImplTest {
         when(mediaEntity.getChecksum()).thenReturn(calculatedChecksum);
         when(objectRecordStatusEntityFailureFileSize.getId()).thenReturn(5);
         when(objectRecordStatusEntityAwaiting.getId()).thenReturn(9);
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        when(objectDirectoryStatusRepository.getReferenceById(5)).thenReturn(objectRecordStatusEntityFailureFileSize);
-        when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(5)).thenReturn(objectRecordStatusEntityFailureFileSize);
+        when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
         when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(Arrays.asList("doc", "docx"));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(1);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
@@ -423,8 +423,8 @@ class InboundToUnstructuredProcessorImplTest {
         when(objectRecordStatusEntityAwaiting.getId()).thenReturn(9);
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
 
-        when(objectDirectoryStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
+        when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
+        when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
 
         when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(List.of("mp2"));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(100);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-1724](https://tools.hmcts.net/jira/browse/DMP-1724)
[DMP-1696](https://tools.hmcts.net/jira/browse/DMP-1696)

### Change description ###

Following [DMP-1696](https://tools.hmcts.net/jira/browse/DMP-1696) and trying addAudio locally, it appears that the new checksum field needs to be set on saved media.
* Rename `ObjectRecordStatusEnum` following DMP-1696 updates
* Correct flyway application config (`spring.flyway.out-of-order=true`)
* Updated MediaEntity#caseNumberList to remove `@Type(ListArrayType.class)` which causes Spring Boot v3.2.1 startup ERROR


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
