### PR TITLE
DMP-1854_json_document converted to json_string for API

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/DailyListEntityTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/DailyListEntityTest.java
@@ -4,42 +4,95 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.dailylist.model.DailyListJsonObject;
+import uk.gov.hmcts.darts.dailylist.model.DailyListPatchRequest;
+import uk.gov.hmcts.darts.dailylist.model.PostDailyListResponse;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.CPP;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.XHIBIT;
 
 @AutoConfigureMockMvc
 class DailyListEntityTest extends IntegrationBase {
 
+    public static final String DAILYLISTS = "/dailylists";
+    public static final String SOURCE_SYSTEM = "source_system";
+    public static final String JSON_STRING = "json_string";
+    public static final String DAL_ID = "dal_id";
     @Autowired
     private transient MockMvc mockMvc;
+
+    @MockBean
+    UserIdentity mockUserIdentity;
 
     @Test
     void dailyListAddDailyListEndpoint() throws Exception {
         dartsDatabase.createCourthouseWithNameAndCode("SWANSEA", 457, "Swansea");
 
         String jsonDocument = getContentsFromFile("tests/DailyListTest/dailyListAddDailyListEndpoint/requestBody.json");
-        MockHttpServletRequestBuilder requestBuilder = post("/dailylists")
+        MockHttpServletRequestBuilder requestBuilder = post(DAILYLISTS)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .queryParam("source_system", "CPP")
-            .header("json_document", jsonDocument);
+            .queryParam(SOURCE_SYSTEM, "CPP")
+            .header(JSON_STRING, jsonDocument);
         MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk()).andReturn();
 
-        assertThat(response.getResponse().getContentAsString()).contains("dal_id");
+        assertThat(response.getResponse().getContentAsString()).contains(DAL_ID);
     }
 
     private String getContentsFromFile(String filelocation) throws IOException {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         File file = new File(classLoader.getResource(filelocation).getFile());
-        return FileUtils.readFileToString(file, "UTF-8");
+        return FileUtils.readFileToString(file, StandardCharsets.UTF_8);
     }
+
+    @Test
+    void dailyListPatchDailyListEndpoint() throws Exception {
+        when(mockUserIdentity.userHasGlobalAccess(Set.of(XHIBIT, CPP))).thenReturn(true);
+
+        dartsDatabase.createCourthouseWithNameAndCode("SWANSEA", 457, "Swansea");
+
+        String jsonDocument1 = getContentsFromFile("tests/DailyListTest/dailyListAddDailyListEndpoint/requestBody.json");
+        String jsonDocument2 = getContentsFromFile("tests/dailylist/DailyListServiceTest/insert1_ok/DailyListRequest.json");
+
+        MockHttpServletRequestBuilder requestBuilder = post(DAILYLISTS)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .queryParam(SOURCE_SYSTEM, "CPP")
+            .header(JSON_STRING, jsonDocument1);
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk()).andReturn();
+
+        DailyListJsonObject dailyList = objectMapper.readValue(jsonDocument1, DailyListJsonObject.class);
+        PostDailyListResponse postDailyListResponse = objectMapper.readValue(response.getResponse().getContentAsString(), PostDailyListResponse.class);
+
+        DailyListPatchRequest patchRequest = new DailyListPatchRequest();
+        patchRequest.setDailyListId(postDailyListResponse.getDalId());
+        patchRequest.setDailyListJson(dailyList);
+
+        String dalID = String.valueOf(postDailyListResponse.getDalId());
+
+        MockHttpServletRequestBuilder requestBuilder2 = patch(DAILYLISTS)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .queryParam(SOURCE_SYSTEM, "CPP")
+            .queryParam(DAL_ID, dalID)
+            .header(JSON_STRING, jsonDocument2);
+        MvcResult patchResponse = mockMvc.perform(requestBuilder2).andExpect(status().isOk()).andReturn();
+
+        assertThat(patchResponse.getResponse().getContentAsString()).contains(DAL_ID);
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/controller/DailyListController.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/controller/DailyListController.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.dailylist.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
+import uk.gov.hmcts.darts.common.config.ObjectMapperConfig;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
@@ -55,17 +58,26 @@ public class DailyListController implements DailyListsApi {
     private final DailyListService dailyListService;
     private final DailyListProcessor processor;
 
+    ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig();
+    ObjectMapper objectMapper = objectMapperConfig.objectMapper();
+
+
+    @SneakyThrows
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {XHIBIT, CPP})
     public ResponseEntity<PostDailyListResponse> dailylistsPatch(
-        @NotNull @Parameter(name = "dal_id", description = "ID of the DailyList in the database.", required = true, in = ParameterIn.QUERY)
-        @Valid @RequestParam(value = "dal_id", required = true) Integer dalId,
-        @NotNull @Parameter(name = "json_document", description = "JSON representation of the 'document' received in the addDocument request.<p> **" +
-            "Conditional mandatory** either this or xml_document needs to be provided, or both.", required = true, in = ParameterIn.HEADER)
-        @RequestHeader(value = "json_document", required = true) DailyListJsonObject jsonDocument
+        @javax.validation.constraints.NotNull @Parameter(name = "dal_id", description = "ID of the DailyList in the database.",
+            required = true, in = ParameterIn.QUERY)
+        @javax.validation.Valid @RequestParam(value = "dal_id", required = true) Integer dalId,
+        @javax.validation.constraints.NotNull @Parameter(name = "json_string", description = "JSON representation of the 'document' received in the " +
+            "addDocument request.<p> **Conditional mandatory** either this or xml_document needs to be provided, or both.",
+            required = true, in = ParameterIn.HEADER)
+        @RequestHeader(value = "json_string", required = true) String jsonString
     ) {
+        DailyListJsonObject jsonDocument = objectMapper.readValue(jsonString, DailyListJsonObject.class);
+
         DailyListPatchRequest dailyListPatchRequest = new DailyListPatchRequest();
         dailyListPatchRequest.setDailyListId(dalId);
         dailyListPatchRequest.setDailyListJson(jsonDocument);
@@ -74,6 +86,7 @@ public class DailyListController implements DailyListsApi {
 
     }
 
+    @SneakyThrows
     @Override
     @Operation(
         operationId = "dailylistsPost",
@@ -103,23 +116,31 @@ public class DailyListController implements DailyListsApi {
     public ResponseEntity<PostDailyListResponse> dailylistsPost(
         @NotNull @Parameter(name = "source_system", description = "The source system that has sent the message", required = true, in = ParameterIn.QUERY)
         @Valid @RequestParam(value = "source_system", required = true) String sourceSystem,
-        @Parameter(name = "courthouse", description = "The courthouse that the dailyList represents. <p> **Conditional mandatory**, required if " +
-            "json_document not provided", in = ParameterIn.QUERY) @Valid @RequestParam(value = "courthouse", required = false) String courthouse,
-        @Parameter(name = "hearing_date", description = "The date that the dailyList represents. <p> **Conditional mandatory**, required if json_document " +
-            "not provided", in = ParameterIn.QUERY) @Valid @RequestParam(value = "hearing_date", required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hearingDate,
-        @Parameter(name = "unique_id", description = "The uniqueId. <p> **Conditional mandatory**, required if json_document not provided",
-            in = ParameterIn.QUERY) @Valid @RequestParam(value = "unique_id", required = false) String uniqueId,
-        @Parameter(name = "published_ts", description = "The date that the dailyList was published. <p> **Conditional mandatory**, required if json_document " +
-            "not provided", in = ParameterIn.QUERY) @Valid @RequestParam(value = "published_ts", required = false)
-        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime publishedTs,
-        @Parameter(name = "xml_document", description = "XML representation of the 'document' received in the addDocument request.<p> **Conditional " +
-            "mandatory** either this or json_document needs to be provided, or both. This will not be parsed but just stored in the database as a string",
-            in = ParameterIn.HEADER) @RequestHeader(value = "xml_document", required = false) String xmlDocument,
-        @Parameter(name = "json_document", description = "JSON representation of the 'document' received in the addDocument request.<p> **Conditional " +
-            "mandatory** either this or xml_document needs to be provided, or both.", in = ParameterIn.HEADER) @RequestHeader(value = "json_document",
-            required = false) DailyListJsonObject jsonDocument
+        @Parameter(name = "courthouse", description = "The courthouse that the dailyList represents. <p> **" +
+            "Conditional mandatory**, required if json_document not provided", in = ParameterIn.QUERY)
+        @Valid @RequestParam(value = "courthouse", required = false) String courthouse,
+        @Parameter(name = "hearing_date", description = "The date that the dailyList represents. <p> **Conditional mandatory**, required if " +
+            "json_document not provided", in = ParameterIn.QUERY)
+        @Valid @RequestParam(value = "hearing_date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate hearingDate,
+        @Parameter(name = "unique_id", description = "The uniqueId. <p> **Conditional mandatory**, required if " +
+            "json_document not provided", in = ParameterIn.QUERY)
+        @Valid @RequestParam(value = "unique_id", required = false) String uniqueId,
+        @Parameter(name = "published_ts", description = "The date that the dailyList was published. <p> **Conditional mandatory**, required if " +
+            "json_document not provided", in = ParameterIn.QUERY)
+        @Valid @RequestParam(value = "published_ts", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime publishedTs,
+        @Parameter(name = "xml_document", description = "XML representation of the 'document' received in the addDocument request.<p> " +
+            "**Conditional mandatory** either this or json_document needs to be provided, or both. This will not be parsed but just " +
+            "stored in the database as a string", in = ParameterIn.HEADER) @RequestHeader(value = "xml_document", required = false) String xmlDocument,
+        @Parameter(name = "json_string", description = "JSON representation of the 'document' received in the addDocument request.<p>" +
+            "**Conditional mandatory** either this or xml_document needs to be provided, or both.",
+            in = ParameterIn.HEADER) @RequestHeader(value = "json_string", required = false) String jsonString
     ) {
+        DailyListJsonObject jsonDocument = null;
+        Optional<String> jsonDoc = Optional.ofNullable(jsonString);
+        if (jsonDoc.isPresent()) {
+            jsonDocument = objectMapper.readValue(jsonDoc.get(), DailyListJsonObject.class);
+        }
+
         DailyListPostRequest postRequest = new DailyListPostRequest();
         postRequest.setSourceSystem(sourceSystem);
         postRequest.setCourthouse(courthouse);

--- a/src/main/resources/openapi/dailylist.yaml
+++ b/src/main/resources/openapi/dailylist.yaml
@@ -60,9 +60,10 @@ paths:
           description: "XML representation of the 'document' received in the addDocument request.<p>
             **Conditional mandatory** either this or json_document needs to be provided, or both. This will not be parsed but just stored in the database as a string"
         - in: header
-          name: json_document
+          name: json_string #json_document
           schema:
-            $ref: '#/components/schemas/PostDailyListJson'
+            type: string
+            #$ref: '#/components/schemas/PostDailyListJson'
           description: "JSON representation of the 'document' received in the addDocument request.<p>
             **Conditional mandatory** either this or xml_document needs to be provided, or both."
 
@@ -109,9 +110,10 @@ paths:
           description: "ID of the DailyList in the database."
           required: true
         - in: header
-          name: json_document
+          name: json_string #json_document
           schema:
-            $ref: '#/components/schemas/PostDailyListJson'
+            type: string
+            #$ref: '#/components/schemas/PostDailyListJson'
           description: "JSON representation of the 'document' received in the addDocument request.<p>
             **Conditional mandatory** either this or xml_document needs to be provided, or both."
           required: true


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-1854



### Change description ###
The gateway feign library can not work with the json_document header i.e. it does not marshall the json, instead it uses the object string. This likely relates to the fact that headers do not have a specific content type within HTTP.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
