### PR TITLE
DMP-1724 Change the ATS Download logic

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/config/AudioConfigurationProperties.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/config/AudioConfigurationProperties.java
@@ -30,6 +30,7 @@ public class AudioConfigurationProperties {
     @NotEmpty
     private String tempBlobWorkspace;
 
+    private List<String> allowedMediaFormats = new ArrayList<>();
     private Integer maxFileSize;
-    private List<String> allowedExtensions = new ArrayList<>();
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -122,7 +122,6 @@ public class AudioRequestsController implements AudioRequestsApi {
         return StreamingResponseEntityUtil.createResponseEntity(audioFileStream, httpRangeList);
     }
 
-
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     public ResponseEntity<Void> updateTransformedMediaLastAccessedTimestamp(Integer transformedMediaId) {
@@ -138,7 +137,9 @@ public class AudioRequestsController implements AudioRequestsApi {
     }
 
     @Override
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     public ResponseEntity<GetAudioRequestResponse> getYourAudio(Integer userId, Boolean expired) {
         return new ResponseEntity<>(mediaRequestService.getAudioRequests(userId, expired), HttpStatus.OK);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/enums/AudioRequestOutputFormat.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/enums/AudioRequestOutputFormat.java
@@ -1,8 +1,15 @@
 package uk.gov.hmcts.darts.audio.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum AudioRequestOutputFormat {
 
-    MP3,
-    ZIP
+    MP3(".mp3"),
+    ZIP(".zip");
+
+    private final String extension;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
@@ -123,11 +123,11 @@ public class AudioServiceImpl implements AudioService {
 
     @Override
     public void linkAudioAndHearing(AddAudioMetadataRequest addAudioMetadataRequest, MediaEntity savedMedia) {
-        for (String caseId : addAudioMetadataRequest.getCases()) {
+        for (String caseNumber : addAudioMetadataRequest.getCases()) {
             HearingEntity hearing = retrieveCoreObjectService.retrieveOrCreateHearing(
                 addAudioMetadataRequest.getCourthouse(),
                 addAudioMetadataRequest.getCourtroom(),
-                caseId,
+                caseNumber,
                 addAudioMetadataRequest.getStartedAt().toLocalDate()
             );
             hearing.addMedia(savedMedia);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -165,7 +165,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
      *
      * @param requestId The id of the AudioRequest to be processed.
      */
-    @SuppressWarnings({"PMD.AvoidInstantiatingObjectsInLoops", "PMD.AvoidRethrowingException"})
+    @SuppressWarnings("PMD.AvoidRethrowingException")
     private void processAudioRequest(Integer requestId) {
 
         log.info("Starting processing for audio request id: {}", requestId);
@@ -207,9 +207,18 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
 
             int index = 1;
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd_MMM_uuuu");
+            final String fileNamePrefix = String.format(
+                "%s_%s_",
+                hearingEntity.getCourtCase().getCaseNumber(),
+                hearingEntity.getHearingDate().format(formatter)
+            );
             for (AudioFileInfo generatedAudioFile : generatedAudioFiles) {
-                final String fileName = hearingEntity.getCourtCase().getCaseNumber() + "_" + hearingEntity.getHearingDate().format(formatter) + "_"
-                    + index++ + ".mp3";
+                final String fileName = String.format(
+                    "%s%d%s",
+                    fileNamePrefix,
+                    index++,
+                    (audioRequestOutputFormat.equals(AudioRequestOutputFormat.MP3) ? ".mp3" : ".zip")
+                );
 
                 try (InputStream inputStream = Files.newInputStream(generatedAudioFile.getPath())) {
                     blobId = transformedMediaHelper.saveToStorage(mediaRequestEntity, BinaryData.fromStream(inputStream), fileName, generatedAudioFile);

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorImpl.java
@@ -123,12 +123,14 @@ public class InboundToUnstructuredProcessorImpl implements InboundToUnstructured
                 }
             } catch (BlobStorageException e) {
                 log.error("Failed to get BLOB from datastore {} for file {} for EOD ID: {}",
-                          getInboundContainerName(), inboundExternalObjectDirectory.getExternalLocation(), inboundExternalObjectDirectory.getId());
+                          getInboundContainerName(), inboundExternalObjectDirectory.getExternalLocation(), inboundExternalObjectDirectory.getId()
+                );
                 unstructuredExternalObjectDirectoryEntity.setStatus(getStatus(FAILURE_FILE_NOT_FOUND));
                 setNumTransferAttempts(unstructuredExternalObjectDirectoryEntity);
             } catch (Exception e) {
                 log.error("Failed to move from inbound to unstructured for EOD ID: {}, with error: {}",
-                          inboundExternalObjectDirectory.getId(), e.getMessage(), e);
+                          inboundExternalObjectDirectory.getId(), e.getMessage(), e
+                );
                 unstructuredExternalObjectDirectoryEntity.setStatus(getStatus(FAILURE));
                 setNumTransferAttempts(unstructuredExternalObjectDirectoryEntity);
             } finally {
@@ -220,7 +222,7 @@ public class InboundToUnstructuredProcessorImpl implements InboundToUnstructured
                 unstructured,
                 mediaEntity.getChecksum(),
                 checksum,
-                audioConfigurationProperties.getAllowedExtensions(),
+                audioConfigurationProperties.getAllowedMediaFormats(),
                 mediaEntity.getMediaFormat().toLowerCase(),
                 audioConfigurationProperties.getMaxFileSize(),
                 mediaEntity.getFileSize()
@@ -258,14 +260,15 @@ public class InboundToUnstructuredProcessorImpl implements InboundToUnstructured
     private void performValidation(
         ExternalObjectDirectoryEntity unstructured,
         String incomingChecksum, String calculatedChecksum,
-        List<String> allowedExtensions, String extension,
+        List<String> allowedMediaFormats, String mediaFormat,
         Integer maxFileSize, Long fileSize) {
         if (incomingChecksum == null || calculatedChecksum.compareTo(incomingChecksum) != 0) {
             log.error("Checksum comparison failed, incoming \"{}\" not equal to calculated \"{}\", for unstructured EOD: {}",
-                      incomingChecksum, calculatedChecksum, unstructured.getId());
+                      incomingChecksum, calculatedChecksum, unstructured.getId()
+            );
             unstructured.setStatus(getStatus(FAILURE_CHECKSUM_FAILED));
         }
-        if (!allowedExtensions.contains(extension)) {
+        if (!allowedMediaFormats.contains(mediaFormat)) {
             unstructured.setStatus(getStatus(FAILURE_FILE_TYPE_CHECK_FAILED));
         }
         if (fileSize > maxFileSize) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -112,9 +112,9 @@ darts:
     temp-blob-workspace: ${user.home}/audiotransform/tempworkspace
     outbounddeleter:
       last-accessed-deletion-day: 2
-    allowed-extensions:
-      - "mp2"
+    allowed-media-formats:
       - "mpeg2"
+      - "mp2"
     max-file-size: 524288000
   azure:
     active-directory-b2c-base-uri: https://hmctsstgextid.b2clogin.com

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -114,6 +114,7 @@ darts:
       last-accessed-deletion-day: 2
     allowed-extensions:
       - "mp2"
+      - "mpeg2"
     max-file-size: 524288000
   azure:
     active-directory-b2c-base-uri: https://hmctsstgextid.b2clogin.com

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImplTest.java
@@ -69,7 +69,7 @@ class OutboundFileProcessorImplTest {
         List<List<AudioFileInfo>> sessions = outboundFileProcessor.processAudioForDownload(
             mediaEntityToDownloadLocation,
             TIME_12_00,
-            TIME_13_00
+            TIME_12_10
         );
 
         assertEquals(1, sessions.size());
@@ -83,19 +83,14 @@ class OutboundFileProcessorImplTest {
     }
 
     @Test
-    void processAudioForDownloadShouldReturnOneSessionWithOneAudioWhenProvidedWithTwoContinuousAudios()
+    void processAudioForDownloadShouldReturnTwoSessionsEachWithOneAudioWhenProvidedWithTwoContinuousAudios()
         throws ExecutionException, InterruptedException, IOException {
 
-        var concatenatedAudioFileInfo = new AudioFileInfo(TIME_12_00.toInstant(),
-                                                          TIME_12_20.toInstant(),
-                                                          null,
-                                                          null,null);
-        when(audioOperationService.concatenate(any(), any()))
-            .thenReturn(concatenatedAudioFileInfo);
-
-        var trimmedAudioFileInfo = new AudioFileInfo();
+        var firstTrimmedAudioFileInfo = new AudioFileInfo();
+        var secondTrimmedAudioFileInfo = new AudioFileInfo();
         when(audioOperationService.trim(any(), any(), any(), any()))
-            .thenReturn(trimmedAudioFileInfo);
+            .thenReturn(firstTrimmedAudioFileInfo)
+            .thenReturn(secondTrimmedAudioFileInfo);
 
         var mediaEntity1 = createMediaEntity(
             TIME_12_00,
@@ -114,17 +109,21 @@ class OutboundFileProcessorImplTest {
         List<List<AudioFileInfo>> sessions = outboundFileProcessor.processAudioForDownload(
             mediaEntityToDownloadLocation,
             TIME_12_00,
-            TIME_13_00
+            TIME_12_20
         );
 
-        assertEquals(1, sessions.size());
-        List<AudioFileInfo> session = sessions.get(0);
+        assertEquals(2, sessions.size());
+        List<AudioFileInfo> firstSession = sessions.get(0);
+        List<AudioFileInfo> secondSession = sessions.get(1);
 
-        assertEquals(1, session.size());
-        assertEquals(trimmedAudioFileInfo, session.get(0));
+        assertEquals(1, firstSession.size());
+        assertEquals(firstTrimmedAudioFileInfo, firstSession.get(0));
 
-        verify(audioOperationService, times(1)).concatenate(any(), any());
-        verify(audioOperationService, times(1)).trim(any(), any(), any(), any());
+        assertEquals(1, secondSession.size());
+        assertEquals(secondTrimmedAudioFileInfo, secondSession.get(0));
+
+        verify(audioOperationService, never()).concatenate(any(), any());
+        verify(audioOperationService, times(2)).trim(any(), any(), any(), any());
     }
 
     @Test
@@ -154,7 +153,7 @@ class OutboundFileProcessorImplTest {
         List<List<AudioFileInfo>> sessions = outboundFileProcessor.processAudioForDownload(
             mediaEntityToDownloadLocation,
             TIME_12_00,
-            TIME_13_00
+            TIME_12_10
         );
 
         assertEquals(1, sessions.size());
@@ -195,7 +194,7 @@ class OutboundFileProcessorImplTest {
         List<List<AudioFileInfo>> sessions = outboundFileProcessor.processAudioForDownload(
             mediaEntityToDownloadLocation,
             TIME_12_00,
-            TIME_13_00
+            TIME_12_30
         );
 
         assertEquals(2, sessions.size());
@@ -220,10 +219,13 @@ class OutboundFileProcessorImplTest {
         when(audioOperationService.concatenateWithGaps(any(), any(), any()))
             .thenReturn(concatenatedAudioFileInfoList);
 
-        AudioFileInfo mergedAudioFile = new AudioFileInfo(TIME_12_00.toInstant(),
-                                                          TIME_12_20.toInstant(),
-                                                          null,
-                                                          1,null);
+        AudioFileInfo mergedAudioFile = new AudioFileInfo(
+            TIME_12_00.toInstant(),
+            TIME_12_20.toInstant(),
+            null,
+            1,
+            null
+        );
         when(audioOperationService.merge(any(), any()))
             .thenReturn(mergedAudioFile);
 
@@ -282,10 +284,13 @@ class OutboundFileProcessorImplTest {
         when(audioOperationService.concatenateWithGaps(any(), any(), any()))
             .thenReturn(concatenatedAudioFileInfoList);
 
-        AudioFileInfo mergedAudioFile = new AudioFileInfo(TIME_12_00.toInstant(),
-                                                          TIME_12_20.toInstant(),
-                                                          null,
-                                                          1,null);
+        AudioFileInfo mergedAudioFile = new AudioFileInfo(
+            TIME_12_00.toInstant(),
+            TIME_12_20.toInstant(),
+            null,
+            1,
+            null
+        );
         when(audioOperationService.merge(any(), any()))
             .thenReturn(mergedAudioFile);
 

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
@@ -241,7 +241,10 @@ class AudioTransformationServiceImplTest {
     void filterMediaByMediaRequestDatesWithStartDateExactRequestAndEndDateExactRequest() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
-        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframe(mediaEntities, mediaRequestEntity);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
 
         assertEquals(3, mediaEntitiesResult.size());
         assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
@@ -252,7 +255,10 @@ class AudioTransformationServiceImplTest {
     void filterMediaByMediaRequestDatesWithStartDateAfterRequestAndEndDateBeforeRequest() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_01, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_12_59);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
-        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframe(mediaEntities, mediaRequestEntity);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
         assertEquals(3, mediaEntitiesResult.size());
         assertEquals(TIME_12_01, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_59, mediaEntitiesResult.get(2).getEnd());
@@ -262,7 +268,10 @@ class AudioTransformationServiceImplTest {
     void filterMediaByMediaRequestDatesWithStartDateBeforeRequestAndEndDateAfterRequest() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_11_59, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_01);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
-        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframe(mediaEntities, mediaRequestEntity);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
         assertEquals(3, mediaEntitiesResult.size());
         assertEquals(TIME_11_59, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_13_01, mediaEntitiesResult.get(2).getEnd());
@@ -272,7 +281,10 @@ class AudioTransformationServiceImplTest {
     void filterMediaByMediaRequestDatesWithStartDateAndEndDateExactMiddleMediaMatch() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_11_59, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_01);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_20, TIME_12_40);
-        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframe(mediaEntities, mediaRequestEntity);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
         assertEquals(1, mediaEntitiesResult.size());
         assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_40, mediaEntitiesResult.get(0).getEnd());
@@ -282,7 +294,10 @@ class AudioTransformationServiceImplTest {
     void filterMediaByMediaRequestDatesWithStartDateBetweenRequestAndEndDateBetweenRequest() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_21, TIME_12_39);
-        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframe(mediaEntities, mediaRequestEntity);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
         assertEquals(1, mediaEntitiesResult.size());
         assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_40, mediaEntitiesResult.get(0).getEnd());
@@ -292,7 +307,10 @@ class AudioTransformationServiceImplTest {
     void filterMediaByMediaRequestDatesWithRequestStartAndEndDateOutSideMediaRange() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_12_59);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_13_00, TIME_13_01);
-        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframe(mediaEntities, mediaRequestEntity);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
         assertEquals(0, mediaEntitiesResult.size());
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorImplTest.java
@@ -49,12 +49,12 @@ import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 @SuppressWarnings({"PMD.ExcessiveImports"})
 class InboundToUnstructuredProcessorImplTest {
 
-    public static final int MAX_FILE_SIZE_VALID = 100;
-    public static final String MP_2 = "mp2";
-    public static final String TEST_DOC = "test.doc";
-    public static final String DOC = "doc";
-    public static final String DOCX = "docx";
-    public static final String TEST_BINARY_DATA = "test binary data";
+    private static final int MAX_FILE_SIZE_VALID = 100;
+    private static final String MP2 = "mp2";
+    private static final String TEST_DOC = "test.doc";
+    private static final String DOC = "doc";
+    private static final String DOCX = "docx";
+    private static final String TEST_BINARY_DATA = "test binary data";
     @Mock
     private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
     @Mock
@@ -127,7 +127,7 @@ class InboundToUnstructuredProcessorImplTest {
         when(externalLocationTypeRepository.getReferenceById(1)).thenReturn(externalLocationTypeInbound);
         when(externalObjectDirectoryEntityInbound.getMedia()).thenReturn(mediaEntity);
 
-        when(mediaEntity.getMediaFormat()).thenReturn("mp2");
+        when(mediaEntity.getMediaFormat()).thenReturn(MP2);
         when(mediaEntity.getFileSize()).thenReturn((long) binaryData.toString().length());
         when(mediaEntity.getChecksum()).thenReturn(calculatedChecksum);
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
@@ -139,7 +139,7 @@ class InboundToUnstructuredProcessorImplTest {
         setExpectationsForFailedStates();
 
 
-        when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(List.of(MP_2));
+        when(audioConfigurationProperties.getAllowedMediaFormats()).thenReturn(List.of(MP2));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(MAX_FILE_SIZE_VALID);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
         List<ExternalObjectDirectoryEntity> inboundList = new ArrayList<>(Collections.singletonList(externalObjectDirectoryEntityInbound));
@@ -208,13 +208,12 @@ class InboundToUnstructuredProcessorImplTest {
             .thenReturn(objectRecordStatusEntityStored);
         when(objectRecordStatusEntityFailureChecksum.getId()).thenReturn(7);
 
-        when(mediaEntity.getMediaFormat()).thenReturn("mp2");
+        when(mediaEntity.getMediaFormat()).thenReturn(MP2);
         when(mediaEntity.getFileSize()).thenReturn((long) binaryData.toString().length());
         when(mediaEntity.getChecksum()).thenReturn(calculatedChecksum);
         when(objectRecordStatusEntityStored.getId()).thenReturn(2);
         when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
-        //when(objectDirectoryStatusRepository.getReferenceById(9)).thenReturn(objectDirectoryStatusEntityAwaiting);
-        when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(List.of(MP_2));
+        when(audioConfigurationProperties.getAllowedMediaFormats()).thenReturn(List.of(MP2));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(MAX_FILE_SIZE_VALID);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
         List<ExternalObjectDirectoryEntity> inboundList = new ArrayList<>(Collections.singletonList(externalObjectDirectoryEntityInbound));
@@ -308,7 +307,7 @@ class InboundToUnstructuredProcessorImplTest {
 
         when(externalLocationTypeRepository.getReferenceById(1)).thenReturn(externalLocationTypeInbound);
         when(externalObjectDirectoryEntityInbound.getMedia()).thenReturn(mediaEntity);
-        when(mediaEntity.getMediaFormat()).thenReturn("mp2");
+        when(mediaEntity.getMediaFormat()).thenReturn("mpeg2");
         when(mediaEntity.getFileSize()).thenReturn((long) binaryData.toString().length());
         when(mediaEntity.getChecksum()).thenReturn(calculatedChecksum);
 
@@ -319,7 +318,7 @@ class InboundToUnstructuredProcessorImplTest {
         when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
 
 
-        when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(Arrays.asList("doc", "docx"));
+        when(audioConfigurationProperties.getAllowedMediaFormats()).thenReturn(Arrays.asList("wave"));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(100);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
         List<ExternalObjectDirectoryEntity> inboundList = new ArrayList<>(Collections.singletonList(externalObjectDirectoryEntityInbound));
@@ -344,7 +343,7 @@ class InboundToUnstructuredProcessorImplTest {
 
         when(externalLocationTypeRepository.getReferenceById(1)).thenReturn(externalLocationTypeInbound);
         when(externalObjectDirectoryEntityInbound.getMedia()).thenReturn(mediaEntity);
-        when(mediaEntity.getMediaFormat()).thenReturn("mp2");
+        when(mediaEntity.getMediaFormat()).thenReturn(MP2);
         when(mediaEntity.getFileSize()).thenReturn((long) binaryData.toString().length());
         when(mediaEntity.getChecksum()).thenReturn("invalid-checksum");
         when(objectRecordStatusEntityFailureChecksum.getId()).thenReturn(7);
@@ -352,7 +351,7 @@ class InboundToUnstructuredProcessorImplTest {
         when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
         when(objectRecordStatusRepository.getReferenceById(7)).thenReturn(objectRecordStatusEntityFailureChecksum);
         when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
-        when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(Arrays.asList("mp2"));
+        when(audioConfigurationProperties.getAllowedMediaFormats()).thenReturn(Arrays.asList(MP2));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(MAX_FILE_SIZE_VALID);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
         List<ExternalObjectDirectoryEntity> inboundList = new ArrayList<>(Collections.singletonList(externalObjectDirectoryEntityInbound));
@@ -378,7 +377,7 @@ class InboundToUnstructuredProcessorImplTest {
 
         when(externalLocationTypeRepository.getReferenceById(1)).thenReturn(externalLocationTypeInbound);
         when(externalObjectDirectoryEntityInbound.getMedia()).thenReturn(mediaEntity);
-        when(mediaEntity.getMediaFormat()).thenReturn("mp2");
+        when(mediaEntity.getMediaFormat()).thenReturn(MP2);
         when(mediaEntity.getFileSize()).thenReturn((long) binaryData.toString().length());
         when(mediaEntity.getChecksum()).thenReturn(calculatedChecksum);
         when(objectRecordStatusEntityFailureFileSize.getId()).thenReturn(5);
@@ -386,7 +385,7 @@ class InboundToUnstructuredProcessorImplTest {
         when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
         when(objectRecordStatusRepository.getReferenceById(5)).thenReturn(objectRecordStatusEntityFailureFileSize);
         when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
-        when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(Arrays.asList("doc", "docx"));
+        when(audioConfigurationProperties.getAllowedMediaFormats()).thenReturn(Arrays.asList(MP2));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(1);
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);
         List<ExternalObjectDirectoryEntity> inboundList = new ArrayList<>(Collections.singletonList(externalObjectDirectoryEntityInbound));
@@ -413,7 +412,7 @@ class InboundToUnstructuredProcessorImplTest {
         when(externalLocationTypeRepository.getReferenceById(1)).thenReturn(externalLocationTypeInbound);
 
         when(externalObjectDirectoryEntityInbound.getMedia()).thenReturn(mediaEntity);
-        when(mediaEntity.getMediaFormat()).thenReturn("mp2");
+        when(mediaEntity.getMediaFormat()).thenReturn(MP2);
         when(mediaEntity.getFileSize()).thenReturn((long) binaryData.toString().length());
         when(mediaEntity.getChecksum()).thenReturn(calculatedChecksum);
 
@@ -426,7 +425,7 @@ class InboundToUnstructuredProcessorImplTest {
         when(objectRecordStatusRepository.getReferenceById(2)).thenReturn(objectRecordStatusEntityStored);
         when(objectRecordStatusRepository.getReferenceById(9)).thenReturn(objectRecordStatusEntityAwaiting);
 
-        when(audioConfigurationProperties.getAllowedExtensions()).thenReturn(List.of("mp2"));
+        when(audioConfigurationProperties.getAllowedMediaFormats()).thenReturn(List.of(MP2));
         when(audioConfigurationProperties.getMaxFileSize()).thenReturn(100);
 
         when(dataManagementService.getBlobData(any(), any())).thenReturn(binaryData);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-1724](https://tools.hmcts.net/jira/browse/DMP-1724)

### Change description ###

* Update OutboundFileProcessorImpl#processAudioForDownload to remove concatenateByChannel and update session descriminator * Also sort ATS Media by start_ts, channel
* Fix transformed_media output_filename e.g. T20231009-1_04_Jan_2024_1.zip
* Fix config for InboundToUnstructuredProcessor media validation * allowed-media-formats: "mpeg2"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
