### PR TITLE
Secrets and local blob storage improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ Alternatively, you can log into the [Azure home page](https://portal.azure.com/#
 `Key Vault -> darts-stg -> Secrets`. Note in your Portal Settings you must have the `CJS Common Platform` directory
 active for the secrets to be visible.
 
+> Note: there is also a convenient script for exporting all these secret values from the key-vault, ensure you have the Azure CLI, `az`, installed and have run `az login`.
+> ```bash
+> source bin/secrets-stg.sh
+> ```
+
 Once you have obtained the values, set the environment variables on your system. E.g. On Mac, you may run this command
 in the terminal, replacing `<<env var name>>` and `<<secret value>>` as necessary:
 
@@ -136,11 +141,8 @@ Environment Variable Name: AZURE_STORAGE_CONNECTION_STRING
 Environment Variable Value:
 
 ```
-DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={DEFAULT_ACCOUNT_KEY};BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
+DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
 ```
-
-Replace the {DEFAULT_ACCOUNT_KEY} with the value provided in the following
-link: https://github.com/Azure/Azurite#default-storage-account
 
 ## Building the application
 
@@ -216,6 +218,12 @@ If you want to run the darts-api outside of docker and run only the dependant se
 
 ```bash
 ./bin/dcup noapi
+```
+
+To stop all services, use:
+
+```bash
+./bin/dcdown
 ```
 
 ### Alternative script to run application

--- a/bin/secrets-stg.sh
+++ b/bin/secrets-stg.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# To set the secrets in your shell, source this file ie. source ./bin/secrets-stg.sh
+
+echo "Exporting secrets from Azure keyvault (darts-stg), please ensure you have \"az\" installed and you have logged in, using \"az login\"."
+
+export GOVUK_NOTIFY_API_KEY="$(az keyvault secret show --vault-name darts-stg --name GovukNotifyTestApiKey | jq .value -r)"
+export FUNC_TEST_ROPC_USERNAME="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCUsername | jq .value -r)"
+export FUNC_TEST_ROPC_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCPassword | jq .value -r)"
+export AAD_B2C_TENANT_ID_KEY="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CTenantId | jq .value -r)"
+export AAD_B2C_CLIENT_ID_KEY="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CClientId | jq .value -r)"
+export AAD_B2C_CLIENT_SECRET_KEY="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CClientSecret | jq .value -r)"
+export AAD_B2C_ROPC_CLIENT_ID_KEY="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCClientId | jq .value -r)"
+export AAD_B2C_ROPC_CLIENT_SECRET_KEY="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCClientSecret | jq .value -r)"
+export AZURE_STORAGE_CONNECTION_STRING="$(az keyvault secret show --vault-name darts-stg --name AzureStorageConnectionString | jq .value -r)"
+export AAD_TENANT_ID="$(az keyvault secret show --vault-name darts-stg --name AzureADTenantId | jq .value -r)"
+export AAD_CLIENT_ID="$(az keyvault secret show --vault-name darts-stg --name AzureADClientId | jq .value -r)"
+export AAD_CLIENT_SECRET="$(az keyvault secret show --vault-name darts-stg --name AzureADClientSecret | jq .value -r)"
+export XHIBIT_USER_NAME="$(az keyvault secret show --vault-name darts-stg --name XhibitUserName | jq .value -r)"
+export XHIBIT_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name XhibitPassword | jq .value -r)"
+export CPP_USER_NAME="$(az keyvault secret show --vault-name darts-stg --name CppUserName | jq .value -r)"
+export CPP_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name CppPassword | jq .value -r)"
+export DARPC_USER_NAME="$(az keyvault secret show --vault-name darts-stg --name DarPcUserName | jq .value -r)"
+export DARPC_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name DarPcPassword | jq .value -r)"
+export SYSTEM_USER_EMAIL="$(az keyvault secret show --vault-name darts-stg --name DartsSystemUserEmail | jq .value -r)"
+export DAR_MIDTIER_USER_NAME="$(az keyvault secret show --vault-name darts-stg --name DarMidTierUserName | jq .value -r)"
+export DAR_MIDTIER_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name DarMidTierPassword | jq .value -r)"
+export AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCGlobalUsername | jq .value -r)"
+export AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name AzureAdB2CFuncTestROPCGlobalPassword | jq .value -r)"
+export AZURE_AD_FUNCTIONAL_TEST_USERNAME="$(az keyvault secret show --vault-name darts-stg --name AzureADFunctionalTestUsername | jq .value -r)"
+export AZURE_AD_FUNCTIONAL_TEST_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name AzureADFunctionalTestPassword | jq .value -r)"
+export ARM_STORAGE_CONNECTION_STRING="$(az keyvault secret show --vault-name darts-stg --name ARMConnectionString | jq .value -r)"

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -19,7 +19,7 @@ services:
       - GOVUK_NOTIFY_API_KEY
       - AAD_B2C_ROPC_CLIENT_ID_KEY
       - AAD_B2C_ROPC_CLIENT_SECRET_KEY
-      - AZURE_STORAGE_CONNECTION_STRING
+      - AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;
       - AAD_TENANT_ID
       - AAD_CLIENT_ID
       - AAD_CLIENT_SECRET
@@ -92,6 +92,16 @@ services:
       - "6379:6379"
     volumes:
       - darts-cache:/var/lib/redis/data
+    networks:
+      - darts-network
+
+  darts-blob-storage:
+    container_name: darts-blob-storage
+    image: mcr.microsoft.com/azure-storage/azurite
+    ports:
+      - "10000:10000"
+      - "10001:10001"
+      - "10002:10002"
     networks:
       - darts-network
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- adding script to help export required secrets from Azure, using the CLI
- running azurite by default in the docker-compose
- removing the need to separately get the account key, it's public anyway

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
