### PR TITLE
Update usermanagement api spec to include user last modified and crea…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
@@ -88,7 +88,7 @@ class PatchUserIntTest extends IntegrationBase {
             .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
             .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
             .andExpect(jsonPath("$.active").value(true))
-            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.last_login_at").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
             .andExpect(jsonPath("$.security_group_ids", Matchers.containsInAnyOrder(
                 ORIGINAL_SECURITY_GROUP_ID_1,
                 ORIGINAL_SECURITY_GROUP_ID_2
@@ -140,7 +140,7 @@ class PatchUserIntTest extends IntegrationBase {
             .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
             .andExpect(jsonPath("$.description").value("An updated description"))
             .andExpect(jsonPath("$.active").value(false))
-            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.last_login_at").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
             .andExpect(jsonPath("$.security_group_ids").isEmpty());
 
         transactionTemplate.execute(status -> {
@@ -219,7 +219,7 @@ class PatchUserIntTest extends IntegrationBase {
             .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
             .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
             .andExpect(jsonPath("$.active").value(false))
-            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.last_login_at").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
             .andExpect(jsonPath("$.security_group_ids").isEmpty());
 
         transactionTemplate.execute(status -> {
@@ -253,7 +253,7 @@ class PatchUserIntTest extends IntegrationBase {
             .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
             .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
             .andExpect(jsonPath("$.active").value(true))
-            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.last_login_at").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
             .andExpect(jsonPath("$.security_group_ids").isEmpty());
 
         transactionTemplate.execute(status -> {
@@ -287,7 +287,7 @@ class PatchUserIntTest extends IntegrationBase {
             .andExpect(jsonPath("$.email_address").value(ORIGINAL_EMAIL_ADDRESS))
             .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
             .andExpect(jsonPath("$.active").value(true))
-            .andExpect(jsonPath("$.last_login").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
+            .andExpect(jsonPath("$.last_login_at").value(ORIGINAL_LAST_LOGIN_TIME.toString()))
             .andExpect(jsonPath("$.security_group_ids", not(Matchers.containsInAnyOrder(
                 ORIGINAL_SECURITY_GROUP_ID_1,
                 ORIGINAL_SECURITY_GROUP_ID_2

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.darts.usermanagement.model.User;
 import uk.gov.hmcts.darts.usermanagement.model.UserPatch;
 import uk.gov.hmcts.darts.usermanagement.model.UserSearch;
 import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
-import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndLastLogin;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndTimestamps;
 import uk.gov.hmcts.darts.usermanagement.service.UserManagementService;
 
 import java.util.List;
@@ -29,7 +29,7 @@ public class UserController implements UserApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = ADMIN)
-    public ResponseEntity<List<UserWithIdAndLastLogin>> getUsers(Integer courthouseId, String emailAddress) {
+    public ResponseEntity<List<UserWithIdAndTimestamps>> getUsers(Integer courthouseId, String emailAddress) {
         return UserApi.super.getUsers(courthouseId, emailAddress);
     }
 
@@ -46,8 +46,8 @@ public class UserController implements UserApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = ADMIN)
-    public ResponseEntity<UserWithIdAndLastLogin> modifyUser(Integer userId, UserPatch userPatch) {
-        UserWithIdAndLastLogin updatedUser = userManagementService.modifyUser(userId, userPatch);
+    public ResponseEntity<UserWithIdAndTimestamps> modifyUser(Integer userId, UserPatch userPatch) {
+        UserWithIdAndTimestamps updatedUser = userManagementService.modifyUser(userId, userPatch);
 
         return ResponseEntity.ok(updatedUser);
     }
@@ -55,7 +55,7 @@ public class UserController implements UserApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = ADMIN)
-    public ResponseEntity<List<UserWithIdAndLastLogin>> search(UserSearch userSearch) {
+    public ResponseEntity<List<UserWithIdAndTimestamps>> search(UserSearch userSearch) {
         return ResponseEntity.ok(userManagementService.search(userSearch));
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/mapper/impl/UserAccountMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/mapper/impl/UserAccountMapper.java
@@ -7,7 +7,7 @@ import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.usermanagement.model.User;
 import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
-import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndLastLogin;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndTimestamps;
 
 @Mapper(componentModel = "spring",
     unmappedSourcePolicy = ReportingPolicy.IGNORE,
@@ -37,7 +37,7 @@ public interface UserAccountMapper {
         @Mapping(source = "emailAddress", target = "emailAddress"),
         @Mapping(source = "userDescription", target = "description"),
         @Mapping(source = "active", target = "active"),
-        @Mapping(source = "lastLoginTime", target = "lastLogin")
+        @Mapping(source = "lastLoginTime", target = "lastLoginAt")
     })
-    UserWithIdAndLastLogin mapToUserWithIdAndLastLoginModel(UserAccountEntity userAccountEntity);
+    UserWithIdAndTimestamps mapToUserWithIdAndLastLoginModel(UserAccountEntity userAccountEntity);
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementService.java
@@ -4,16 +4,16 @@ import uk.gov.hmcts.darts.usermanagement.model.User;
 import uk.gov.hmcts.darts.usermanagement.model.UserPatch;
 import uk.gov.hmcts.darts.usermanagement.model.UserSearch;
 import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
-import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndLastLogin;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndTimestamps;
 
 import java.util.List;
 
 public interface UserManagementService {
 
-    UserWithIdAndLastLogin modifyUser(Integer userId, UserPatch userPatch);
+    UserWithIdAndTimestamps modifyUser(Integer userId, UserPatch userPatch);
 
     UserWithId createUser(User user);
 
-    List<UserWithIdAndLastLogin> search(UserSearch userSearch);
+    List<UserWithIdAndTimestamps> search(UserSearch userSearch);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
@@ -16,7 +16,7 @@ import uk.gov.hmcts.darts.usermanagement.model.User;
 import uk.gov.hmcts.darts.usermanagement.model.UserPatch;
 import uk.gov.hmcts.darts.usermanagement.model.UserSearch;
 import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
-import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndLastLogin;
+import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndTimestamps;
 import uk.gov.hmcts.darts.usermanagement.service.UserManagementService;
 
 import java.time.OffsetDateTime;
@@ -72,13 +72,13 @@ public class UserManagementServiceImpl implements UserManagementService {
 
     @Override
     @Transactional
-    public UserWithIdAndLastLogin modifyUser(Integer userId, UserPatch userPatch) {
+    public UserWithIdAndTimestamps modifyUser(Integer userId, UserPatch userPatch) {
         userAccountExistsValidator.validate(userId);
 
         UserAccountEntity updatedUserEntity = userAccountRepository.findById(userId)
             .map(userEntity -> updatedUserAccount(userPatch, userEntity)).orElseThrow();
 
-        UserWithIdAndLastLogin user = userAccountMapper.mapToUserWithIdAndLastLoginModel(updatedUserEntity);
+        UserWithIdAndTimestamps user = userAccountMapper.mapToUserWithIdAndLastLoginModel(updatedUserEntity);
         List<Integer> securityGroupIds = mapSecurityGroupEntitiesToIds(updatedUserEntity.getSecurityGroupEntities());
         user.setSecurityGroupIds(securityGroupIds);
 
@@ -86,12 +86,12 @@ public class UserManagementServiceImpl implements UserManagementService {
     }
 
     @Override
-    public List<UserWithIdAndLastLogin> search(UserSearch userSearch) {
-        List<UserWithIdAndLastLogin> userWithIdAndLastLoginList = new ArrayList<>();
+    public List<UserWithIdAndTimestamps> search(UserSearch userSearch) {
+        List<UserWithIdAndTimestamps> userWithIdAndLastLoginList = new ArrayList<>();
 
         userSearchQuery.getUsers(userSearch.getFullName(), userSearch.getEmailAddress(), userSearch.getActive())
             .forEach(userAccountEntity -> {
-                UserWithIdAndLastLogin userWithIdAndLastLogin = userAccountMapper.mapToUserWithIdAndLastLoginModel(userAccountEntity);
+                UserWithIdAndTimestamps userWithIdAndLastLogin = userAccountMapper.mapToUserWithIdAndLastLoginModel(userAccountEntity);
                 userWithIdAndLastLogin.setSecurityGroupIds(mapSecurityGroupEntitiesToIds(userAccountEntity.getSecurityGroupEntities()));
                 userWithIdAndLastLoginList.add(userWithIdAndLastLogin);
             });

--- a/src/main/resources/openapi/usermanagement.yaml
+++ b/src/main/resources/openapi/usermanagement.yaml
@@ -29,7 +29,7 @@ paths:
             $ref: '#/components/schemas/UserEmailAddress'
       responses:
         '200':
-          $ref: '#/components/responses/UserArraySuccessResponseWithIdAndLastLogin'
+          $ref: '#/components/responses/UserArraySuccessResponseWithIdAndTimestamps'
 
     post:
       summary: Create new user
@@ -52,7 +52,7 @@ paths:
         - $ref: '#/components/parameters/UserId'
       responses:
         '200':
-          $ref: '#/components/responses/UserSuccessResponseWithIdAndLastLogin'
+          $ref: '#/components/responses/UserSuccessResponseWithIdAndTimestamps'
         '404':
           $ref: '#/components/responses/UserNotFound'
 
@@ -67,7 +67,7 @@ paths:
         $ref: '#/components/requestBodies/UserPatchRequest'
       responses:
         '200':
-          $ref: '#/components/responses/UserSuccessResponseWithIdAndLastLogin'
+          $ref: '#/components/responses/UserSuccessResponseWithIdAndTimestamps'
         '400':
           $ref: '#/components/responses/BadUserPatchRequest'
         '404':
@@ -83,7 +83,7 @@ paths:
         $ref: '#/components/requestBodies/UserSearchRequest'
       responses:
         '200':
-          $ref: '#/components/responses/UserArraySuccessResponseWithIdAndLastLogin'
+          $ref: '#/components/responses/UserArraySuccessResponseWithIdAndTimestamps'
         '400':
           description: Bad Request Error
           content:
@@ -189,20 +189,20 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/UserWithId'
-    UserSuccessResponseWithIdAndLastLogin:
+    UserSuccessResponseWithIdAndTimestamps:
       description: 'Success'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/UserWithIdAndLastLogin'
-    UserArraySuccessResponseWithIdAndLastLogin:
+            $ref: '#/components/schemas/UserWithIdAndTimestamps'
+    UserArraySuccessResponseWithIdAndTimestamps:
       description: 'Success'
       content:
         application/json:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/UserWithIdAndLastLogin'
+              $ref: '#/components/schemas/UserWithIdAndTimestamps'
     SecurityGroupArraySuccessResponse:
       description: 'Success'
       content:
@@ -393,12 +393,18 @@ components:
           $ref: '#/components/schemas/UserId'
       allOf:
         - $ref: '#/components/schemas/User'
-    UserWithIdAndLastLogin:
+    UserWithIdAndTimestamps:
       type: object
       properties:
         id:
           $ref: '#/components/schemas/UserId'
-        last_login:
+        last_login_at:
+          type: string
+          format: date-time
+        last_modified_at:
+          type: string
+          format: date-time
+        created_at:
           type: string
           format: date-time
       allOf:


### PR DESCRIPTION
Expose user created and user last modified timestamps in openapi in preparation for sprint 20.

Opportunity is also taken to align timestamp fields with HMCTS naming convention per https://hmcts.github.io/restful-api-standards/#235

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
