### PR TITLE
DMP-1632 Fixing error for duplicate audio requests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
@@ -247,6 +247,7 @@ class AudioRequestsControllerAddAudioRequestIntTest extends IntegrationBase {
 
         mockMvc.perform(requestBuilder)
             .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.type").value("AUDIO_REQUESTS_104"))
             .andReturn();
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.audio.component.AudioRequestResponseMapper;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
+import uk.gov.hmcts.darts.audio.exception.AudioRequestsApiError;
 import uk.gov.hmcts.darts.audio.service.MediaRequestService;
 import uk.gov.hmcts.darts.audio.util.StreamingResponseEntityUtil;
 import uk.gov.hmcts.darts.audiorequests.http.api.AudioRequestsApi;
@@ -20,6 +21,7 @@ import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
 import uk.gov.hmcts.darts.audiorequests.model.GetAudioRequestResponse;
 import uk.gov.hmcts.darts.audiorequests.model.GetAudioRequestResponseV1;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
 
 import java.io.InputStream;
 import java.util.List;
@@ -98,17 +100,11 @@ public class AudioRequestsController implements AudioRequestsApi {
         MediaRequestEntity audioRequest;
 
         if (mediaRequestService.isUserDuplicateAudioRequest(audioRequestDetails)) {
-            return new ResponseEntity<>(HttpStatus.CONFLICT);
+            throw new DartsApiException(AudioRequestsApiError.DUPLICATE_MEDIA_REQUEST);
         }
 
-        try {
-            audioRequest = mediaRequestService.saveAudioRequest(audioRequestDetails);
-            addAudioResponse = audioRequestResponseMapper.mapToAddAudioResponse(audioRequest);
-        } catch (Exception e) {
-            log.error("Failed to request audio {}", e.getMessage());
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
-
+        audioRequest = mediaRequestService.saveAudioRequest(audioRequestDetails);
+        addAudioResponse = audioRequestResponseMapper.mapToAddAudioResponse(audioRequest);
         mediaRequestService.scheduleMediaRequestPendingNotification(audioRequest);
         return new ResponseEntity<>(addAudioResponse, HttpStatus.OK);
     }

--- a/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioRequestsApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioRequestsApiError.java
@@ -28,6 +28,11 @@ public enum AudioRequestsApiError implements DartsApiError {
         "103",
         HttpStatus.NOT_FOUND,
         "The requested transformed media cannot be found"
+    ),
+    DUPLICATE_MEDIA_REQUEST(
+        "104",
+        HttpStatus.CONFLICT,
+        "An audio request already exists with these properties"
     );
 
     private static final String ERROR_TYPE_PREFIX = "AUDIO_REQUESTS";


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-1632

### Change description ###

- we should be returning the standard problem object
- not doing this causes issues with the DARTS portal's ability to detect errors successfully

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
