### PR TITLE
DMP-2044 Update getAudioMetadata: only fetch media from channel 1

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.darts.audio.http.api.AudioApi;
 import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.audio.model.AudioMetadata;
 import uk.gov.hmcts.darts.audio.service.AudioService;
-import uk.gov.hmcts.darts.audio.service.AudioTransformationService;
 import uk.gov.hmcts.darts.audio.util.StreamingResponseEntityUtil;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
@@ -37,7 +36,6 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
 public class AudioController implements AudioApi {
 
     private final AudioService audioService;
-    private final AudioTransformationService audioTransformationService;
     private final AudioResponseMapper audioResponseMapper;
 
     @Override
@@ -46,7 +44,7 @@ public class AudioController implements AudioApi {
         securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA, RCJ_APPEALS},
         globalAccessSecurityRoles = {JUDGE})
     public ResponseEntity<List<AudioMetadata>> getAudioMetadata(Integer hearingId) {
-        List<MediaEntity> mediaEntities = audioTransformationService.getMediaMetadata(hearingId);
+        List<MediaEntity> mediaEntities = audioService.getAudioMetadata(hearingId, 1);
         List<AudioMetadata> audioMetadata = audioResponseMapper.mapToAudioMetadata(mediaEntities);
 
         return new ResponseEntity<>(audioMetadata, HttpStatus.OK);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/AudioService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/AudioService.java
@@ -5,8 +5,11 @@ import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 
 import java.io.InputStream;
+import java.util.List;
 
 public interface AudioService {
+
+    List<MediaEntity> getAudioMetadata(Integer hearingId, Integer channel);
 
     InputStream preview(Integer mediaId);
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
@@ -35,6 +35,7 @@ import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -70,6 +71,11 @@ public class AudioServiceImpl implements AudioService {
             mediaEntity.getChannel(),
             downloadPath
         );
+    }
+
+    @Override
+    public List<MediaEntity> getAudioMetadata(Integer hearingId, Integer channel) {
+        return mediaRepository.findAllByHearingIdAndChannel(hearingId, channel);
     }
 
     @Override
@@ -155,7 +161,8 @@ public class AudioServiceImpl implements AudioService {
                 addAudioMetadataRequest.getCourthouse(),
                 caseNumber,
                 addAudioMetadataRequest.getStartedAt().minusMinutes(audioConfigurationProperties.getPreAmbleDuration()),
-                addAudioMetadataRequest.getEndedAt().plusMinutes(audioConfigurationProperties.getPostAmbleDuration()));
+                addAudioMetadataRequest.getEndedAt().plusMinutes(audioConfigurationProperties.getPostAmbleDuration())
+            );
 
             var associatedHearings = courtLogs.stream()
                 .flatMap(h -> h.getHearingEntities().stream())

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
@@ -19,4 +19,14 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Integer> {
         """)
     List<MediaEntity> findAllByHearingId(Integer hearingId);
 
+    @Query("""
+           SELECT me
+           FROM HearingEntity he
+           JOIN he.mediaList me
+           WHERE he.id = :hearingId
+           AND me.channel = :channel
+           ORDER BY me.start
+        """)
+    List<MediaEntity> findAllByHearingIdAndChannel(Integer hearingId, Integer channel);
+
 }

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.darts.audio.model.AudioFileInfo;
 import uk.gov.hmcts.darts.audio.service.AudioOperationService;
 import uk.gov.hmcts.darts.audio.service.AudioService;
 import uk.gov.hmcts.darts.audio.service.AudioTransformationService;
-import uk.gov.hmcts.darts.audit.service.AuditService;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
@@ -32,7 +31,6 @@ import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
-import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.service.FileOperationService;
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.common.util.FileContentChecksum;
@@ -67,17 +65,12 @@ class AudioServiceImplTest {
     private static final OffsetDateTime START_TIME = OffsetDateTime.parse("2023-01-01T12:00:00Z");
     private static final OffsetDateTime END_TIME = OffsetDateTime.parse("2023-01-01T13:00:00Z");
 
-    private static final List<String> HANDHELD_AUDIO_COURTROOM_NUMBERS = Arrays.asList("199");
-
     @Captor
     ArgumentCaptor<MediaEntity> mediaEntityArgumentCaptor;
     @Captor
     ArgumentCaptor<BinaryData> inboundBlobStorageArgumentCaptor;
     @Mock
     private AudioTransformationService audioTransformationService;
-
-    @Mock
-    private TransientObjectDirectoryRepository transientObjectDirectoryRepository;
 
     @Mock
     private AudioOperationService audioOperationService;
@@ -107,9 +100,6 @@ class AudioServiceImplTest {
     private DataManagementApi dataManagementApi;
 
     private AudioService audioService;
-
-    @Mock
-    private AuditService auditService;
 
     @BeforeEach
     void setUp() {
@@ -243,7 +233,7 @@ class AudioServiceImplTest {
         MediaEntity mediaEntity = createMediaEntity(STARTED_AT, ENDED_AT);
 
         when(audioConfigurationProperties.getHandheldAudioCourtroomNumbers())
-            .thenReturn(Arrays.asList(addAudioMetadataRequest.getCourtroom()));
+            .thenReturn(List.of(addAudioMetadataRequest.getCourtroom()));
 
         audioService.linkAudioToHearingByEvent(addAudioMetadataRequest, mediaEntity);
         verify(hearingRepository, times(0)).saveAndFlush(any());
@@ -265,7 +255,7 @@ class AudioServiceImplTest {
             anyString(),
             any(),
             any()
-        )).thenReturn(Arrays.asList(eventEntity));
+        )).thenReturn(List.of(eventEntity));
 
         audioService.linkAudioToHearingByEvent(addAudioMetadataRequest, mediaEntity);
         verify(hearingRepository, times(1)).saveAndFlush(any());


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-2044](https://tools.hmcts.net/jira/browse/DMP-2044)

### Change description ###

GET /audio/hearings/{hearing_id}/audios
* Channel 1 Media metadata for provided hearing

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
