### PR TITLE
DMP-1470 New email template: Audio Request Being Processed From Archive

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/notification/service/GovNotifyServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/notification/service/GovNotifyServiceTest.java
@@ -132,10 +132,11 @@ class GovNotifyServiceTest {
             parameterMap
         );
         assertEquals("Your transcript request was rejected", emailResponse.getSubject());
-        compare("""
-                 Your transcript request for case ID TheCaseId has been rejected due to TheRejectionReason.
+        compare(
+            """
+                Your transcript request for case ID TheCaseId has been rejected due to TheRejectionReason.
 
-                 You can resubmit your request, but take into account the reason for the original request's rejection.""",
+                You can resubmit your request, but take into account the reason for the original request's rejection.""",
             emailResponse
         );
     }
@@ -153,40 +154,55 @@ class GovNotifyServiceTest {
     }
 
     @Test
+    void audioRequestBeingProcessedFromArchive() throws NotificationClientException, TemplateNotFoundException {
+        SendEmailResponse emailResponse = createAndSend(NotificationApi.NotificationTemplate.AUDIO_REQUEST_PROCESSING_ARCHIVE.toString());
+        assertEquals("DARTS has received your audio recording order", emailResponse.getSubject());
+        compare("""
+                    We have received your audio recording order for case Number TheCaseId.
+
+                    Processing your order may take a little longer as it must be retrieved from the archives.
+
+                    We'll notify you when it is ready and available for use.
+
+                    Alternatively, you can visit the Your audio section of the DARTS Portal to check its progress.""", emailResponse);
+    }
+
+    @Test
     void errorProcessingAudio() throws NotificationClientException, TemplateNotFoundException {
         Map<String, String> parameterMap = new ConcurrentHashMap<>();
         parameterMap.put(REQUEST_ID, "TheRequestID");
         parameterMap.put(COURTHOUSE, "TheCourthouse");
         parameterMap.put(DEFENDANTS, "Defendant1,Defendant2");
         parameterMap.put(HEARING_DATE, "TheHearingDate");
-        parameterMap.put(AUDIO_START_TIME,"TheStartTime");
+        parameterMap.put(AUDIO_START_TIME, "TheStartTime");
         parameterMap.put(AUDIO_END_TIME, "TheEndTime");
         SendEmailResponse emailResponse = createAndSend(
             NotificationApi.NotificationTemplate.ERROR_PROCESSING_AUDIO.toString(),
             parameterMap
         );
         assertEquals("Your audio recording order has failed", emailResponse.getSubject());
-        compare("""
-                    Your audio recording order for case ID TheCaseId has failed.
+        compare(
+            """
+                Your audio recording order for case ID TheCaseId has failed.
 
-                    Due to unforeseen errors, your audio recording order has failed.
+                Due to unforeseen errors, your audio recording order has failed.
 
-                    To resolve this issue, email crownITsupport@justice.gov.uk quoting TheRequestID, and provide them with the following information:
+                To resolve this issue, email crownITsupport@justice.gov.uk quoting TheRequestID, and provide them with the following information:
 
-                    ## Case details
+                ## Case details
 
-                    Case ID: TheCaseId
-                    Courthouse: TheCourthouse
-                    Defendants: Defendant1,Defendant2
+                Case ID: TheCaseId
+                Courthouse: TheCourthouse
+                Defendants: Defendant1,Defendant2
 
-                    ## Audio details
+                ## Audio details
 
-                    Hearing date: TheHearingDate
-                    Requested start time: TheStartTime
-                    Requested end time: TheEndTime
+                Hearing date: TheHearingDate
+                Requested start time: TheStartTime
+                Requested end time: TheEndTime
 
-                    They will raise a Service Now ticket to process this issue.""",
-                emailResponse
+                They will raise a Service Now ticket to process this issue.""",
+            emailResponse
         );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryImplIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryImplIntTest.java
@@ -1,0 +1,153 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.darts.audio.component.AudioRequestBeingProcessedFromArchiveQuery;
+import uk.gov.hmcts.darts.audio.model.AudioRequestBeingProcessedFromArchiveQueryResult;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@Transactional
+@TestInstance(PER_CLASS)
+class AudioRequestBeingProcessedFromArchiveQueryImplIntTest extends IntegrationBase {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private AudioRequestBeingProcessedFromArchiveQuery audioRequestBeingProcessedFromArchiveQuery;
+
+    @BeforeAll
+    @SuppressWarnings("checkstyle:linelength")
+    void beforeAll() {
+        jdbcTemplate.update(
+            """
+                INSERT INTO darts.courthouse (cth_id, courthouse_code, courthouse_name, created_ts, last_modified_ts, created_by, last_modified_by, display_name)
+                VALUES (-1, NULL, 'Bristol', '2023-11-17 15:06:15.859244+00', '2023-11-17 15:06:15.859244+00', NULL, NULL, 'Bristol');
+
+                INSERT INTO darts.user_account (usr_id, dm_user_s_object_id, user_name, user_email_address, description, created_ts, last_modified_ts, last_login_ts, last_modified_by, created_by, account_guid, is_system_user, is_active, user_full_name)
+                VALUES (-10, NULL, 'Richard B', 'Richard.B@example.com', NULL, NULL, NULL, NULL, NULL, NULL, NULL, false, true, 'Richard B');
+
+                INSERT INTO darts.security_group_courthouse_ae (grp_id, cth_id)
+                VALUES (-4, -1);
+
+                INSERT INTO darts.security_group_user_account_ae (usr_id, grp_id)
+                VALUES (-10, -4);
+
+                INSERT INTO darts.court_case (cas_id, cth_id, evh_id, case_object_id, case_number, case_closed, interpreter_used, case_closed_ts, version_label, created_ts, created_by, last_modified_ts, last_modified_by)
+                VALUES (-1, -1, NULL, NULL, 'T20231009-1', false, false, NULL, NULL, NULL, NULL, NULL, NULL);
+
+                INSERT INTO darts.courtroom (ctr_id, cth_id, courtroom_name, created_ts, created_by)
+                VALUES (-1, -1, 'Court 1', NULL, NULL);
+
+                INSERT INTO darts.hearing (hea_id, cas_id, ctr_id, hearing_date, scheduled_start_time, hearing_is_actual, judge_hearing_date, created_ts, created_by, last_modified_ts, last_modified_by)
+                VALUES (101, -1, -1, '2024-01-04', NULL, false, NULL, '2024-01-04 15:52:41.084085+00', NULL, '2024-01-04 15:52:41.084114+00', NULL);
+
+                INSERT INTO darts.media (med_id, ctr_id, media_object_id, channel, total_channels, reference_id, start_ts, end_ts, case_number, version_label, created_ts, created_by, last_modified_ts, last_modified_by, media_file, media_format, file_size, checksum, media_type, content_object_id, is_hidden, media_status)
+                VALUES
+                (181, -1, NULL, 1, 4, NULL, '2024-01-04 11:00:00+00', '2024-01-04 11:00:05+00', '{T20231009-1}', NULL, '2024-01-04 15:52:41.020977+00', NULL, '2024-01-04 15:52:41.090043+00', NULL, '0001.a00', 'mpeg2', 240744, 'wysXTgRikGN6nMB8AJ0JrQ==', 'A', NULL, false, NULL),
+                (182, -1, NULL, 2, 4, NULL, '2024-01-04 11:00:00+00', '2024-01-04 11:00:05+00', '{T20231009-1}', NULL, '2024-01-04 15:55:08.840021+00', NULL, '2024-01-04 15:55:08.85461+00', NULL, '0001.a01', 'mpeg2', 240744, 'wysXTgRikGN6nMB8AJ0JrQ==', 'A', NULL, false, NULL),
+                (183, -1, NULL, 3, 4, NULL, '2024-01-04 11:00:00+00', '2024-01-04 11:00:05+00', '{T20231009-1}', NULL, '2024-01-04 15:58:18.090826+00', NULL, '2024-01-04 15:58:18.123383+00', NULL, '0001.a02', 'mpeg2', 240744, 'wysXTgRikGN6nMB8AJ0JrQ==', 'A', NULL, false, NULL),
+                (184, -1, NULL, 4, 4, NULL, '2024-01-04 11:00:00+00', '2024-01-04 11:00:05+00', '{T20231009-1}', NULL, '2024-01-04 15:59:16.518523+00', NULL, '2024-01-04 15:59:16.543656+00', NULL, '0001.a03', 'mpeg2', 240744, 'wysXTgRikGN6nMB8AJ0JrQ==', 'A', NULL, false, NULL),
+                (185, -1, NULL, 1, 4, NULL, '2024-01-04 11:00:10+00', '2024-01-04 11:00:15+00', '{T20231009-1}', NULL, '2024-01-04 16:02:05.190864+00', NULL, '2024-01-04 16:02:05.205125+00', NULL, '0002.a00', 'mpeg2', 240744, 'T2UrmSYWNZmvvYqBcMnV0g==', 'A', NULL, false, NULL),
+                (186, -1, NULL, 2, 4, NULL, '2024-01-04 11:00:10+00', '2024-01-04 11:00:15+00', '{T20231009-1}', NULL, '2024-01-04 16:04:08.13524+00', NULL, '2024-01-04 16:04:08.164205+00', NULL, '0002.a01', 'mpeg2', 240744, 'T2UrmSYWNZmvvYqBcMnV0g==', 'A', NULL, false, NULL),
+                (187, -1, NULL, 3, 4, NULL, '2024-01-04 11:00:10+00', '2024-01-04 11:00:15+00', '{T20231009-1}', NULL, '2024-01-04 16:05:56.147182+00', NULL, '2024-01-04 16:05:56.167154+00', NULL, '0002.a02', 'mpeg2', 240744, 'T2UrmSYWNZmvvYqBcMnV0g==', 'A', NULL, false, NULL),
+                (188, -1, NULL, 4, 4, NULL, '2024-01-04 11:00:10+00', '2024-01-04 11:00:15+00', '{T20231009-1}', NULL, '2024-01-04 16:06:39.336742+00', NULL, '2024-01-04 16:06:39.351721+00', NULL, '0002.a03', 'mpeg2', 240744, 'T2UrmSYWNZmvvYqBcMnV0g==', 'A', NULL, false, NULL),
+                (189, -1, NULL, 1, 4, NULL, '2024-01-04 11:00:15+00', '2024-01-04 11:00:20+00', '{T20231009-1}', NULL, '2024-01-04 16:10:03.323052+00', NULL, '2024-01-04 16:10:03.340479+00', NULL, '0003.a00', 'mpeg2', 240744, 'DCu19W4toRtk4h5/d76+AQ==', 'A', NULL, false, NULL),
+                (190, -1, NULL, 2, 4, NULL, '2024-01-04 11:00:15+00', '2024-01-04 11:00:20+00', '{T20231009-1}', NULL, '2024-01-04 16:10:47.145318+00', NULL, '2024-01-04 16:10:47.187171+00', NULL, '0003.a01', 'mpeg2', 240744, 'DCu19W4toRtk4h5/d76+AQ==', 'A', NULL, false, NULL),
+                (191, -1, NULL, 3, 4, NULL, '2024-01-04 11:00:15+00', '2024-01-04 11:00:20+00', '{T20231009-1}', NULL, '2024-01-04 16:12:13.419041+00', NULL, '2024-01-04 16:12:13.442933+00', NULL, '0003.a02', 'mpeg2', 240744, 'DCu19W4toRtk4h5/d76+AQ==', 'A', NULL, false, NULL),
+                (192, -1, NULL, 4, 4, NULL, '2024-01-04 11:00:15+00', '2024-01-04 11:00:20+00', '{T20231009-1}', NULL, '2024-01-04 16:12:59.607793+00', NULL, '2024-01-04 16:12:59.640079+00', NULL, '0003.a03', 'mpeg2', 240744, 'DCu19W4toRtk4h5/d76+AQ==', 'A', NULL, false, NULL),
+                (193, -1, NULL, 1, 4, NULL, '2024-01-04 11:00:30+00', '2024-01-04 11:00:35+00', '{T20231009-1}', NULL, '2024-01-04 16:14:36.967939+00', NULL, '2024-01-04 16:14:36.988925+00', NULL, '0004.a00', 'mpeg2', 240744, 'PmpSQZyELyNV4o1HuhF9HA==', 'A', NULL, false, NULL),
+                (194, -1, NULL, 2, 4, NULL, '2024-01-04 11:00:30+00', '2024-01-04 11:00:35+00', '{T20231009-1}', NULL, '2024-01-04 16:15:37.00364+00', NULL, '2024-01-04 16:15:37.034789+00', NULL, '0004.a01', 'mpeg2', 240744, 'PmpSQZyELyNV4o1HuhF9HA==', 'A', NULL, false, NULL),
+                (201, -1, NULL, 3, 4, NULL, '2024-01-04 11:00:30+00', '2024-01-04 11:00:35+00', '{T20231009-1}', NULL, '2024-01-04 16:32:36.089388+00', NULL, '2024-01-04 16:32:36.117606+00', NULL, '0004.a02', 'mpeg2', 240744, 'PmpSQZyELyNV4o1HuhF9HA==', 'A', NULL, false, NULL),
+                (202, -1, NULL, 4, 4, NULL, '2024-01-04 11:00:30+00', '2024-01-04 11:00:35+00', '{T20231009-1}', NULL, '2024-01-04 16:33:09.466088+00', NULL, '2024-01-04 16:33:09.507292+00', NULL, '0004.a03', 'mpeg2', 240744, 'PmpSQZyELyNV4o1HuhF9HA==', 'A', NULL, false, NULL);
+
+                INSERT INTO darts.hearing_media_ae (hea_id, med_id)
+                VALUES
+                (101, 181),
+                (101, 182),
+                (101, 183),
+                (101, 184),
+                (101, 185),
+                (101, 186),
+                (101, 187),
+                (101, 188),
+                (101, 189),
+                (101, 190),
+                (101, 191),
+                (101, 192),
+                (101, 193),
+                (101, 194),
+                (101, 201),
+                (101, 202);
+
+                INSERT INTO darts.external_object_directory (eod_id, med_id, trd_id, ado_id, ors_id, elt_id, external_location, checksum, transfer_attempts, created_ts, last_modified_ts, last_modified_by, created_by, cad_id, manifest_file, event_date_ts, external_file_id, external_record_id)
+                VALUES
+                (2541, 181, NULL, NULL, 2, 1, '197b3953-c3dc-417e-a7c2-a974339b96ae', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:52:41.115953+00', '2024-01-04 15:52:41.11597+00', -45, -45, NULL, NULL, NULL, NULL, NULL),
+                (2543, 182, NULL, NULL, 2, 1, 'afafc1d0-b1e0-4955-88ea-616a35073e08', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:55:08.852917+00', '2024-01-04 15:55:08.852923+00', -45, -45, NULL, NULL, NULL, NULL, NULL),
+                (2544, 183, NULL, NULL, 2, 1, 'c15137df-1a2b-4c0d-b309-bc9238330efb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:58:18.120536+00', '2024-01-04 15:58:18.120547+00', -45, -45, NULL, NULL, NULL, NULL, NULL),
+                (2546, 184, NULL, NULL, 2, 1, '8f37e682-633c-465b-b1e3-75cdf4a04d85', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:59:16.538801+00', '2024-01-04 15:59:16.538821+00', -45, -45, NULL, NULL, NULL, NULL, NULL),
+
+                (2547, 184, NULL, NULL, 11, 2, 'e9dce141-5f58-4bfd-8660-bce8e0759acb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:59:30.057281+00', '2024-01-04 15:59:30.291683+00', 0, 0, NULL, NULL, NULL, NULL, NULL),
+                (2561, 181, NULL, NULL, 11, 2, 'e4a003a0-2184-4f2b-a4e2-4ed85a36f734', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:53:30.132639+00', '2024-01-04 15:53:30.486242+00', 0, 0, NULL, NULL, NULL, NULL, NULL),
+                (2562, 182, NULL, NULL, 11, 2, 'a3c10ea0-01c2-43f1-bfe7-3b25b7902dfb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:55:30.075869+00', '2024-01-04 15:55:30.334252+00', 0, 0, NULL, NULL, NULL, NULL, NULL),
+                (2545, 183, NULL, NULL, 11, 2, '0e5d566a-00d9-4d02-bcaf-f01f7c582f99', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:58:30.071231+00', '2024-01-04 15:58:30.345809+00', 0, 0, NULL, NULL, NULL, NULL, NULL),
+
+                (2750, 184, NULL, NULL, 2, 3, '8b7dff0f-a2e7-4210-8a5e-f216d8c874eb', 'wysXTgRikGN6nMB8AJ0JrQ==', 1, '2024-01-22 16:10:17.427415+00', '2024-01-22 16:10:17.681265+00', 0, 0, NULL, NULL, NULL, NULL, NULL),
+                (2759, 181, NULL, NULL, 2, 3, '71c3e02b-b7d2-4603-be74-e8c39faaf285', 'wysXTgRikGN6nMB8AJ0JrQ==', 1, '2024-01-22 16:10:19.834748+00', '2024-01-22 16:10:20.093688+00', 0, 0, NULL, NULL, NULL, NULL, NULL),
+                (2763, 182, NULL, NULL, 2, 3, '0dde5ec4-d16d-4940-a923-a73bacd969bb', 'wysXTgRikGN6nMB8AJ0JrQ==', 1, '2024-01-22 16:10:20.882012+00', '2024-01-22 16:10:21.144768+00', 0, 0, NULL, NULL, NULL, NULL, NULL),
+                (2766, 183, NULL, NULL, 2, 3, '2ba50586-e892-4ff9-a11a-67c38d23837a', 'wysXTgRikGN6nMB8AJ0JrQ==', 1, '2024-01-22 16:10:21.677894+00', '2024-01-22 16:10:21.933572+00', 0, 0, NULL, NULL, NULL, NULL, NULL);
+
+                INSERT INTO darts.media_request (mer_id, hea_id, requestor, request_status, request_type, req_proc_attempts, start_ts, end_ts, created_ts, last_modified_ts, created_by, last_modified_by, current_owner)
+                VALUES
+                (421, 101, -10, 'OPEN', 'DOWNLOAD', 0, '2024-01-04 11:00:02+00', '2024-01-04 11:00:19+00', '2024-01-22 15:41:04.393833+00', '2024-01-22 15:41:04.393866+00', -10, -10, -10);
+                """);
+    }
+
+    @AfterAll
+    void afterAll() {
+        jdbcTemplate.update(
+            """
+                DELETE FROM darts.media_request WHERE hea_id=101;
+                DELETE FROM darts.external_object_directory WHERE eod_id>=2541;
+                DELETE FROM darts.hearing_media_ae WHERE hea_id=101;
+                DELETE FROM darts.media WHERE ctr_id=-1;
+
+                DELETE FROM darts.hearing WHERE hea_id=101;
+                DELETE FROM darts.court_case WHERE cas_id=-1;
+                DELETE FROM darts.courtroom WHERE ctr_id=-1;
+
+                DELETE FROM darts.security_group_courthouse_ae WHERE grp_id=-4 AND cth_id=-1;
+                DELETE FROM darts.security_group_user_account_ae WHERE usr_id=-10 AND grp_id=-4;
+                DELETE FROM darts.user_account WHERE usr_id=-10;
+
+                DELETE FROM darts.courthouse WHERE cth_id=-1;
+                """);
+    }
+
+    @Test
+    void givenAudioRequestBeingProcessedFromArchive_thenReturnResults() throws Exception {
+        Integer mediaRequestId = 421;
+        final List<AudioRequestBeingProcessedFromArchiveQueryResult> results = audioRequestBeingProcessedFromArchiveQuery.getResults(
+            mediaRequestId);
+
+        List expected = List.of(
+            new AudioRequestBeingProcessedFromArchiveQueryResult(181, 2561, 2759),
+            new AudioRequestBeingProcessedFromArchiveQueryResult(182, 2562, 2763),
+            new AudioRequestBeingProcessedFromArchiveQueryResult(183, 2545, 2766),
+            new AudioRequestBeingProcessedFromArchiveQueryResult(184, 2547, 2750)
+        );
+        assertEquals(expected.size(), results.size());
+        assertEquals(expected, results);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/AudioRequestBeingProcessedFromArchiveQuery.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/AudioRequestBeingProcessedFromArchiveQuery.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.darts.audio.component;
+
+import uk.gov.hmcts.darts.audio.model.AudioRequestBeingProcessedFromArchiveQueryResult;
+
+import java.util.List;
+
+public interface AudioRequestBeingProcessedFromArchiveQuery {
+
+    List<AudioRequestBeingProcessedFromArchiveQueryResult> getResults(Integer mediaRequestId);
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryImpl.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.audio.component.AudioRequestBeingProcessedFromArchiveQuery;
+import uk.gov.hmcts.darts.audio.model.AudioRequestBeingProcessedFromArchiveQueryResult;
+
+import java.util.List;
+
+import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
+import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.DELETED;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
+
+@Component
+@RequiredArgsConstructor
+public class AudioRequestBeingProcessedFromArchiveQueryImpl implements AudioRequestBeingProcessedFromArchiveQuery {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final AudioRequestBeingProcessedFromArchiveQueryResultRowMapper rowMapper;
+
+    @Override
+    public List<AudioRequestBeingProcessedFromArchiveQueryResult> getResults(Integer mediaRequestId) {
+        return jdbcTemplate.query(
+            """
+                SELECT
+                    med.med_id,
+                    eod_unstructured.eod_id AS unstructured_eod_id,
+                    eod_arm.eod_id          AS arm_eod_id
+                FROM
+                    darts.media_request mer
+                JOIN
+                    darts.hearing hea
+                ON
+                    mer.hea_id = hea.hea_id
+                JOIN
+                    darts.hearing_media_ae hem
+                ON
+                    hea.hea_id = hem.hea_id
+                JOIN
+                    darts.media med
+                ON
+                    med.med_id = hem.med_id
+                AND
+                    (mer.start_ts >= med.start_ts
+                    AND med.end_ts <= mer.end_ts)
+                JOIN
+                    darts.external_object_directory eod_unstructured
+                ON
+                    med.med_id = eod_unstructured.med_id
+                AND eod_unstructured.elt_id = :unstructured_elt_id
+                AND eod_unstructured.ors_id = :unstructured_ors_id
+                JOIN
+                    darts.external_object_directory eod_arm
+                ON
+                    med.med_id = eod_arm.med_id
+                AND eod_arm.elt_id = :arm_elt_id
+                AND eod_arm.ors_id = :arm_ors_id
+                WHERE
+                    mer.mer_id = :mer_id
+                ORDER BY
+                    med.med_id ASC
+                """,
+            new MapSqlParameterSource()
+                .addValue("mer_id", mediaRequestId)
+                .addValue("unstructured_elt_id", UNSTRUCTURED.getId())
+                .addValue("unstructured_ors_id", DELETED.getId())
+                .addValue("arm_elt_id", ARM.getId())
+                .addValue("arm_ors_id", STORED.getId()),
+            rowMapper
+        );
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryResultRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryResultRowMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.darts.audio.component.impl;
+
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.audio.model.AudioRequestBeingProcessedFromArchiveQueryResult;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@Component
+public class AudioRequestBeingProcessedFromArchiveQueryResultRowMapper implements RowMapper<AudioRequestBeingProcessedFromArchiveQueryResult> {
+
+    @Override
+    public AudioRequestBeingProcessedFromArchiveQueryResult mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new AudioRequestBeingProcessedFromArchiveQueryResult(
+            rs.getInt("med_id"),
+            rs.getInt("unstructured_eod_id"),
+            rs.getInt("arm_eod_id")
+        );
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/model/AudioRequestBeingProcessedFromArchiveQueryResult.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/model/AudioRequestBeingProcessedFromArchiveQueryResult.java
@@ -1,0 +1,6 @@
+package uk.gov.hmcts.darts.audio.model;
+
+public record AudioRequestBeingProcessedFromArchiveQueryResult(Integer mediaId,
+                                                               Integer unstructuredExternalObjectDirectoryId,
+                                                               Integer armExternalObjectDirectoryId) {
+}

--- a/src/main/java/uk/gov/hmcts/darts/notification/api/NotificationApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/api/NotificationApi.java
@@ -14,6 +14,7 @@ public interface NotificationApi {
         ERROR_PROCESSING_AUDIO("error_processing_audio"),
         REQUESTED_AUDIO_AVAILABLE("requested_audio_is_available"),
         AUDIO_REQUEST_PROCESSING("audio_request_being_processed"),
+        AUDIO_REQUEST_PROCESSING_ARCHIVE("audio_request_being_processed_from_archive"),
         COURT_MANAGER_APPROVE_TRANSCRIPT("court_manager_approve_transcript"),
         REQUEST_TO_TRANSCRIBER("request_to_transcriber"),
         TRANSCRIPTION_AVAILABLE("transcription_available"),

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -149,6 +149,7 @@ darts:
       api-key: ${GOVUK_NOTIFY_API_KEY:00000000-0000-0000-0000-000000000000}
       template-map:
         audio_request_being_processed: d0890ee6-b3d3-45aa-b53a-fcbd651f8aef
+        audio_request_being_processed_from_archive: a2104bc2-1a36-4c4f-b68f-2dfd6adbf438
         court_manager_approve_transcript: a8390fa6-3f18-44c0-b224-f59971a5e20a
         error_processing_audio: 707fc9fd-4a64-4503-bf6a-4c6bd7dda1dd
         request_to_transcriber: 12a70a9c-9bcf-4880-8291-1a5c6a4c4b08

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
@@ -307,7 +307,7 @@ class MediaRequestServiceImplTest {
         mediaRequestService.deleteAudioRequest(mediaRequestId);
 
         verify(mockTransformedMediaRepository).findByMediaRequestId(mediaRequestId);
-        verify(mockMediaRequestRepository).deleteById(eq(mediaRequestId));
+        verify(mockMediaRequestRepository).deleteById(mediaRequestId);
         verify(dataManagementApi).deleteBlobDataFromOutboundContainer(any(UUID.class));
         verify(mockTransientObjectDirectoryRepository).deleteById(any());
     }
@@ -330,7 +330,7 @@ class MediaRequestServiceImplTest {
 
         mediaRequestService.deleteAudioRequest(mediaRequestId);
 
-        verify(mockMediaRequestRepository).deleteById(eq(mediaRequestId));
+        verify(mockMediaRequestRepository).deleteById(mediaRequestId);
         verifyNoInteractions(dataManagementApi);
         verify(mockTransientObjectDirectoryRepository).deleteById(any());
     }
@@ -350,7 +350,7 @@ class MediaRequestServiceImplTest {
         mediaRequestService.deleteAudioRequest(mediaRequestId);
 
         verify(mockTransformedMediaRepository).findByMediaRequestId(mediaRequestId);
-        verify(mockMediaRequestRepository).deleteById(eq(mediaRequestId));
+        verify(mockMediaRequestRepository).deleteById(mediaRequestId);
         verify(dataManagementApi, times(0)).deleteBlobDataFromOutboundContainer(any(UUID.class));
         verify(mockTransientObjectDirectoryRepository, times(0)).deleteById(any());
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-1470](https://tools.hmcts.net/jira/browse/DMP-1470)

### Change description ###

Added a new query (`AudioRequestBeingProcessedFromArchiveQuery`) to help us check whether the filtered hearing media for the audio request has external_object_directory entries for unstructured (Deleted) and arm (Stored), needed to send the new notification: Audio Request Being Processed From Archive

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
