### PR TITLE
DMP-2069: Setting whether an event is a log entry from the mid-tier

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerCourtLogsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerCourtLogsTest.java
@@ -107,6 +107,7 @@ class EventsControllerCourtLogsTest extends IntegrationBase {
         Assertions.assertEquals(SOME_DATE_TIME, persistedEvent.getTimestamp());
         Assertions.assertEquals(SOME_COURTROOM, persistedEvent.getCourtroom().getName());
         Assertions.assertEquals(SOME_COURTHOUSE, persistedEvent.getCourtroom().getCourthouse().getCourthouseName());
+        Assertions.assertEquals(true, persistedEvent.getIsLogEntry());
         Assertions.assertDoesNotThrow(() -> UUID.fromString(persistedEvent.getMessageId()));
 
         Assertions.assertNull(persistedEvent.getLegacyEventId());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StandardEventHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StandardEventHandlerTest.java
@@ -72,6 +72,7 @@ class StandardEventHandlerTest extends IntegrationBaseWithGatewayStub {
         var persistedEvent = dartsDatabase.getAllEvents().get(0);
 
         assertThat(persistedEvent.getCourtroom().getName()).isEqualTo(SOME_ROOM);
+        assertThat(persistedEvent.getIsLogEntry()).isEqualTo(false);
         assertThat(persistedCase.getCourthouse().getCourthouseName()).isEqualTo(SOME_COURTHOUSE);
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
@@ -105,6 +106,7 @@ class StandardEventHandlerTest extends IntegrationBaseWithGatewayStub {
         var persistedEvent = dartsDatabase.getAllEvents().get(0);
 
         assertThat(persistedEvent.getCourtroom().getName()).isEqualTo(SOME_ROOM);
+        assertThat(persistedEvent.getIsLogEntry()).isEqualTo(false);
         assertThat(persistedCase.getCourthouse().getCourthouseName()).isEqualTo(SOME_COURTHOUSE);
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
@@ -140,6 +142,7 @@ class StandardEventHandlerTest extends IntegrationBaseWithGatewayStub {
         var persistedEvent = dartsDatabase.getAllEvents().get(0);
 
         assertThat(persistedEvent.getCourtroom().getName()).isEqualTo(SOME_OTHER_ROOM);
+        assertThat(persistedEvent.getIsLogEntry()).isEqualTo(false);
         assertThat(persistedCase.getCourthouse().getCourthouseName()).isEqualTo(SOME_COURTHOUSE);
         assertThat(caseHearing.size()).isEqualTo(1);
         assertThat(caseHearing.get(0).getHearingIsActual()).isEqualTo(true);
@@ -177,6 +180,7 @@ class StandardEventHandlerTest extends IntegrationBaseWithGatewayStub {
         var persistedEvent = dartsDatabase.getAllEvents().get(0);
 
         assertThat(persistedEvent.getCourtroom().getName()).isEqualTo(SOME_ROOM);
+        assertThat(persistedEvent.getIsLogEntry()).isEqualTo(false);
         assertThat(persistedCase.getCourthouse().getCourthouseName()).isEqualTo(SOME_COURTHOUSE);
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);

--- a/src/main/java/uk/gov/hmcts/darts/event/component/impl/DartsEventMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/component/impl/DartsEventMapperImpl.java
@@ -27,6 +27,7 @@ public class DartsEventMapperImpl implements DartsEventMapper {
         dartsEvent.setEventText(request.getText());
         dartsEvent.setDateTime(request.getLogEntryDateTime());
         dartsEvent.setRetentionPolicy(null);
+        dartsEvent.setIsMidTier(true);
 
         return dartsEvent;
     }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/handler/base/EventHandlerBase.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/handler/base/EventHandlerBase.java
@@ -45,7 +45,7 @@ public abstract class EventHandlerBase implements EventHandler {
         event.setEventText(dartsEvent.getEventText());
         event.setEventType(eventHandler);
         event.setMessageId(dartsEvent.getMessageId());
-        event.setIsLogEntry(false);
+        event.setIsLogEntry(dartsEvent.getIsMidTier());
         return event;
     }
 

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -311,6 +311,9 @@ components:
         end_time:
           type: string
           format: date-time
+        is_mid_tier:
+          type: boolean
+          default: false
 
     EventsResponse:
       type: object

--- a/src/test/java/uk/gov/hmcts/darts/event/component/impl/DartsEventMapperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/component/impl/DartsEventMapperImplTest.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -58,6 +59,7 @@ class DartsEventMapperImplTest {
         assertEquals(SOME_TEXT, dartsEvent.getEventText());
         assertEquals(SOME_DATE_TIME, dartsEvent.getDateTime());
         assertNull(dartsEvent.getRetentionPolicy());
+        assertThat(dartsEvent.getIsMidTier(), is(true));
     }
 
 }


### PR DESCRIPTION
Setting whether an event is a log entry from the mid-tier

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
