### PR TITLE
DMP-1729: Removing redundant api field

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/CasesMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/CasesMapper.java
@@ -139,9 +139,6 @@ public class CasesMapper {
 
         singleCase.setReportingRestrictions(sortedByTimestamp(reportingRestrictions));
 
-        //Will be removed when FE up to date
-        populateReportingRestrictionField(caseEntity, singleCase);
-
         return singleCase;
     }
 
@@ -155,12 +152,6 @@ public class CasesMapper {
         var reportingRestriction = new ReportingRestriction();
         reportingRestriction.setEventName(name);
         return reportingRestriction;
-    }
-
-    private static void populateReportingRestrictionField(CourtCaseEntity caseEntity, SingleCase singleCase) {
-        if (caseEntity.getReportingRestrictions() != null) {
-            singleCase.setReportingRestriction(caseEntity.getReportingRestrictions().getEventName());
-        }
     }
 
     private ReportingRestriction toReportingRestriction(HearingReportingRestrictionsEntity restrictionsEntity) {

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -575,10 +575,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/defence'
-        reporting_restriction:
-          type: string
-          example: "Section 4(2) of the Contempt of Court Act 1981"
-          description: 'Any reporting restrictions associated with the case.'
         reporting_restrictions:
           $ref: './common.yaml#/components/schemas/reporting_restrictions'
         retain_until_date_time:

--- a/src/test/resources/Tests/cases/CasesMapperTest/testMapToSingleCaseWithReportingRestriction/expectedResponse.json
+++ b/src/test/resources/Tests/cases/CasesMapperTest/testMapToSingleCaseWithReportingRestriction/expectedResponse.json
@@ -18,6 +18,5 @@
     "defence_Case00001_1",
     "defence_Case00001_2"
   ],
-  "reporting_restriction": "test reporting restriction name",
   "reporting_restrictions": [{"event_name": "test reporting restriction name"}]
 }


### PR DESCRIPTION
Removing redundant api field

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
