### PR TITLE
DMP-2151: Implement ArmTokenClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -384,6 +384,10 @@ dependencies {
   annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
   annotationProcessor('org.hibernate.orm:hibernate-jpamodelgen:6.4.2.Final')
 
+  // Added to resolve issue where the default Feign client will silently convert GET requests to POST if the request contains a body
+  // Ref: https://github.com/spring-cloud/spring-cloud-openfeign/issues/832
+  implementation group: 'io.github.openfeign', name: 'feign-hc5', version: '13.2'
+
   testImplementation 'com.h2database:h2:2.2.224'
   testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.7.1'
   testImplementation 'org.mockito:mockito-inline:5.2.0'

--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.55
+version: 0.0.56
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -77,6 +77,8 @@ java:
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
         - name: ARMSasEndpoint
           alias: ARM_SAS_ENDPOINT
+        - name: ArmTokenBaseUrl
+          alias: ARM_TOKEN_BASE_URL
   environment:
     ENABLE_FLYWAY: true
     RUN_DB_MIGRATION_ON_STARTUP: true

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -74,6 +74,8 @@ java:
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
         - name: ARMSasEndpoint
           alias: ARM_SAS_ENDPOINT
+        - name: ArmTokenBaseUrl
+          alias: ARM_TOKEN_BASE_URL
   environment:
     NOTIFICATION_SCHEDULER_CRON: "3 */2 * * * MON-FRI"
     POSTGRES_SSL_MODE: require
@@ -161,6 +163,8 @@ function:
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
         - name: ARMSasEndpoint
           alias: ARM_SAS_ENDPOINT
+        - name: ArmTokenBaseUrl
+          alias: ARM_TOKEN_BASE_URL
   environment:
     ATS_MODE: true
     POSTGRES_SSL_MODE: require

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -41,6 +41,7 @@ services:
       - AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME
       - AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
       - ARM_SAS_ENDPOINT
+      - ARM_TOKEN_BASE_URL=http://darts-stub-services:4551
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/client/ArmClientIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/client/ArmClientIntTest.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.darts.arm.client;
+
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import feign.FeignException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.darts.arm.client.model.ArmTokenRequest;
+import uk.gov.hmcts.darts.arm.client.model.ArmTokenResponse;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * At time of writing, ArmTokenClient has been written in isolation in preparation for dependant
+ * tickets DMP-1911 and DMP-1912. It currently has no callers, so this integration test is the only
+ * way to verify functionality.
+ *
+ * <p>If you're reading this and ArmTokenClient now has a caller, consider removing this test in favour
+ * of a broader integration test.
+ */
+@TestPropertySource(properties = {
+    "darts.storage.arm.token-base-url=http://localhost:8080"
+})
+class ArmClientIntTest extends IntegrationBase {
+
+    @Autowired
+    private ArmTokenClient armTokenClient;
+
+    @Autowired
+    private WireMockServer wireMockServer;
+
+    private static final String TOKEN_PATH = "/api/v1/token";
+
+    @Test
+    void getTokenShouldSucceedIfServerReturns200Success() {
+        // Given
+        stubFor(
+            WireMock.get(urlEqualTo(TOKEN_PATH))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-type", "application/json")
+                        .withBody(
+                            """
+                                {
+                                    "access_token": "some-token",
+                                    "token_type": "some-token-type",
+                                    "expires_in": "some-expiry"
+                                }
+                                """
+                        )
+                        .withStatus(200)));
+
+        ArmTokenRequest armTokenRequest = createTokenRequest();
+
+        // When
+        ArmTokenResponse token = armTokenClient.getToken(armTokenRequest);
+
+        // Then
+        wireMockServer.verify(getRequestedFor(urlEqualTo(TOKEN_PATH))
+                                  .withRequestBody(equalTo("grant_type=password&username=some-username&password=some-password")));
+
+        assertEquals("some-token", token.getAccessToken());
+        assertEquals("some-token-type", token.getTokenType());
+        assertEquals("some-expiry", token.getExpiresIn());
+    }
+
+    @Test
+    void getTokenShouldThrowExceptionIfServerReturns403Forbidden() {
+        // Given
+        stubFor(
+            WireMock.get(urlEqualTo(TOKEN_PATH))
+                .willReturn(
+                    aResponse()
+                        .withStatus(403)));
+
+        ArmTokenRequest armTokenRequest = createTokenRequest();
+
+        // When
+        FeignException exception = assertThrows(FeignException.class, () -> armTokenClient.getToken(armTokenRequest));
+
+        // Then
+        assertEquals("[403 Forbidden] during [GET] to [http://localhost:8080/api/v1/token] [ArmTokenClient#getToken(ArmTokenRequest)]: []",
+                     exception.getMessage());
+    }
+
+    private static ArmTokenRequest createTokenRequest() {
+        return new ArmTokenRequest("some-username", "some-password", "password");
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/ArmClientConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/ArmClientConfig.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.darts.arm.client;
+
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import groovy.util.logging.Slf4j;
+import org.springframework.context.annotation.Bean;
+import uk.gov.hmcts.darts.arm.client.model.ArmTokenRequest;
+
+@Slf4j
+public class ArmClientConfig {
+
+    @Bean
+    public Encoder armTokenClientEncoder() {
+        // Normally SpringFormEncoder would be used to encode form data, but this doesn't support the "text/plain" Content-Type required by ARM API. Therefore,
+        // we must implement our own encoder here.
+        return (o, type, requestTemplate) -> {
+            if (o instanceof ArmTokenRequest armTokenRequest) {
+                encodeArmTokenRequest(armTokenRequest, requestTemplate);
+            } else {
+                throw new EncodeException(String.format("%s is not a type supported by this encoder.", o.getClass()));
+            }
+        };
+    }
+
+    private void encodeArmTokenRequest(ArmTokenRequest armTokenRequest, RequestTemplate requestTemplate) {
+        requestTemplate.body(String.format(
+                                 "grant_type=%s&username=%s&password=%s",
+                                 armTokenRequest.grantType(),
+                                 armTokenRequest.username(),
+                                 armTokenRequest.password()
+                             )
+        );
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/ArmTokenClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/ArmTokenClient.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.darts.arm.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import uk.gov.hmcts.darts.arm.client.model.ArmTokenRequest;
+import uk.gov.hmcts.darts.arm.client.model.ArmTokenResponse;
+
+@FeignClient(
+    name = "arm-token-client",
+    url = "${darts.storage.arm.token-base-url}",
+    configuration = ArmClientConfig.class
+)
+public interface ArmTokenClient {
+
+    @GetMapping(path = "/api/v1/token", consumes = MediaType.TEXT_PLAIN_VALUE)
+    ArmTokenResponse getToken(ArmTokenRequest armTokenRequest);
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/ArmTokenClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/ArmTokenClient.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.arm.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import uk.gov.hmcts.darts.arm.client.config.ArmClientConfig;
 import uk.gov.hmcts.darts.arm.client.model.ArmTokenRequest;
 import uk.gov.hmcts.darts.arm.client.model.ArmTokenResponse;
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/config/ArmClientConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/config/ArmClientConfig.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.darts.arm.client;
+package uk.gov.hmcts.darts.arm.client.config;
 
 import feign.RequestTemplate;
 import feign.codec.EncodeException;

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/ArmTokenRequest.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/ArmTokenRequest.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.darts.arm.client.model;
+
+import org.apache.commons.lang3.Validate;
+
+public record ArmTokenRequest(String username, String password, String grantType) {
+
+    public ArmTokenRequest {
+        Validate.notBlank(username, "username must not be blank");
+        Validate.notBlank(password, "password must not be blank");
+        Validate.notBlank(grantType, "grant type must not be blank");
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/ArmTokenResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/ArmTokenResponse.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.darts.arm.client.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class ArmTokenResponse {
+
+    @JsonProperty("access_token")
+    public String accessToken;
+    @JsonProperty("token_type")
+    public String tokenType;
+    @JsonProperty("expires_in")
+    public String expiresIn;
+
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -25,6 +25,9 @@ darts:
     enabled: ${TESTING_SUPPORT_ENDPOINTS_ENABLED:true}
   redis:
     ssl-enabled: false
+  storage:
+    arm:
+      token-base-url: ${ARM_TOKEN_BASE_URL:localhost:4551}
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -176,6 +176,7 @@ darts:
       date_time_format: yyyy-MM-dd'T'HH:mm:ss
       file_extension: a360
       list-blobs-timeout-duration: 60s
+      token-base-url: ${ARM_TOKEN_BASE_URL:}
     blob:
       connection-string: ${AZURE_STORAGE_CONNECTION_STRING:}
       container-name:

--- a/src/test/java/uk/gov/hmcts/darts/arm/client/ArmClientConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/client/ArmClientConfigTest.java
@@ -4,6 +4,7 @@ import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.arm.client.config.ArmClientConfig;
 import uk.gov.hmcts.darts.arm.client.model.ArmTokenRequest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/uk/gov/hmcts/darts/arm/client/ArmClientConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/client/ArmClientConfigTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.darts.arm.client;
+
+import feign.RequestTemplate;
+import feign.codec.EncodeException;
+import feign.codec.Encoder;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.arm.client.model.ArmTokenRequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ArmClientConfigTest {
+
+    @Test
+    void encodeShouldPopulateRequestBodyWithExpectedContentFromRequest() {
+        // Given
+        var armClientConfig = new ArmClientConfig();
+        Encoder encoder = armClientConfig.armTokenClientEncoder();
+
+        var armTokenRequest = new ArmTokenRequest("some-username", "some-password", "some-grant-type");
+        var requestTemplate = new RequestTemplate();
+
+        // When
+        encoder.encode(armTokenRequest, null, requestTemplate);
+
+        // Then
+        assertEquals("grant_type=some-grant-type&username=some-username&password=some-password", new String(requestTemplate.body()));
+    }
+
+    @Test
+    void encodeShouldThrowExceptionWhenProvidedWithUnexpectedType() {
+        // Given
+        var armClientConfig = new ArmClientConfig();
+        Encoder encoder = armClientConfig.armTokenClientEncoder();
+
+        var someUnsupportedType = new Object();
+        var requestTemplate = new RequestTemplate();
+
+        // When
+        EncodeException exception = assertThrows(EncodeException.class, () -> encoder.encode(someUnsupportedType, null, requestTemplate));
+
+        // Then
+        assertEquals("class java.lang.Object is not a type supported by this encoder.", exception.getMessage());
+    }
+
+}


### PR DESCRIPTION
# [DMP-2151](https://tools.hmcts.net/jira/browse/DMP-2151)

Implement API client to obtain an access token for ARM.

KeyVault entries for `ArmTokenBaseUrl` have been added in Azure for `stg` and `demo`.

Associated wiremock stub is located here: https://github.com/hmcts/darts-stub-services/pull/71

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
