### PR TITLE
DMP-1737-ARM-PullResponseFiles

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmResponseFilesProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmResponseFilesProcessorIntTest.java
@@ -491,7 +491,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
             "6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_0_uf.rsp";
         String uploadFileJson = TestUtils.getContentsFromFile(uploadFileTestFilename);
         BinaryData uploadFileBinaryData = BinaryData.fromString(uploadFileJson);
-        when(armDataManagementApi.getResponseBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
+        when(armDataManagementApi.getBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         when(userIdentity.getUserAccount()).thenReturn(testUser);
@@ -558,7 +558,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
             "6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_1_uf.rsp";
         String uploadFileJson = TestUtils.getContentsFromFile(uploadFileTestFilename);
         BinaryData uploadFileBinaryData = BinaryData.fromString(uploadFileJson);
-        when(armDataManagementApi.getResponseBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
+        when(armDataManagementApi.getBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         when(userIdentity.getUserAccount()).thenReturn(testUser);
@@ -624,7 +624,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
             "6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_1_uf.rsp";
         String uploadFileJson = TestUtils.getContentsFromFile(uploadFileTestFilename);
         BinaryData uploadFileBinaryData = BinaryData.fromString(uploadFileJson);
-        when(armDataManagementApi.getResponseBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
+        when(armDataManagementApi.getBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         when(userIdentity.getUserAccount()).thenReturn(testUser);
@@ -687,7 +687,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
             "6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_1_uf.rsp";
         String uploadFileJson = TestUtils.getContentsFromFile(uploadFileTestFilename);
         BinaryData uploadFileBinaryData = BinaryData.fromString(uploadFileJson);
-        when(armDataManagementApi.getResponseBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
+        when(armDataManagementApi.getBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
 
         armResponseFilesProcessor.processResponseFiles();
 
@@ -744,7 +744,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
             "6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_1_uf.rsp";
         String uploadFileJson = TestUtils.getContentsFromFile(uploadFileTestFilename);
         BinaryData uploadFileBinaryData = BinaryData.fromString(uploadFileJson);
-        when(armDataManagementApi.getResponseBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
+        when(armDataManagementApi.getBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
 
         armResponseFilesProcessor.processResponseFiles();
 
@@ -802,7 +802,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
             "6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_1_uf.rsp";
         String uploadFileJson = TestUtils.getContentsFromFile(uploadFileTestFilename);
         BinaryData uploadFileBinaryData = BinaryData.fromString(uploadFileJson);
-        when(armDataManagementApi.getResponseBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
+        when(armDataManagementApi.getBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         when(userIdentity.getUserAccount()).thenReturn(testUser);
@@ -866,7 +866,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
             "6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_1_uf.rsp";
         String uploadFileJson = TestUtils.getContentsFromFile(uploadFileTestFilename);
         BinaryData uploadFileBinaryData = BinaryData.fromString(uploadFileJson);
-        when(armDataManagementApi.getResponseBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
+        when(armDataManagementApi.getBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
 
         doNothing().when(armDataManagementApi).deleteResponseBlob(inputUploadBlobFilename);
         doNothing().when(armDataManagementApi).deleteResponseBlob(createRecordFilename);
@@ -929,7 +929,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
             "6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_1_uf.rsp";
         String uploadFileJson = TestUtils.getContentsFromFile(uploadFileTestFilename);
         BinaryData uploadFileBinaryData = BinaryData.fromString(uploadFileJson);
-        when(armDataManagementApi.getResponseBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
+        when(armDataManagementApi.getBlobData(uploadFileFilename)).thenReturn(uploadFileBinaryData);
 
         armResponseFilesProcessor.processResponseFiles();
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/api/ArmDataManagementApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/api/ArmDataManagementApi.java
@@ -12,7 +12,7 @@ public interface ArmDataManagementApi {
 
     List<String> listResponseBlobs(String prefix);
 
-    BinaryData getResponseBlobData(String blobName);
+    BinaryData getBlobData(String blobName);
 
     void deleteResponseBlob(String blobName);
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/api/impl/ArmDataManagementApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/api/impl/ArmDataManagementApiImpl.java
@@ -31,10 +31,10 @@ public class ArmDataManagementApiImpl implements ArmDataManagementApi {
         return armService.listResponseBlobs(getArmContainerName(), prefix);
     }
 
-    public BinaryData getResponseBlobData(String blobName) {
+    public BinaryData getBlobData(String blobPathAndName) {
         return armService.getBlobData(
             getArmContainerName(),
-            armDataManagementConfiguration.getFolders().getResponse() + blobName
+            blobPathAndName
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmResponseFilesProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmResponseFilesProcessorImpl.java
@@ -170,7 +170,7 @@ public class ArmResponseFilesProcessorImpl implements ArmResponseFilesProcessor 
             try {
                 UploadFileFilenameProcessor uploadFileFilenameProcessor = new UploadFileFilenameProcessor(uploadFilename);
 
-                BinaryData uploadFileBinary = armDataManagementApi.getResponseBlobData(uploadFilename);
+                BinaryData uploadFileBinary = armDataManagementApi.getBlobData(uploadFilename);
                 readUploadFile(
                     externalObjectDirectory,
                     uploadFileBinary,

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmServiceImpl.java
@@ -68,6 +68,13 @@ public class ArmServiceImpl implements ArmService {
         return listBlobs(containerClient, prefix);
     }
 
+    /**
+     * Returns a list of the blobs in the response dropzone containing the specified filename with full path.
+     *
+     * @param containerName name of container
+     * @param filename      name of file to look for
+     * @return list of the blobs in the response dropzone containing the specified filename with full path
+     */
     public List<String> listResponseBlobs(String containerName, String filename) {
         BlobContainerClient containerClient = armDataManagementDao.getBlobContainerClient(containerName);
         String prefix = armDataManagementConfiguration.getFolders().getResponse() + filename;
@@ -80,10 +87,10 @@ public class ArmServiceImpl implements ArmService {
         log.debug("About to list files for {}", prefix);
         listBlobsHierarchicalListing(blobContainerClient, FILE_PATH_DELIMITER, prefix).forEach(blob -> {
             if (Boolean.TRUE.equals(blob.isPrefix())) {
-                log.info("Virtual directory prefix: {}}", FILE_PATH_DELIMITER + blob.getName());
+                log.info("Virtual directory prefix: {}", FILE_PATH_DELIMITER + blob.getName());
                 listBlobsHierarchicalListing(blobContainerClient, FILE_PATH_DELIMITER, blob.getName());
             } else {
-                log.info("Blob name: {}}", blob.getName());
+                log.info("Blob name: {}", blob.getName());
                 files.add(blob.getName());
             }
         });

--- a/src/test/java/uk/gov/hmcts/darts/arm/api/impl/ArmDataManagementApiImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/api/impl/ArmDataManagementApiImplTest.java
@@ -84,12 +84,6 @@ class ArmDataManagementApiImplTest {
     @Test
     void getResponseBlobData() {
 
-        var foldersConfig = new ArmDataManagementConfiguration.Folders();
-        foldersConfig.setSubmission(ARM_DROP_ZONE);
-        foldersConfig.setCollected(ARM_DROP_ZONE);
-        foldersConfig.setResponse(ARM_DROP_ZONE);
-        when(armDataManagementConfiguration.getFolders()).thenReturn(foldersConfig);
-
         byte[] testStringInBytes = TEST_BINARY_STRING.getBytes(StandardCharsets.UTF_8);
         BinaryData data = BinaryData.fromBytes(testStringInBytes);
         String blobname = "1_1_1";
@@ -97,7 +91,7 @@ class ArmDataManagementApiImplTest {
         String blobNameAndPath = ARM_DROP_ZONE + blobname;
         when(armService.getBlobData(ARM_BLOB_CONTAINER_NAME, blobNameAndPath)).thenReturn(data);
 
-        BinaryData binaryData = armDataManagementApi.getResponseBlobData(blobname);
+        BinaryData binaryData = armDataManagementApi.getBlobData(blobNameAndPath);
         assertEquals(data, binaryData);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-1737

### Change description ###

Fixed issue whereby the list blobs returns the blob name and path so setting path for get was unneccesary


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
