### PR TITLE
Revert "Temp use of distroless-debug base image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD lib/ffmpeg-release-amd64-static.tar.xz /usr/local/bin
 RUN cp -p ffmpeg*/ffmpeg /usr/bin
 
  # renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
-FROM hmctspublic.azurecr.io/base/java:17-distroless-debug
+FROM hmctspublic.azurecr.io/base/java:17-distroless
 COPY --from=build-env /usr/bin/ffmpeg /usr/bin
 
 COPY lib/applicationinsights.json /opt/app/


### PR DESCRIPTION
Reverts hmcts/darts-api#994

It didn't work, reverting the change.