### PR TITLE
DMP-2194 - When "last_accessed_ts" or "created_ts" is set on the date for Saturday or Sunday, it does not get picked up by automated job on Tuesday.

### DIFF
--- a/src/main/resources/db/migration/common/V1_268__update_outbound_deleter_automated_task_updated.sql
+++ b/src/main/resources/db/migration/common/V1_268__update_outbound_deleter_automated_task_updated.sql
@@ -1,0 +1,1 @@
+UPDATE darts.automated_task set cron_expression = '00 1 * * * *' where aut_id = 3;

--- a/src/main/resources/db/migration/common/V1_268__update_outbound_deleter_automated_task_updated.sql
+++ b/src/main/resources/db/migration/common/V1_268__update_outbound_deleter_automated_task_updated.sql
@@ -1,1 +1,1 @@
-UPDATE darts.automated_task set cron_expression = '00 1 * * * *' where aut_id = 3;
+UPDATE darts.automated_task set cron_expression = '0 1 * * * *' where aut_id = 3;


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-2194


Original criteria of deleting items accessed on the weekend has been changed as the job will now run on Wednesday 1 am instead of Tuesday 10 pm. This means that items will not be deleted on Tuesday but on Wednesday as 48 hours will not have passed since last access.