### PR TITLE
Remove overly restrictive regex constraint from usermanagement openapi

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
@@ -175,7 +175,7 @@ class PatchUserIntTest extends IntegrationBase {
         MockHttpServletRequestBuilder request = buildRequest(userId)
             .content("""
                          {
-                           "full_name": " ",
+                           "full_name": "",
                            "description": ""
                          }
                          """);

--- a/src/main/resources/openapi/usermanagement.yaml
+++ b/src/main/resources/openapi/usermanagement.yaml
@@ -316,7 +316,6 @@ components:
     UserName:
       minLength: 1
       maxLength: 256
-      pattern: ^\S$|^\S[a-zA-Z '-]*\S$
       type: string
     UserEmailAddress:
       minLength: 1


### PR DESCRIPTION
Regex for username field of user search is overly-restrictive at this time. A separate excerise will review all applied openapi constraints and tighen/loosen as necessary, with steer from migrated legacy data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
