### PR TITLE
Remove unnecessary sleep that was contributing to a large increase in…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
@@ -21,18 +21,12 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 @Profile("intTest")
-@SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
 public class DataManagementServiceStubImpl implements DataManagementService {
 
     @Override
     public BinaryData getBlobData(String containerName, UUID blobId) {
         logStubUsageWarning();
 
-        try {
-            Thread.sleep(6000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
         log.warn("Returning dummy file to mimic Blob storage download");
         return BinaryData.fromBytes(new byte[1024]);
     }


### PR DESCRIPTION
This change eliminates an unnecessary(?) `Thread.sleep` introduced in https://github.com/hmcts/darts-api/pull/965 which had the side effect of adding 6s to every integration test that invokes data management service, and overall a ~4m increase in local build time.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
