### PR TITLE
DMP-2005 Adding event received log entry for Dynatrace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -405,6 +405,7 @@ dependencies {
 
   // https://mvnrepository.com/artifact/org.awaitility/awaitility-proxy
   testImplementation group: 'org.awaitility', name: 'awaitility-proxy', version: '3.1.6'
+  testImplementation 'io.github.hakky54:logcaptor:2.9.2'
 
   compileJava.dependsOn = openApiGenerateTaskList
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DartsEventNullHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DartsEventNullHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -8,6 +9,7 @@ import uk.gov.hmcts.darts.common.repository.EventHandlerRepository;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.service.EventDispatcher;
 import uk.gov.hmcts.darts.event.service.handler.DartsEventNullHandler;
+import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.time.OffsetDateTime;
@@ -25,6 +27,9 @@ class DartsEventNullHandlerTest extends IntegrationBase {
 
     @SpyBean
     DartsEventNullHandler nullEventHandler;
+
+    @Mock
+    LogApi logApi;
 
     @Autowired
     EventHandlerRepository eventHandlerRepository;
@@ -47,7 +52,7 @@ class DartsEventNullHandlerTest extends IntegrationBase {
         event.setCaseNumbers(List.of("123"));
         event.setDateTime(today);
 
-        EventDispatcher eventDispatcher = new EventDispatcherImpl(List.of(nullEventHandler), eventHandlerRepository);
+        EventDispatcher eventDispatcher = new EventDispatcherImpl(List.of(nullEventHandler), eventHandlerRepository, logApi);
         eventDispatcher.receive(event);
 
         Mockito.verify(nullEventHandler, Mockito.times(1)).handle(any(), any());

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventDispatcherImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventDispatcherImpl.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.darts.common.repository.EventHandlerRepository;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.service.EventDispatcher;
 import uk.gov.hmcts.darts.event.service.EventHandler;
+import uk.gov.hmcts.darts.log.api.LogApi;
 
 import java.util.List;
 import java.util.Map;
@@ -31,10 +32,13 @@ public class EventDispatcherImpl implements EventDispatcher {
 
     private final List<EventHandler> eventHandlers;
     private final EventHandlerRepository eventHandlerRepository;
+
+    private final LogApi logApi;
     private final Map<String, EventHandlerEntity> eventHandlerCache = new ConcurrentHashMap<>();
 
     @Override
     public void receive(DartsEvent event) {
+        logApi.eventReceived(event);
         EventHandlerEntity foundHandlerEntity = findHandler(event);
         Optional<EventHandler> foundHandler = eventHandlers.stream()
             .filter(handler -> handler.isHandlerFor(foundHandlerEntity.getHandler()))

--- a/src/main/java/uk/gov/hmcts/darts/log/api/LogApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/api/LogApi.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.darts.log.api;
 
-import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 
-@Service
 public interface LogApi {
     void eventReceived(DartsEvent event);
 }

--- a/src/main/java/uk/gov/hmcts/darts/log/api/LogApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/api/LogApi.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.darts.log.api;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+
+@Service
+public interface LogApi {
+    void eventReceived(DartsEvent event);
+}

--- a/src/main/java/uk/gov/hmcts/darts/log/api/impl/LogApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/api/impl/LogApiImpl.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.darts.log.api.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.log.service.EventLoggerService;
+
+@Service
+@RequiredArgsConstructor
+public class LogApiImpl implements LogApi {
+
+    private final EventLoggerService eventLoggerService;
+
+    @Override
+    public void eventReceived(DartsEvent event) {
+        eventLoggerService.eventReceived(event);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/log/enums/EventSource.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/enums/EventSource.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.darts.log.enums;
+
+public enum EventSource {
+    CPP, XHB, UNKNOWN
+}

--- a/src/main/java/uk/gov/hmcts/darts/log/service/EventLoggerService.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/service/EventLoggerService.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.darts.log.service;
 
-import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 
-@Service
 public interface EventLoggerService {
     void eventReceived(DartsEvent event);
 }

--- a/src/main/java/uk/gov/hmcts/darts/log/service/EventLoggerService.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/service/EventLoggerService.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.darts.log.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+
+@Service
+public interface EventLoggerService {
+    void eventReceived(DartsEvent event);
+}

--- a/src/main/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImpl.java
@@ -28,26 +28,25 @@ public class EventLoggerServiceImpl implements EventLoggerService {
     public void eventReceived(DartsEvent event) {
         var isPollCheck = false;
         EventSource source = EventSource.UNKNOWN;
-        if (StringUtils.equals(event.getEventText(), xhbDailyTestEventText)) {
-            isPollCheck = true;
-            source = EventSource.XHB;
-        } else if (StringUtils.equals(event.getEventText(), cppDailyTestEventText)) {
-            isPollCheck = true;
-            source = EventSource.CPP;
+        try {
+            // Xhibit sends event positive IDs, CPP send negative event IDs
+            if (Integer.parseInt(event.getEventId()) >= 0) {
+                source = EventSource.XHB;
+                if (StringUtils.equals(event.getEventText(), xhbDailyTestEventText)) {
+                    isPollCheck = true;
+                }
+            } else {
+                source = EventSource.CPP;
+                if (StringUtils.equals(event.getEventText(), cppDailyTestEventText)) {
+                    isPollCheck = true;
+                }
+            }
+        } catch (NumberFormatException e) {
+            // continue with source UNKNOWN
         }
         if (isPollCheck) {
             logPollCheck(event.getMessageId(), event.getEventId(), source, event.getDateTime());
         } else {
-            try {
-                // Xhibit sends event positive IDs, CPP send negative event IDs
-                if (Integer.parseInt(event.getEventId()) >= 0) {
-                    source = EventSource.XHB;
-                } else {
-                    source = EventSource.CPP;
-                }
-            } catch (NumberFormatException e) {
-                // continue with source UNKNOWN
-            }
             logEvent(event.getMessageId(), event.getEventId(), event.getCourthouse(),
                      event.getCourtroom(), source, event.getDateTime());
         }

--- a/src/main/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImpl.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.darts.log.service.impl;
 
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
@@ -10,14 +13,16 @@ import uk.gov.hmcts.darts.log.service.EventLoggerService;
 import java.time.OffsetDateTime;
 
 @Service
+@AllArgsConstructor
+@NoArgsConstructor
 @Slf4j
 public class EventLoggerServiceImpl implements EventLoggerService {
 
     @Value("${darts.log.events.event-type-length.xhb}")
-    private int xhbEventTypeLength;
+    private Integer xhbEventTypeLength;
 
     @Value("${darts.log.events.event-type-length.cpp}")
-    private int cppEventTypeLength;
+    private Integer cppEventTypeLength;
 
     @Value("${darts.log.events.daily-test-event-text.xhb}")
     private String xhbDailyTestEventText;
@@ -29,21 +34,19 @@ public class EventLoggerServiceImpl implements EventLoggerService {
     public void eventReceived(DartsEvent event) {
         var isPollCheck = false;
         EventSource source = EventSource.UNKNOWN;
-        if (event.getEventText() != null && event.getEventText().equals(xhbDailyTestEventText)) {
+        if (StringUtils.equals(event.getEventText(), xhbDailyTestEventText)) {
             isPollCheck = true;
             source = EventSource.XHB;
-        }
-        if (event.getEventText() != null && event.getEventText().equals(cppDailyTestEventText)) {
+        } else if (StringUtils.equals(event.getEventText(), cppDailyTestEventText)) {
             isPollCheck = true;
             source = EventSource.CPP;
         }
         if (isPollCheck) {
             logPollCheck(event.getMessageId(), event.getEventId(), source, event.getDateTime());
         } else {
-            if (event.getType() != null && event.getType().length() == xhbEventTypeLength) {
+            if (event.getType() != null && xhbEventTypeLength != null && event.getType().length() == xhbEventTypeLength) {
                 source = EventSource.XHB;
-            }
-            if (event.getType() != null && event.getType().length() == cppEventTypeLength) {
+            } else if (event.getType() != null && cppEventTypeLength != null && event.getType().length() == cppEventTypeLength) {
                 source = EventSource.CPP;
             }
             logEvent(event.getMessageId(), event.getEventId(), event.getCourthouse(),

--- a/src/main/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImpl.java
@@ -18,12 +18,6 @@ import java.time.OffsetDateTime;
 @Slf4j
 public class EventLoggerServiceImpl implements EventLoggerService {
 
-    @Value("${darts.log.events.event-type-length.xhb}")
-    private Integer xhbEventTypeLength;
-
-    @Value("${darts.log.events.event-type-length.cpp}")
-    private Integer cppEventTypeLength;
-
     @Value("${darts.log.events.daily-test-event-text.xhb}")
     private String xhbDailyTestEventText;
 
@@ -44,10 +38,15 @@ public class EventLoggerServiceImpl implements EventLoggerService {
         if (isPollCheck) {
             logPollCheck(event.getMessageId(), event.getEventId(), source, event.getDateTime());
         } else {
-            if (event.getType() != null && xhbEventTypeLength != null && event.getType().length() == xhbEventTypeLength) {
-                source = EventSource.XHB;
-            } else if (event.getType() != null && cppEventTypeLength != null && event.getType().length() == cppEventTypeLength) {
-                source = EventSource.CPP;
+            try {
+                // Xhibit sends event positive IDs, CPP send negative event IDs
+                if (Integer.parseInt(event.getEventId()) >= 0) {
+                    source = EventSource.XHB;
+                } else {
+                    source = EventSource.CPP;
+                }
+            } catch (NumberFormatException e) {
+                // continue with source UNKNOWN
             }
             logEvent(event.getMessageId(), event.getEventId(), event.getCourthouse(),
                      event.getCourtroom(), source, event.getDateTime());

--- a/src/main/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImpl.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.darts.log.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+import uk.gov.hmcts.darts.log.enums.EventSource;
+import uk.gov.hmcts.darts.log.service.EventLoggerService;
+
+import java.time.OffsetDateTime;
+
+@Service
+@Slf4j
+public class EventLoggerServiceImpl implements EventLoggerService {
+
+    @Value("${darts.log.events.event-type-length.xhb}")
+    private int xhbEventTypeLength;
+
+    @Value("${darts.log.events.event-type-length.cpp}")
+    private int cppEventTypeLength;
+
+    @Value("${darts.log.events.daily-test-event-text.xhb}")
+    private String xhbDailyTestEventText;
+
+    @Value("${darts.log.events.daily-test-event-text.cpp}")
+    private String cppDailyTestEventText;
+
+    @Override
+    public void eventReceived(DartsEvent event) {
+        var isPollCheck = false;
+        EventSource source = EventSource.UNKNOWN;
+        if (event.getEventText() != null && event.getEventText().equals(xhbDailyTestEventText)) {
+            isPollCheck = true;
+            source = EventSource.XHB;
+        }
+        if (event.getEventText() != null && event.getEventText().equals(cppDailyTestEventText)) {
+            isPollCheck = true;
+            source = EventSource.CPP;
+        }
+        if (isPollCheck) {
+            logPollCheck(event.getMessageId(), event.getEventId(), source, event.getDateTime());
+        } else {
+            if (event.getType() != null && event.getType().length() == xhbEventTypeLength) {
+                source = EventSource.XHB;
+            }
+            if (event.getType() != null && event.getType().length() == cppEventTypeLength) {
+                source = EventSource.CPP;
+            }
+            logEvent(event.getMessageId(), event.getEventId(), event.getCourthouse(),
+                     event.getCourtroom(), source, event.getDateTime());
+        }
+    }
+
+    private void logPollCheck(String messageId, String eventId, EventSource source, OffsetDateTime dateTime) {
+        log.info("Event received: message_id={}, event_id={}, source={}, poll_check=true, date_time={}",
+                 messageId, eventId, source, dateTime);
+    }
+
+    private void logEvent(String messageId, String eventId, String courthouse, String courtroom, EventSource source, OffsetDateTime dateTime) {
+        log.info("Event received: message_id={}, event_id={}, courthouse={}, courtroom={}, source={}, date_time={}",
+                 messageId, eventId, courthouse, courtroom, source, dateTime);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -235,9 +235,6 @@ darts:
     sse-preview-timeout: 120 # in seconds
   log:
     events:
-      event-type-length:
-        xhb: ${EVENT_LOG_XHB_TYPE_LENGTH:5}
-        cpp: ${EVENT_LOG_CPP_TYPE_LENGTH:4}
       daily-test-event-text:
         xhb: ${EVENT_LOG_XHB_DAILY_TEST_TEXT:Xhibit Daily Test}
         cpp: ${EVENT_LOG_CPP_DAILY_TEST_TEXT:CPP Daily Test}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -233,6 +233,14 @@ darts:
   sse:
     heartbeat: 5 # in seconds
     sse-preview-timeout: 120 # in seconds
+  log:
+    events:
+      event-type-length:
+        xhb: ${EVENT_LOG_XHB_TYPE_LENGTH:5}
+        cpp: ${EVENT_LOG_CPP_TYPE_LENGTH:4}
+      daily-test-event-text:
+        xhb: ${EVENT_LOG_XHB_DAILY_TEST_TEXT:Xhibit Daily Test}
+        cpp: ${EVENT_LOG_CPP_DAILY_TEST_TEXT:CPP Daily Test}
 
 dbMigration:
   # When true, the app will run DB migration on startup.

--- a/src/test/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImplTest.java
@@ -1,0 +1,152 @@
+package uk.gov.hmcts.darts.log.service.impl;
+
+import nl.altindag.log.LogCaptor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+import uk.gov.hmcts.darts.log.enums.EventSource;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith({MockitoExtension.class})
+@SuppressWarnings("PMD.LawOfDemeter")
+class EventLoggerServiceImplTest {
+
+    EventLoggerServiceImpl eventLoggerService;
+
+    private static LogCaptor logCaptor;
+
+    @BeforeAll
+    public static void setupLogCaptor() {
+        logCaptor = LogCaptor.forClass(EventLoggerServiceImpl.class);
+        logCaptor.setLogLevelToInfo();
+    }
+
+    @AfterEach
+    public void clearLogs() {
+        logCaptor.clearLogs();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        logCaptor.close();
+    }
+
+    @BeforeEach
+    void setUp() {
+        eventLoggerService = new EventLoggerServiceImpl();
+        ReflectionTestUtils.setField(eventLoggerService, "xhbDailyTestEventText", "Xhibit Daily Test");
+        ReflectionTestUtils.setField(eventLoggerService, "cppDailyTestEventText", "CPP Daily Test");
+        ReflectionTestUtils.setField(eventLoggerService, "xhbEventTypeLength", 5);
+        ReflectionTestUtils.setField(eventLoggerService, "cppEventTypeLength", 4);
+    }
+
+    @Test
+    void testLogsXhbPollCheck() {
+        var event = createDartsEvent("20705", "10703", "Xhibit Daily Test");
+        eventLoggerService.eventReceived(event);
+        var logEntry = String.format("Event received: message_id=%s, event_id=%s, source=%s, poll_check=true, date_time=%s",
+                                     event.getMessageId(), event.getEventId(), EventSource.XHB, event.getDateTime());
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
+        assertEquals(logEntry, infoLogs.get(0));
+    }
+
+    @Test
+    void testLogsCppPollCheck() {
+        var event = createDartsEvent("20705", "10703", "CPP Daily Test");
+        eventLoggerService.eventReceived(event);
+        var logEntry = String.format("Event received: message_id=%s, event_id=%s, source=%s, poll_check=true, date_time=%s",
+                                     event.getMessageId(), event.getEventId(), EventSource.CPP, event.getDateTime());
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
+        assertEquals(logEntry, infoLogs.get(0));
+    }
+
+    @Test
+    void testLogsXhbEvent() {
+        var event = createDartsEvent("10200", "1002", "Some event text");
+        eventLoggerService.eventReceived(event);
+        var logEntry = String.format("Event received: message_id=%s, event_id=%s, courthouse=%s, courtroom=%s, source=%s, date_time=%s",
+                                     event.getMessageId(), event.getEventId(), event.getCourthouse(),
+                                     event.getCourtroom(), EventSource.XHB, event.getDateTime());
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
+        assertEquals(logEntry, infoLogs.get(0));
+    }
+
+    @Test
+    void testLogsCppEvent() {
+        var event = createDartsEvent("1000", "1002", "Some event text");
+        eventLoggerService.eventReceived(event);
+        var logEntry = String.format("Event received: message_id=%s, event_id=%s, courthouse=%s, courtroom=%s, source=%s, date_time=%s",
+                                     event.getMessageId(), event.getEventId(), event.getCourthouse(),
+                                     event.getCourtroom(), EventSource.CPP, event.getDateTime());
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
+        assertEquals(logEntry, infoLogs.get(0));
+    }
+
+    @Test
+    void testHandlesEmptyEventText() {
+        var event = createDartsEvent("1000", "1002", null);
+        eventLoggerService.eventReceived(event);
+        var logEntry = String.format("Event received: message_id=%s, event_id=%s, courthouse=%s, courtroom=%s, source=%s, date_time=%s",
+                                     event.getMessageId(), event.getEventId(), event.getCourthouse(),
+                                     event.getCourtroom(), EventSource.CPP, event.getDateTime());
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
+        assertEquals(logEntry, infoLogs.get(0));
+    }
+
+    @Test
+    void testHandlesEmptyEventType() {
+        var event = createDartsEvent(null, "1002", "Some event text");
+        eventLoggerService.eventReceived(event);
+        var logEntry = String.format("Event received: message_id=%s, event_id=%s, courthouse=%s, courtroom=%s, source=%s, date_time=%s",
+                                     event.getMessageId(), event.getEventId(), event.getCourthouse(),
+                                     event.getCourtroom(), EventSource.UNKNOWN, event.getDateTime());
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
+        assertEquals(logEntry, infoLogs.get(0));
+    }
+
+    @Test
+    void testHandlesNullCourthouseCourtroom() {
+        var event = createDartsEvent("1000", "1002", "Some event text");
+        event.setCourthouse(null);
+        event.setCourtroom(null);
+        eventLoggerService.eventReceived(event);
+        var logEntry = String.format("Event received: message_id=%s, event_id=%s, courthouse=%s, courtroom=%s, source=%s, date_time=%s",
+                                     event.getMessageId(), event.getEventId(), event.getCourthouse(),
+                                     event.getCourtroom(), EventSource.CPP, event.getDateTime());
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
+        assertEquals(logEntry, infoLogs.get(0));
+    }
+
+    private DartsEvent createDartsEvent(String eventType, String eventSubType, String eventText) {
+        var eventDate = OffsetDateTime.of(2024, 10, 10, 10, 0, 0, 0, ZoneOffset.UTC);
+        DartsEvent event = new DartsEvent();
+        event.setType(eventType);
+        event.setSubType(eventSubType);
+        event.setEventId("4354");
+        event.setCourthouse("SWANSEA");
+        event.setCourtroom("1");
+        event.setMessageId("test-message-id");
+        event.setEventText(eventText);
+        event.setDateTime(eventDate);
+        return event;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/log/service/impl/EventLoggerServiceImplTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.log.enums.EventSource;
 
@@ -44,11 +43,7 @@ class EventLoggerServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        eventLoggerService = new EventLoggerServiceImpl();
-        ReflectionTestUtils.setField(eventLoggerService, "xhbDailyTestEventText", "Xhibit Daily Test");
-        ReflectionTestUtils.setField(eventLoggerService, "cppDailyTestEventText", "CPP Daily Test");
-        ReflectionTestUtils.setField(eventLoggerService, "xhbEventTypeLength", 5);
-        ReflectionTestUtils.setField(eventLoggerService, "cppEventTypeLength", 4);
+        eventLoggerService = new EventLoggerServiceImpl(5, 4, "Xhibit Daily Test", "CPP Daily Test");
     }
 
     @Test
@@ -133,6 +128,24 @@ class EventLoggerServiceImplTest {
         List<String> infoLogs = logCaptor.getInfoLogs();
         assertEquals(1, infoLogs.size());
         assertEquals(logEntry, infoLogs.get(0));
+    }
+
+    @Test
+    void handlesNullXhbEventTypeLengthConfig() {
+        var event = createDartsEvent("1000", "1002", "Some event text");
+        eventLoggerService = new EventLoggerServiceImpl(null, 4, "Xhibit Daily Test", "CPP Daily Test");
+        eventLoggerService.eventReceived(event);
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
+    }
+
+    @Test
+    void handlesNullCppEventTypeLengthConfig() {
+        var event = createDartsEvent("1000", "1002", "Some event text");
+        eventLoggerService = new EventLoggerServiceImpl(5, null, "Xhibit Daily Test", "CPP Daily Test");
+        eventLoggerService.eventReceived(event);
+        List<String> infoLogs = logCaptor.getInfoLogs();
+        assertEquals(1, infoLogs.size());
     }
 
     private DartsEvent createDartsEvent(String eventType, String eventSubType, String eventText) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2005

### Change description ###

This might appear over-engineered for a log entry, however doing this has some advantages:

1. these logs are driving a business requirement, so we can fully unit test them
2. we can keep all the logs for Dynatrace in one package

Change include

- including poll checks
- adding check values to config to allow easy overriding via flux
- adding new log package to keep logging in a central place
- exposing via internal "api" package
- unit testing log entries as these are business requirements
- unit testing that the log service is called when an event is received

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

