### PR TITLE
 DMP-2259 Move @Transactional to single iteration of OutboundAudioDeleter automated task

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.service;
 
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -43,9 +42,6 @@ import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.PROCESSING;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
-//Requires transactional as the object is being created manually rather than being autowired.
-// We are doing this, so we can mock out different dates to test the service.
-@Transactional
 @SuppressWarnings("PMD.ExcessiveImports")
 class OutboundAudioDeleterProcessorTest extends IntegrationBase {
 
@@ -136,8 +132,8 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
 
         assertEquals(1, outboundAudioDeleterProcessor.markForDeletion().size());
 
-        assertTransientObjectDirectoryStateChanged(markedForDeletion);
-        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion);
+        assertTransientObjectDirectoryStateChanged(markedForDeletion.getId());
+        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion.getId());
 
 
     }
@@ -172,7 +168,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         );
 
         assertEquals(1, outboundAudioDeleterProcessor.markForDeletion().size());
-        assertTransientObjectDirectoryStateChanged(markedForDeletion);
+        assertTransientObjectDirectoryStateChanged(markedForDeletion.getId());
         assertEquals(
             EXPIRED,
             dartsDatabase.getMediaRequestRepository().findById(savedMediaRequest.getId()).get().getStatus()
@@ -209,7 +205,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.of(2023, 10, 23, 22, 0, 0, 0, ZoneOffset.UTC));
 
         assertEquals(0, outboundAudioDeleterProcessor.markForDeletion().size());
-        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion);
+        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion.getId());
     }
 
 
@@ -253,7 +249,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         when(bankHolidaysService.getBankHolidaysLocalDateList()).thenReturn(holidays);
 
         assertEquals(0, outboundAudioDeleterProcessor.markForDeletion().size());
-        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion);
+        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion.getId());
     }
 
     @Test
@@ -296,8 +292,8 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         );
 
         assertEquals(1, outboundAudioDeleterProcessor.markForDeletion().size());
-        assertTransientObjectDirectoryStateChanged(markedForDeletion);
-        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion);
+        assertTransientObjectDirectoryStateChanged(markedForDeletion.getId());
+        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion.getId());
 
     }
 
@@ -332,7 +328,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
 
 
         outboundAudioDeleterProcessor.markForDeletion();
-        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion);
+        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion.getId());
 
 
         //last accessed saturday
@@ -354,7 +350,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         );
 
         outboundAudioDeleterProcessor.markForDeletion();
-        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion);
+        assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion.getId());
 
     }
 
@@ -364,9 +360,9 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         TransientObjectDirectoryEntity markedForDeletion = createMediaRequestsAndTransientObjectDirectoryWithHearingWithLastAccessedTimeIsNull();
 
         assertEquals(1, outboundAudioDeleterProcessor.markForDeletion().size());
-        assertTransientObjectDirectoryStateChanged(markedForDeletion);
-        assertEquals(EXPIRED, markedForDeletion.getTransformedMedia().getMediaRequest().getStatus());
-
+        assertTransientObjectDirectoryStateChanged(markedForDeletion.getId());
+        TransientObjectDirectoryEntity tod = dartsDatabase.getTransientObjectDirectoryRepository().findById(markedForDeletion.getId()).get();
+        assertEquals(EXPIRED, tod.getTransformedMedia().getMediaRequest().getStatus());
     }
 
 
@@ -426,40 +422,44 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
     }
 
 
-    private void assertTransientObjectDirectoryStateChanged(TransientObjectDirectoryEntity transientObjectDirectoryEntity) {
+    private void assertTransientObjectDirectoryStateChanged(Integer id) {
+
+        TransientObjectDirectoryEntity transientObjectDirectory = dartsDatabase.getTransientObjectDirectoryRepository().findById(id).get();
 
         assertEquals(
             MARKED_FOR_DELETION.getId(),
-            transientObjectDirectoryEntity.getStatus().getId()
+            transientObjectDirectory.getStatus().getId()
         );
 
         assertEquals(
             "system_housekeeping",
-            transientObjectDirectoryEntity.getLastModifiedBy().getUserName()
+            transientObjectDirectory.getLastModifiedBy().getUserName()
         );
 
-        assertNotNull(transientObjectDirectoryEntity.getTransformedMedia().getExpiryTime());
-        assertEquals(1, transientObjectDirectoryEntity.getTransformedMedia().getLastModifiedBy().getId());
+        assertNotNull(transientObjectDirectory.getTransformedMedia().getExpiryTime());
+        assertEquals(1, transientObjectDirectory.getTransformedMedia().getLastModifiedBy().getId());
     }
 
-    private void assertTransientObjectDirectoryStateNotChanged(TransientObjectDirectoryEntity transientObjectDirectoryEntity) {
+    private void assertTransientObjectDirectoryStateNotChanged(Integer id) {
+
+        TransientObjectDirectoryEntity transientObjectDirectory = dartsDatabase.getTransientObjectDirectoryRepository().findById(id).get();
+
         assertNotEquals(
             MARKED_FOR_DELETION.getId(),
-            transientObjectDirectoryEntity.getStatus().getId()
+            transientObjectDirectory.getStatus().getId()
         );
-
 
         assertNotEquals(
             "system_housekeeping",
-            transientObjectDirectoryEntity.getLastModifiedBy().getUserName()
+            transientObjectDirectory.getLastModifiedBy().getUserName()
         );
 
         assertEquals(
             STORED.getId(),
-            transientObjectDirectoryEntity.getStatus().getId()
+            transientObjectDirectory.getStatus().getId()
         );
 
-        assertNull(transientObjectDirectoryEntity.getTransformedMedia().getExpiryTime());
+        assertNull(transientObjectDirectory.getTransformedMedia().getExpiryTime());
     }
 
 
@@ -484,8 +484,8 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             null,
             null
         );
+        transformedMediaEntity.setCreatedDateTime(createdAt);
         TransformedMediaEntity savedTM = dartsDatabase.save(transformedMediaEntity);
-        savedTM.setCreatedDateTime(createdAt);
 
         return dartsDatabase.getTransientObjectDirectoryRepository().saveAndFlush(transientObjectDirectoryStub.createTransientObjectDirectoryEntity(
             savedTM,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.task.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
@@ -13,8 +12,6 @@ import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
-import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
-import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.common.service.bankholidays.BankHolidaysService;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.data.AudioTestData;
@@ -33,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.COMPLETED;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.EXPIRED;
@@ -64,21 +60,11 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
     @Autowired
     private OutboundAudioDeleterProcessor outboundAudioDeleterProcessor;
 
-    @Mock
-    private SystemUserHelper systemUserHelper;
-
-    @Mock
-    private UserAccountRepository userAccountRepository;
-
     @BeforeEach
     void setUp() {
         requestor = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         //setting clock to 2023-10-27
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.of(2023, 10, 27, 22, 0, 0, 0, ZoneOffset.UTC));
-        when(systemUserHelper.findSystemUserGuid(anyString())).thenReturn("value");
-        UserAccountEntity systemUser = new UserAccountEntity();
-        systemUser.setId(0);
-        when(userAccountRepository.findSystemUser(anyString())).thenReturn(systemUser);
     }
 
     @Test
@@ -431,9 +417,10 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             transientObjectDirectory.getStatus().getId()
         );
 
+        UserAccountEntity userAccountEntity = dartsDatabase.getUserAccountRepository().findById(transientObjectDirectory.getLastModifiedBy().getId()).get();
         assertEquals(
             "system_housekeeping",
-            transientObjectDirectory.getLastModifiedBy().getUserName()
+            userAccountEntity.getUserName()
         );
 
         assertNotNull(transientObjectDirectory.getTransformedMedia().getExpiryTime());
@@ -449,9 +436,10 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             transientObjectDirectory.getStatus().getId()
         );
 
+        UserAccountEntity userAccountEntity = dartsDatabase.getUserAccountRepository().findById(transientObjectDirectory.getLastModifiedBy().getId()).get();
         assertNotEquals(
             "system_housekeeping",
-            transientObjectDirectory.getLastModifiedBy().getUserName()
+            userAccountEntity.getUserName()
         );
 
         assertEquals(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TransformedMediaStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TransformedMediaStub.java
@@ -35,7 +35,7 @@ public class TransformedMediaStub {
         }
         transformedMediaEntity.setExpiryTime(expiry);
         transformedMediaEntity.setLastAccessed(lastAccessed);
-        return transformedMediaRepository.save(transformedMediaEntity);
+        return transformedMediaRepository.saveAndFlush(transformedMediaEntity);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TransientObjectDirectoryStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TransientObjectDirectoryStub.java
@@ -43,7 +43,7 @@ public class TransientObjectDirectoryStub {
         transientObjectDirectoryEntity.setStatus(objectRecordStatusEntity);
         transientObjectDirectoryEntity.setExternalLocation(externalLocation);
         transientObjectDirectoryEntity.setLastModifiedDateTime(OffsetDateTime.now());
-        transientObjectDirectoryRepository.save(transientObjectDirectoryEntity);
+        transientObjectDirectoryRepository.saveAndFlush(transientObjectDirectoryEntity);
         return transientObjectDirectoryEntity;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TransientObjectDirectoryStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TransientObjectDirectoryStub.java
@@ -42,7 +42,7 @@ public class TransientObjectDirectoryStub {
         transientObjectDirectoryEntity.setLastModifiedBy(userAccountStub.getIntegrationTestUserAccountEntity());
         transientObjectDirectoryEntity.setStatus(objectRecordStatusEntity);
         transientObjectDirectoryEntity.setExternalLocation(externalLocation);
-        transientObjectDirectoryEntity.setLastModifiedDateTime(OffsetDateTime.now());
+        transientObjectDirectoryEntity.setLastModifiedDateTime(OffsetDateTime.parse("2024-02-12T13:45:00Z"));
         transientObjectDirectoryRepository.saveAndFlush(transientObjectDirectoryEntity);
         return transientObjectDirectoryEntity;
     }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/OutboundAudioDeleterProcessorSingleElement.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/OutboundAudioDeleterProcessorSingleElement.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.darts.audio.service;
+
+import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
+import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
+import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+
+import java.util.List;
+
+public interface OutboundAudioDeleterProcessorSingleElement {
+
+    List<TransientObjectDirectoryEntity> markForDeletion(UserAccountEntity userAccount,
+                                                            TransformedMediaEntity transformedMedia);
+
+    void markMediaRequestAsExpired(MediaRequestEntity mediaRequest, UserAccountEntity userAccount);
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/OutboundAudioDeleterProcessorSingleElement.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/OutboundAudioDeleterProcessorSingleElement.java
@@ -9,8 +9,7 @@ import java.util.List;
 
 public interface OutboundAudioDeleterProcessorSingleElement {
 
-    List<TransientObjectDirectoryEntity> markForDeletion(UserAccountEntity userAccount,
-                                                            TransformedMediaEntity transformedMedia);
+    List<TransientObjectDirectoryEntity> markForDeletion(UserAccountEntity userAccount, TransformedMediaEntity transformedMedia);
 
     void markMediaRequestAsExpired(MediaRequestEntity mediaRequest, UserAccountEntity userAccount);
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
@@ -20,7 +20,8 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toSet;
 
 
 @Service
@@ -52,13 +53,14 @@ public class OutboundAudioDeleterProcessorImpl implements OutboundAudioDeleterPr
         List<TransientObjectDirectoryEntity> deletedValues = new ArrayList<>();
         for (TransformedMediaEntity transformedMedia: transformedMediaList) {
             try {
-                deletedValues.addAll(singleElementProcessor.markForDeletion(systemUser, transformedMedia));
+                List<TransientObjectDirectoryEntity> deleted = singleElementProcessor.markForDeletion(systemUser, transformedMedia);
+                deletedValues.addAll(deleted);
             } catch (Exception exception) {
-                log.error("Unable to mark for deletion transformed media with id: {}", transformedMedia.getId(), exception);
+                log.error("Unable to mark for deletion transformed media {}", transformedMedia.getId(), exception);
             }
         }
 
-        Set<MediaRequestEntity> mediaRequests = transformedMediaList.stream().map(TransformedMediaEntity::getMediaRequest).collect(Collectors.toSet());
+        Set<MediaRequestEntity> mediaRequests = transformedMediaList.stream().map(TransformedMediaEntity::getMediaRequest).collect(toSet());
         mediaRequests.forEach(mr -> singleElementProcessor.markMediaRequestAsExpired(mr, systemUser));
 
         return deletedValues;

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
@@ -1,104 +1,67 @@
 package uk.gov.hmcts.darts.audio.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
-import uk.gov.hmcts.darts.audio.enums.MediaRequestStatus;
 import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.audio.service.OutboundAudioDeleterProcessor;
-import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
+import uk.gov.hmcts.darts.audio.service.OutboundAudioDeleterProcessorSingleElement;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
-import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
-import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
-
-import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
 
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class OutboundAudioDeleterProcessorImpl implements OutboundAudioDeleterProcessor {
-    private final TransientObjectDirectoryRepository transientObjectDirectoryRepository;
     private final UserAccountRepository userAccountRepository;
-    private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final LastAccessedDeletionDayCalculator deletionDayCalculator;
     private final SystemUserHelper systemUserHelper;
     private final TransformedMediaRepository transformedMediaRepository;
+    private final OutboundAudioDeleterProcessorSingleElement singleElementProcessor;
 
     @Value("${darts.audio.outbounddeleter.last-accessed-deletion-day:2}")
     private int deletionDays;
 
-    @Transactional
     public List<TransientObjectDirectoryEntity> markForDeletion() {
+
+        UserAccountEntity systemUser = userAccountRepository.findSystemUser(systemUserHelper.findSystemUserGuid(
+                "housekeeping"));
+        if (systemUser == null) {
+            throw new DartsApiException(AudioApiError.MISSING_SYSTEM_USER);
+        }
 
         OffsetDateTime deletionStartDateTime = deletionDayCalculator.getStartDateForDeletion(deletionDays);
 
         List<TransformedMediaEntity> transformedMediaList = transformedMediaRepository.findAllDeletableTransformedMedia(
-            deletionStartDateTime
-        );
-
-        List<TransientObjectDirectoryEntity> transientObjectDirectoryEntities = transientObjectDirectoryRepository
-            .findByTransformedMediaIdIn(transformedMediaList.stream().map(TransformedMediaEntity::getId)
-                                            .collect(Collectors.toList()));
-
-        UserAccountEntity systemUser = userAccountRepository.findSystemUser(systemUserHelper.findSystemUserGuid(
-            "housekeeping"));
-
-        if (systemUser == null) {
-            throw new DartsApiException(AudioApiError.MISSING_SYSTEM_USER);
-        }
-        ObjectRecordStatusEntity deletionStatus = objectRecordStatusRepository.getReferenceById(
-            MARKED_FOR_DELETION.getId());
+            deletionStartDateTime);
 
         List<TransientObjectDirectoryEntity> deletedValues = new ArrayList<>();
-        for (TransientObjectDirectoryEntity entity : transientObjectDirectoryEntities) {
-            TransformedMediaEntity transformedMedia = entity.getTransformedMedia();
-            transformedMedia.setExpiryTime(OffsetDateTime.now());
-            transformedMedia.setLastModifiedBy(systemUser);
-            markTransientObjectDirectoryAsDeleted(entity, systemUser, deletionStatus);
-            deletedValues.add(entity);
+        for (TransformedMediaEntity transformedMedia: transformedMediaList) {
+            try {
+                deletedValues.addAll(singleElementProcessor.markForDeletion(systemUser, transformedMedia));
+            } catch (Exception exception) {
+                log.error("Unable to mark for deletion transformed media with id: {}", transformedMedia.getId(), exception);
+            }
         }
 
-        for (TransformedMediaEntity tm : transformedMediaList) {
-            markMediaRequestAsExpired(tm.getMediaRequest(), systemUser);
-        }
+        Set<MediaRequestEntity> mediaRequests = transformedMediaList.stream().map(TransformedMediaEntity::getMediaRequest).collect(Collectors.toSet());
+        mediaRequests.forEach(mr -> singleElementProcessor.markMediaRequestAsExpired(mr, systemUser));
 
         return deletedValues;
-    }
-
-    private void markTransientObjectDirectoryAsDeleted(TransientObjectDirectoryEntity entity, UserAccountEntity systemUser,
-                                                       ObjectRecordStatusEntity deletionStatus) {
-        entity.setLastModifiedBy(systemUser);
-        entity.setStatus(deletionStatus);
-    }
-
-    /**
-     * Marks media request as expired if all transformed medias related to the request have an expiry time.
-     *
-     * @param mediaRequest media request to be marked as expired.
-     */
-
-    private void markMediaRequestAsExpired(MediaRequestEntity mediaRequest, UserAccountEntity systemUser) {
-        List<TransformedMediaEntity> transformedMedias = transformedMediaRepository.findByMediaRequestId(mediaRequest.getId());
-        boolean areAllTransformedMediasExpired = transformedMedias.stream().allMatch(t -> t.getExpiryTime() != null);
-        if (areAllTransformedMediasExpired) {
-            mediaRequest.setLastModifiedBy(systemUser);
-            mediaRequest.setStatus(MediaRequestStatus.EXPIRED);
-        }
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorSingleElementImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorSingleElementImpl.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.darts.audio.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
+import uk.gov.hmcts.darts.audio.enums.MediaRequestStatus;
+import uk.gov.hmcts.darts.audio.service.OutboundAudioDeleterProcessorSingleElement;
+import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
+import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
+import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
+import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
+import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OutboundAudioDeleterProcessorSingleElementImpl implements OutboundAudioDeleterProcessorSingleElement {
+
+    private final ObjectRecordStatusRepository objectRecordStatusRepository;
+    private final TransformedMediaRepository transformedMediaRepository;
+    private final TransientObjectDirectoryRepository transientObjectDirectoryRepository;
+
+    @Override
+    @Transactional
+    public List<TransientObjectDirectoryEntity> markForDeletion(UserAccountEntity userAccount,
+                                                          TransformedMediaEntity transformedMedia) {
+
+        ObjectRecordStatusEntity deletionStatus = objectRecordStatusRepository.getReferenceById(MARKED_FOR_DELETION.getId());
+        //TODO verify these changes are propagated to DB if integration test is not transactional. Are these detached at this point?
+        transformedMedia.setExpiryTime(OffsetDateTime.now());
+        transformedMedia.setLastModifiedBy(userAccount);
+
+        List<TransientObjectDirectoryEntity> transientObjectDirectoryEntities = transientObjectDirectoryRepository.findByTransformedMediaId(
+            transformedMedia.getId()
+        );
+
+        for (TransientObjectDirectoryEntity entity : transientObjectDirectoryEntities) {
+            markTransientObjectDirectoryAsDeleted(entity, userAccount, deletionStatus);
+        }
+
+        return transientObjectDirectoryEntities;
+    }
+
+    private void markTransientObjectDirectoryAsDeleted(TransientObjectDirectoryEntity entity, UserAccountEntity systemUser,
+                                                       ObjectRecordStatusEntity deletionStatus) {
+        entity.setLastModifiedBy(systemUser);
+        entity.setStatus(deletionStatus);
+    }
+
+    /**
+     * Marks media request as expired if all transformed medias related to the request have an expiry time.
+     *
+     * @param mediaRequest media request to be marked as expired.
+     */
+    @Override
+    @Transactional
+    public void markMediaRequestAsExpired(MediaRequestEntity mediaRequest, UserAccountEntity userAccount) {
+        List<TransformedMediaEntity> transformedMedias = transformedMediaRepository.findByMediaRequestId(mediaRequest.getId());
+        boolean areAllTransformedMediasExpired = transformedMedias.stream().allMatch(t -> t.getExpiryTime() != null);
+        if (areAllTransformedMediasExpired) {
+            mediaRequest.setLastModifiedBy(userAccount);
+            mediaRequest.setStatus(MediaRequestStatus.EXPIRED);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorSingleElementImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorSingleElementImpl.java
@@ -11,12 +11,12 @@ import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 
-import java.time.OffsetDateTime;
 import java.util.List;
 
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
@@ -31,6 +31,7 @@ public class OutboundAudioDeleterProcessorSingleElementImpl implements OutboundA
     private final TransformedMediaRepository transformedMediaRepository;
     private final TransientObjectDirectoryRepository transientObjectDirectoryRepository;
     private final MediaRequestRepository mediaRequestRepository;
+    private final CurrentTimeHelper currentTimeHelper;
 
     @Override
     @Transactional
@@ -69,7 +70,7 @@ public class OutboundAudioDeleterProcessorSingleElementImpl implements OutboundA
 
     private void markTransformedMediaAsExpired(UserAccountEntity userAccount, TransformedMediaEntity transformedMedia) {
 
-        transformedMedia.setExpiryTime(OffsetDateTime.now());
+        transformedMedia.setExpiryTime(currentTimeHelper.currentOffsetDateTime());
         transformedMedia.setLastModifiedBy(userAccount);
         transformedMediaRepository.saveAndFlush(transformedMedia);
     }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorSingleElementImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorSingleElementImpl.java
@@ -34,8 +34,7 @@ public class OutboundAudioDeleterProcessorSingleElementImpl implements OutboundA
 
     @Override
     @Transactional
-    public List<TransientObjectDirectoryEntity> markForDeletion(UserAccountEntity userAccount,
-                                                          TransformedMediaEntity transformedMedia) {
+    public List<TransientObjectDirectoryEntity> markForDeletion(UserAccountEntity userAccount, TransformedMediaEntity transformedMedia) {
 
         markTransformedMediaAsExpired(userAccount, transformedMedia);
 
@@ -58,6 +57,7 @@ public class OutboundAudioDeleterProcessorSingleElementImpl implements OutboundA
     @Override
     @Transactional
     public void markMediaRequestAsExpired(MediaRequestEntity mediaRequest, UserAccountEntity userAccount) {
+
         List<TransformedMediaEntity> transformedMedias = transformedMediaRepository.findByMediaRequestId(mediaRequest.getId());
         boolean areAllTransformedMediasExpired = transformedMedias.stream().allMatch(t -> t.getExpiryTime() != null);
         if (areAllTransformedMediasExpired) {
@@ -68,6 +68,7 @@ public class OutboundAudioDeleterProcessorSingleElementImpl implements OutboundA
     }
 
     private void markTransformedMediaAsExpired(UserAccountEntity userAccount, TransformedMediaEntity transformedMedia) {
+
         transformedMedia.setExpiryTime(OffsetDateTime.now());
         transformedMedia.setLastModifiedBy(userAccount);
         transformedMediaRepository.saveAndFlush(transformedMedia);
@@ -75,6 +76,7 @@ public class OutboundAudioDeleterProcessorSingleElementImpl implements OutboundA
 
     private void markTransientObjectDirectoryAsDeleted(TransientObjectDirectoryEntity entity, UserAccountEntity systemUser,
                                                        ObjectRecordStatusEntity deletionStatus) {
+
         entity.setLastModifiedBy(systemUser);
         entity.setStatus(deletionStatus);
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TransientObjectDirectoryEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TransientObjectDirectoryEntity.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,11 +29,11 @@ public class TransientObjectDirectoryEntity extends CreatedModifiedBaseEntity im
     @SequenceGenerator(name = "tod_gen", sequenceName = "tod_seq", allocationSize = 1)
     private Integer id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "trm_id", foreignKey = @ForeignKey(name = "tod_transformed_media_fk"), nullable = false)
     private TransformedMediaEntity transformedMedia;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "ors_id", foreignKey = @ForeignKey(name = "tod_object_record_status_fk"), nullable = false)
     private ObjectRecordStatusEntity status;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedModifiedBaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedModifiedBaseEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.common.entity.base;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
@@ -20,7 +21,7 @@ public class CreatedModifiedBaseEntity extends CreatedBaseEntity {
     @Column(name = "last_modified_ts")
     private OffsetDateTime lastModifiedDateTime;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "last_modified_by")
     private UserAccountEntity lastModifiedBy;
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedModifiedBaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedModifiedBaseEntity.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.common.entity.base;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
@@ -21,7 +20,7 @@ public class CreatedModifiedBaseEntity extends CreatedBaseEntity {
     @Column(name = "last_modified_ts")
     private OffsetDateTime lastModifiedDateTime;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "last_modified_by")
     private UserAccountEntity lastModifiedBy;
 }

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImplTest.java
@@ -5,34 +5,36 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.audio.service.OutboundAudioDeleterProcessorSingleElement;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
+import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
-import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
-import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OutboundAudioDeleterProcessorImplTest {
     @Mock
     LastAccessedDeletionDayCalculator lastAccessedDeletionDayCalculator;
-
-    @Mock
-    private TransientObjectDirectoryRepository transientObjectDirectoryRepository;
-
     @Mock
     private UserAccountRepository userAccountRepository;
     @Mock
+    private UserAccountEntity userAccountEntity;
+    @Mock
     private ObjectRecordStatusRepository objectRecordStatusRepository;
+    @Mock
+    private OutboundAudioDeleterProcessorSingleElement singleElementProcessor;
     private OutboundAudioDeleterProcessorImpl outboundAudioDeleterProcessorImpl;
 
     @Mock
@@ -44,26 +46,35 @@ class OutboundAudioDeleterProcessorImplTest {
     @BeforeEach
     void setUp() {
         this.outboundAudioDeleterProcessorImpl = new OutboundAudioDeleterProcessorImpl(
-            transientObjectDirectoryRepository,
-            userAccountRepository,
-            objectRecordStatusRepository, lastAccessedDeletionDayCalculator,
-            systemUserHelper, transformedMediaRepository
+            userAccountRepository, lastAccessedDeletionDayCalculator,
+            systemUserHelper, transformedMediaRepository,
+            singleElementProcessor
         );
         when(systemUserHelper.findSystemUserGuid(anyString())).thenReturn("value");
-
+        when(userAccountRepository.findSystemUser(any())).thenReturn(userAccountEntity);
     }
 
     @Test
     void testDeleteWhenSystemUserDoesNotExist() {
-        List<TransformedMediaEntity> value = new ArrayList<>();
-        value.add(new TransformedMediaEntity());
+        when(userAccountRepository.findSystemUser(any())).thenReturn(null);
 
-        when(transformedMediaRepository.findAllDeletableTransformedMedia(any())).thenReturn(value);
-
-        when(systemUserHelper.findSystemUserGuid(anyString())).thenReturn(null);
         assertThrows(DartsApiException.class, () ->
             outboundAudioDeleterProcessorImpl.markForDeletion());
     }
 
+    @Test
+    void testContinuesProcessingNextIterationOnException() {
+        List<TransformedMediaEntity> transformedMediaEntities = List.of(new TransformedMediaEntity(), new TransformedMediaEntity());
+        when(transformedMediaRepository.findAllDeletableTransformedMedia(any())).thenReturn(transformedMediaEntities);
+
+        var deletedValues = List.of(new TransientObjectDirectoryEntity());
+        when(singleElementProcessor.markForDeletion(any(), any()))
+                .thenThrow(new RuntimeException("Some error!"))
+                .thenReturn(deletedValues);
+
+        List<TransientObjectDirectoryEntity> result = outboundAudioDeleterProcessorImpl.markForDeletion();
+
+        assertThat(result).isEqualTo(deletedValues);
+    }
 }
 

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImplTest.java
@@ -64,16 +64,19 @@ class OutboundAudioDeleterProcessorImplTest {
 
     @Test
     void testContinuesProcessingNextIterationOnException() {
+        // given
         List<TransformedMediaEntity> transformedMediaEntities = List.of(new TransformedMediaEntity(), new TransformedMediaEntity());
         when(transformedMediaRepository.findAllDeletableTransformedMedia(any())).thenReturn(transformedMediaEntities);
 
         var deletedValues = List.of(new TransientObjectDirectoryEntity());
         when(singleElementProcessor.markForDeletion(any(), any()))
-                .thenThrow(new RuntimeException("Some error!"))
+                .thenThrow(new RuntimeException("Some error"))
                 .thenReturn(deletedValues);
 
+        // when
         List<TransientObjectDirectoryEntity> result = outboundAudioDeleterProcessorImpl.markForDeletion();
 
+        // then
         assertThat(result).isEqualTo(deletedValues);
     }
 }


### PR DESCRIPTION
…d operation iteration to improve job performance

### JIRA link ###
https://tools.hmcts.net/jira/browse/DMP-2259


### Change description ###
Additional changes:
- removed `@Transactional` from integration tests to prevent false negatives (test passing when instead it should have failed due to a bug in the production code). Integration tests would be better not be `@Transactional` to have the test running in a setting that replicates Production
- changed some JPA one-to-one entity associations to be eagerly fetched (default) rather than lazy. Lazy loading is recommended for *-to-many associations, but lazy loading one-to-one complicates working with entities and should be enabled only **after** measuring performance and if justified by a relevant perf improvement. To avoids premature optimisations.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
