### PR TITLE
DMP-2277 Fixing request transcription duplicate checking logic

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
@@ -178,6 +178,50 @@ public class TranscriptionStub {
         return transcriptionRepository.saveAndFlush(transcriptionEntity);
     }
 
+    @Transactional
+    public TranscriptionEntity createAndSaveCompletedTranscription(UserAccountEntity userAccountEntity,
+                                                                   CourtCaseEntity courtCaseEntity,
+                                                                   HearingEntity hearingEntity,
+                                                                   OffsetDateTime startDate,
+                                                                   OffsetDateTime endDate,
+                                                                   OffsetDateTime workflowTimestamp,
+                                                                   Boolean hideRequestFromRequester) {
+        var transcriptionEntity = this.createTranscriptionWithStatus(
+            userAccountEntity,
+            courtCaseEntity,
+            hearingEntity,
+            workflowTimestamp,
+            getTranscriptionStatusByEnum(COMPLETE)
+        );
+        transcriptionEntity.setHideRequestFromRequestor(hideRequestFromRequester);
+        transcriptionEntity.setStartTime(startDate);
+        transcriptionEntity.setEndTime(endDate);
+        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+    }
+
+    @Transactional
+    public TranscriptionEntity createAndSaveCompletedTranscription(UserAccountEntity userAccountEntity,
+                                                                   CourtCaseEntity courtCaseEntity,
+                                                                   HearingEntity hearingEntity,
+                                                                   OffsetDateTime startDate,
+                                                                   OffsetDateTime endDate,
+                                                                   TranscriptionTypeEntity transcriptionType,
+                                                                   OffsetDateTime workflowTimestamp,
+                                                                   Boolean hideRequestFromRequester) {
+        var transcriptionEntity = this.createTranscriptionWithStatus(
+            userAccountEntity,
+            courtCaseEntity,
+            hearingEntity,
+            workflowTimestamp,
+            getTranscriptionStatusByEnum(COMPLETE)
+        );
+        transcriptionEntity.setHideRequestFromRequestor(hideRequestFromRequester);
+        transcriptionEntity.setStartTime(startDate);
+        transcriptionEntity.setEndTime(endDate);
+        transcriptionEntity.setTranscriptionType(transcriptionType);
+        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+    }
+
     public TranscriptionWorkflowEntity createTranscriptionWorkflowEntity(TranscriptionEntity transcriptionEntity,
                                                                          UserAccountEntity user,
                                                                          OffsetDateTime timestamp,

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionStatusEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionStatusEntity.java
@@ -5,13 +5,19 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Table(name = "transcription_status")
 @Getter
+@NoArgsConstructor
 @Setter
 public class TranscriptionStatusEntity {
+
+    public TranscriptionStatusEntity(Integer id) {
+        this.setId(id);
+    }
 
     @Id
     @Column(name = "trs_id", nullable = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepository.java
@@ -45,19 +45,21 @@ public interface TranscriptionRepository extends JpaRepository<TranscriptionEnti
     @Query("""
         SELECT t
         FROM TranscriptionEntity t
-        join t.hearings hearing
+        JOIN t.hearings hearing
         WHERE hearing.id = :hearingId
         AND t.transcriptionType = :transcriptionType
-        AND t.startTime = :startTime
-        AND t.endTime = :endTime
+        AND (t.startTime IS NULL OR t.startTime = :startTime)
+        AND (t.endTime IS NULL OR t.endTime = :endTime)
         AND t.isManualTranscription = :isManual
+        AND t.transcriptionStatus NOT IN (:ignoreStatuses)
         """)
-    List<TranscriptionEntity> findByHearingIdTypeStartAndEndAndIsManual(
+    List<TranscriptionEntity> findByHearingIdTypeStartAndEndAndIsManualAndNotStatus(
         Integer hearingId,
         TranscriptionTypeEntity transcriptionType,
         OffsetDateTime startTime,
         OffsetDateTime endTime,
-        Boolean isManual
+        Boolean isManual,
+        List<TranscriptionStatusEntity> ignoreStatuses
     );
 
     List<TranscriptionEntity> findByIdIn(List<Integer> transcriptionIds);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[TODO](https://tools.hmcts.net/jira/browse/DMP-2277)

### Change description ###

- don't match on closed or rejected transcriptions
- also checking requests without start/end times
- only returning `duplicate_transcription_id` when a matching record is completed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
