### PR TITLE
NOJIRA: moved to new Gradle API to reduce configuration time. Marked …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
   id 'checkstyle'
   id 'pmd'
   id 'jacoco'
+  id 'idea'
   id 'io.spring.dependency-management' version '1.1.4'
   id 'org.springframework.boot' version '3.2.2'
   id 'org.owasp.dependencycheck' version '9.0.9'
@@ -29,7 +30,7 @@ jacoco {
 group = 'uk.gov.hmcts'
 version = '0.0.1'
 
-compileJava   {
+compileJava {
   sourceCompatibility = '17'
   targetCompatibility = '17'
 }
@@ -42,7 +43,7 @@ java {
 
 sourceSets {
   main {
-    java.srcDirs += 'build/generated/openapi/src/main/java'
+    java.srcDir "$buildDir/generated/openapi/src/main/java"
   }
 
   functionalTest {
@@ -73,7 +74,18 @@ sourceSets {
   }
 }
 
-configurations.all {
+idea {
+  module {
+    testSources.from(sourceSets.integrationTest.allSource.srcDirs)
+    testResources.from(sourceSets.integrationTest.resources.srcDirs)
+    testSources.from(sourceSets.functionalTest.allSource.srcDirs)
+    testResources.from(sourceSets.functionalTest.resources.srcDirs)
+    testSources.from(sourceSets.smokeTest.allSource.srcDirs)
+    testResources.from(sourceSets.smokeTest.resources.srcDirs)
+  }
+}
+
+configurations.configureEach {
   exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on' // bcprov-jdk18on-1.73.jar CVE-2023-33201
 }
 
@@ -90,7 +102,7 @@ configurations {
   openapispecifications
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
@@ -99,7 +111,7 @@ tasks.withType(JavaExec).configureEach {
   javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
   useJUnitPlatform()
 
   testLogging {
@@ -107,21 +119,21 @@ tasks.withType(Test) {
   }
 }
 
-task functional(type: Test) {
+tasks.register('functional', Test) {
   description = "Runs functional tests"
   group = "Verification"
   testClassesDirs = sourceSets.functionalTest.output.classesDirs
   classpath = sourceSets.functionalTest.runtimeClasspath
 }
 
-task integration(type: Test) {
+tasks.register('integration', Test) {
   description = "Runs integration tests"
   group = "Verification"
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-task smoke(type: Test) {
+tasks.register('smoke', Test) {
   description = "Runs Smoke Tests"
   testClassesDirs = sourceSets.smokeTest.output.classesDirs
   classpath = sourceSets.smokeTest.runtimeClasspath
@@ -307,7 +319,7 @@ swaggerList.each {
   def apiName = it.getName().replace(".yaml", "");
   def taskName = "openApiGenerate" + apiName.capitalize()
   openApiGenerateTaskList << taskName
-  tasks.create(taskName, org.openapitools.generator.gradle.plugin.tasks.GenerateTask, {
+  tasks.register(taskName, org.openapitools.generator.gradle.plugin.tasks.GenerateTask, {
     generatorName = "spring"
     inputSpec = "$rootDir/src/main/resources/openapi/".toString() + "${apiName}.yaml"
     outputDir = "$buildDir/generated/openapi".toString()
@@ -484,13 +496,13 @@ flyway {
 }
 
 // this can be run to clean the DB down allowing from a fresh migration from scratch
-task cleanPostgresDatabase(type: org.flywaydb.gradle.task.FlywayCleanTask) {
+tasks.register('cleanPostgresDatabase', org.flywaydb.gradle.task.FlywayCleanTask) {
   if (project.hasProperty("dburl")) {
     url = "jdbc:postgresql://${dburl}"
   }
 }
 
-task migratePostgresDatabase(type: org.flywaydb.gradle.task.FlywayMigrateTask) {
+tasks.register('migratePostgresDatabase', org.flywaydb.gradle.task.FlywayMigrateTask) {
   baselineOnMigrate = true
   if (project.hasProperty("dburl")) {
     url = "jdbc:postgresql://${dburl}"
@@ -498,7 +510,7 @@ task migratePostgresDatabase(type: org.flywaydb.gradle.task.FlywayMigrateTask) {
 }
 
 // Add a new jar that will be published to maven with the classifier -openapi
-task openapiJar(type: Jar) {
+tasks.register('openapiJar', Jar) {
   archiveClassifier = 'openapi'
   from layout.buildDirectory.dir("processedSpecs").get().asFile
 }
@@ -513,7 +525,7 @@ publishing {
     }
 }
 
-task updateOpenSpecificationsWithVersion() {
+tasks.register('updateOpenSpecificationsWithVersion') {
 
   doLast {
     def fileDir = "$projectDir/src/main/resources/openapi/"


### PR DESCRIPTION
Description:

- Moved to new Gradle API to reduce configuration time and eliminate IDE warnings. See here for details: https://blog.gradle.org/preview-avoiding-task-configuration-time
- Marked integrationTests and other tests source sets as test sources by using Intellij IDEA plugin. So that these are correctly recognised as test sources by IntelliJ

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
