### PR TITLE
Origin/dmp 2282 implement get  admin courthouses courthouse

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/FunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/FunctionalTest.java
@@ -87,7 +87,7 @@ public class FunctionalTest {
             .delete();
     }
 
-    private RequestSpecification buildRequestWithAuth(AccessTokenClient accessTokenClient) {
+    protected RequestSpecification buildRequestWithAuth(AccessTokenClient accessTokenClient) {
         return RestAssured.given()
             .header("Authorization", String.format("Bearer %s", accessTokenClient.getAccessToken()));
     }

--- a/src/functionalTest/java/uk/gov/hmcts/darts/courthouses/CourthousesFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/courthouses/CourthousesFunctionalTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.courthouses;
 
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.darts.AccessTokenClient;
 import uk.gov.hmcts.darts.FunctionalTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CourthousesFunctionalTest extends FunctionalTest {
 
     public static final String COURTHOUSES_URI = "/courthouses";
+    public static final String ADMIN_COURTHOUSES_URI = "/admin/courthouses";
     public static final String COURTHOUSE_BODY = """
         {"courthouse_name": "BIRMINGHAM","display_name": "Birmingham","code": 5705}""";
     public static final String COURTHOUSE_UPDATEBODY = """
@@ -38,6 +42,14 @@ class CourthousesFunctionalTest extends FunctionalTest {
     public static final int INTERNAL_SERVER_ERROR = 500;
 
     private int testCourthouseId;
+
+    @Autowired
+    private AccessTokenClient externalGlobalAccessTokenClient;
+
+    @Override
+    public RequestSpecification buildRequestWithExternalGlobalAccessAuth() {
+        return buildRequestWithAuth(externalGlobalAccessTokenClient);
+    }
 
     @Test
     @Order(1)
@@ -121,10 +133,10 @@ class CourthousesFunctionalTest extends FunctionalTest {
     @Test
     @Order(6)
     void getExistingCourthouse() {
-        Response response = buildRequestWithExternalAuth()
+        Response response = buildRequestWithExternalGlobalAccessAuth()
             .contentType(ContentType.JSON)
             .when()
-            .baseUri(getUri(COURTHOUSES_URI + "/" + testCourthouseId))
+            .baseUri(getUri(ADMIN_COURTHOUSES_URI + "/" + testCourthouseId))
             .get()
             .then()
             .extract().response();
@@ -136,10 +148,10 @@ class CourthousesFunctionalTest extends FunctionalTest {
     @Test
     @Order(7)
     void getCourthouseIdDoesNotExist() {
-        Response response = buildRequestWithExternalAuth()
+        Response response = buildRequestWithExternalGlobalAccessAuth()
             .contentType(ContentType.JSON)
             .when()
-            .baseUri(getUri(COURTHOUSES_URI + COURTHOUSE_BAD_ID))
+            .baseUri(getUri(ADMIN_COURTHOUSES_URI + COURTHOUSE_BAD_ID))
             .get()
             .then()
             .extract().response();

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CourthouseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CourthouseEntity.java
@@ -14,8 +14,10 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.collections4.CollectionUtils;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -49,7 +51,33 @@ public class CourthouseEntity extends CreatedModifiedBaseEntity {
         inverseJoinColumns = {@JoinColumn(name = "grp_id")})
     private Set<SecurityGroupEntity> securityGroups = new LinkedHashSet<>();
 
+    @ManyToMany
+    @JoinTable(name = "courthouse_region_ae",
+        joinColumns = {@JoinColumn(name = "cth_id")},
+        inverseJoinColumns = {@JoinColumn(name = "reg_id")})
+    private Set<RegionEntity> regions = new LinkedHashSet<>();
+
     @Column(name = "display_name")
     private String displayName;
+
+    public RegionEntity getRegion() throws IllegalStateException {
+
+        if (regions != null && regions.size() > 1) {
+            throw new IllegalStateException();
+        } else if (CollectionUtils.isEmpty(regions)) {
+            return null;
+        }
+
+        return regions.stream().findFirst().get();
+    }
+
+    public void setRegion(RegionEntity region) throws IllegalStateException {
+
+        if (regions != null && regions.size() > 1) {
+            throw new IllegalStateException();
+        }
+
+        regions = (region == null) ? Collections.emptySet() : Collections.singleton(region);
+    }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/RegionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/RegionEntity.java
@@ -5,11 +5,17 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 
 @Entity
@@ -27,5 +33,11 @@ public class RegionEntity {
 
     @Column(name = "region_name")
     private String regionName;
+
+    @ManyToMany
+    @JoinTable(name = "courthouse_region_ae",
+        joinColumns = {@JoinColumn(name = "cth_id")},
+        inverseJoinColumns = {@JoinColumn(name = "reg_id")})
+    private Set<CourthouseEntity> courthouseEntities = new LinkedHashSet<>();
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/mapper/AdminCourthouseToCourthouseEntityMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/mapper/AdminCourthouseToCourthouseEntityMapper.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.darts.courthouse.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
+import uk.gov.hmcts.darts.courthouse.model.AdminCourthouse;
+import uk.gov.hmcts.darts.courthouse.model.Courthouse;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE, componentModel = "spring")
+public interface AdminCourthouseToCourthouseEntityMapper {
+    CourthouseEntity mapToEntity(Courthouse courthouse);
+
+    AdminCourthouse mapFromEntityToAdminCourthouse(CourthouseEntity courthouseEntity);
+
+    @Mappings({
+        @Mapping(target = "createdDateTime", source = "createdDateTime", qualifiedByName = "createdDateTime"),
+        @Mapping(target = "lastModifiedDateTime", source = "lastModifiedDateTime", qualifiedByName = "lastModifiedDateTime")
+    })
+
+    List<AdminCourthouse> mapFromListEntityToListAdminCourthouse(List<CourthouseEntity> courthouses);
+
+    default String map(OffsetDateTime value) {
+        return value.toString();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/service/CourthouseService.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/service/CourthouseService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.courthouse.service;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.courthouse.exception.CourthouseCodeNotMatchException;
 import uk.gov.hmcts.darts.courthouse.exception.CourthouseNameNotFoundException;
+import uk.gov.hmcts.darts.courthouse.model.AdminCourthouse;
 import uk.gov.hmcts.darts.courthouse.model.Courthouse;
 
 import java.util.List;
@@ -21,4 +22,6 @@ public interface CourthouseService {
 
     CourthouseEntity retrieveAndUpdateCourtHouse(Integer courthouseCode, String courthouseName)
         throws CourthouseNameNotFoundException, CourthouseCodeNotMatchException;
+
+    AdminCourthouse getAdminCourtHouseById(Integer id);
 }

--- a/src/main/resources/openapi/courthouse.yaml
+++ b/src/main/resources/openapi/courthouse.yaml
@@ -24,7 +24,7 @@ paths:
         '400':
           description: A required parameter is missing or an invalid datatype or value was provided for property.
         '409':
-            description: Resource already exists.
+          description: Resource already exists.
         '500':
           description: Internal Server Error
     get:
@@ -41,7 +41,7 @@ paths:
         '500':
           description: Internal Server Error
 
-  /courthouses/{courthouse_id}:
+  /admin/courthouses/{courthouse_id}:
     get:
       tags:
         - Courthouses
@@ -58,13 +58,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ExtendedCourthouse'
+                $ref: '#/components/schemas/AdminCourthouse'
         '400':
           description: A required parameter is missing or an invalid datatype or value was provided for property.
+        '403':
+          description: Forbidden Error
+          content:
+            application/json+problem:
+              schema:
+                allOf:
+                  - $ref: './problem.yaml'
+                  - type: object
+                    required:
+                      - type
+                    properties:
+                      type:
+                        $ref: '#/components/schemas/UserAuthorisation403_109ErrorCode'
+              example:
+                type: AUTHORISATION_109
+                title: User is not authorised for this endpoint
+                status: 403
         '404':
           description: Resource with the provided id does not exist.
         '500':
           description: Internal Server Error
+  /courthouses/{courthouse_id}:
     put:
       tags:
         - Courthouses
@@ -85,7 +103,7 @@ paths:
         '409':
           description: Returned in the case where courthouse name or code amended is not unique.
         '404':
-            description: Resource with the provided id does not exist.
+          description: Resource with the provided id does not exist.
         '500':
           description: Internal Server Error
     delete:
@@ -127,6 +145,23 @@ components:
           type: integer
         display_name:
           type: string
+        region_id:
+          type: integer
+          example: 0
+    AdminCourthouse:
+      allOf:
+        - $ref: '#/components/schemas/ExtendedCourthouse'
+        - type: object
+          properties:
+            region_id:
+              type: integer
+              example: 0
+            security_group_ids:
+              type: array
+              items:
+                type: integer
+              example: [1, 2]
+
     ExtendedCourthouse:
       allOf:
         - $ref: '#/components/schemas/Courthouse'
@@ -137,24 +172,33 @@ components:
             created_date_time:
               type: string
               format: date-time
+              example: "2024-02-09T14:26:31.118Z"
             last_modified_date_time:
               type: string
               format: date-time
+              example: "2024-02-09T14:26:31.118Z"
+
     CourtList:
       type: array
       items:
         $ref: '#/components/schemas/ExtendedCourthouse'
 
     CourthouseErrorCode:
-     type: string
-     enum:
-      - "COURTHOUSE_100"
-      - "COURTHOUSE_101"
-     x-enum-varnames: [ COURTHOUSE_NAME_PROVIDED_ALREADY_EXISTS, COURTHOUSE_CODE_PROVIDED_ALREADY_EXISTS ]
+      type: string
+      enum:
+        - "COURTHOUSE_100"
+        - "COURTHOUSE_101"
+      x-enum-varnames: [ COURTHOUSE_NAME_PROVIDED_ALREADY_EXISTS, COURTHOUSE_CODE_PROVIDED_ALREADY_EXISTS ]
 
     CourthouseTitleErrors:
-     type: string
-     enum:
-      - "Provided courthouse name already exists."
-      - "Provided courthouse code already exists."
-     x-enum-varnames: [ COURTHOUSE_NAME_PROVIDED_ALREADY_EXISTS, COURTHOUSE_CODE_PROVIDED_ALREADY_EXISTS ]
+      type: string
+      enum:
+        - "Provided courthouse name already exists."
+        - "Provided courthouse code already exists."
+      x-enum-varnames: [ COURTHOUSE_NAME_PROVIDED_ALREADY_EXISTS, COURTHOUSE_CODE_PROVIDED_ALREADY_EXISTS ]
+
+    UserAuthorisation403_109ErrorCode:
+      type: string
+      enum:
+        - "AUTHORISATION_109"
+      x-enum-varnames: [ USER_NOT_AUTHORISED_FOR_ENDPOINT ]

--- a/src/test/java/uk/gov/hmcts/darts/courthouse/service/CourthouseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/courthouse/service/CourthouseServiceImplTest.java
@@ -9,6 +9,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
+import uk.gov.hmcts.darts.common.entity.RegionEntity;
+import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.CourthouseRepository;
 import uk.gov.hmcts.darts.courthouse.exception.CourthouseCodeNotMatchException;
@@ -17,10 +19,14 @@ import uk.gov.hmcts.darts.courthouse.mapper.CourthouseToCourthouseEntityMapper;
 import uk.gov.hmcts.darts.courthouse.model.Courthouse;
 
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -234,6 +240,124 @@ class CourthouseServiceImplTest {
         courthouseEntity.setCode(SWANSEA_CODE);
         return courthouseEntity;
     }
+
+    @Test
+    void adminCourtHouseEmptyRegions() {
+
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+        Set<RegionEntity> regions = new LinkedHashSet<>();
+
+        courthouseEntity.setRegions(regions);
+
+        assertNull(courthouseEntity.getRegion());
+
+    }
+
+    @Test
+    void adminCourtHouseNullRegions() {
+
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+        courthouseEntity.setRegions(null);
+        courthouseEntity.setRegion(null);
+
+        assertNull(courthouseEntity.getRegion());
+
+    }
+
+    @Test
+    void adminCourtHouseSetOneRegionAndNoRegions() {
+
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+
+        RegionEntity region1 = new RegionEntity();
+        region1.setId(5);
+
+        courthouseEntity.setRegions(null);
+        courthouseEntity.setRegion(region1);
+
+        assertEquals(5, courthouseEntity.getRegion().getId());
+    }
+
+    @Test
+    void adminCourtHouseSetRegionsAndRegion() {
+
+        Set<RegionEntity> regions = new LinkedHashSet<>();
+        RegionEntity region1 = new RegionEntity();
+        region1.setId(5);
+        RegionEntity region2 = new RegionEntity();
+        region2.setId(6);
+        regions.add(region1);
+
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+        courthouseEntity.setRegions(regions);
+        courthouseEntity.setRegion(region2);
+
+        assertEquals(6, courthouseEntity.getRegion().getId());
+    }
+
+    @Test
+    void adminCourtHouseSetRegionsWithTwoRegionEntities() {
+
+        Set<RegionEntity> regions = new LinkedHashSet<>();
+        RegionEntity region1 = new RegionEntity();
+        region1.setId(5);
+        RegionEntity region2 = new RegionEntity();
+        region2.setId(6);
+        regions.add(region1);
+        regions.add(region2);
+
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+        courthouseEntity.setRegions(regions);
+
+        Exception exception = assertThrows(IllegalStateException.class, courthouseEntity::getRegion);
+
+        assertNull(exception.getMessage());
+
+    }
+
+    @Test
+    void adminCourtHouseSetOneRegion() {
+
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+
+        Set<RegionEntity> regions = new LinkedHashSet<>();
+        RegionEntity region1 = new RegionEntity();
+        region1.setId(5);
+
+        courthouseEntity.setRegions(regions);
+        courthouseEntity.setRegion(region1);
+
+        assertEquals(5, courthouseEntity.getRegion().getId());
+
+    }
+
+    @Test
+    void adminCourtHouseSecurityRegions() {
+
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+        courthouseEntity.setCourthouseName(TEST_COURTHOUSE_NAME);
+        courthouseEntity.setId(88);
+        courthouseEntity.setCode(CODE);
+
+        Set<SecurityGroupEntity> securityGroups = new LinkedHashSet<>();
+        SecurityGroupEntity securityGroup1 = new SecurityGroupEntity();
+        securityGroup1.setId(3);
+        SecurityGroupEntity securityGroup2 = new SecurityGroupEntity();
+        securityGroup2.setId(4);
+
+        securityGroups.add(securityGroup1);
+        securityGroups.add(securityGroup2);
+
+        courthouseEntity.setSecurityGroups(securityGroups);
+
+        Set<SecurityGroupEntity> secGrps = courthouseEntity.getSecurityGroups();
+        Set<Integer> expectedList = new LinkedHashSet<>(Arrays.asList(3, 4));
+        Set<Integer> actualList = secGrps.stream().map(SecurityGroupEntity::getId).collect(Collectors.toSet());
+
+        assertEquals(expectedList, actualList);
+
+    }
+
 
 
 }


### PR DESCRIPTION
This PR relates to 2 jira tickets:

1. https://tools.hmcts.net/jira/browse/DMP-2282
2. https://tools.hmcts.net/jira/browse/DMP-2296


### Change description ###
Implement this relation in both CourthouseEntity and RegionEntity as a many-to-many Set, such that the association is navigable from both directions.

Change the path of `GET /courthouses/{courthouse_id}` to `GET /admin/courthouses/{courthouse_id}`, and update the API response schema to include `region_id` and `security_group_ids` fields as below. Authorisation should also be added to ensure only users with ADMIN role can call this endpoint.

Response
{
  "id": 0,
  "courthouse_name": "string",
  "display_name": "string",
  "region_id": 0 \\ NEW,
  "security_group_ids": [ 1, 2 ] \\ NEW
  "created_date_time": "2024-02-09T14:26:31.118Z",
  "last_modified_date_time": "2024-02-09T14:26:31.118Z"
} 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
