### PR TITLE
Schedule notifications to invalid addresses in database

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/notification/service/NotificationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/notification/service/NotificationServiceTest.java
@@ -74,21 +74,6 @@ class NotificationServiceTest extends IntegrationBase {
     }
 
     @Test
-    void scheduleNotificationInvalidEmail() {
-        var caseId = dartsDatabase.save(someMinimalCase()).getId();
-        SaveNotificationToDbRequest request = SaveNotificationToDbRequest.builder()
-            .eventId("An eventId")
-            .caseId(caseId)
-            .emailAddresses("test@test@.com")
-            .build();
-
-        service.scheduleNotification(request);
-
-        List<NotificationEntity> resultList = dartsDatabase.getNotificationsForCase(caseId);
-        assertEquals(0, resultList.size());
-    }
-
-    @Test
     void sendNotificationToGovNotifyNow() throws TemplateNotFoundException {
         var caseId = dartsDatabase.save(someMinimalCase()).getId();
         when(templateIdHelper.findTemplateId(REQUEST_TO_TRANSCRIBER.toString())).thenReturn(

--- a/src/main/java/uk/gov/hmcts/darts/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/service/impl/NotificationServiceImpl.java
@@ -102,7 +102,6 @@ public class NotificationServiceImpl implements NotificationService {
                 emailAddressList,
                 request.getUserAccountsToEmail().stream()
                     .map(UserAccountEntity::getEmailAddress)
-                    .filter(emailAddress -> EmailValidator.getInstance().isValid(emailAddress))
                     .toList()
             );
         }
@@ -111,10 +110,6 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     private NotificationEntity saveNotificationToDb(String eventId, Integer caseId, String emailAddress, String templateValues) {
-        if (!emailValidator.isValid(emailAddress)) {
-            log.warn("The supplied email address, {}, is not valid, and so has been ignored.", emailAddress);
-            return null;
-        }
         NotificationEntity dbNotification = new NotificationEntity();
         dbNotification.setEventId(eventId);
         dbNotification.setCourtCase(caseRepository.getReferenceById(caseId));


### PR DESCRIPTION
### Change description ###
When a notification has an invalid email address, we should still store that notification in a failed state in the database. Gov Notify has it's own inbuilt invalid email address feature out of the box. Without this change, there is a risk that notifications would be lost with no chance of recovery. This change would allow a DB admin to change an email address stored against a failed scheduled notification and resend if the need ever arose. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
