### PR TITLE
DMP-2394 Removed `@Transactional` from some tests, and fixed producti…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestType;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.notification.api.NotificationApi;
@@ -71,7 +70,6 @@ class AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest extends
         hearing = given.aHearingWith("T202304130121", "some-courthouse", "some-courtroom", MOCK_HEARING_DATE);
     }
 
-    @Transactional
     @Test
     @SuppressWarnings("PMD.LawOfDemeter")
     public void handleKedaInvocationForMediaRequestsShouldSucceedAndUpdateRequestStatusToCompletedAndScheduleSuccessNotificationForDownload() {
@@ -104,7 +102,6 @@ class AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest extends
     }
 
     @Test
-    @Transactional
     @SuppressWarnings("PMD.LawOfDemeter")
     public void handleKedaInvocationForMediaRequestsShouldSucceedAndUpdateRequestStatusToCompletedAndScheduleSuccessNotificationForPlayback() {
         given.aMediaEntityGraph();
@@ -186,7 +183,6 @@ class AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest extends
 
     @ParameterizedTest
     @EnumSource(names = {"DOWNLOAD", "PLAYBACK"})
-    @Transactional
     public void handleKedaInvocationForMediaRequestsShouldNotInvokeProcessAudioRequestWhenNoOpenMediaRequestsExist(
         AudioRequestType audioRequestType) {
         given.aUserAccount(EMAIL_ADDRESS);

--- a/src/main/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImpl.java
@@ -45,7 +45,7 @@ public class DataManagementFacadeImpl implements DataManagementFacade {
                 if (containerName.isPresent()
                         && dataToDownload.isForLocationType(getForDatastoreContainerType(type))
                         && processObjectDirectoryForContainerType(dataToDownload, type, configuration.isFetchFromDetsEnabled())) {
-                        log.info("Downloading blob id {} from container {}", dataToDownload.getExternalLocationType(), type.name());
+                        log.info("Downloading blob id {} from container {}", dataToDownload.getExternalLocation(), type.name());
 
                     processDownloadResponse(type, dataToDownload, downloadableExternalObjectDirectories, container.get());
                 }


### PR DESCRIPTION
…on bug that emerged after the removal

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-2394


### Change description ###
Removed `@Transactional` from some of the existing integration tests. After this change, [this production code existing bug](https://yrk32651.live.dynatrace.com/ui/logs-events?gtf=-7d%20to%20now&gf=all&sortDirection=desc&visibleColumns=timestamp&visibleColumns=status&visibleColumns=content&advancedQueryMode=false&visualizationType=table&isDefaultQuery=true#ZmV0Y2glMjBsb2dzJTIwJTJGJTJGJTJDJTIwc2NhbkxpbWl0R0J5dGVzJTNBJTIwNTAwJTJDJTIwc2FtcGxpbmdSYXRpbyUzQSUyMDEwMDAlMEElN0MlMjBmaWx0ZXIlMjBtYXRjaGVzUGhyYXNlKGNvbnRlbnQlMkMlMjAlMjJjb3VsZCUyMG5vdCUyMGluaXRpYWxpemUlMjBwcm94eSUyMiklMEElN0MlMjBzb3J0JTIwdGltZXN0YW1wJTIwZGVzYw==) became visible in the tests console output in the form of an exception, even though the tests were still successful. Fixed the bug as well.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
