### PR TITLE
DMP-782: Implement streams for first phase of add audio flow to impro…

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/datamanagement/DataManagementServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/datamanagement/DataManagementServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.datamanagement;
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.BlobStorageException;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.darts.common.datamanagement.component.impl.FileBasedDownload
 import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -105,4 +107,16 @@ class DataManagementServiceTest {
             assertEquals(TEST_BINARY_STRING, new String(responseMetaData.getInputStream().readAllBytes()));
         }
     }
+
+    @Test
+    void saveBlobDataShouldSucceedAndReturnUuid() {
+        byte[] testStringInBytes = TEST_BINARY_STRING.getBytes(StandardCharsets.UTF_8);
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(testStringInBytes);
+
+        var uuid = dataManagementService.saveBlobData(unstructuredStorageContainerName, byteArrayInputStream);
+
+        assertTrue(uuid instanceof UUID);
+        assertTrue(StringUtils.isNotEmpty(uuid.toString()));
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
@@ -88,25 +88,6 @@ class AudioTransformationServiceTest extends IntegrationBase {
     }
 
     @Test
-    void shouldSaveAudioBlobData() {
-        String containerName = dataManagementConfiguration.getOutboundContainerName();
-
-        when(mockDataManagementService.saveBlobData(
-                containerName,
-                BINARY_DATA
-        )).thenReturn(BLOB_LOCATION);
-
-        UUID externalLocation = audioTransformationService.saveAudioBlobData(BINARY_DATA);
-
-        assertEquals(BLOB_LOCATION, externalLocation);
-        verify(mockDataManagementService).saveBlobData(
-                containerName,
-                BINARY_DATA
-        );
-        verifyNoMoreInteractions(mockDataManagementService);
-    }
-
-    @Test
     void getMediaMetadataShouldReturnExpectedMediaEntitiesWhenHearingIdHasRelatedMedia() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity1());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundToUnstructuredProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundToUnstructuredProcessorIntTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.task.service;
 
+import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -46,7 +47,7 @@ class InboundToUnstructuredProcessorIntTest extends IntegrationBase {
     @BeforeEach
     public void setup() {
         externalObjectDirectoryStub = dartsDatabase.getExternalObjectDirectoryStub();
-        when(dataManagementService.saveBlobData(any(), any())).thenReturn(UUID.randomUUID());
+        when(dataManagementService.saveBlobData(any(), any(BinaryData.class))).thenReturn(UUID.randomUUID());
     }
 
     @Test
@@ -99,7 +100,7 @@ class InboundToUnstructuredProcessorIntTest extends IntegrationBase {
         dartsDatabase.getTranscriptionStub().updateTranscriptionWithDocument(transcription, STORED, INBOUND);
 
         when(dataManagementService.getBlobData(any(), any())).thenReturn(getBinaryTranscriptionDocumentData());
-        when(dataManagementService.saveBlobData(any(), any())).thenReturn(UUID.randomUUID());
+        when(dataManagementService.saveBlobData(any(), any(BinaryData.class))).thenReturn(UUID.randomUUID());
 
         var existingUnstructuredStored = eodRepository.findByStatusAndType(dartsDatabase.getObjectRecordStatusEntity(STORED),
                                                                            dartsDatabase.getExternalLocationTypeEntity(UNSTRUCTURED));
@@ -120,7 +121,7 @@ class InboundToUnstructuredProcessorIntTest extends IntegrationBase {
         List<Integer> createdUnstructuredTranscriptionId = createdUnstructured.stream().map(
             eod -> eod.getTranscriptionDocumentEntity().getTranscription().getId()).collect(toList());
         assertThat(createdUnstructuredTranscriptionId).contains(transcription.getId());
-        verify(dataManagementService).saveBlobData(any(), any());
+        verify(dataManagementService).saveBlobData(any(), any(BinaryData.class));
     }
 
     @Test
@@ -150,7 +151,7 @@ class InboundToUnstructuredProcessorIntTest extends IntegrationBase {
                                                                                   dartsDatabase.getExternalLocationTypeEntity(UNSTRUCTURED));
         assertThat(unstructuredAfterProcessing).hasSize(1);
         assertThat(unstructuredAfterProcessing.get(0).getId()).isEqualTo(unstructuredBeforeProcessing.get(0).getId());
-        verify(dataManagementService, never()).saveBlobData(any(), any());
+        verify(dataManagementService, never()).saveBlobData(any(), any(BinaryData.class));
     }
 
     @Test
@@ -180,6 +181,6 @@ class InboundToUnstructuredProcessorIntTest extends IntegrationBase {
                                                                             dartsDatabase.getExternalLocationTypeEntity(UNSTRUCTURED));
         assertThat(unstructuredAfterProcessing).hasSize(1);
         assertThat(unstructuredAfterProcessing.get(0).getId()).isEqualTo(unstructuredBeforeProcessing.get(0).getId());
-        verify(dataManagementService).saveBlobData(any(), any());
+        verify(dataManagementService).saveBlobData(any(), any(BinaryData.class));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Date;
 import java.util.Map;
@@ -41,6 +42,15 @@ public class DataManagementServiceStubImpl implements DataManagementService {
 
     @Override
     public UUID saveBlobData(String containerName, BinaryData binaryData) {
+        return saveBlobData();
+    }
+
+    @Override
+    public UUID saveBlobData(String containerName, InputStream inputStream) {
+        return saveBlobData();
+    }
+
+    private UUID saveBlobData() {
         logStubUsageWarning();
 
         UUID uuid = UUID.randomUUID();
@@ -68,6 +78,8 @@ public class DataManagementServiceStubImpl implements DataManagementService {
 
     @Override
     public Response<Void> deleteBlobData(String containerName, UUID blobId) {
+        logStubUsageWarning();
+
         log.info("Delete blob data method executed");
         return null;
     }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/AudioTransformationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/AudioTransformationService.java
@@ -14,10 +14,6 @@ public interface AudioTransformationService {
 
     BinaryData getUnstructuredAudioBlob(UUID location);
 
-    BinaryData getOutboundAudioBlob(UUID location);
-
-    UUID saveAudioBlobData(BinaryData binaryData);
-
     List<MediaEntity> getMediaMetadata(Integer hearingId);
 
     Optional<UUID> getMediaLocation(MediaEntity media, Integer containerLocationId);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
@@ -41,9 +41,13 @@ import uk.gov.hmcts.darts.common.sse.SentServerEventsHeartBeatEmitter;
 import uk.gov.hmcts.darts.common.util.FileContentChecksum;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -136,13 +140,19 @@ public class AudioServiceImpl implements AudioService {
     @Override
     @Transactional
     public void addAudio(MultipartFile audioFileStream, AddAudioMetadataRequest addAudioMetadataRequest) {
+        MessageDigest md5Digest;
+        try {
+            md5Digest = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new DartsApiException(FAILED_TO_UPLOAD_AUDIO_FILE, e);
+        }
+
         final UUID externalLocation;
         final String checksum;
 
-        try {
-            BinaryData binaryData = BinaryData.fromStream(audioFileStream.getInputStream());
-            checksum = fileContentChecksum.calculate(binaryData.toBytes());
-            externalLocation = dataManagementApi.saveBlobDataToInboundContainer(binaryData);
+        try (var digestInputStream = new DigestInputStream(new BufferedInputStream(audioFileStream.getInputStream()), md5Digest)) {
+            externalLocation = dataManagementApi.saveBlobDataToInboundContainer(digestInputStream);
+            checksum = fileContentChecksum.calculate(digestInputStream);
         } catch (IOException e) {
             throw new DartsApiException(FAILED_TO_UPLOAD_AUDIO_FILE, e);
         }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -113,16 +113,6 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
     }
 
     @Override
-    public BinaryData getOutboundAudioBlob(UUID location) {
-        return dataManagementApi.getBlobDataFromOutboundContainer(location);
-    }
-
-    @Override
-    public UUID saveAudioBlobData(BinaryData binaryData) {
-        return dataManagementApi.saveBlobDataToOutboundContainer(binaryData);
-    }
-
-    @Override
     public List<MediaEntity> getMediaMetadata(Integer hearingId) {
         return mediaRepository.findAllByHearingId(hearingId);
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/util/FileContentChecksum.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/util/FileContentChecksum.java
@@ -2,23 +2,30 @@ package uk.gov.hmcts.darts.common.util;
 
 import org.springframework.stereotype.Component;
 
+import java.security.DigestInputStream;
+
 import static org.apache.commons.codec.binary.Base64.encodeBase64;
 import static org.apache.commons.codec.digest.DigestUtils.md5;
 
+/**
+ * Calculates the file checksum equivalent to the Azure Blob Storage CONTENT-MD5 tag value as a base64 encoded
+ * representation of the binary MD5 hash value. This could be done in Bash e.g. openssl md5 -binary "Test
+ * Document.doc" | base64
+ */
 @Component
 @SuppressWarnings({"java:S4790"})
 public class FileContentChecksum {
 
-    /**
-     * Calculates the file checksum equivalent to the Azure Blob Storage CONTENT-MD5 tag value as a base64 encoded
-     * representation of the binary MD5 hash value. This could be done in Bash e.g. openssl md5 -binary "Test
-     * Document.doc" | base64
-     *
-     * @param bytes the file content
-     * @return the calculated checksum
-     */
     public String calculate(byte[] bytes) {
-        return new String(encodeBase64(md5(bytes)));
+        return encodeToString(md5(bytes));
+    }
+
+    public String calculate(DigestInputStream digestInputStream) {
+        return encodeToString(digestInputStream.getMessageDigest().digest());
+    }
+
+    private String encodeToString(byte[] bytes) {
+        return new String(encodeBase64(bytes));
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/util/FileContentChecksum.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/util/FileContentChecksum.java
@@ -13,9 +13,13 @@ import static org.apache.commons.codec.digest.DigestUtils.md5;
  * Document.doc" | base64
  */
 @Component
-@SuppressWarnings({"java:S4790"})
+@SuppressWarnings({"java:S4790", "checkstyle:SummaryJavadoc"})
 public class FileContentChecksum {
 
+    /**
+     * @deprecated This implementation is not memory-efficient with large files, use calculate(DigestInputStream digestInputStream) instead.
+     */
+    @Deprecated
     public String calculate(byte[] bytes) {
         return encodeToString(md5(bytes));
     }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/api/DataManagementApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/api/DataManagementApi.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.darts.common.datamanagement.api.BlobContainerDownloadable;
 import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 
+import java.io.InputStream;
 import java.util.Map;
 import java.util.UUID;
 
@@ -16,8 +17,6 @@ public interface DataManagementApi extends BlobContainerDownloadable {
     BinaryData getBlobDataFromOutboundContainer(UUID blobId);
 
     BinaryData getBlobDataFromInboundContainer(UUID blobId);
-
-    UUID saveBlobDataToOutboundContainer(BinaryData binaryData);
 
     BlobClient saveBlobDataToContainer(BinaryData binaryData, DatastoreContainerType container, Map<String, String> metadata);
 
@@ -33,5 +32,8 @@ public interface DataManagementApi extends BlobContainerDownloadable {
 
     UUID saveBlobDataToInboundContainer(BinaryData binaryData);
 
+    UUID saveBlobDataToInboundContainer(InputStream inputStream);
+
     UUID saveBlobDataToUnstructuredContainer(BinaryData binaryData);
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/api/impl/DataManagementApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/api/impl/DataManagementApiImpl.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
 
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@SuppressWarnings("checkstyle:SummaryJavadoc")
 public class DataManagementApiImpl implements DataManagementApi {
 
     private final DataManagementService dataManagementService;
@@ -38,11 +40,6 @@ public class DataManagementApiImpl implements DataManagementApi {
     @Override
     public BinaryData getBlobDataFromInboundContainer(UUID blobId) {
         return dataManagementService.getBlobData(getInboundContainerName(), blobId);
-    }
-
-    @Override
-    public UUID saveBlobDataToOutboundContainer(BinaryData binaryData) {
-        return dataManagementService.saveBlobData(getOutboundContainerName(), binaryData);
     }
 
     @Override
@@ -79,6 +76,15 @@ public class DataManagementApiImpl implements DataManagementApi {
         dataManagementService.deleteBlobData(getUnstructuredContainerName(), blobId);
     }
 
+    @Override
+    public UUID saveBlobDataToInboundContainer(InputStream inputStream) {
+        return dataManagementService.saveBlobData(getInboundContainerName(), inputStream);
+    }
+
+    /**
+     * @deprecated This implementation is not memory-efficient with large files, use saveBlobDataToInboundContainer(InputStream inputStream) instead.
+     */
+    @Deprecated
     @Override
     public UUID saveBlobDataToInboundContainer(BinaryData binaryData) {
         return dataManagementService.saveBlobData(getInboundContainerName(), binaryData);

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/config/DataManagementConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/config/DataManagementConfiguration.java
@@ -6,13 +6,27 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import uk.gov.hmcts.darts.common.datamanagement.StorageConfiguration;
 
+import java.time.Duration;
+
 @Slf4j
 @Configuration
 @Getter
 public class DataManagementConfiguration extends StorageConfiguration {
 
-    @Value("${darts.storage.blob.connection-string}")
+    @Value("${darts.storage.blob.client.connection-string}")
     private String blobStorageAccountConnectionString;
+
+    @Value("${darts.storage.blob.client.block-size-bytes}")
+    private long blobClientBlockSizeBytes;
+
+    @Value("${darts.storage.blob.client.max-single-upload-size-bytes}")
+    private long blobClientMaxSingleUploadSizeBytes;
+
+    @Value("${darts.storage.blob.client.max-concurrency}")
+    private int blobClientMaxConcurrency;
+
+    @Value("${darts.storage.blob.client.timeout}")
+    private Duration blobClientTimeout;
 
     @Value("${darts.storage.blob.container-name.unstructured}")
     private String unstructuredContainerName;

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.darts.common.datamanagement.component.impl.DownloadResponseM
 import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 
+import java.io.InputStream;
 import java.util.Map;
 import java.util.UUID;
 
@@ -14,6 +15,8 @@ public interface DataManagementService {
     BinaryData getBlobData(String containerName, UUID blobId);
 
     UUID saveBlobData(String containerName, BinaryData binaryData);
+
+    UUID saveBlobData(String containerName, InputStream inputStream);
 
     BlobClient saveBlobData(String containerName, BinaryData binaryData, Map<String, String> metadata);
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -204,7 +204,13 @@ darts:
       fetch-from-dets-enabled: true
       temp-blob-workspace: ${user.home}/dets/tempworkspace
     blob:
-      connection-string: ${AZURE_STORAGE_CONNECTION_STRING:}
+      client:
+        connection-string: ${AZURE_STORAGE_CONNECTION_STRING:}
+        ## See https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blobs-tune-upload-download-java
+        block-size-bytes: 10_000_000
+        max-single-upload-size-bytes: 10_000_000
+        max-concurrency: 5
+        timeout: 15m
       temp-blob-workspace: ${user.home}/blob/tempworkspace
       container-name:
         unstructured: darts-unstructured

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
@@ -79,7 +79,7 @@ class AudioServiceImplTest {
     @Captor
     ArgumentCaptor<MediaEntity> mediaEntityArgumentCaptor;
     @Captor
-    ArgumentCaptor<BinaryData> inboundBlobStorageArgumentCaptor;
+    ArgumentCaptor<InputStream> inboundBlobStorageArgumentCaptor;
     @Mock
     SentServerEventsHeartBeatEmitter heartBeatEmitter;
     @Captor
@@ -246,6 +246,7 @@ class AudioServiceImplTest {
 
     @Test
     void addAudio() throws IOException {
+        // Given
         HearingEntity hearingEntity = new HearingEntity();
         when(retrieveCoreObjectService.retrieveOrCreateHearing(
             anyString(),
@@ -274,13 +275,11 @@ class AudioServiceImplTest {
         );
         AddAudioMetadataRequest addAudioMetadataRequest = createAddAudioRequest(startedAt, endedAt);
 
+        // When
         audioService.addAudio(audioFile, addAudioMetadataRequest);
 
+        // Then
         verify(dataManagementApi).saveBlobDataToInboundContainer(inboundBlobStorageArgumentCaptor.capture());
-        var binaryData = inboundBlobStorageArgumentCaptor.getValue();
-        assertEquals(BinaryData.fromStream(audioFile.getInputStream()).toString(), binaryData.toString());
-
-
         verify(mediaRepository).save(mediaEntityArgumentCaptor.capture());
         verify(hearingRepository, times(3)).saveAndFlush(any());
         MediaEntity savedMedia = mediaEntityArgumentCaptor.getValue();

--- a/src/test/java/uk/gov/hmcts/darts/common/util/FileContentChecksumTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/FileContentChecksumTest.java
@@ -2,15 +2,38 @@ package uk.gov.hmcts.darts.common.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FileContentChecksumTest {
 
     private final FileContentChecksum checksum = new FileContentChecksum();
+    private static final byte[] TEST_DATA = "test".getBytes(StandardCharsets.UTF_8);
+    public static final String EXPECTED_MD5_CHECKSUM = "CY9rzUYh03PK3k6DJie09g==";
 
     @Test
-    void calculate() {
-        assertEquals("CY9rzUYh03PK3k6DJie09g==", checksum.calculate("test".getBytes()));
+    void calculateFromBytes() {
+        assertEquals(EXPECTED_MD5_CHECKSUM, checksum.calculate(TEST_DATA));
+    }
+
+    @Test
+    void calculateFromInputStream() throws NoSuchAlgorithmException, IOException {
+        var md5Digest = MessageDigest.getInstance("MD5");
+
+        ByteArrayInputStream testDataInputStream = new ByteArrayInputStream(TEST_DATA);
+
+        try (var digestInputStream = new DigestInputStream(testDataInputStream, md5Digest)) {
+            // The digest is based on what has been consumed from the stream, so we must first consume the entire stream before computing the digest.
+            digestInputStream.readAllBytes();
+
+            assertEquals(EXPECTED_MD5_CHECKSUM, checksum.calculate(digestInputStream));
+        }
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
@@ -19,7 +19,9 @@ import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.service.impl.DataManagementServiceImpl;
 
+import java.io.ByteArrayInputStream;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -75,6 +77,19 @@ class DataManagementServiceImplTest {
         when(dataManagementFactory.getBlobContainerClient(BLOB_CONTAINER_NAME, serviceClient)).thenReturn(blobContainerClient);
         when(dataManagementFactory.getBlobClient(any(), any())).thenReturn(blobClient);
         UUID blobId = dataManagementService.saveBlobData(BLOB_CONTAINER_NAME, BINARY_DATA);
+        assertNotNull(blobId);
+    }
+
+    @Test
+    void testSaveBlobDataViaInputStream() {
+        when(dataManagementConfiguration.getBlobClientBlockSizeBytes()).thenReturn(1L);
+        when(dataManagementConfiguration.getBlobClientMaxSingleUploadSizeBytes()).thenReturn(1L);
+        when(dataManagementConfiguration.getBlobClientMaxConcurrency()).thenReturn(1);
+        when(dataManagementConfiguration.getBlobClientTimeout()).thenReturn(Duration.ofMinutes(1));
+
+        when(dataManagementFactory.getBlobContainerClient(BLOB_CONTAINER_NAME, serviceClient)).thenReturn(blobContainerClient);
+        when(dataManagementFactory.getBlobClient(any(), any())).thenReturn(blobClient);
+        UUID blobId = dataManagementService.saveBlobData(BLOB_CONTAINER_NAME, new ByteArrayInputStream(TEST_BINARY_STRING.getBytes()));
         assertNotNull(blobId);
     }
 


### PR DESCRIPTION
# [DMP-782](https://tools.hmcts.net/jira/browse/DMP-782)

The existing `POST /audios` endpoint accepts a binary payload (audio) which is subsequently uploaded to the Inbound Datastore via the Azure Blob Client.

The existing implementation reads the full binary payload into memory at various stages in this flow, including:
* When computing the checksum
* When passing the `BinaryData` instance to the blob client's `upload` method.

This PR reworks that flow to favour streams, such that:
* The checksum is computed as the stream is consumed, using `DigestInputStream`
* The input stream is passed directly to the blob client

The blobClient will break the payload down into multiple pieces, and will initiate an API (upload) call to Azure for each piece. BlobClient will consume into memory the entire size of that piece, so we also configure BlobClient to limit the size of those pieces. Additional configuration parameters are exposed as Spring properties such that they can be tuned during performance testing. Current values are not expected to be final.

## Testing

Behaviour between `master` branch and `dmp-782-streams` branch was compared **locally**.

An audio file - `noise_large.mp2` - was generated with filesize of ~320MB, close to the 350MB max filesize supported by DARTS. Requests were made to `POST /audios` as follows to observe behaviour for such large files:

```shell
curl -v --request POST \
  --url http://localhost:4550/audios \
  --header 'Authorization: Bearer <token>' \
  --header 'Content-Type: multipart/form-data' \
  --form 'file=@/Users/chrisbellingham/Music/noise_large.mp2;type=audio/mpeg' \
  --form 'metadata={"started_at":"2023-11-23T10:36:05.362Z","ended_at":"2023-11-23T10:36:05.362Z","channel":1,"total_channels":4,"format":"mp2","filename":"filename_goes_here","courthouse":"SWANSEA","courtroom":1,"media_file":"media_file_goes_here","file_size":100,"checksum":null,"cases":[1]};type=application/json'
```

JVM was configured to set fixed values for Max and Initial heap (`-Xmx1024m -Xms1024m`) to give a stable basis for comparison.

### Existing `master` branch

Request fails with:
```
Caused by: java.lang.OutOfMemoryError: Java heap space
```

### `dmp-782-streams` branch

Request succeeds after ~3 mins. File is present within the Inbound container in Azure, and an `external_object_directory` record is created with the expected checksum value.

To test how the memory usage scales with concurrency, two requests were made ~1 minute apart:

![add_audio_profile](https://github.com/hmcts/darts-api/assets/131763968/1d657dab-3401-4f29-b9f0-e29f8f1948fb)

Garbage collection was manually triggered aggressively during upload to obtain an accurate view of actual usage (blue line). From delta between requests, the memory cost of a single request is ~70MB for a 320MB request payload.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
