### PR TITLE
DMP-656 Add missing @Service annotation needed to support DETS BlobContainerDownloadable

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/dets/api/impl/DetsDataManagementApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/dets/api/impl/DetsDataManagementApiImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.dets.api.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.datamanagement.StorageConfiguration;
 import uk.gov.hmcts.darts.common.datamanagement.component.impl.DownloadResponseMetaData;
 import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
@@ -12,6 +13,7 @@ import uk.gov.hmcts.darts.dets.service.DetsApiService;
 import java.util.Objects;
 import java.util.Optional;
 
+@Service
 @RequiredArgsConstructor
 public class DetsDataManagementApiImpl implements DetsDataManagementApi {
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-656](https://tools.hmcts.net/jira/browse/DMP-656)

### Change description ###

Add missing `@Service` annotation needed to support DETS BlobContainerDownloadable.

Referring to https://github.com/hmcts/darts-api/blob/master/src/main/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImpl.java#L20

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
