### PR TITLE
Removing default dar pc notification url

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -58,8 +58,6 @@ services:
   darts-gateway:
     container_name: darts-gateway
     image: darts-gateway:master
-    environment:
-      - DAR_NOTIFY_DEFAULT_URL=http://darts-stub-services:4551/VIQDARNotifyEvent/DARNotifyEvent.asmx
     ports:
       - "8070:8070"
     networks:


### PR DESCRIPTION
Removing default dar pc notification url.  The url will now come only from the node_register table.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
