### PR TITLE
DMP-2157 Handling multiple cases for transcriptions

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntity.java
@@ -118,20 +118,25 @@ public class TranscriptionEntity extends CreatedModifiedBaseEntity {
         }
     }
 
-    /*
-        courtCases should be looped through
+    /**
+     * Get the court case associated with this transcription, using hearing as the preferred route.
+     * If no hearings as associated, check for a directly related court case.
+     * <p>
+     * This is detailed further in <a href="https://tools.hmcts.net/jira/browse/DMP-2157">DMP-2157</a>
+     * A potential enhancement for officially supporting this many-to-many is detailed in
+     * <a href="https://tools.hmcts.net/jira/browse/DMP-2489">DMP-2489</a>
+     * </p>
+     * @return CourtCaseEntity if found, otherwise null
      */
-    @Deprecated
     public CourtCaseEntity getCourtCase() {
-        if (CollectionUtils.isEmpty(courtCases)) {
-            HearingEntity hearing = getHearing();
-            if (hearing == null) {
-                return null;
-            } else {
-                return hearing.getCourtCase();
-            }
+        HearingEntity hearing = getHearing();
+        if (hearing != null) {
+            return hearing.getCourtCase();
         }
-        return courtCases.get(0);
+        if (!CollectionUtils.isEmpty(courtCases)) {
+            return courtCases.get(0);
+        }
+        return null;
     }
 
     public HearingEntity getHearing() {

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntityTest.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.darts.common.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TranscriptionEntityTest {
+
+    @Test
+    void testGetCourtCaseViaHearing() {
+        var courtCase = new CourtCaseEntity();
+        var hearingCourtCase = new CourtCaseEntity();
+        var transcription = new TranscriptionEntity();
+        transcription.setCourtCases(List.of(courtCase));
+        var hearing = new HearingEntity();
+        hearing.setCourtCase(hearingCourtCase);
+        transcription.setHearings(List.of(hearing));
+        assertEquals(hearingCourtCase, transcription.getCourtCase());
+    }
+
+    @Test
+    void testGetCourtCaseViaHearingMultiple() {
+        var courtCase = new CourtCaseEntity();
+        var hearingCourtCase1 = new CourtCaseEntity();
+        var hearingCourtCase2 = new CourtCaseEntity();
+        var transcription = new TranscriptionEntity();
+        transcription.setCourtCases(List.of(courtCase));
+        var hearing1 = new HearingEntity();
+        var hearing2 = new HearingEntity();
+        hearing1.setCourtCase(hearingCourtCase1);
+        hearing2.setCourtCase(hearingCourtCase2);
+        transcription.setHearings(List.of(hearing1, hearing2));
+        assertEquals(hearingCourtCase1, transcription.getCourtCase());
+    }
+
+    @Test
+    void testGetCourtCaseDirect() {
+        var courtCase = new CourtCaseEntity();
+        var transcription = new TranscriptionEntity();
+        transcription.setCourtCases(List.of(courtCase));
+        assertEquals(courtCase, transcription.getCourtCase());
+    }
+
+    @Test
+    void testGetCourtCaseDirectMultiple() {
+        var courtCase1 = new CourtCaseEntity();
+        var courtCase2 = new CourtCaseEntity();
+        var transcription = new TranscriptionEntity();
+        transcription.setCourtCases(List.of(courtCase1, courtCase2));
+        assertEquals(courtCase1, transcription.getCourtCase());
+    }
+
+    @Test
+    void testGetCourtCaseNone() {
+        var transcription = new TranscriptionEntity();
+        assertEquals(null, transcription.getCourtCase());
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2157

### Change description ###

This has been discussed with Sashi and the many-to-many between transcription and both cases and hearings was added to future-proof a potential requirement to link transcriptions to multiple cases/hearings. This isn't part of the heritage solution and isn't expected in the modernised one at this time.

When fetching the case related to any transcription the preferred route is to go via the hearing, using the "hearing_transcription_ae" table. If there isn't a link via hearing we check the direct link to case, via the "case_transcription_ae" table.

In both scenarios it's possible, but not expected, to get links to multiple cases. It has been decided that we should use only the first entry in the association tables until such a time as the enhancement to allow multiples has been fleshed out.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
