### PR TITLE
Dmp 2488 annotation document entity persist and merge

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationPostTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.annotation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -8,12 +9,18 @@ import org.springframework.boot.test.json.BasicJsonTester;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.hmcts.darts.annotations.model.Annotation;
+import uk.gov.hmcts.darts.common.entity.AnnotationEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.net.URI;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
@@ -36,28 +43,42 @@ class AnnotationPostTest extends IntegrationBase {
     @Test
     void returnsAnnotationId() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        HearingEntity hearingEntity = createSomeMinimalHearing();
+        hearingEntity = dartsDatabase.save(hearingEntity);
 
         var mvcResult = mockMvc.perform(
                 multipart(ENDPOINT)
                     .file(someAnnotationPostDocument())
-                    .file(someAnnotationPostBodyFor(createSomeMinimalHearing())))
+                    .file(someAnnotationPostBodyFor(hearingEntity)))
             .andExpect(status().isOk())
-                .andReturn();
+            .andReturn();
 
         var response = mvcResult.getResponse().getContentAsString();
         assertThat(json.from(response)).hasJsonPathNumberValue("annotation_id");
+        String actualJson = mvcResult.getResponse().getContentAsString();
+        Integer annotationId = JsonPath.parse(actualJson).read("$.annotation_id");
+        assertNotNull(annotationId);
+
+        Optional<AnnotationEntity> annotation = dartsDatabase.getAnnotationRepository().findById(annotationId);
+        assertTrue(annotation.isPresent());
+
+        List<AnnotationEntity> annotationByHearing = dartsDatabase.getAnnotationRepository().findByHearingId(hearingEntity.getId());
+        assertFalse(annotationByHearing.isEmpty());
+
+        assertThat(dartsDatabase.findExternalObjectDirectoryFor(annotationId).size()).isEqualTo(2);
     }
 
     @Test
     void allowsJudgeWithGlobalAccessToUploadAnnotations() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
-
+        HearingEntity hearingEntity = createSomeMinimalHearing();
+        hearingEntity = dartsDatabase.save(hearingEntity);
         mockMvc.perform(
-                        multipart(ENDPOINT)
-                                .file(someAnnotationPostDocument())
-                                .file(someAnnotationPostBodyFor(createSomeMinimalHearing())))
-                .andExpect(status().isOk())
-                .andReturn();
+                multipart(ENDPOINT)
+                    .file(someAnnotationPostDocument())
+                    .file(someAnnotationPostBodyFor(hearingEntity)))
+            .andExpect(status().isOk())
+            .andReturn();
     }
 
     @Test
@@ -66,11 +87,11 @@ class AnnotationPostTest extends IntegrationBase {
         given.anAuthenticatedUserAuthorizedForCourthouse(JUDGE, hearing.getCourtroom().getCourthouse());
 
         mockMvc.perform(
-                        multipart(ENDPOINT)
-                                .file(someAnnotationPostDocument())
-                                .file(someAnnotationPostBodyFor(hearing)))
-                .andExpect(status().isOk())
-                .andReturn();
+                multipart(ENDPOINT)
+                    .file(someAnnotationPostDocument())
+                    .file(someAnnotationPostBodyFor(hearing)))
+            .andExpect(status().isOk())
+            .andReturn();
     }
 
     @Test
@@ -78,10 +99,10 @@ class AnnotationPostTest extends IntegrationBase {
         given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
 
         mockMvc.perform(
-                        multipart(ENDPOINT)
-                                .file(someAnnotationPostBodyFor(createSomeMinimalHearing())))
-                .andExpect(status().isBadRequest())
-                .andReturn();
+                multipart(ENDPOINT)
+                    .file(someAnnotationPostBodyFor(createSomeMinimalHearing())))
+            .andExpect(status().isBadRequest())
+            .andReturn();
     }
 
     @Test
@@ -89,10 +110,10 @@ class AnnotationPostTest extends IntegrationBase {
         given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
 
         mockMvc.perform(
-                        multipart(ENDPOINT)
-                                .file(someAnnotationPostDocument()))
-                .andExpect(status().isBadRequest())
-                .andReturn();
+                multipart(ENDPOINT)
+                    .file(someAnnotationPostDocument()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
     }
 
     @Test
@@ -100,42 +121,41 @@ class AnnotationPostTest extends IntegrationBase {
         given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
 
         mockMvc.perform(
-                        multipart(ENDPOINT)
-                                .file(someAnnotationPostBodyNullHearingId())
-                                .file(someAnnotationPostDocument()))
-                .andExpect(status().isBadRequest())
-                .andReturn();
+                multipart(ENDPOINT)
+                    .file(someAnnotationPostBodyNullHearingId())
+                    .file(someAnnotationPostDocument()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
     }
 
     private MockMultipartFile someAnnotationPostBodyFor(HearingEntity hearingEntity) throws JsonProcessingException {
-        dartsDatabase.save(hearingEntity);
         var annotation = new Annotation(hearingEntity.getId());
         annotation.setComment("some comment");
 
         return new MockMultipartFile(
-                "annotation",
-                null,
-                "application/json",
-                objectMapper.writeValueAsString(annotation).getBytes()
+            "annotation",
+            null,
+            "application/json",
+            objectMapper.writeValueAsString(annotation).getBytes()
         );
     }
 
     private MockMultipartFile someAnnotationPostBodyNullHearingId() throws JsonProcessingException {
         var annotation = new Annotation(null);
         return new MockMultipartFile(
-                "annotation",
-                null,
-                "application/json",
-                objectMapper.writeValueAsString(annotation).getBytes()
+            "annotation",
+            null,
+            "application/json",
+            objectMapper.writeValueAsString(annotation).getBytes()
         );
     }
 
     private static MockMultipartFile someAnnotationPostDocument() {
         return new MockMultipartFile(
-                "file",
-                "some-filename.doc",
-                "application/msword",
-                "some-content".getBytes()
+            "file",
+            "some-filename.doc",
+            "application/msword",
+            "some-content".getBytes()
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationUploadServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationUploadServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.annotation;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,12 +17,16 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.darts.testutils.data.HearingTestData.createSomeMinimalHearing;
 
 @SuppressWarnings("VariableDeclarationUsageDistance")
+@Slf4j
 class AnnotationUploadServiceTest extends IntegrationBase {
     private static final String REQUESTER_EMAIL = "test.user@example.com";
 
@@ -47,8 +52,7 @@ class AnnotationUploadServiceTest extends IntegrationBase {
 
         var annotationId = uploadService.upload(document, annotation);
 
-        assertThat(dartsDatabase.findAnnotationById(annotationId))
-            .isInstanceOf(AnnotationEntity.class);
+        assertThat(dartsDatabase.findAnnotationById(annotationId)).isInstanceOf(AnnotationEntity.class);
     }
 
     @Test
@@ -72,8 +76,7 @@ class AnnotationUploadServiceTest extends IntegrationBase {
 
         var annotationId = uploadService.upload(document, annotation);
 
-        assertThat(dartsDatabase.findAnnotationDocumentFor(annotationId))
-            .isInstanceOf(AnnotationDocumentEntity.class);
+        assertThat(dartsDatabase.findAnnotationDocumentFor(annotationId)).isInstanceOf(AnnotationDocumentEntity.class);
     }
 
     @Test
@@ -84,8 +87,13 @@ class AnnotationUploadServiceTest extends IntegrationBase {
 
         var annotationId = uploadService.upload(document, annotation);
 
-        assertThat(dartsDatabase.findExternalObjectDirectoryFor(annotationId).size())
-            .isEqualTo(2);
+        Optional<AnnotationEntity> annotationEntityOptional = dartsDatabase.getAnnotationRepository().findById(annotationId);
+        assertTrue(annotationEntityOptional.isPresent());
+
+        List<AnnotationEntity> annotationByHearing = dartsDatabase.getAnnotationRepository().findByHearingId(hearing.getId());
+        assertFalse(annotationByHearing.isEmpty());
+
+        assertThat(dartsDatabase.findExternalObjectDirectoryFor(annotationId).size()).isEqualTo(2);
     }
 
     private MultipartFile someMultipartFile() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -474,8 +474,10 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         String testAnnotation = "TestAnnotation";
         AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(
-            testUser, testAnnotation, hearing);
-        dartsDatabase.save(annotation);
+            testUser, testAnnotation);
+        dartsDatabase.getAnnotationRepository().save(annotation);
+        hearing.addAnnotation(annotation);
+        dartsDatabase.save(hearing);
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -484,7 +486,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
-        dartsDatabase.save(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,
@@ -533,9 +534,10 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         String testAnnotation = "TestAnnotation";
-        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(
-            testUser, testAnnotation, hearing);
-        dartsDatabase.save(annotation);
+        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(testUser, testAnnotation);
+        dartsDatabase.getAnnotationRepository().save(annotation);
+        hearing.addAnnotation(annotation);
+        dartsDatabase.save(hearing);
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -544,7 +546,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
-        dartsDatabase.save(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,
@@ -553,7 +554,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             UUID.randomUUID()
         );
         armEod.setTransferAttempts(1);
-        dartsDatabase.getExternalObjectDirectoryRepository().saveAndFlush(armEod);
+        dartsDatabase.save(armEod);
 
         when(armDataManagementConfiguration.getAnnotationRecordClass()).thenReturn(DARTS);
         when(armDataManagementConfiguration.getAnnotationRecordPropertiesFile()).thenReturn(
@@ -594,10 +595,10 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         String testAnnotation = "TestAnnotation";
-
-        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(
-            testUser, testAnnotation, hearing);
-        dartsDatabase.getAnnotationRepository().saveAndFlush(annotation);
+        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(testUser, testAnnotation);
+        dartsDatabase.getAnnotationRepository().save(annotation);
+        hearing.addAnnotation(annotation);
+        dartsDatabase.save(hearing);
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -606,7 +607,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
-        dartsDatabase.getAnnotationDocumentRepository().saveAndFlush(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,
@@ -615,7 +615,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             UUID.randomUUID()
         );
         armEod.setTransferAttempts(1);
-        dartsDatabase.getExternalObjectDirectoryRepository().saveAndFlush(armEod);
+        dartsDatabase.save(armEod);
 
         when(armDataManagementConfiguration.getAnnotationRecordClass()).thenReturn(DARTS);
         when(armDataManagementConfiguration.getAnnotationRecordPropertiesFile()).thenReturn(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -473,11 +473,8 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         String testAnnotation = "TestAnnotation";
-        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(
-            testUser, testAnnotation);
+        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAndSaveAnnotationEntityWith(testUser, testAnnotation, hearing);
         dartsDatabase.getAnnotationRepository().save(annotation);
-        hearing.addAnnotation(annotation);
-        dartsDatabase.save(hearing);
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -535,10 +532,8 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         String testAnnotation = "TestAnnotation";
-        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(testUser, testAnnotation);
+        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAndSaveAnnotationEntityWith(testUser, testAnnotation, hearing);
         dartsDatabase.getAnnotationRepository().save(annotation);
-        hearing.addAnnotation(annotation);
-        dartsDatabase.save(hearing);
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -597,10 +592,9 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         String testAnnotation = "TestAnnotation";
-        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(testUser, testAnnotation);
+        AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAndSaveAnnotationEntityWith(testUser, testAnnotation, hearing);
         dartsDatabase.getAnnotationRepository().save(annotation);
-        hearing.addAnnotation(annotation);
-        dartsDatabase.save(hearing);
+
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -630,7 +624,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         when(armDataManagementConfiguration.getPublisher()).thenReturn(DARTS);
         when(armDataManagementConfiguration.getRegion()).thenReturn(REGION);
         when(armDataManagementConfiguration.getFileExtension()).thenReturn(FILE_EXTENSION);
-
 
         String prefix = String.format("%d_%d_1", armEod.getId(), annotationDocument.getId());
         ArchiveRecordFileInfo archiveRecordFileInfo = archiveRecordService.generateArchiveRecord(armEod.getId(), prefix);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -475,6 +475,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         String testAnnotation = "TestAnnotation";
         AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(
             testUser, testAnnotation, hearing);
+        dartsDatabase.save(annotation);
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -483,6 +484,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
+        dartsDatabase.save(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,
@@ -533,6 +535,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         String testAnnotation = "TestAnnotation";
         AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(
             testUser, testAnnotation, hearing);
+        dartsDatabase.save(annotation);
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -541,6 +544,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
+        dartsDatabase.save(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,
@@ -593,6 +597,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
 
         AnnotationEntity annotation = dartsDatabase.getAnnotationStub().createAnnotationEntity(
             testUser, testAnnotation, hearing);
+        dartsDatabase.getAnnotationRepository().saveAndFlush(annotation);
 
         final String fileName = "judges-notes.txt";
         final String fileType = "text/plain";
@@ -601,6 +606,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
+        dartsDatabase.getAnnotationDocumentRepository().saveAndFlush(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -486,6 +486,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
+        dartsDatabase.save(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,
@@ -546,6 +547,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
+        dartsDatabase.save(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,
@@ -607,6 +609,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         final String checksum = "C3CCA7021CF79B42F245AF350601C284";
         AnnotationDocumentEntity annotationDocument = dartsDatabase.getAnnotationStub()
             .createAnnotationDocumentEntity(annotation, fileName, fileType, fileSize, testUser, uploadedDateTime, checksum);
+        dartsDatabase.save(annotationDocument);
 
         ExternalObjectDirectoryEntity armEod = dartsDatabase.getExternalObjectDirectoryStub().createExternalObjectDirectory(
             annotationDocument,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AnnotationStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AnnotationStub.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.AnnotationEntity;
-import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.repository.AnnotationDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.AnnotationRepository;
@@ -27,19 +26,10 @@ public class AnnotationStub {
         return annotationRepository.save(annotationEntity);
     }
 
-    @Transactional
-    public AnnotationEntity createAndSaveAnnotationEntityWith(UserAccountEntity currentOwner,
-                                                              String annotationText,
-                                                              HearingEntity hearingEntity) {
-        AnnotationEntity annotationEntity = createAnnotationEntity(currentOwner, annotationText, hearingEntity);
-        return annotationRepository.save(annotationEntity);
-    }
-
-    public static AnnotationEntity createAnnotationEntity(UserAccountEntity currentOwner, String annotationText, HearingEntity hearingEntity) {
+    public static AnnotationEntity createAnnotationEntity(UserAccountEntity currentOwner, String annotationText) {
         AnnotationEntity annotationEntity = new AnnotationEntity();
         annotationEntity.setCurrentOwner(currentOwner);
         annotationEntity.setText(annotationText);
-        annotationEntity.addHearing(hearingEntity);
         annotationEntity.setTimestamp(OffsetDateTime.now());
         annotationEntity.setCreatedBy(currentOwner);
         return annotationEntity;
@@ -74,8 +64,5 @@ public class AnnotationStub {
 
         return annotationDocument;
     }
-
-    public void saveAnnotation(AnnotationEntity annotationEntity) {
-        annotationRepository.saveAndFlush(annotationEntity);
-    }
+    
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AnnotationStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AnnotationStub.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.AnnotationEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.repository.AnnotationDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.AnnotationRepository;
@@ -26,6 +27,15 @@ public class AnnotationStub {
         return annotationRepository.save(annotationEntity);
     }
 
+    @Transactional
+    public AnnotationEntity createAndSaveAnnotationEntityWith(UserAccountEntity currentOwner,
+                                                              String annotationText,
+                                                              HearingEntity hearingEntity) {
+        AnnotationEntity annotationEntity = createAnnotationEntity(currentOwner, annotationText);
+        annotationEntity.addHearing(hearingEntity);
+        return annotationRepository.save(annotationEntity);
+    }
+
     public static AnnotationEntity createAnnotationEntity(UserAccountEntity currentOwner, String annotationText) {
         AnnotationEntity annotationEntity = new AnnotationEntity();
         annotationEntity.setCurrentOwner(currentOwner);
@@ -36,7 +46,6 @@ public class AnnotationStub {
     }
 
 
-    @Transactional
     public AnnotationDocumentEntity createAndSaveAnnotationDocumentEntityWith(AnnotationEntity annotationEntity,
                                                                               String fileName,
                                                                               String fileType,
@@ -64,5 +73,5 @@ public class AnnotationStub {
 
         return annotationDocument;
     }
-    
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/annotation/builders/AnnotationMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/builders/AnnotationMapper.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.annotations.model.Annotation;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.common.entity.AnnotationEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 
 @Component
@@ -19,10 +20,11 @@ public class AnnotationMapper {
         annotationEntity.setText(annotation.getComment());
         annotationEntity.setDeleted(false);
         annotationEntity.setTimestamp(currentTimeHelper.currentOffsetDateTime());
-        annotationEntity.setCurrentOwner(authorisationApi.getCurrentUser());
+        UserAccountEntity currentUser = authorisationApi.getCurrentUser();
+        annotationEntity.setCurrentOwner(currentUser);
         annotationEntity.setCreatedDateTime(currentTimeHelper.currentOffsetDateTime());
-        annotationEntity.setLastModifiedBy(authorisationApi.getCurrentUser());
-        annotationEntity.setCreatedBy(authorisationApi.getCurrentUser());
+        annotationEntity.setLastModifiedBy(currentUser);
+        annotationEntity.setCreatedBy(currentUser);
 
         return annotationEntity;
     }

--- a/src/main/java/uk/gov/hmcts/darts/annotation/persistence/AnnotationPersistenceService.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/persistence/AnnotationPersistenceService.java
@@ -43,8 +43,8 @@ public class AnnotationPersistenceService {
             }
         );
 
-        externalObjectDirectoryRepository.saveAndFlush(inboundExternalObjectDirectory);
-        externalObjectDirectoryRepository.saveAndFlush(unstructuredExternalObjectDirectory);
+        externalObjectDirectoryRepository.save(inboundExternalObjectDirectory);
+        externalObjectDirectoryRepository.save(unstructuredExternalObjectDirectory);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/hmcts/darts/annotation/persistence/AnnotationPersistenceService.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/persistence/AnnotationPersistenceService.java
@@ -43,8 +43,8 @@ public class AnnotationPersistenceService {
             }
         );
 
-        externalObjectDirectoryRepository.save(inboundExternalObjectDirectory);
-        externalObjectDirectoryRepository.save(unstructuredExternalObjectDirectory);
+        externalObjectDirectoryRepository.saveAndFlush(inboundExternalObjectDirectory);
+        externalObjectDirectoryRepository.saveAndFlush(unstructuredExternalObjectDirectory);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/hmcts/darts/annotation/persistence/AnnotationPersistenceService.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/persistence/AnnotationPersistenceService.java
@@ -28,9 +28,9 @@ public class AnnotationPersistenceService {
 
     @Transactional
     public void persistAnnotation(
-            ExternalObjectDirectoryEntity inboundExternalObjectDirectory,
-            ExternalObjectDirectoryEntity unstructuredExternalObjectDirectory,
-            Integer hearingId) {
+        ExternalObjectDirectoryEntity inboundExternalObjectDirectory,
+        ExternalObjectDirectoryEntity unstructuredExternalObjectDirectory,
+        Integer hearingId) {
 
         final var hearing = hearingRepository.findById(hearingId);
 
@@ -39,8 +39,8 @@ public class AnnotationPersistenceService {
                 auditApi.recordAudit(IMPORT_ANNOTATION, userIdentity.getUserAccount(), hearingEntity.getCourtCase());
                 var annotation = inboundExternalObjectDirectory.getAnnotationDocumentEntity().getAnnotation();
                 hearing.get().addAnnotation(annotation);
+                hearingRepository.save(hearingEntity);
             }
-
         );
 
         externalObjectDirectoryRepository.save(inboundExternalObjectDirectory);

--- a/src/main/java/uk/gov/hmcts/darts/annotation/service/impl/AnnotationUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/service/impl/AnnotationUploadServiceImpl.java
@@ -52,7 +52,7 @@ public class AnnotationUploadServiceImpl implements AnnotationUploadService {
 
         var checksum = fileContentChecksum.calculate(binaryData.toBytes());
         var annotationDocumentEntity = annotationDocumentBuilder.buildFrom(multipartFile, annotationEntity, checksum);
-        //annotationDocumentRepository.save(annotationDocumentEntity);
+        annotationDocumentRepository.save(annotationDocumentEntity);
 
         var inboundExternalObjectDirectory = externalObjectDirectoryBuilder.buildFrom(
             annotationDocumentEntity, containerLocations.inboundLocation(), INBOUND);

--- a/src/main/java/uk/gov/hmcts/darts/annotation/service/impl/AnnotationUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/service/impl/AnnotationUploadServiceImpl.java
@@ -13,6 +13,8 @@ import uk.gov.hmcts.darts.annotation.service.AnnotationUploadService;
 import uk.gov.hmcts.darts.annotations.model.Annotation;
 import uk.gov.hmcts.darts.common.component.validation.Validator;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.AnnotationDocumentRepository;
+import uk.gov.hmcts.darts.common.repository.AnnotationRepository;
 import uk.gov.hmcts.darts.common.util.FileContentChecksum;
 
 import java.io.IOException;
@@ -34,6 +36,8 @@ public class AnnotationUploadServiceImpl implements AnnotationUploadService {
     private final Validator<Annotation> hearingExistsValidator;
     private final Validator<MultipartFile> fileTypeValidator;
     private final AnnotationDataManagement annotationDataManagement;
+    private final AnnotationRepository annotationRepository;
+    private final AnnotationDocumentRepository annotationDocumentRepository;
 
     @Override
     public Integer upload(MultipartFile multipartFile, Annotation annotation) {
@@ -44,13 +48,16 @@ public class AnnotationUploadServiceImpl implements AnnotationUploadService {
         var containerLocations = annotationDataManagement.upload(binaryData, multipartFile.getOriginalFilename());
 
         var annotationEntity = annotationMapper.mapFrom(annotation);
+        annotationRepository.save(annotationEntity);
+
         var checksum = fileContentChecksum.calculate(binaryData.toBytes());
         var annotationDocumentEntity = annotationDocumentBuilder.buildFrom(multipartFile, annotationEntity, checksum);
+        annotationDocumentRepository.save(annotationDocumentEntity);
 
         var inboundExternalObjectDirectory = externalObjectDirectoryBuilder.buildFrom(
-              annotationDocumentEntity, containerLocations.inboundLocation(), INBOUND);
+            annotationDocumentEntity, containerLocations.inboundLocation(), INBOUND);
         var unstructuredExternalObjectDirectory = externalObjectDirectoryBuilder.buildFrom(
-              annotationDocumentEntity, containerLocations.unstructuredLocation(), UNSTRUCTURED);
+            annotationDocumentEntity, containerLocations.unstructuredLocation(), UNSTRUCTURED);
 
         try {
             annotationPersistenceService.persistAnnotation(

--- a/src/main/java/uk/gov/hmcts/darts/annotation/service/impl/AnnotationUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/service/impl/AnnotationUploadServiceImpl.java
@@ -52,7 +52,7 @@ public class AnnotationUploadServiceImpl implements AnnotationUploadService {
 
         var checksum = fileContentChecksum.calculate(binaryData.toBytes());
         var annotationDocumentEntity = annotationDocumentBuilder.buildFrom(multipartFile, annotationEntity, checksum);
-        annotationDocumentRepository.save(annotationDocumentEntity);
+        //annotationDocumentRepository.save(annotationDocumentEntity);
 
         var inboundExternalObjectDirectory = externalObjectDirectoryBuilder.buildFrom(
             annotationDocumentEntity, containerLocations.inboundLocation(), INBOUND);
@@ -66,6 +66,7 @@ public class AnnotationUploadServiceImpl implements AnnotationUploadService {
                 annotation.getHearingId());
 
         } catch (RuntimeException exception) {
+            log.error("Unable to persist annotation ", exception);
             annotationDataManagement.attemptToDeleteDocument(containerLocations.inboundLocation());
             annotationDataManagement.attemptToDeleteDocument(containerLocations.unstructuredLocation());
         }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/UnstructuredToArmProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/UnstructuredToArmProcessorImpl.java
@@ -112,9 +112,9 @@ public class UnstructuredToArmProcessorImpl implements UnstructuredToArmProcesso
                 } else {
                     unstructuredExternalObjectDirectory = currentExternalObjectDirectory;
                     armExternalObjectDirectory = createArmExternalObjectDirectoryEntity(currentExternalObjectDirectory);
+                    updateExternalObjectDirectoryStatus(armExternalObjectDirectory, armIngestionStatus);
                 }
 
-                updateExternalObjectDirectoryStatus(armExternalObjectDirectory, armIngestionStatus);
 
                 String rawFilename = generateFilename(armExternalObjectDirectory);
                 log.info("Start of ARM Push processing for EOD {} running at: {}", armExternalObjectDirectory.getId(), OffsetDateTime.now());
@@ -154,7 +154,6 @@ public class UnstructuredToArmProcessorImpl implements UnstructuredToArmProcesso
         );
         armExternalObjectDirectory.setStatus(armStatus);
         armExternalObjectDirectory.setLastModifiedBy(userAccount);
-        armExternalObjectDirectory.setLastModifiedDateTime(OffsetDateTime.now());
         externalObjectDirectoryRepository.saveAndFlush(armExternalObjectDirectory);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationDocumentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationDocumentEntity.java
@@ -16,9 +16,6 @@ import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.OffsetDateTime;
 
-import static jakarta.persistence.CascadeType.MERGE;
-import static jakarta.persistence.CascadeType.PERSIST;
-
 @Entity
 @Setter
 @Getter
@@ -31,7 +28,7 @@ public class AnnotationDocumentEntity {
     @SequenceGenerator(name = "ado_gen", sequenceName = "ado_seq", allocationSize = 1)
     private Integer id;
 
-    @ManyToOne(cascade = {PERSIST, MERGE})
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ann_id", nullable = false)
     private AnnotationEntity annotation;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
@@ -57,7 +57,7 @@ public class AnnotationEntity extends CreatedModifiedBaseEntity {
     @OneToMany(fetch = FetchType.EAGER, mappedBy = AnnotationDocumentEntity_.ANNOTATION)
     private List<AnnotationDocumentEntity> annotationDocuments = new ArrayList<>();
 
-    @ManyToMany
+    @ManyToMany()
     @JoinTable(name = "hearing_annotation_ae",
         joinColumns = {@JoinColumn(name = "ann_id")},
         inverseJoinColumns = {@JoinColumn(name = "hea_id")})

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalObjectDirectoryEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalObjectDirectoryEntity.java
@@ -43,7 +43,7 @@ public class ExternalObjectDirectoryEntity extends CreatedModifiedBaseEntity imp
     @JoinColumn(name = "trd_id", foreignKey = @ForeignKey(name = "eod_transcription_document_fk"))
     private TranscriptionDocumentEntity transcriptionDocumentEntity;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = {PERSIST, MERGE})
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ado_id", foreignKey = @ForeignKey(name = "eod_annotation_document_fk"))
     private AnnotationDocumentEntity annotationDocumentEntity;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -186,10 +186,10 @@ darts:
       file-extension: a360
       list-blobs-timeout-duration: 60s
 
-      media-record-properties-file: properties/arm/{ARM_PROPERTY_FILE_ENVIRONMENT}/media-record.properties
-      transcription-record-properties-file: properties/arm/{ARM_PROPERTY_FILE_ENVIRONMENT}/transcription-record.properties
-      annotation-record-properties-file: properties/arm/{ARM_PROPERTY_FILE_ENVIRONMENT}/annotation-record.properties
-      case-record-properties-file: properties/arm/{ARM_PROPERTY_FILE_ENVIRONMENT}/case-record.properties
+      media-record-properties-file: properties/arm/${ARM_PROPERTY_FILE_ENVIRONMENT}/media-record.properties
+      transcription-record-properties-file: properties/arm/${ARM_PROPERTY_FILE_ENVIRONMENT}/transcription-record.properties
+      annotation-record-properties-file: properties/arm/${ARM_PROPERTY_FILE_ENVIRONMENT}/annotation-record.properties
+      case-record-properties-file: properties/arm/${ARM_PROPERTY_FILE_ENVIRONMENT}/case-record.properties
 
       response-cleanup-buffer-days: 0
 

--- a/src/test/java/uk/gov/hmcts/darts/annotation/service/impl/AnnotationUploadTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/annotation/service/impl/AnnotationUploadTest.java
@@ -23,6 +23,8 @@ import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.AnnotationDocumentRepository;
+import uk.gov.hmcts.darts.common.repository.AnnotationRepository;
 import uk.gov.hmcts.darts.common.util.FileContentChecksum;
 
 import java.io.IOException;
@@ -65,6 +67,10 @@ class AnnotationUploadTest {
     private AuditApi auditApi;
     @Mock
     private UserAccountEntity userAccountEntity;
+    @Mock
+    private AnnotationRepository annotationRepository;
+    @Mock
+    private AnnotationDocumentRepository annotationDocumentRepository;
 
     private final AnnotationEntity annotationEntity = someAnnotationEntity();
     private final AnnotationDocumentEntity annotationDocumentEntity = someAnnotationDocument();
@@ -83,7 +89,9 @@ class AnnotationUploadTest {
             annotationPersistenceService,
             hearingExistsValidator,
             fileTypeValidator,
-            annotationDataManagement
+            annotationDataManagement,
+            annotationRepository,
+            annotationDocumentRepository
         );
 
         when(hearing.getId()).thenReturn(1);

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmProcessorImplTest.java
@@ -339,7 +339,7 @@ class UnstructuredToArmProcessorImplTest {
 
         unstructuredToArmProcessor.processUnstructuredToArm();
 
-        verify(externalObjectDirectoryRepository, times(2)).saveAndFlush(externalObjectDirectoryEntityCaptor.capture());
+        verify(externalObjectDirectoryRepository).saveAndFlush(externalObjectDirectoryEntityCaptor.capture());
     }
 
     @Test
@@ -482,7 +482,7 @@ class UnstructuredToArmProcessorImplTest {
 
         unstructuredToArmProcessor.processUnstructuredToArm();
 
-        verify(externalObjectDirectoryRepository, times(2)).saveAndFlush(externalObjectDirectoryEntityCaptor.capture());
+        verify(externalObjectDirectoryRepository).saveAndFlush(externalObjectDirectoryEntityCaptor.capture());
 
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2490
https://tools.hmcts.net/jira/browse/DMP-2488
https://tools.hmcts.net/jira/browse/DMP-2500

### Change description ###

Removed persist and merge from annotation document and external object directory as it was causing issues when saving the annotation document to the eod and having the correct hearing attached

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
