### PR TITLE
DMP-2262 reset audio request to open if audio is present in inbound b…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
@@ -38,6 +38,8 @@ public class AudioTransformationServiceHandleKedaInvocationForMediaRequestsGiven
     private static final OffsetDateTime TIME_13_01 = OffsetDateTime.parse("2023-01-01T13:01Z");
     private static final OffsetDateTime TIME_13_30 = OffsetDateTime.parse("2023-01-01T13:30Z");
     private static final OffsetDateTime TIME_14_00 = OffsetDateTime.parse("2023-01-01T14:00Z");
+    private static final OffsetDateTime TIME_20_00 = OffsetDateTime.parse("2023-01-01T20:00Z");
+    private static final OffsetDateTime TIME_20_30 = OffsetDateTime.parse("2023-01-01T20:30Z");
 
 
     private final DartsDatabaseStub dartsDatabaseStub;
@@ -76,11 +78,17 @@ public class AudioTransformationServiceHandleKedaInvocationForMediaRequestsGiven
                                                                    TIME_14_00,
                                                                    channelNumber
             );
+            var mediaEntity5 = dartsDatabaseStub.createMediaEntity("testCourthouse", "testCourtroom",
+                                                                   TIME_20_00,
+                                                                   TIME_20_30,
+                                                                   channelNumber
+            );
 
             hearingEntity.addMedia(mediaEntity);
             hearingEntity.addMedia(mediaEntity2);
             hearingEntity.addMedia(mediaEntity3);
             hearingEntity.addMedia(mediaEntity4);
+            hearingEntity.addMedia(mediaEntity5);
             dartsDatabaseStub.getHearingRepository().saveAndFlush(hearingEntity);
 
             var inboundExternalObjectDirectoryEntity = dartsDatabaseStub.getExternalObjectDirectoryStub()
@@ -107,6 +115,13 @@ public class AudioTransformationServiceHandleKedaInvocationForMediaRequestsGiven
             var inboundExternalObjectDirectoryEntity4 = dartsDatabaseStub.getExternalObjectDirectoryStub()
                 .createExternalObjectDirectory(
                     mediaEntity4,
+                    objectRecordStatusEnum,
+                    inboundExternalLocationTypeEnum,
+                    UUID.randomUUID()
+                );
+            var inboundExternalObjectDirectoryEntity5 = dartsDatabaseStub.getExternalObjectDirectoryStub()
+                .createExternalObjectDirectory(
+                    mediaEntity5,
                     objectRecordStatusEnum,
                     inboundExternalLocationTypeEnum,
                     UUID.randomUUID()
@@ -145,6 +160,7 @@ public class AudioTransformationServiceHandleKedaInvocationForMediaRequestsGiven
             dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(inboundExternalObjectDirectoryEntity2);
             dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(inboundExternalObjectDirectoryEntity3);
             dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(inboundExternalObjectDirectoryEntity4);
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(inboundExternalObjectDirectoryEntity5);
             dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(unstructuredExternalObjectDirectoryEntity);
             dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(unstructuredExternalObjectDirectoryEntity2);
             dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(unstructuredExternalObjectDirectoryEntity3);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.darts.audiorequests.model.AudioRequestType;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
+import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
 
 import java.time.LocalDate;
@@ -19,7 +20,6 @@ import java.util.UUID;
 
 import static org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.OPEN;
-import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @Transactional
 @Service
@@ -48,9 +48,9 @@ public class AudioTransformationServiceHandleKedaInvocationForMediaRequestsGiven
 
     public void aMediaEntityGraph() {
 
-        var externalLocationTypeEntity = dartsDatabaseStub.getExternalLocationTypeEntity(
-            ExternalLocationTypeEnum.UNSTRUCTURED);
-        var objectRecordStatusEntity = dartsDatabaseStub.getObjectRecordStatusEntity(STORED);
+        var inboundExternalLocationTypeEnum = ExternalLocationTypeEnum.INBOUND;
+        var unstructuredExternalLocationTypeEnum = ExternalLocationTypeEnum.UNSTRUCTURED;
+        var objectRecordStatusEnum = ObjectRecordStatusEnum.STORED;
 
         for (int channelNumber = 1; channelNumber <= 4; channelNumber++) {
 
@@ -83,41 +83,72 @@ public class AudioTransformationServiceHandleKedaInvocationForMediaRequestsGiven
             hearingEntity.addMedia(mediaEntity4);
             dartsDatabaseStub.getHearingRepository().saveAndFlush(hearingEntity);
 
-
-            var externalObjectDirectoryEntity = dartsDatabaseStub.getExternalObjectDirectoryStub()
+            var inboundExternalObjectDirectoryEntity = dartsDatabaseStub.getExternalObjectDirectoryStub()
                 .createExternalObjectDirectory(
                     mediaEntity,
-                    objectRecordStatusEntity,
-                    externalLocationTypeEntity,
+                    objectRecordStatusEnum,
+                    inboundExternalLocationTypeEnum,
                     UUID.randomUUID()
                 );
-            var externalObjectDirectoryEntity2 = dartsDatabaseStub.getExternalObjectDirectoryStub()
+            var inboundExternalObjectDirectoryEntity2 = dartsDatabaseStub.getExternalObjectDirectoryStub()
                 .createExternalObjectDirectory(
                     mediaEntity2,
-                    objectRecordStatusEntity,
-                    externalLocationTypeEntity,
+                    objectRecordStatusEnum,
+                    inboundExternalLocationTypeEnum,
                     UUID.randomUUID()
                 );
-            var externalObjectDirectoryEntity3 = dartsDatabaseStub.getExternalObjectDirectoryStub()
+            var inboundExternalObjectDirectoryEntity3 = dartsDatabaseStub.getExternalObjectDirectoryStub()
                 .createExternalObjectDirectory(
                     mediaEntity3,
-                    objectRecordStatusEntity,
-                    externalLocationTypeEntity,
+                    objectRecordStatusEnum,
+                    inboundExternalLocationTypeEnum,
                     UUID.randomUUID()
                 );
-
-            var externalObjectDirectoryEntity4 = dartsDatabaseStub.getExternalObjectDirectoryStub()
+            var inboundExternalObjectDirectoryEntity4 = dartsDatabaseStub.getExternalObjectDirectoryStub()
                 .createExternalObjectDirectory(
                     mediaEntity4,
-                    objectRecordStatusEntity,
-                    externalLocationTypeEntity,
+                    objectRecordStatusEnum,
+                    inboundExternalLocationTypeEnum,
+                    UUID.randomUUID()
+                );
+            var unstructuredExternalObjectDirectoryEntity = dartsDatabaseStub.getExternalObjectDirectoryStub()
+                .createExternalObjectDirectory(
+                    mediaEntity,
+                    objectRecordStatusEnum,
+                    unstructuredExternalLocationTypeEnum,
+                    UUID.randomUUID()
+                );
+            var unstructuredExternalObjectDirectoryEntity2 = dartsDatabaseStub.getExternalObjectDirectoryStub()
+                .createExternalObjectDirectory(
+                    mediaEntity2,
+                    objectRecordStatusEnum,
+                    unstructuredExternalLocationTypeEnum,
+                    UUID.randomUUID()
+                );
+            var unstructuredExternalObjectDirectoryEntity3 = dartsDatabaseStub.getExternalObjectDirectoryStub()
+                .createExternalObjectDirectory(
+                    mediaEntity3,
+                    objectRecordStatusEnum,
+                    unstructuredExternalLocationTypeEnum,
                     UUID.randomUUID()
                 );
 
-            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(externalObjectDirectoryEntity);
-            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(externalObjectDirectoryEntity2);
-            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(externalObjectDirectoryEntity3);
-            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(externalObjectDirectoryEntity4);
+            var unstructuredExternalObjectDirectoryEntity4 = dartsDatabaseStub.getExternalObjectDirectoryStub()
+                .createExternalObjectDirectory(
+                    mediaEntity4,
+                    objectRecordStatusEnum,
+                    unstructuredExternalLocationTypeEnum,
+                    UUID.randomUUID()
+                );
+
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(inboundExternalObjectDirectoryEntity);
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(inboundExternalObjectDirectoryEntity2);
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(inboundExternalObjectDirectoryEntity3);
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(inboundExternalObjectDirectoryEntity4);
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(unstructuredExternalObjectDirectoryEntity);
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(unstructuredExternalObjectDirectoryEntity2);
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(unstructuredExternalObjectDirectoryEntity3);
+            dartsDatabaseStub.getExternalObjectDirectoryRepository().saveAndFlush(unstructuredExternalObjectDirectoryEntity4);
         }
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.SystemCommandExecutorStubImpl;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.COMPLETED;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.FAILED;
+import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.OPEN;
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.AUDIO_END_TIME;
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.AUDIO_START_TIME;
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.COURTHOUSE;
@@ -52,6 +54,8 @@ class AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest extends
     public static final String TIME_12_00 = "12:00:00";
     public static final String TIME_13_00 = "13:00:00";
     public static final String NOT_AVAILABLE = "N/A";
+    private static final OffsetDateTime TIME_20_00 = OffsetDateTime.parse("2023-01-01T20:00Z");
+    private static final OffsetDateTime TIME_20_30 = OffsetDateTime.parse("2023-01-01T20:30Z");
 
     @Autowired
     private AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder given;
@@ -130,6 +134,29 @@ class AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest extends
         assertNull(notificationEntity.getTemplateValues());
         assertEquals(NotificationStatus.OPEN, notificationEntity.getStatus());
         assertEquals(EMAIL_ADDRESS, notificationEntity.getEmailAddress());
+    }
+
+    @Test
+    @SuppressWarnings("PMD.LawOfDemeter")
+    public void handleKedaInvocationForMediaRequestsShouldResetRequestStatusToOpen() {
+        given.aMediaEntityGraph();
+        var userAccountEntity = given.aUserAccount(EMAIL_ADDRESS);
+        given.aMediaRequestEntityForHearingWithRequestType(
+            hearing,
+            AudioRequestType.PLAYBACK,
+            userAccountEntity,
+            TIME_20_00,
+            TIME_20_30
+        );
+
+        Integer mediaRequestId = given.getMediaRequestEntity().getId();
+
+        audioTransformationService.handleKedaInvocationForMediaRequests();
+
+        var mediaRequestEntity = dartsDatabase.getMediaRequestRepository()
+            .findById(mediaRequestId)
+            .orElseThrow();
+        assertEquals(OPEN, mediaRequestEntity.getStatus());
     }
 
     @ParameterizedTest

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -312,12 +312,8 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
                                                              ExternalLocationTypeEnum location1,
                                                              ExternalLocationTypeEnum location2) {
 
-        for (MediaEntity mediaEntity : mediaEntities) {
-            if (!existsMediaInTwoStorageLocation(mediaEntity, location1, location2)) {
-                return false;
-            }
-        }
-        return true;
+        return mediaEntities.stream()
+            .allMatch(mediaEntity -> existsMediaInTwoStorageLocation(mediaEntity, location1, location2));
     }
 
     private boolean existsMediaInTwoStorageLocation(MediaEntity mediaEntity,

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
@@ -61,6 +62,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.FAILED;
+import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.OPEN;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.PROCESSING;
 import static uk.gov.hmcts.darts.audiorequests.model.AudioRequestType.DOWNLOAD;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
@@ -201,6 +203,14 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
                 mediaRequestEntity
             );
 
+            boolean hasAllMediaBeenCopiedFromInboundStorage = checkAllMediaExistsInTwoStorageLocations(filteredMediaEntities,
+                                                                                          ExternalLocationTypeEnum.INBOUND,
+                                                                                          ExternalLocationTypeEnum.UNSTRUCTURED);
+            if (!hasAllMediaBeenCopiedFromInboundStorage) {
+                mediaRequestService.updateAudioRequestStatus(requestId, OPEN);
+                return;
+            }
+
             Map<MediaEntity, Path> downloadedMedias = downloadAndSaveMediaToWorkspace(filteredMediaEntities);
 
             List<AudioFileInfo> generatedAudioFiles;
@@ -296,6 +306,28 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
         } catch (FileNotDownloadedException e) {
             throw new RuntimeException("Retrieval from storage failed for MediaId " + mediaEntity.getId(), e);
         }
+    }
+
+    private boolean checkAllMediaExistsInTwoStorageLocations(List<MediaEntity> mediaEntities,
+                                                             ExternalLocationTypeEnum location1,
+                                                             ExternalLocationTypeEnum location2) {
+
+        for (MediaEntity mediaEntity : mediaEntities) {
+            if (!existsMediaInTwoStorageLocation(mediaEntity, location1, location2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean existsMediaInTwoStorageLocation(MediaEntity mediaEntity,
+                                                                   ExternalLocationTypeEnum location1,
+                                                                   ExternalLocationTypeEnum location2) {
+
+        ExternalLocationTypeEntity firstLocationEntity = externalLocationTypeRepository.getReferenceById(location1.getId());
+        ExternalLocationTypeEntity secondLocationEntity = externalLocationTypeRepository.getReferenceById(location2.getId());
+
+        return externalObjectDirectoryRepository.existsMediaFileIn2StorageLocations(mediaEntity, firstLocationEntity, secondLocationEntity);
     }
 
     @SuppressWarnings("PMD.LawOfDemeter")

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -159,6 +159,20 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
 
     @Query(
         """
+            SELECT COUNT(eod) > 0
+            FROM ExternalObjectDirectoryEntity eod, ExternalObjectDirectoryEntity eod2
+            WHERE eod.media = eod2.media
+            AND eod.externalLocationType = :location1
+            AND eod2.externalLocationType = :location2
+            AND eod.media = :media
+            """
+    )
+    boolean existsMediaFileIn2StorageLocations(MediaEntity media,
+                                                  ExternalLocationTypeEntity location1,
+                                                  ExternalLocationTypeEntity location2);
+
+    @Query(
+        """
             SELECT eod.id FROM ExternalObjectDirectoryEntity eod, ExternalObjectDirectoryEntity eod2
             WHERE eod.media is not null
             AND eod.media = eod2.media
@@ -223,10 +237,10 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     @Query(
         """
             SELECT eod.id FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status = :status 
+            WHERE eod.status = :status
             AND eod.externalLocationType = :type
-            AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2 
-            where (eod2.status = :notExistsStatus or eod2.transferAttempts >= :maxTransferAttempts) 
+            AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2
+            where (eod2.status = :notExistsStatus or eod2.transferAttempts >= :maxTransferAttempts)
             AND eod2.externalLocationType = :notExistsType
             and (eod.media = eod2.media
               OR eod.transcriptionDocumentEntity = eod2.transcriptionDocumentEntity


### PR DESCRIPTION
…ut not unstructured

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-2262


### Change description ###
For media that is in scope for a media request, check that media exists in both inbound and unstructured storage.
If media has yet to be copied over to unstructured, reset the audio request status to OPEN.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
