### PR TITLE
DMP-2339: Fixing response codes when security groups and regions are not found

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/repository/SecurityGroupRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/SecurityGroupRepository.java
@@ -5,10 +5,13 @@ import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface SecurityGroupRepository extends JpaRepository<SecurityGroupEntity, Integer> {
 
     Optional<SecurityGroupEntity> findByGroupNameIgnoreCase(String name);
+
+    boolean existsAllByIdIn(Set<Integer> ids);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/exception/CourthouseApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/exception/CourthouseApiError.java
@@ -50,6 +50,16 @@ public enum CourthouseApiError implements DartsApiError {
         CourthouseErrorCode.COURTHOUSE_NAME_CANNOT_BE_CHANGED_CASES_EXISTING.getValue(),
         HttpStatus.UNPROCESSABLE_ENTITY,
         CourthouseTitleErrors.COURTHOUSE_NAME_CANNOT_BE_CHANGED_CASES_EXISTING.toString()
+    ),
+    REGION_DOES_NOT_EXIST(
+        CourthouseErrorCode.REGION_DOES_NOT_EXIST.getValue(),
+        HttpStatus.BAD_REQUEST,
+        CourthouseTitleErrors.REGION_DOES_NOT_EXIST.getValue()
+    ),
+    SECURITY_GROUP_DOES_NOT_EXIST(
+        CourthouseErrorCode.SECURITY_GROUP_DOES_NOT_EXIST.getValue(),
+        HttpStatus.BAD_REQUEST,
+        CourthouseTitleErrors.SECURITY_GROUP_DOES_NOT_EXIST.getValue()
     );
 
     private static final String ERROR_TYPE_PREFIX = "COURTHOUSE";

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/exception/CourthouseApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/exception/CourthouseApiError.java
@@ -50,16 +50,6 @@ public enum CourthouseApiError implements DartsApiError {
         CourthouseErrorCode.COURTHOUSE_NAME_CANNOT_BE_CHANGED_CASES_EXISTING.getValue(),
         HttpStatus.UNPROCESSABLE_ENTITY,
         CourthouseTitleErrors.COURTHOUSE_NAME_CANNOT_BE_CHANGED_CASES_EXISTING.toString()
-    ),
-    REGION_DOES_NOT_EXIST(
-        CourthouseErrorCode.REGION_DOES_NOT_EXIST.getValue(),
-        HttpStatus.BAD_REQUEST,
-        CourthouseTitleErrors.REGION_DOES_NOT_EXIST.getValue()
-    ),
-    SECURITY_GROUP_DOES_NOT_EXIST(
-        CourthouseErrorCode.SECURITY_GROUP_DOES_NOT_EXIST.getValue(),
-        HttpStatus.BAD_REQUEST,
-        CourthouseTitleErrors.SECURITY_GROUP_DOES_NOT_EXIST.getValue()
     );
 
     private static final String ERROR_TYPE_PREFIX = "COURTHOUSE";

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/validation/CourthousePatchValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/validation/CourthousePatchValidator.java
@@ -7,7 +7,12 @@ import uk.gov.hmcts.darts.common.component.validation.BiValidator;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.CaseRepository;
 import uk.gov.hmcts.darts.common.repository.CourthouseRepository;
+import uk.gov.hmcts.darts.common.repository.RegionRepository;
+import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
+import uk.gov.hmcts.darts.courthouse.exception.CourthouseApiError;
 import uk.gov.hmcts.darts.courthouse.model.CourthousePatch;
+
+import java.util.HashSet;
 
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.darts.courthouse.exception.CourthouseApiError.COURTHOUSE_DISPLAY_NAME_PROVIDED_ALREADY_EXISTS;
@@ -21,6 +26,8 @@ public class CourthousePatchValidator implements BiValidator<CourthousePatch, In
 
     private final CourthouseRepository repository;
     private final CaseRepository caseRepository;
+    private final RegionRepository regionRepository;
+    private final SecurityGroupRepository securityGroupRepository;
 
     @Override
     @Transactional(value = Transactional.TxType.REQUIRED)
@@ -41,6 +48,18 @@ public class CourthousePatchValidator implements BiValidator<CourthousePatch, In
         if (nonNull(patch.getDisplayName())) {
             if (repository.existsByDisplayNameIgnoreCaseAndIdNot(patch.getDisplayName(), id)) {
                 throw new DartsApiException(COURTHOUSE_DISPLAY_NAME_PROVIDED_ALREADY_EXISTS);
+            }
+        }
+
+        if (nonNull(patch.getRegionId())) {
+            if (!regionRepository.existsById(patch.getRegionId())) {
+                throw new DartsApiException(CourthouseApiError.REGION_DOES_NOT_EXIST);
+            }
+        }
+
+        if (nonNull(patch.getSecurityGroupIds()) && !patch.getSecurityGroupIds().isEmpty()) {
+            if (!securityGroupRepository.existsAllByIdIn(new HashSet<>(patch.getSecurityGroupIds()))) {
+                throw new DartsApiException(CourthouseApiError.SECURITY_GROUP_DOES_NOT_EXIST);
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/validation/CourthousePatchValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/validation/CourthousePatchValidator.java
@@ -53,13 +53,13 @@ public class CourthousePatchValidator implements BiValidator<CourthousePatch, In
 
         if (nonNull(patch.getRegionId())) {
             if (!regionRepository.existsById(patch.getRegionId())) {
-                throw new DartsApiException(CourthouseApiError.REGION_DOES_NOT_EXIST);
+                throw new DartsApiException(CourthouseApiError.REGION_ID_DOES_NOT_EXIST);
             }
         }
 
         if (nonNull(patch.getSecurityGroupIds()) && !patch.getSecurityGroupIds().isEmpty()) {
             if (!securityGroupRepository.existsAllByIdIn(new HashSet<>(patch.getSecurityGroupIds()))) {
-                throw new DartsApiException(CourthouseApiError.SECURITY_GROUP_DOES_NOT_EXIST);
+                throw new DartsApiException(CourthouseApiError.SECURITY_GROUP_ID_DOES_NOT_EXIST);
             }
         }
     }

--- a/src/test/java/uk/gov/hmcts/darts/courthouse/validation/CourthousePatchValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/courthouse/validation/CourthousePatchValidatorTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.darts.common.repository.CaseRepository;
 import uk.gov.hmcts.darts.common.repository.CourthouseRepository;
 import uk.gov.hmcts.darts.common.repository.RegionRepository;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
+import uk.gov.hmcts.darts.courthouse.exception.CourthouseApiError;
 import uk.gov.hmcts.darts.courthouse.model.CourthousePatch;
 
 import java.util.List;
@@ -25,6 +26,7 @@ import static uk.gov.hmcts.darts.courthouse.exception.CourthouseApiError.COURTHO
 import static uk.gov.hmcts.darts.courthouse.exception.CourthouseApiError.COURTHOUSE_NAME_CANNOT_BE_CHANGED_CASES_EXISTING;
 import static uk.gov.hmcts.darts.courthouse.exception.CourthouseApiError.COURTHOUSE_NAME_PROVIDED_ALREADY_EXISTS;
 import static uk.gov.hmcts.darts.courthouse.exception.CourthouseApiError.COURTHOUSE_NOT_FOUND;
+import static uk.gov.hmcts.darts.courthouse.exception.CourthouseApiError.SECURITY_GROUP_ID_DOES_NOT_EXIST;
 
 @ExtendWith(MockitoExtension.class)
 class CourthousePatchValidatorTest {
@@ -97,7 +99,7 @@ class CourthousePatchValidatorTest {
 
         assertThatThrownBy(() -> validator.validate(someCourtHousePatchForRegion(2), 1))
             .isInstanceOf(DartsApiException.class)
-            .hasFieldOrPropertyWithValue("error", REGION_DOES_NOT_EXIST);
+            .hasFieldOrPropertyWithValue("error", CourthouseApiError.REGION_ID_DOES_NOT_EXIST);
     }
 
     @Test
@@ -107,7 +109,7 @@ class CourthousePatchValidatorTest {
 
         assertThatThrownBy(() -> validator.validate(someCourtHousePatchForSecurityGroup(2), 1))
             .isInstanceOf(DartsApiException.class)
-            .hasFieldOrPropertyWithValue("error", SECURITY_GROUP_DOES_NOT_EXIST);
+            .hasFieldOrPropertyWithValue("error", SECURITY_GROUP_ID_DOES_NOT_EXIST);
     }
 
     @Test


### PR DESCRIPTION
Fixing response codes when security groups and regions are not found


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
