### PR TITLE
DMP-2262 ATS KEDA re-process ordering fix

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
@@ -3,11 +3,13 @@ package uk.gov.hmcts.darts.audio.service;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.enums.AudioRequestOutputFormat;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.testutils.IntegrationPerClassBase;
 
 import java.time.OffsetDateTime;
@@ -31,6 +33,9 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
 
     @Autowired
     private MediaRequestService mediaRequestService;
+
+    @MockBean
+    private CurrentTimeHelper currentTimeHelper;
 
     private AudioRequestDetails requestDetails;
 
@@ -128,7 +133,6 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
     }
 
     @Test
-
     void shouldUpdateStatusToProcessing() {
         MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestStatus(1, PROCESSING);
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -44,6 +44,7 @@ import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
 import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
@@ -86,10 +87,11 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     private final TransformedMediaDetailsMapper transformedMediaDetailsMapper;
     private final MediaRequestDetailsMapper mediaRequestDetailsMapper;
     private final AudioRequestBeingProcessedFromArchiveQuery audioRequestBeingProcessedFromArchiveQuery;
+    private final CurrentTimeHelper currentTimeHelper;
 
     @Override
     public Optional<MediaRequestEntity> getOldestMediaRequestByStatus(MediaRequestStatus status) {
-        return mediaRequestRepository.findTopByStatusOrderByCreatedDateTimeAsc(status);
+        return mediaRequestRepository.findTopByStatusOrderByLastModifiedDateTimeAsc(status);
     }
 
     @Override
@@ -110,7 +112,6 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     public MediaRequestEntity updateAudioRequestStatus(Integer id, MediaRequestStatus status) {
         MediaRequestEntity mediaRequestEntity = getMediaRequestById(id);
         mediaRequestEntity.setStatus(status);
-
         return mediaRequestRepository.saveAndFlush(mediaRequestEntity);
     }
 
@@ -305,7 +306,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     @Override
     public void updateTransformedMediaLastAccessedTimestamp(Integer transformedMediaId) {
         TransformedMediaEntity foundEntity = getTransformedMediaById(transformedMediaId);
-        foundEntity.setLastAccessed(OffsetDateTime.now());
+        foundEntity.setLastAccessed(currentTimeHelper.currentOffsetDateTime());
         transformedMediaRepository.saveAndFlush(foundEntity);
     }
 
@@ -317,7 +318,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
             throw new DartsApiException(AudioRequestsApiError.TRANSFORMED_MEDIA_NOT_FOUND);
         }
         for (TransformedMediaEntity transformedMedia : foundEntityList) {
-            transformedMedia.setLastAccessed(OffsetDateTime.now());
+            transformedMedia.setLastAccessed(currentTimeHelper.currentOffsetDateTime());
             transformedMediaRepository.saveAndFlush(transformedMedia);
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRequestRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRequestRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Repository
 public interface MediaRequestRepository extends JpaRepository<MediaRequestEntity, Integer> {
 
-    Optional<MediaRequestEntity> findTopByStatusOrderByCreatedDateTimeAsc(MediaRequestStatus status);
+    Optional<MediaRequestEntity> findTopByStatusOrderByLastModifiedDateTimeAsc(MediaRequestStatus status);
 
     @Query("""
         SELECT count(distinct(tm.id)) FROM MediaRequestEntity mr, TransformedMediaEntity tm


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2262

### Change description ###

- KEDA can skip a request because audio is not ready
- when the status is set back to OPEN the last modified date will be set
- then find OPEN requests by last modified date
- this means that specific request will be at the "back of the queue"
- this prevents multiple requests with audio that is not ready from hogging the KEDA jobs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
