### PR TITLE
DMP-2582 - increase advanced search performance

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -181,6 +181,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
         String requestBody = """
             {
               "courthouse": "SWANSEA",
+              "courtroom": "courtroom",
               "date_to": "2023-09-20",
               "date_from": "2023-05-20"
             }""";
@@ -204,7 +205,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
             {
               "courthouse": "SWANSEA",
               "courtroom": "1",
-              "event_text_contains": "5b"
+              "event_text_contains": "t5b"
             }""";
 
         MockHttpServletRequestBuilder requestBuilder = post(ENDPOINT_URL)
@@ -226,7 +227,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
             {
               "courthouse": "SWANSEA",
               "courtroom": "1",
-              "judge_name": "3a"
+              "judge_name": "e3a"
             }""";
 
         MockHttpServletRequestBuilder requestBuilder = post(ENDPOINT_URL)

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -32,6 +32,8 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.testutils.TestUtils.getContentsFromFile;
 import static uk.gov.hmcts.darts.testutils.data.CaseTestData.createCaseAt;
@@ -54,6 +56,7 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
     CaseService service;
     CourthouseEntity swanseaCourthouse;
     UserAccountEntity user;
+    CourtroomEntity courtroom1;
 
     @BeforeEach
     void setupData() {
@@ -87,7 +90,7 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
         case8.setCaseNumber("case8");
 
         JudgeEntity judge = createJudgeWithName("aJudge");
-        CourtroomEntity courtroom1 = createCourtRoomWithNameAtCourthouse(swanseaCourthouse, "courtroom1");
+        courtroom1 = createCourtRoomWithNameAtCourthouse(swanseaCourthouse, "courtroom1");
         HearingEntity hearing1a = createHearingWithDefaults(case1, courtroom1, LocalDate.of(2023, 5, 20), judge);
 
         HearingEntity hearing1b = createHearingWithDefaults(case1, courtroom1, LocalDate.of(2023, 5, 21), judge);
@@ -272,6 +275,45 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
     }
 
     @Test
+    void getWithCourthouseNotExist() {
+
+        GetCasesSearchRequest request = GetCasesSearchRequest.builder()
+            .courthouse("jyguiyfgiytfuiytfuyrt")
+            .build();
+
+        setupUserAccountAndSecurityGroup();
+
+        List<AdvancedSearchResult> resultList = service.advancedSearch(request);
+        assertTrue(resultList.isEmpty());
+    }
+
+    @Test
+    void getWithCourthouse() throws IOException {
+
+        GetCasesSearchRequest request = GetCasesSearchRequest.builder()
+            .courthouse(swanseaCourthouse.getCourthouseName())
+            .build();
+
+        setupUserAccountAndSecurityGroup();
+
+        List<AdvancedSearchResult> resultList = service.advancedSearch(request);
+        assertEquals(8, resultList.size());
+    }
+
+    @Test
+    void getWithCourthouseId() {
+
+        GetCasesSearchRequest request = GetCasesSearchRequest.builder()
+            .courthouseId(swanseaCourthouse.getId())
+            .build();
+
+        setupUserAccountAndSecurityGroup();
+
+        List<AdvancedSearchResult> resultList = service.advancedSearch(request);
+        assertEquals(8, resultList.size());
+    }
+
+    @Test
     void getWithCourtroom() throws IOException {
 
         GetCasesSearchRequest request = GetCasesSearchRequest.builder()
@@ -285,6 +327,20 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
         String expectedResponse = TestUtils.removeIds(getContentsFromFile(
             "tests/cases/CaseServiceAdvancedSearchTest/getWithCourtroom/expectedResponse.json"));
         compareJson(actualResponse, expectedResponse);
+    }
+
+    @Test
+    void getWithCourtroomId() throws IOException {
+
+
+        GetCasesSearchRequest request = GetCasesSearchRequest.builder()
+            .courtroomId(courtroom1.getId())
+            .build();
+
+        setupUserAccountAndSecurityGroup();
+
+        List<AdvancedSearchResult> resultList = service.advancedSearch(request);
+        assertEquals(8, resultList.size());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -255,6 +255,23 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
     }
 
     @Test
+    void getWithCourthouseCourtroom() throws IOException {
+
+        GetCasesSearchRequest request = GetCasesSearchRequest.builder()
+            .courthouse(swanseaCourthouse.getCourthouseName())
+            .courtroom("roOm2")
+            .build();
+
+        setupUserAccountAndSecurityGroup();
+
+        List<AdvancedSearchResult> resultList = service.advancedSearch(request);
+        String actualResponse = TestUtils.removeIds(objectMapper.writeValueAsString(resultList));
+        String expectedResponse = TestUtils.removeIds(getContentsFromFile(
+            "tests/cases/CaseServiceAdvancedSearchTest/getWithCourtroom/expectedResponse.json"));
+        compareJson(actualResponse, expectedResponse);
+    }
+
+    @Test
     void getWithCourtroom() throws IOException {
 
         GetCasesSearchRequest request = GetCasesSearchRequest.builder()

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
@@ -155,6 +155,8 @@ class PatchUserIntTest extends IntegrationBase {
             );
             assertEquals(ORIGINAL_SYSTEM_USER_FLAG, latestUserAccountEntity.getIsSystemUser());
 
+            assertEquals(existingAccount.getCreatedDateTime(), latestUserAccountEntity.getCreatedDateTime());
+            assertThat(latestUserAccountEntity.getLastModifiedDateTime(), greaterThan(existingAccount.getLastModifiedDateTime()));
             assertEquals(ORIGINAL_LAST_LOGIN_TIME, latestUserAccountEntity.getLastLoginTime());
             assertEquals(user.getId(), latestUserAccountEntity.getLastModifiedBy().getId());
             assertEquals(user.getId(), latestUserAccountEntity.getCreatedBy().getId());

--- a/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.cases.http.api.CasesApi;
 import uk.gov.hmcts.darts.cases.model.AddCaseRequest;
-import uk.gov.hmcts.darts.cases.model.AdvancedSearchDetails;
+import uk.gov.hmcts.darts.cases.model.AdvancedSearchRequest;
 import uk.gov.hmcts.darts.cases.model.AdvancedSearchResult;
 import uk.gov.hmcts.darts.cases.model.Annotation;
 import uk.gov.hmcts.darts.cases.model.GetCasesRequest;
@@ -94,16 +94,18 @@ public class CaseController implements CasesApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     public ResponseEntity<List<AdvancedSearchResult>> casesSearchPost(
-        AdvancedSearchDetails advancedSearchDetails
+        AdvancedSearchRequest advancedSearchRequest
     ) {
         GetCasesSearchRequest request = GetCasesSearchRequest.builder()
-            .caseNumber(StringUtils.trimToNull(advancedSearchDetails.getCaseNumber()))
-            .courthouse(StringUtils.trimToNull(advancedSearchDetails.getCourthouse()))
-            .courtroom(StringUtils.trimToNull(advancedSearchDetails.getCourtroom()))
-            .judgeName(StringUtils.trimToNull(advancedSearchDetails.getJudgeName()))
-            .defendantName(StringUtils.trimToNull(advancedSearchDetails.getDefendantName()))
-            .dateFrom(advancedSearchDetails.getDateFrom()).dateTo(advancedSearchDetails.getDateTo())
-            .eventTextContains(StringUtils.trimToNull(advancedSearchDetails.getEventTextContains()))
+            .caseNumber(StringUtils.trimToNull(advancedSearchRequest.getCaseNumber()))
+            .courthouse(StringUtils.trimToNull(advancedSearchRequest.getCourthouse()))
+            .courthouseId(advancedSearchRequest.getCourthouseId())
+            .courtroom(StringUtils.trimToNull(advancedSearchRequest.getCourtroom()))
+            .courtroomId(advancedSearchRequest.getCourtroomId())
+            .judgeName(StringUtils.trimToNull(advancedSearchRequest.getJudgeName()))
+            .defendantName(StringUtils.trimToNull(advancedSearchRequest.getDefendantName()))
+            .dateFrom(advancedSearchRequest.getDateFrom()).dateTo(advancedSearchRequest.getDateTo())
+            .eventTextContains(StringUtils.trimToNull(advancedSearchRequest.getEventTextContains()))
             .build();
 
         RequestValidator.validate(request);

--- a/src/main/java/uk/gov/hmcts/darts/cases/exception/AdvancedSearchNoResultsException.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/exception/AdvancedSearchNoResultsException.java
@@ -1,0 +1,4 @@
+package uk.gov.hmcts.darts.cases.exception;
+
+public class AdvancedSearchNoResultsException extends Exception {
+}

--- a/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
@@ -95,7 +95,6 @@ public class AdvancedSearchRequestHelper {
         CollectionUtils.addAll(predicates, addCourtCaseCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addHearingDateCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addCourthouseCourtroomCriteria(request, criteriaBuilder, courtCaseJoin));
-        //CollectionUtils.addAll(predicates, addCourtroomCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addJudgeCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addDefendantCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addEventCriteria(request, criteriaBuilder, courtCaseJoin));
@@ -121,20 +120,6 @@ public class AdvancedSearchRequestHelper {
 
     private String surroundValue(String value, String surroundWith) {
         return surroundWith + value + surroundWith;
-    }
-
-    private List<Predicate> addCourtroomCriteria(GetCasesSearchRequest request,
-                                                 CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
-        List<Predicate> predicateList = new ArrayList<>();
-        if (StringUtils.isNotBlank(request.getCourtroom())) {
-            Join<HearingEntity, CourtroomEntity> courtroomJoin = joinCourtroom(courtCaseJoin);
-
-            predicateList.add(criteriaBuilder.like(
-                criteriaBuilder.upper(courtroomJoin.get(CourtroomEntity_.NAME)),
-                surroundWithPercentagesUpper(request.getCourtroom())
-            ));
-        }
-        return predicateList;
     }
 
     private List<Predicate> addDefendantCriteria(GetCasesSearchRequest request,
@@ -186,7 +171,6 @@ public class AdvancedSearchRequestHelper {
                                                    CriteriaBuilder criteriaBuilder,
                                                    Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) throws AdvancedSearchNoResultsException {
         List<Predicate> predicateList = new ArrayList<>();
-        //Join<HearingEntity, CourtroomEntity> courtroomJoin = joinCourtroom(courtCaseJoin);
         Join<CourtCaseEntity, HearingEntity> hearingJoin = joinHearing(courtCaseJoin);
         if (request.getCourtroomId() != null) {
             CourtroomEntity courtroomReference = courtroomRepository.getReferenceById(request.getCourtroomId());
@@ -211,6 +195,9 @@ public class AdvancedSearchRequestHelper {
         }
 
         List<Integer> courtroomIdList = courtroomRepository.findAllIdByCourtroomNameLike(request.getCourtroom());
+        if (courtroomIdList.isEmpty()) {
+            throw new AdvancedSearchNoResultsException();
+        }
         List<CourtroomEntity> courtroomEntityList = courtroomIdList.stream().map(id -> courtroomRepository.getReferenceById(id)).toList();
         predicateList.add(
             hearingJoin.get(HearingEntity_.COURTROOM).in(

--- a/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
@@ -56,8 +56,6 @@ public class AdvancedSearchRequestHelper {
     private final CourthouseRepository courthouseRepository;
 
     public List<Integer> getMatchingCourtCases(GetCasesSearchRequest request) throws AdvancedSearchNoResultsException {
-        //first figure out if we can identify a courthouse/courtroom, as the postgres optimiser doesn't seem to work correctly.
-
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         CriteriaQuery<Integer> criteriaQuery = criteriaBuilder.createQuery(Integer.class);
         Root<UserAccountCourtCaseEntity> caseRoot = criteriaQuery.from(UserAccountCourtCaseEntity.class);
@@ -154,7 +152,7 @@ public class AdvancedSearchRequestHelper {
                                                            CriteriaBuilder criteriaBuilder,
                                                            Join<UserAccountCourtCaseEntity,
                                                                CourtCaseEntity> courtCaseJoin) throws AdvancedSearchNoResultsException {
-        boolean courtroomProvided = StringUtils.isNotBlank(request.getCourtroom()) || request.getCourthouseId() != null;
+        boolean courtroomProvided = StringUtils.isNotBlank(request.getCourtroom()) || request.getCourtroomId() != null;
         List<Predicate> predicateList = new ArrayList<>();
         if (courtroomProvided) {
             return addCourtroomIdCriteria(request, criteriaBuilder, courtCaseJoin);
@@ -175,7 +173,7 @@ public class AdvancedSearchRequestHelper {
         if (request.getCourtroomId() != null) {
             CourtroomEntity courtroomReference = courtroomRepository.getReferenceById(request.getCourtroomId());
             predicateList.add(criteriaBuilder.equal(
-                hearingJoin.get(CourtroomEntity_.ID),
+                hearingJoin.get(HearingEntity_.COURTROOM),
                 courtroomReference)
             );
             return predicateList;

--- a/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
@@ -11,15 +11,16 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.cases.exception.AdvancedSearchNoResultsException;
 import uk.gov.hmcts.darts.cases.model.GetCasesSearchRequest;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity_;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
-import uk.gov.hmcts.darts.common.entity.CourthouseEntity_;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity_;
 import uk.gov.hmcts.darts.common.entity.DefendantEntity;
@@ -32,24 +33,31 @@ import uk.gov.hmcts.darts.common.entity.JudgeEntity;
 import uk.gov.hmcts.darts.common.entity.JudgeEntity_;
 import uk.gov.hmcts.darts.common.entity.UserAccountCourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountCourtCaseEntity_;
-import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.entity.UserAccountEntity_;
+import uk.gov.hmcts.darts.common.repository.CourthouseRepository;
+import uk.gov.hmcts.darts.common.repository.CourtroomRepository;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 
+import static uk.gov.hmcts.darts.cases.service.impl.CaseServiceImpl.MAX_RESULTS;
+
 @Component
 @SuppressWarnings({"PMD.TooManyMethods"})
 @RequiredArgsConstructor
+@Slf4j
 public class AdvancedSearchRequestHelper {
     @PersistenceContext
     private final EntityManager entityManager;
 
     private final UserIdentity userIdentity;
+    private final CourtroomRepository courtroomRepository;
+    private final CourthouseRepository courthouseRepository;
 
-    public List<Integer> getMatchingCourtCases(GetCasesSearchRequest request) {
+    public List<Integer> getMatchingCourtCases(GetCasesSearchRequest request) throws AdvancedSearchNoResultsException {
+        //first figure out if we can identify a courthouse/courtroom, as the postgres optimiser doesn't seem to work correctly.
+
         CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
         CriteriaQuery<Integer> criteriaQuery = criteriaBuilder.createQuery(Integer.class);
         Root<UserAccountCourtCaseEntity> caseRoot = criteriaQuery.from(UserAccountCourtCaseEntity.class);
@@ -66,27 +74,28 @@ public class AdvancedSearchRequestHelper {
         criteriaQuery.select(namePath).distinct(true);
 
         TypedQuery<Integer> query = entityManager.createQuery(criteriaQuery);
+        query.setMaxResults(MAX_RESULTS + 1);
         return query.getResultList();
     }
 
     private List<Predicate> createUserPredicates(CriteriaBuilder criteriaBuilder, Root<UserAccountCourtCaseEntity> caseRoot) {
         List<Predicate> predicates = new ArrayList<>();
-        Join<UserAccountCourtCaseEntity, UserAccountEntity> userJoin = caseRoot.join(UserAccountCourtCaseEntity_.USER_ACCOUNT);
         predicates.add(
-            criteriaBuilder.equal(userJoin.get(UserAccountEntity_.ID),
-            userIdentity.getUserAccount().getId()
+            criteriaBuilder.equal(caseRoot.get(UserAccountCourtCaseEntity_.userAccount),
+                                  userIdentity.getUserAccount()
             )
         );
         return predicates;
     }
 
     private List<Predicate> createCourtCasePredicates(GetCasesSearchRequest request,
-                                                      CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
+                                                      CriteriaBuilder criteriaBuilder,
+                                                      Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) throws AdvancedSearchNoResultsException {
         List<Predicate> predicates = new ArrayList<>();
         CollectionUtils.addAll(predicates, addCourtCaseCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addHearingDateCriteria(request, criteriaBuilder, courtCaseJoin));
-        CollectionUtils.addAll(predicates, addCourthouseCriteria(request, criteriaBuilder, courtCaseJoin));
-        CollectionUtils.addAll(predicates, addCourtroomCriteria(request, criteriaBuilder, courtCaseJoin));
+        CollectionUtils.addAll(predicates, addCourthouseCourtroomCriteria(request, criteriaBuilder, courtCaseJoin));
+        //CollectionUtils.addAll(predicates, addCourtroomCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addJudgeCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addDefendantCriteria(request, criteriaBuilder, courtCaseJoin));
         CollectionUtils.addAll(predicates, addEventCriteria(request, criteriaBuilder, courtCaseJoin));
@@ -94,7 +103,7 @@ public class AdvancedSearchRequestHelper {
         return predicates;
     }
 
-    private List<Predicate> addCourtCaseCriteria(GetCasesSearchRequest request, 
+    private List<Predicate> addCourtCaseCriteria(GetCasesSearchRequest request,
                                                  CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
         List<Predicate> predicateList = new ArrayList<>();
         if (StringUtils.isNotBlank(request.getCaseNumber())) {
@@ -114,7 +123,7 @@ public class AdvancedSearchRequestHelper {
         return surroundWith + value + surroundWith;
     }
 
-    private List<Predicate> addCourtroomCriteria(GetCasesSearchRequest request, 
+    private List<Predicate> addCourtroomCriteria(GetCasesSearchRequest request,
                                                  CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
         List<Predicate> predicateList = new ArrayList<>();
         if (StringUtils.isNotBlank(request.getCourtroom())) {
@@ -128,7 +137,7 @@ public class AdvancedSearchRequestHelper {
         return predicateList;
     }
 
-    private List<Predicate> addDefendantCriteria(GetCasesSearchRequest request, 
+    private List<Predicate> addDefendantCriteria(GetCasesSearchRequest request,
                                                  CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
         List<Predicate> predicateList = new ArrayList<>();
         if (StringUtils.isNotBlank(request.getDefendantName())) {
@@ -142,7 +151,7 @@ public class AdvancedSearchRequestHelper {
         return predicateList;
     }
 
-    private List<Predicate> addEventCriteria(GetCasesSearchRequest request, 
+    private List<Predicate> addEventCriteria(GetCasesSearchRequest request,
                                              CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
         List<Predicate> predicateList = new ArrayList<>();
         if (StringUtils.isNotBlank(request.getEventTextContains())) {
@@ -156,20 +165,85 @@ public class AdvancedSearchRequestHelper {
         return predicateList;
     }
 
-    private List<Predicate> addCourthouseCriteria(GetCasesSearchRequest request, 
-                                                  CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
+    private List<Predicate> addCourthouseCourtroomCriteria(GetCasesSearchRequest request,
+                                                           CriteriaBuilder criteriaBuilder,
+                                                           Join<UserAccountCourtCaseEntity,
+                                                               CourtCaseEntity> courtCaseJoin) throws AdvancedSearchNoResultsException {
+        boolean courtroomProvided = StringUtils.isNotBlank(request.getCourtroom()) || request.getCourthouseId() != null;
         List<Predicate> predicateList = new ArrayList<>();
+        if (courtroomProvided) {
+            return addCourtroomIdCriteria(request, criteriaBuilder, courtCaseJoin);
+        }
+        boolean courthouseProvided = StringUtils.isNotBlank(request.getCourthouse()) || request.getCourthouseId() != null;
+        if (courthouseProvided) {
+            return addCourthouseIdCriteria(request, criteriaBuilder, courtCaseJoin);
+        }
+
+        return predicateList;
+    }
+
+    private List<Predicate> addCourtroomIdCriteria(GetCasesSearchRequest request,
+                                                   CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
+        List<Predicate> predicateList = new ArrayList<>();
+        //Join<HearingEntity, CourtroomEntity> courtroomJoin = joinCourtroom(courtCaseJoin);
+        Join<CourtCaseEntity, HearingEntity> hearingJoin = joinHearing(courtCaseJoin);
+        if (request.getCourtroomId() != null) {
+            CourtroomEntity courtroomReference = courtroomRepository.getReferenceById(request.getCourtroomId());
+            predicateList.add(criteriaBuilder.equal(
+                hearingJoin.get(CourtroomEntity_.ID),
+                courtroomReference)
+            );
+            return predicateList;
+        }
         if (StringUtils.isNotBlank(request.getCourthouse())) {
-            Join<CourtCaseEntity, CourthouseEntity> courthouseJoin = joinCourthouse(courtCaseJoin);
-            predicateList.add(criteriaBuilder.like(
-                criteriaBuilder.upper(courthouseJoin.get(CourthouseEntity_.COURTHOUSE_NAME)),
-                surroundWithPercentagesUpper(request.getCourthouse())
-            ));
+            List<Integer> courtroomIdList = courtroomRepository.findAllIdByCourthouseNameAndCourtroomNameLike(
+                request.getCourthouse(), request.getCourtroom());
+            List<CourtroomEntity> courtroomEntityList = courtroomIdList.stream().map(id -> courtroomRepository.getReferenceById(id)).toList();
+            predicateList.add(
+                hearingJoin.get(HearingEntity_.COURTROOM).in(
+                    courtroomEntityList)
+            );
+            return predicateList;
+        }
+
+        List<Integer> courtroomIdList = courtroomRepository.findAllIdByCourtroomNameLike(request.getCourtroom());
+        List<CourtroomEntity> courtroomEntityList = courtroomIdList.stream().map(id -> courtroomRepository.getReferenceById(id)).toList();
+        predicateList.add(
+            hearingJoin.get(HearingEntity_.COURTROOM).in(
+                courtroomEntityList)
+        );
+        return predicateList;
+    }
+
+    private List<Predicate> addCourthouseIdCriteria(GetCasesSearchRequest request,
+                                                    CriteriaBuilder criteriaBuilder,
+                                                    Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) throws AdvancedSearchNoResultsException {
+        List<Predicate> predicateList = new ArrayList<>();
+        if (request.getCourthouseId() != null) {
+            CourthouseEntity courthouseReference = courthouseRepository.getReferenceById(request.getCourthouseId());
+            predicateList.add(criteriaBuilder.equal(
+                courtCaseJoin.get(CourtCaseEntity_.COURTHOUSE),
+                courthouseReference)
+            );
+            return predicateList;
+        }
+        if (StringUtils.isNotBlank(request.getCourthouse())) {
+            List<Integer> courthouseIdList = courthouseRepository.findAllIdByDisplayNameOrNameLike(
+                request.getCourthouse());
+            log.debug("Matching list of courthouse IDs for search = {}", courthouseIdList);
+            if (courthouseIdList.isEmpty()) {
+                throw new AdvancedSearchNoResultsException();
+            }
+            List<CourthouseEntity> courthouseRefList = courthouseIdList.stream().map(id -> courthouseRepository.getReferenceById(id)).toList();
+            predicateList.add(
+                courtCaseJoin.get(CourtCaseEntity_.COURTHOUSE).in(
+                    courthouseRefList)
+            );
         }
         return predicateList;
     }
 
-    private List<Predicate> addJudgeCriteria(GetCasesSearchRequest request, 
+    private List<Predicate> addJudgeCriteria(GetCasesSearchRequest request,
                                              CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
         List<Predicate> predicateList = new ArrayList<>();
         if (StringUtils.isNotBlank(request.getJudgeName())) {
@@ -182,7 +256,7 @@ public class AdvancedSearchRequestHelper {
         return predicateList;
     }
 
-    private List<Predicate> addHearingDateCriteria(GetCasesSearchRequest request, 
+    private List<Predicate> addHearingDateCriteria(GetCasesSearchRequest request,
                                                    CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
         List<Predicate> predicateList = new ArrayList<>();
         if (request.getDateFrom() != null || request.getDateTo() != null) {
@@ -204,7 +278,7 @@ public class AdvancedSearchRequestHelper {
     }
 
     @SuppressWarnings("unchecked")
-    private Join<CourtCaseEntity, HearingEntity> joinHearing(Join<UserAccountCourtCaseEntity, CourtCaseEntity>  caseRoot) {
+    private Join<CourtCaseEntity, HearingEntity> joinHearing(Join<UserAccountCourtCaseEntity, CourtCaseEntity> caseRoot) {
         Optional<Join<CourtCaseEntity, ?>> foundJoin = caseRoot.getJoins().stream().filter(join -> join.getAttribute().getName().equals(
             CourtCaseEntity_.HEARINGS)).findAny();
         return foundJoin.map(courtCaseEntityJoin -> (Join<CourtCaseEntity, HearingEntity>) courtCaseEntityJoin)
@@ -227,7 +301,7 @@ public class AdvancedSearchRequestHelper {
     }
 
     @SuppressWarnings("unchecked")
-    private Join<CourtCaseEntity, CourthouseEntity> joinCourthouse(Join<UserAccountCourtCaseEntity, CourtCaseEntity>  caseRoot) {
+    private Join<CourtCaseEntity, CourthouseEntity> joinCourthouse(Join<UserAccountCourtCaseEntity, CourtCaseEntity> caseRoot) {
         Optional<Join<CourtCaseEntity, ?>> foundJoin = caseRoot.getJoins().stream().filter(join -> join.getAttribute().getName().equals(
             CourtroomEntity_.COURTHOUSE)).findAny();
         return foundJoin.map(join -> (Join<CourtCaseEntity, CourthouseEntity>) join)

--- a/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
@@ -183,7 +183,8 @@ public class AdvancedSearchRequestHelper {
     }
 
     private List<Predicate> addCourtroomIdCriteria(GetCasesSearchRequest request,
-                                                   CriteriaBuilder criteriaBuilder, Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) {
+                                                   CriteriaBuilder criteriaBuilder,
+                                                   Join<UserAccountCourtCaseEntity, CourtCaseEntity> courtCaseJoin) throws AdvancedSearchNoResultsException {
         List<Predicate> predicateList = new ArrayList<>();
         //Join<HearingEntity, CourtroomEntity> courtroomJoin = joinCourtroom(courtCaseJoin);
         Join<CourtCaseEntity, HearingEntity> hearingJoin = joinHearing(courtCaseJoin);
@@ -198,6 +199,9 @@ public class AdvancedSearchRequestHelper {
         if (StringUtils.isNotBlank(request.getCourthouse())) {
             List<Integer> courtroomIdList = courtroomRepository.findAllIdByCourthouseNameAndCourtroomNameLike(
                 request.getCourthouse(), request.getCourtroom());
+            if (courtroomIdList.isEmpty()) {
+                throw new AdvancedSearchNoResultsException();
+            }
             List<CourtroomEntity> courtroomEntityList = courtroomIdList.stream().map(id -> courtroomRepository.getReferenceById(id)).toList();
             predicateList.add(
                 hearingJoin.get(HearingEntity_.COURTROOM).in(

--- a/src/main/java/uk/gov/hmcts/darts/cases/model/GetCasesSearchRequest.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/model/GetCasesSearchRequest.java
@@ -15,7 +15,9 @@ public class GetCasesSearchRequest {
 
     String caseNumber;
     String courthouse;
+    Integer courthouseId;
     String courtroom;
+    Integer courtroomId;
     String judgeName;
     String defendantName;
     LocalDate dateFrom;

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.cases.exception.AdvancedSearchNoResultsException;
 import uk.gov.hmcts.darts.cases.exception.CaseApiError;
 import uk.gov.hmcts.darts.cases.helper.AdvancedSearchRequestHelper;
 import uk.gov.hmcts.darts.cases.mapper.AdvancedSearchResponseMapper;
@@ -48,7 +49,7 @@ import java.util.stream.Collectors;
 @SuppressWarnings("PMD.TooManyMethods")
 public class CaseServiceImpl implements CaseService {
 
-    private static final int MAX_RESULTS = 500;
+    public static final int MAX_RESULTS = 500;
     private final CasesMapper casesMapper;
     private final CasesAnnotationMapper annotationMapper;
 
@@ -128,7 +129,12 @@ public class CaseServiceImpl implements CaseService {
 
     @Override
     public List<AdvancedSearchResult> advancedSearch(GetCasesSearchRequest request) {
-        List<Integer> caseIds = advancedSearchRequestHelper.getMatchingCourtCases(request);
+        List<Integer> caseIds = null;
+        try {
+            caseIds = advancedSearchRequestHelper.getMatchingCourtCases(request);
+        } catch (AdvancedSearchNoResultsException e) {
+            return new ArrayList<>();
+        }
         if (caseIds.size() > MAX_RESULTS) {
             throw new DartsApiException(CaseApiError.TOO_MANY_RESULTS);
         }

--- a/src/main/java/uk/gov/hmcts/darts/cases/util/RequestValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/util/RequestValidator.java
@@ -35,7 +35,7 @@ public class RequestValidator {
         //give a point for every letter more than 3
         totalPoints += Math.max(0, StringUtils.length(request.getCaseNumber()) - 3);
         totalPoints += (StringUtils.length(request.getCourthouse()) >= 3 || request.getCourthouseId() != null) ? 1 : 0;
-        totalPoints += (request.getCourtroom() != null || request.getCourthouseId() != null) ? 1 : 0;
+        totalPoints += (request.getCourtroom() != null || request.getCourtroomId() != null) ? 1 : 0;
         totalPoints += StringUtils.length(request.getJudgeName()) >= 3 ? 1 : 0;
         totalPoints += StringUtils.length(request.getDefendantName()) >= 3 ? 1 : 0;
         totalPoints += (request.getDateFrom() != null || request.getDateTo() != null) ? 1 : 0;

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CourthouseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CourthouseRepository.java
@@ -28,6 +28,14 @@ public interface CourthouseRepository extends JpaRepository<CourthouseEntity, In
         """)
     List<CourthouseEntity> findAuthorisedCourthousesForEmailAddressOrGuid(String emailAddress, Set<Integer> roleIds, String guid);
 
+    @Query("""
+        SELECT DISTINCT ch.id
+        FROM CourthouseEntity ch
+        WHERE upper(ch.courthouseName) like upper(%:name%)
+        or upper(ch.displayName) like upper(%:name%)
+        """)
+    List<Integer> findAllIdByDisplayNameOrNameLike(String name);
+
     Optional<CourthouseEntity> findByDisplayNameIgnoreCase(String displayName);
 
     boolean existsByCourthouseNameIgnoreCaseAndIdNot(String name, Integer id);

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CourthouseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CourthouseRepository.java
@@ -31,8 +31,8 @@ public interface CourthouseRepository extends JpaRepository<CourthouseEntity, In
     @Query("""
         SELECT DISTINCT ch.id
         FROM CourthouseEntity ch
-        WHERE upper(ch.courthouseName) like upper(%:name%)
-        or upper(ch.displayName) like upper(%:name%)
+        WHERE upper(ch.courthouseName) like upper(CONCAT('%', :name, '%'))
+        or upper(ch.displayName) like upper(CONCAT('%', :name, '%'))
         """)
     List<Integer> findAllIdByDisplayNameOrNameLike(String name);
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CourthouseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CourthouseRepository.java
@@ -29,7 +29,7 @@ public interface CourthouseRepository extends JpaRepository<CourthouseEntity, In
     List<CourthouseEntity> findAuthorisedCourthousesForEmailAddressOrGuid(String emailAddress, Set<Integer> roleIds, String guid);
 
     @Query("""
-        SELECT DISTINCT ch.id
+        SELECT ch.id
         FROM CourthouseEntity ch
         WHERE upper(ch.courthouseName) like upper(CONCAT('%', :name, '%'))
         or upper(ch.displayName) like upper(CONCAT('%', :name, '%'))

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CourtroomRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CourtroomRepository.java
@@ -24,8 +24,8 @@ public interface CourtroomRepository extends JpaRepository<CourtroomEntity, Inte
 
     @Query("""
         SELECT cr.id FROM CourthouseEntity ch, CourtroomEntity cr
-        WHERE upper(ch.courthouseName) like upper(%:courthouse%)
-        AND upper(cr.name) like upper(%:courtroom%)
+        WHERE upper(ch.courthouseName) like upper(CONCAT('%', :courthouse, '%'))
+        AND upper(cr.name) like upper(CONCAT('%', :courtroom, '%'))
         AND cr.courthouse = ch
         """
     )
@@ -33,7 +33,7 @@ public interface CourtroomRepository extends JpaRepository<CourtroomEntity, Inte
 
     @Query("""
         SELECT cr.id FROM CourtroomEntity cr
-        WHERE upper(cr.name) like upper(%:courtroom%)
+        WHERE upper(cr.name) like upper(CONCAT('%', :courtroom, '%'))
         """
     )
     List<Integer> findAllIdByCourtroomNameLike(String courtroom);

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CourtroomRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CourtroomRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 
+import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.hmcts.darts.common.entity.CourtroomEntity.TABLE_NAME;
@@ -13,13 +14,29 @@ import static uk.gov.hmcts.darts.common.entity.CourtroomEntity.TABLE_NAME;
 public interface CourtroomRepository extends JpaRepository<CourtroomEntity, Integer> {
 
     @Query("""
-        SELECT cr FROM CourthouseEntity ch, CourtroomEntity cr\s
-        WHERE upper(ch.courthouseName) = upper(:courthouse)\s
-        AND upper(cr.name) = upper(:courtroom)\s
+        SELECT cr FROM CourthouseEntity ch, CourtroomEntity cr
+        WHERE upper(ch.courthouseName) = upper(:courthouse)
+        AND upper(cr.name) = upper(:courtroom)
         AND cr.courthouse = ch
         """
     )
     Optional<CourtroomEntity> findByCourthouseNameAndCourtroomName(String courthouse, String courtroom);
+
+    @Query("""
+        SELECT cr.id FROM CourthouseEntity ch, CourtroomEntity cr
+        WHERE upper(ch.courthouseName) like upper(%:courthouse%)
+        AND upper(cr.name) like upper(%:courtroom%)
+        AND cr.courthouse = ch
+        """
+    )
+    List<Integer> findAllIdByCourthouseNameAndCourtroomNameLike(String courthouse, String courtroom);
+
+    @Query("""
+        SELECT cr.id FROM CourtroomEntity cr
+        WHERE upper(cr.name) like upper(%:courtroom%)
+        """
+    )
+    List<Integer> findAllIdByCourtroomNameLike(String courtroom);
 
     @Query(value = "SELECT * FROM {h-schema}" + TABLE_NAME + " cr " +
         "WHERE upper(cr." + CourtroomEntity.COURTROOM_NAME + ") = upper(:courtroom) " +

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -281,7 +281,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AdvancedSearchDetails'
+              $ref: '#/components/schemas/AdvancedSearchRequest'
       responses:
         '200':
           description: OK
@@ -521,7 +521,7 @@ components:
         hearings:
           type: array
           items:
-              $ref: '#/components/schemas/advancedSearchResultHearing'
+            $ref: '#/components/schemas/advancedSearchResultHearing'
     advancedSearchResultHearing:
       type: object
       properties:
@@ -602,7 +602,7 @@ components:
         transcript_count:
           type: integer
 
-    AdvancedSearchDetails:
+    AdvancedSearchRequest:
       type: object
       properties:
         case_number:
@@ -613,10 +613,18 @@ components:
           type: string
           example: Swansea
           maxLength: 255
+        courthouseId:
+          type: integer
+          example: 1
+          description: the courthouse ID if known.
         courtroom:
           type: string
           example: 2
           maxLength: 255
+        courtroomId:
+          type: integer
+          example: 1
+          description: the courtroom ID if known.
         judge_name:
           type: string
           example: Judge Walker
@@ -658,22 +666,22 @@ components:
     CaseErrorCode:
       type: string
       enum:
-       - "CASE_100"
-       - "CASE_101"
-       - "CASE_102"
-       - "CASE_103"
-       - "CASE_104"
-       - "CASE_106"
+        - "CASE_100"
+        - "CASE_101"
+        - "CASE_102"
+        - "CASE_103"
+        - "CASE_104"
+        - "CASE_106"
       x-enum-varnames: [ TOO_MANY_RESULTS, NO_CRITERIA_SPECIFIED, CRITERIA_TOO_BROAD, INVALID_REQUEST, CASE_NOT_FOUND, PATCH_CRITERIA_NOT_MET ]
 
     CaseTitleErrors:
       type: string
       enum:
-      - "Too many results have been returned. Please change search criteria."
-      - "No search criteria has been specified, please add at least 1 criteria to search for."
-      - "Search criteria is too broad, please add at least 1 more criteria to search for."
-      - "The request is not valid.."
-      - "The requested case cannot be found"
-      - "The request does not contain any values that are supported by the PATCH operation."
+        - "Too many results have been returned. Please change search criteria."
+        - "No search criteria has been specified, please add at least 1 criteria to search for."
+        - "Search criteria is too broad, please add at least 1 more criteria to search for."
+        - "The request is not valid.."
+        - "The requested case cannot be found"
+        - "The request does not contain any values that are supported by the PATCH operation."
       x-enum-varnames: [ TOO_MANY_RESULTS, NO_CRITERIA_SPECIFIED, CRITERIA_TOO_BROAD, INVALID_REQUEST, CASE_NOT_FOUND, PATCH_CRITERIA_NOT_MET ]
 

--- a/src/test/java/uk/gov/hmcts/darts/cases/util/RequestValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/util/RequestValidatorTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class RequestValidatorTest {
 
     @Test
-    void ok() {
+    void okCaseNumberLongEnough() {
         GetCasesSearchRequest request = GetCasesSearchRequest.builder()
             .caseNumber("gfdgfd")
             .build();
@@ -52,6 +52,24 @@ class RequestValidatorTest {
     }
 
     @Test
+    void raiseNotEnoughCriteriaException2() {
+        GetCasesSearchRequest request = GetCasesSearchRequest.builder()
+            .courthouse("swansea")
+            .courtroom("1")
+            .caseNumber("1")
+            .build();
+
+        var exception = assertThrows(
+            DartsApiException.class,
+            () -> RequestValidator.validate(request)
+        );
+        assertEquals(
+            "Search criteria is too broad, please add at least 1 more criteria to search for.",
+            exception.getMessage()
+        );
+    }
+
+    @Test
     void raiseNotEnoughCriteria2Exception() {
         GetCasesSearchRequest request = GetCasesSearchRequest.builder()
             .courtroom("3")
@@ -72,6 +90,7 @@ class RequestValidatorTest {
         GetCasesSearchRequest request = GetCasesSearchRequest.builder()
             .dateFrom(LocalDate.of(2023, 6, 20))
             .dateTo(LocalDate.of(2023, 6, 19))
+            .caseNumber("123456")
             .build();
 
         var exception = assertThrows(
@@ -89,6 +108,7 @@ class RequestValidatorTest {
         GetCasesSearchRequest request = GetCasesSearchRequest.builder()
             .dateFrom(LocalDate.of(2023, 6, 20))
             .dateTo(LocalDate.of(2023, 6, 20))
+            .caseNumber("123456")
             .build();
 
         RequestValidator.validate(request);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-2582

- results limited to 501
- allowed the requestor to send in the courthouseId or courtroomId (in case we want to enhance the screen to allow it to send these in directly, due to a dropdown)
- i have created a request complexity calculator that takes a few things into account to decide whether enough criteria has been given, e.g. a judge name of 2 characters or less is not considered complex enough, and so would need to be combined with other items to be considered, please see code here https://github.com/hmcts/darts-api/pull/1268/files#diff-196111a004439aa49c440cc62372f141475407729c7a0abbc62a77d17a451e2aR33
- i have also changed the query to get the courthouseId or courtroomId up front, to get around the issue with the postgres optimiser not working correctly.
- i've removed the needless join onto the userAccount table.