### PR TITLE
DMP-2661: Filtering GET /admin/user by user_ids

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerGetUsersIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerGetUsersIntTest.java
@@ -55,7 +55,7 @@ class UserControllerGetUsersIntTest extends IntegrationBase {
     void usersGetShouldReturnForbiddenError() throws Exception {
         superAdminUserStub.givenUserIsNotAuthorised(mockUserIdentity);
 
-        MvcResult mvcResult = mockMvc.perform(get(ENDPOINT_URL).queryParam("courthouse", "-1"))
+        MvcResult mvcResult = mockMvc.perform(get(ENDPOINT_URL))
             .andExpect(status().isForbidden())
             .andReturn();
 
@@ -102,8 +102,7 @@ class UserControllerGetUsersIntTest extends IntegrationBase {
         createEnabledUserAccountEntity(user);
 
         MvcResult response = mockMvc.perform(get(ENDPOINT_URL)
-                                                 .header(EMAIL_ADDRESS, "james.smith@hmcts.com")
-                                                 .queryParam(COURTHOUSE_ID, "21"))
+                                                 .header(EMAIL_ADDRESS, "james.smith@hmcts.com"))
             .andReturn();
 
         assertFalse(response.getResponse().getContentAsString().contains("james.smith@hmcts.com"));

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserQueryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserQueryTest.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.darts.usermanagement.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.usermanagement.component.UserManagementQuery;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.darts.testutils.data.UserAccountTestData.minimalUserAccount;
+
+class UserQueryTest extends IntegrationBase {
+
+    @Autowired
+    private UserManagementQuery userManagementQuery;
+    private UserAccountEntity user1;
+    private UserAccountEntity user2;
+    private UserAccountEntity user3;
+
+    @AfterEach
+    void tearDown() {
+        dartsDatabase.addToUserAccountTrash(user1.getEmailAddress(), user2.getEmailAddress(), user3.getEmailAddress());
+    }
+
+    @Test
+    void searchWithAllOptionalFieldsBlank() {
+        user1 = minimalUserAccount();
+        user2 = minimalUserAccount();
+        user3 = minimalUserAccount();
+        dartsDatabase.saveAll(user1, user2, user3);
+
+        var users = userManagementQuery.getUsers(null, null);
+
+        assertThat(users).extracting("id")
+            .isEqualTo(userIdsDesc(user1, user2, user3));
+    }
+
+    @Test
+    void searchWithOnlyEmailSpecified() {
+        user1 = minimalUserAccount();
+        user1.setEmailAddress("some-user-email");
+        user2 = minimalUserAccount();
+        user3 = minimalUserAccount();
+        dartsDatabase.saveAll(user1, user2, user3);
+
+        var users = userManagementQuery.getUsers(user1.getEmailAddress(), null);
+
+        assertThat(users).extracting("id").containsExactly(user1.getId());
+    }
+
+    @Test
+    void searchWithOneUserIdSpecified() {
+        user1 = minimalUserAccount();
+        user2 = minimalUserAccount();
+        user3 = minimalUserAccount();
+        dartsDatabase.saveAll(user1, user2, user3);
+
+        var users = userManagementQuery.getUsers(null, List.of(user1.getId()));
+
+        assertThat(users).extracting("id").containsExactly(user1.getId());
+    }
+
+    @Test
+    void searchWithMultipleUserIdsSpecified() {
+        user1 = minimalUserAccount();
+        user2 = minimalUserAccount();
+        user3 = minimalUserAccount();
+        dartsDatabase.saveAll(user1, user2, user3);
+
+        var users = userManagementQuery.getUsers(null, List.of(user1.getId(), user3.getId()));
+
+        assertThat(users).extracting("id")
+            .isEqualTo(userIdsDesc(user1, user3));
+    }
+
+    @Test
+    void returnsEmptyListIfNoUsersMatchOnMultiplePredicates() {
+        user1 = minimalUserAccount();
+        user1.setEmailAddress("some-user-email");
+        user2 = minimalUserAccount();
+        user3 = minimalUserAccount();
+        dartsDatabase.saveAll(user1, user2, user3);
+
+        var users = userManagementQuery.getUsers(user1.getEmailAddress(), List.of(user3.getId()));
+
+        assertThat(users).isEmpty();
+    }
+
+    private static List<Integer> userIdsDesc(UserAccountEntity... users) {
+        return Stream.of(users)
+            .map(UserAccountEntity::getId)
+            .sorted((u1, u2) -> u2 - u1)
+            .toList();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.common.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -12,7 +13,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @Repository
-public interface UserAccountRepository extends JpaRepository<UserAccountEntity, Integer> {
+public interface UserAccountRepository extends JpaRepository<UserAccountEntity, Integer>, JpaSpecificationExecutor<UserAccountEntity> {
 
     List<UserAccountEntity> findByEmailAddressIgnoreCase(String emailAddress);
 

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/component/UserManagementQuery.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/component/UserManagementQuery.java
@@ -6,6 +6,6 @@ import java.util.List;
 
 public interface UserManagementQuery {
 
-    List<UserAccountEntity> getUsers(String emailAddress);
+    List<UserAccountEntity> getUsers(String emailAddress, List<Integer> userIds);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserManagementQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserManagementQueryImpl.java
@@ -1,59 +1,31 @@
 package uk.gov.hmcts.darts.usermanagement.component.impl;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.TypedQuery;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.ParameterExpression;
-import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.criteria.Root;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.entity.UserAccountEntity_;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.usermanagement.component.UserManagementQuery;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+import static org.springframework.data.jpa.domain.Specification.where;
+import static uk.gov.hmcts.darts.usermanagement.component.impl.UserQuerySpecifications.hasEmailAddress;
+import static uk.gov.hmcts.darts.usermanagement.component.impl.UserQuerySpecifications.isInIds;
+import static uk.gov.hmcts.darts.usermanagement.component.impl.UserQuerySpecifications.notSystemUser;
 
 @Component
 @RequiredArgsConstructor
 public class UserManagementQueryImpl implements UserManagementQuery {
 
-    private final EntityManager em;
+    private final UserAccountRepository userAccountRepository;
 
-    public List<UserAccountEntity> getUsers(String emailAddress) {
-        CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
-        CriteriaQuery<UserAccountEntity> criteriaQuery = criteriaBuilder.createQuery(UserAccountEntity.class);
-
-        Root<UserAccountEntity> root = criteriaQuery.from(UserAccountEntity.class);
-        criteriaQuery.select(root);
-
-        List<Predicate> wherePredicates = new ArrayList<>();
-        wherePredicates.add(criteriaBuilder.isFalse(root.get(UserAccountEntity_.isSystemUser)));
-        ParameterExpression<String> paramEmailAddress = criteriaBuilder.parameter(String.class);
-
-        boolean isNotBlankEmailAddress = isNotBlank(emailAddress);
-        if (isNotBlankEmailAddress) {
-            wherePredicates.add(criteriaBuilder.equal(
-                criteriaBuilder.lower(root.get(UserAccountEntity_.emailAddress)),
-
-                criteriaBuilder.lower(paramEmailAddress)
-            ));
-        }
-
-        Predicate finalWherePredicate = criteriaBuilder.and(wherePredicates.toArray(Predicate[]::new));
-        criteriaQuery.where(finalWherePredicate);
-        criteriaQuery.orderBy(criteriaBuilder.desc(root.get(UserAccountEntity_.id)));
-
-        TypedQuery<UserAccountEntity> query = em.createQuery(criteriaQuery);
-        if (isNotBlankEmailAddress) {
-            query.setParameter(paramEmailAddress, emailAddress);
-        }
-
-        return query.getResultList();
+    public List<UserAccountEntity> getUsers(String emailAddress, List<Integer> userIds) {
+        return userAccountRepository.findAll(
+            where(notSystemUser())
+                .and(hasEmailAddress(emailAddress))
+                .and(isInIds(userIds)),
+            Sort.by(DESC, "id"));
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserQuerySpecifications.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserQuerySpecifications.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity_;
 import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 public class UserQuerySpecifications {
 
@@ -23,7 +24,7 @@ public class UserQuerySpecifications {
     }
 
     public static Specification<UserAccountEntity> isInIds(List<Integer> userIds) {
-        if (userIds == null || userIds.isEmpty()) {
+        if (isEmpty(userIds)) {
             return null;
         }
         return (root, query, builder) -> root.get(UserAccountEntity_.id).in(userIds);

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserQuerySpecifications.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserQuerySpecifications.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.darts.usermanagement.component.impl;
+
+import org.springframework.data.jpa.domain.Specification;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity_;
+
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class UserQuerySpecifications {
+
+    private UserQuerySpecifications() {
+    }
+
+    public static Specification<UserAccountEntity> hasEmailAddress(String emailAddress) {
+        if (isBlank(emailAddress)) {
+            return null;
+        }
+        return (root, query, cb) -> cb.equal(
+            cb.lower(root.get(UserAccountEntity_.emailAddress)),
+            emailAddress.toLowerCase());
+    }
+
+    public static Specification<UserAccountEntity> isInIds(List<Integer> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return null;
+        }
+        return (root, query, builder) -> root.get(UserAccountEntity_.id).in(userIds);
+    }
+
+    public static Specification<UserAccountEntity> notSystemUser() {
+        return (root, query, builder) -> builder.equal(root.get(UserAccountEntity_.isSystemUser), false);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
@@ -32,8 +32,8 @@ public class UserController implements UserApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
-    public ResponseEntity<List<UserWithIdAndTimestamps>> getUsers(Integer courthouseId, String emailAddress) {
-        return ResponseEntity.ok(userManagementService.getUsers(emailAddress));
+    public ResponseEntity<List<UserWithIdAndTimestamps>> getUsers(List<Integer> userIds, String emailAddress) {
+        return ResponseEntity.ok(userManagementService.getUsers(emailAddress, userIds));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementService.java
@@ -16,7 +16,7 @@ public interface UserManagementService {
 
     List<UserWithIdAndTimestamps> search(UserSearch userSearch);
 
-    List<UserWithIdAndTimestamps> getUsers(String emailAddress);
+    List<UserWithIdAndTimestamps> getUsers(String emailAddress, List<Integer> userIds);
 
     UserWithIdAndTimestamps getUserById(Integer userId);
 

--- a/src/main/resources/openapi/usermanagement.yaml
+++ b/src/main/resources/openapi/usermanagement.yaml
@@ -18,10 +18,14 @@ paths:
       operationId: getUsers
       parameters:
         - in: query
-          name: courthouse_id
+          name: user_ids
           required: false
+          style: form
+          explode: false
           schema:
-            $ref: "#/components/schemas/CourthouseId"
+            type: array
+            items:
+              $ref: '#/components/schemas/UserId'
         - in: header
           name: Email-Address
           required: false

--- a/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/usermanagement/service/UserManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/usermanagement/service/UserManagementServiceImplTest.java
@@ -75,11 +75,9 @@ class UserManagementServiceImplTest {
     void testGetUser() throws IOException {
         List<UserAccountEntity> userAccountEntities = Collections.singletonList(createUserAccount(1, EXISTING_EMAIL_ADDRESS));
 
-        Mockito.when(userManagementQuery.getUsers(
-            eq(EXISTING_EMAIL_ADDRESS)
-        )).thenReturn(userAccountEntities);
+        Mockito.when(userManagementQuery.getUsers(eq(EXISTING_EMAIL_ADDRESS), eq(null))).thenReturn(userAccountEntities);
 
-        List<UserWithIdAndTimestamps> resultList = service.getUsers(EXISTING_EMAIL_ADDRESS);
+        List<UserWithIdAndTimestamps> resultList = service.getUsers(EXISTING_EMAIL_ADDRESS, null);
 
         assertEquals(userAccountEntities.get(0).getUserName(), resultList.get(0).getFullName());
         assertEquals(userAccountEntities.get(0).getEmailAddress(), resultList.get(0).getEmailAddress());


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-2661

- Filtering GET /admin/user by user_ids. 
- Rewrote the query using JPA specifications improve readability and to reduce the boiler plate of directly creating using CriteriaBuilders
- Removed courthouse_id from api as no longer needed. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
