### PR TITLE
DMP-2609: Enabling message_id validation

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
@@ -151,11 +151,10 @@ class PatchUserIntTest extends IntegrationBase {
             assertEquals(ORIGINAL_EMAIL_ADDRESS, latestUserAccountEntity.getEmailAddress());
             assertEquals("An updated description", latestUserAccountEntity.getUserDescription());
             assertEquals(false, latestUserAccountEntity.isActive());
-            assertThat(getSecurityGroupIds(latestUserAccountEntity), empty()
-            );
+            assertThat(getSecurityGroupIds(latestUserAccountEntity), empty());
             assertEquals(ORIGINAL_SYSTEM_USER_FLAG, latestUserAccountEntity.getIsSystemUser());
 
-            assertEquals(existingAccount.getCreatedDateTime(), latestUserAccountEntity.getCreatedDateTime());
+            assertEquals(existingAccount.getCreatedDateTime().toInstant(), latestUserAccountEntity.getCreatedDateTime().toInstant());
             assertThat(latestUserAccountEntity.getLastModifiedDateTime(), greaterThan(existingAccount.getLastModifiedDateTime()));
             assertEquals(ORIGINAL_LAST_LOGIN_TIME, latestUserAccountEntity.getLastLoginTime());
             assertEquals(user.getId(), latestUserAccountEntity.getLastModifiedBy().getId());

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/validation/DailyListPostValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/validation/DailyListPostValidator.java
@@ -18,8 +18,7 @@ public class DailyListPostValidator {
                 || request.getHearingDate() == null
                 || StringUtils.isBlank(request.getUniqueId())
                 || request.getPublishedDateTime() == null
-                // Will uncomment when gateway is ready
-                //  || request.getMessageId() == null
+                || request.getMessageId() == null
                 || StringUtils.isBlank(request.getSourceSystem())) {
                 throw new DartsApiException(DailyListError.XML_EXTRA_PARAMETERS_MISSING);
             }

--- a/src/test/java/uk/gov/hmcts/darts/dailylist/validation/DailyListPostValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/dailylist/validation/DailyListPostValidatorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.dailylist.validation;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.dailylist.model.DailyListJsonObject;
 import uk.gov.hmcts.darts.dailylist.model.DailyListPostRequest;
 
@@ -26,8 +27,10 @@ class DailyListPostValidatorTest {
         request.setUniqueId("test");
         request.setSourceSystem("test");
         request.setCourthouse("test");
+        request.setMessageId("test");
         request.setHearingDate(LocalDate.now());
         request.setPublishedDateTime(OffsetDateTime.now());
+        request.setMessageId("test");
         DailyListPostValidator.validate(request);
     }
 
@@ -40,6 +43,7 @@ class DailyListPostValidatorTest {
         request.setCourthouse("test");
         request.setHearingDate(LocalDate.now());
         request.setPublishedDateTime(OffsetDateTime.now());
+        request.setMessageId("test");
         request.setDailyListJson(new DailyListJsonObject());
         DailyListPostValidator.validate(request);
     }
@@ -52,8 +56,8 @@ class DailyListPostValidatorTest {
         request.setCourthouse("test");
         request.setHearingDate(LocalDate.now());
         request.setPublishedDateTime(OffsetDateTime.now());
-
-        Exception exception = assertThrows(Exception.class, () -> DailyListPostValidator.validate(request));
+        request.setMessageId("test");
+        Exception exception = assertThrows(DartsApiException.class, () -> DailyListPostValidator.validate(request));
         assertThat(exception.getMessage()).contains("If xml_document is being provided");
     }
 
@@ -65,7 +69,8 @@ class DailyListPostValidatorTest {
         request.setCourthouse("test");
         request.setHearingDate(LocalDate.now());
         request.setPublishedDateTime(OffsetDateTime.now());
-        Exception exception = assertThrows(Exception.class, () -> DailyListPostValidator.validate(request));
+        request.setMessageId("test");
+        Exception exception = assertThrows(DartsApiException.class, () -> DailyListPostValidator.validate(request));
         assertThat(exception.getMessage()).contains("Either xml_document");
     }
 
@@ -77,7 +82,8 @@ class DailyListPostValidatorTest {
         request.setCourthouse("test");
         request.setHearingDate(LocalDate.now());
         request.setPublishedDateTime(OffsetDateTime.now());
-        Exception exception = assertThrows(Exception.class, () -> DailyListPostValidator.validate(request));
+        request.setMessageId("test");
+        Exception exception = assertThrows(DartsApiException.class, () -> DailyListPostValidator.validate(request));
         assertThat(exception.getMessage()).contains("If xml_document is being provided");
     }
 
@@ -89,7 +95,8 @@ class DailyListPostValidatorTest {
         request.setSourceSystem("test");
         request.setHearingDate(LocalDate.now());
         request.setPublishedDateTime(OffsetDateTime.now());
-        Exception exception = assertThrows(Exception.class, () -> DailyListPostValidator.validate(request));
+        request.setMessageId("test");
+        Exception exception = assertThrows(DartsApiException.class, () -> DailyListPostValidator.validate(request));
         assertThat(exception.getMessage()).contains("If xml_document is being provided");
     }
 
@@ -100,8 +107,10 @@ class DailyListPostValidatorTest {
         request.setUniqueId("test");
         request.setSourceSystem("test");
         request.setCourthouse("test");
+        request.setMessageId("test");
         request.setPublishedDateTime(OffsetDateTime.now());
-        Exception exception = assertThrows(Exception.class, () -> DailyListPostValidator.validate(request));
+        request.setMessageId("test");
+        Exception exception = assertThrows(DartsApiException.class, () -> DailyListPostValidator.validate(request));
         assertThat(exception.getMessage()).contains("If xml_document is being provided");
     }
 
@@ -112,8 +121,22 @@ class DailyListPostValidatorTest {
         request.setUniqueId("test");
         request.setSourceSystem("test");
         request.setCourthouse("test");
+        request.setMessageId("test");
         request.setHearingDate(LocalDate.now());
-        Exception exception = assertThrows(Exception.class, () -> DailyListPostValidator.validate(request));
+        Exception exception = assertThrows(DartsApiException.class, () -> DailyListPostValidator.validate(request));
+        assertThat(exception.getMessage()).contains("If xml_document is being provided");
+    }
+
+    @Test
+    void error_Xml_missingMessageId() {
+        DailyListPostRequest request = new DailyListPostRequest();
+        request.setDailyListXml("test");
+        request.setUniqueId("test");
+        request.setSourceSystem("test");
+        request.setCourthouse("test");
+        request.setHearingDate(LocalDate.now());
+        request.setPublishedDateTime(OffsetDateTime.now());
+        Exception exception = assertThrows(DartsApiException.class, () -> DailyListPostValidator.validate(request));
         assertThat(exception.getMessage()).contains("If xml_document is being provided");
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-2609

Enabling message_id validation.  Fixing unrelated test. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
