### PR TITLE
DMP-2750 Fixing swagger schema for /userstate endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/HandleOAuthCodeIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/HandleOAuthCodeIntTest.java
@@ -22,8 +22,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
-import uk.gov.hmcts.darts.authorisation.model.Role;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
+import uk.gov.hmcts.darts.authorisation.model.UserStateRole;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.security.KeyPair;
@@ -78,7 +78,7 @@ class HandleOAuthCodeIntTest extends IntegrationBase {
             .thenReturn(Optional.ofNullable(UserState.builder()
                                                 .userId(-1)
                                                 .userName("Test User")
-                                                .roles(Set.of(Role.builder()
+                                                .roles(Set.of(UserStateRole.builder()
                                                                   .roleId(TRANSCRIBER.getId())
                                                                   .roleName(TRANSCRIBER.toString())
                                                                   .globalAccess(false)

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
@@ -8,8 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
-import uk.gov.hmcts.darts.authorisation.model.Role;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
+import uk.gov.hmcts.darts.authorisation.model.UserStateRole;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -141,7 +141,7 @@ class AuthorisationServiceTest extends IntegrationBase {
 
         assertEquals(1, judgeUserState.getRoles().size());
 
-        Role judgeRole = judgeUserState.getRoles().iterator().next();
+        UserStateRole judgeRole = judgeUserState.getRoles().iterator().next();
         assertEquals(JUDGE.getId(), judgeRole.getRoleId());
         assertFalse(judgeRole.getGlobalAccess());
 
@@ -165,7 +165,7 @@ class AuthorisationServiceTest extends IntegrationBase {
 
         assertEquals(1, judgeUserState.getRoles().size());
 
-        Role judgeRole = judgeUserState.getRoles().iterator().next();
+        UserStateRole judgeRole = judgeUserState.getRoles().iterator().next();
         assertEquals(JUDGE.getId(), judgeRole.getRoleId());
         assertTrue(judgeRole.getGlobalAccess());
 
@@ -183,16 +183,16 @@ class AuthorisationServiceTest extends IntegrationBase {
 
         assertEquals(2, userState.getRoles().size());
 
-        Iterator<Role> roleIterator = userState.getRoles().iterator();
+        Iterator<UserStateRole> roleIterator = userState.getRoles().iterator();
 
-        Role approverRole = roleIterator.next();
+        UserStateRole approverRole = roleIterator.next();
         assertEquals(APPROVER.getId(), approverRole.getRoleId());
         assertFalse(approverRole.getGlobalAccess());
         Set<String> approverPermissions = approverRole.getPermissions();
         assertEquals(11, approverPermissions.size());
         assertTrue(approverPermissions.contains("APPROVE_REJECT_TRANSCRIPTION_REQUEST"));
 
-        Role requesterRole = roleIterator.next();
+        UserStateRole requesterRole = roleIterator.next();
         assertEquals(REQUESTER.getId(), requesterRole.getRoleId());
         Set<String> requesterPermissions = requesterRole.getPermissions();
         assertEquals(10, requesterPermissions.size());

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/model/UserState.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/model/UserState.java
@@ -15,6 +15,6 @@ public class UserState {
     @NonNull
     private String userName;
     @NonNull
-    private Set<Role> roles;
+    private Set<UserStateRole> roles;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/model/UserStateRole.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/model/UserStateRole.java
@@ -10,8 +10,7 @@ import java.util.Set;
 
 @Builder
 @Value
-@SuppressWarnings({"PMD.ShortClassName"})
-public class Role {
+public class UserStateRole {
 
     @Include
     @NonNull

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/service/impl/AuthorisationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/service/impl/AuthorisationServiceImpl.java
@@ -14,8 +14,8 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.authorisation.exception.AuthorisationError;
 import uk.gov.hmcts.darts.authorisation.model.GetAuthorisationResult;
-import uk.gov.hmcts.darts.authorisation.model.Role;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
+import uk.gov.hmcts.darts.authorisation.model.UserStateRole;
 import uk.gov.hmcts.darts.authorisation.service.AuthorisationService;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity_;
@@ -113,7 +113,7 @@ public class AuthorisationServiceImpl implements AuthorisationService {
         }
 
         UserState.UserStateBuilder userStateBuilder = UserState.builder();
-        Set<Role> roles = new LinkedHashSet<>();
+        Set<UserStateRole> roles = new LinkedHashSet<>();
         userStateBuilder.roles(roles);
 
         Integer tmpRoleId = 0;
@@ -129,7 +129,7 @@ public class AuthorisationServiceImpl implements AuthorisationService {
                 permissions = new LinkedHashSet<>();
                 courthouses = new LinkedHashSet<>();
 
-                roles.add(Role.builder()
+                roles.add(UserStateRole.builder()
                               .roleId(roleId)
                               .roleName(result.roleName())
                               .globalAccess(result.globalAccess())

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationCommonControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationCommonControllerTest.java
@@ -6,8 +6,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
-import uk.gov.hmcts.darts.authorisation.model.Role;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
+import uk.gov.hmcts.darts.authorisation.model.UserStateRole;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
 
@@ -35,14 +35,14 @@ class AuthenticationCommonControllerTest {
         UserAccountEntity userAccountEntity = CommonTestDataUtil.createUserAccount();
         when(authorisationApi.getCurrentUser()).thenReturn(userAccountEntity);
 
-        Set<Role> newRoles = new HashSet<>();
-        newRoles.add(Role.builder()
+        Set<UserStateRole> newRoles = new HashSet<>();
+        newRoles.add(UserStateRole.builder()
                          .roleId(APPROVER.getId())
                          .roleName(APPROVER.toString())
                          .globalAccess(false)
                          .permissions(new HashSet<>())
                          .build());
-        newRoles.add(Role.builder()
+        newRoles.add(UserStateRole.builder()
                          .roleId(REQUESTER.getId())
                          .roleName(REQUESTER.toString())
                          .globalAccess(false)

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationExternalUserControllerTest.java
@@ -21,8 +21,8 @@ import uk.gov.hmcts.darts.authentication.config.external.ExternalAuthProviderCon
 import uk.gov.hmcts.darts.authentication.model.SecurityToken;
 import uk.gov.hmcts.darts.authentication.service.AuthenticationService;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
-import uk.gov.hmcts.darts.authorisation.model.Role;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
+import uk.gov.hmcts.darts.authorisation.model.UserStateRole;
 import uk.gov.hmcts.darts.common.service.UserAccountService;
 
 import java.net.URI;
@@ -93,7 +93,7 @@ class AuthenticationExternalUserControllerTest {
             Optional.ofNullable(UserState.builder()
                                     .userId(-1)
                                     .userName("Test User")
-                                    .roles(Set.of(Role.builder()
+                                    .roles(Set.of(UserStateRole.builder()
                                                       .roleId(TRANSCRIBER.getId())
                                                       .roleName(TRANSCRIBER.toString())
                                                       .globalAccess(false)

--- a/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationInternalUserControllerTest.java
@@ -21,8 +21,8 @@ import uk.gov.hmcts.darts.authentication.config.internal.InternalAuthProviderCon
 import uk.gov.hmcts.darts.authentication.model.SecurityToken;
 import uk.gov.hmcts.darts.authentication.service.AuthenticationService;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
-import uk.gov.hmcts.darts.authorisation.model.Role;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
+import uk.gov.hmcts.darts.authorisation.model.UserStateRole;
 import uk.gov.hmcts.darts.common.service.UserAccountService;
 
 import java.net.URI;
@@ -90,7 +90,7 @@ class AuthenticationInternalUserControllerTest {
             Optional.ofNullable(UserState.builder()
                                     .userId(-1)
                                     .userName("Test User")
-                                    .roles(Set.of(Role.builder()
+                                    .roles(Set.of(UserStateRole.builder()
                                                       .roleId(TRANSCRIBER.getId())
                                                       .roleName(TRANSCRIBER.toString())
                                                       .globalAccess(false)

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/model/UserStateRoleTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/model/UserStateRoleTest.java
@@ -11,11 +11,11 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 
-class RoleTest {
+class UserStateRoleTest {
 
     @Test
     void builder() {
-        Role role = Role.builder()
+        UserStateRole role = UserStateRole.builder()
             .roleId(APPROVER.getId())
             .roleName(APPROVER.toString())
             .globalAccess(false)
@@ -30,26 +30,26 @@ class RoleTest {
 
     @Test
     void shouldEqualsJudgeRole() {
-        Role role = Role.builder()
+        UserStateRole role = UserStateRole.builder()
             .roleId(JUDGE.getId())
             .roleName(JUDGE.toString())
             .globalAccess(false)
             .permissions(Collections.emptySet())
             .build();
 
-        assertEquals(role, new Role(JUDGE.getId(), JUDGE.toString(), false, Collections.emptySet(),  Collections.emptySet()));
+        assertEquals(role, new UserStateRole(JUDGE.getId(), JUDGE.toString(), false, Collections.emptySet(), Collections.emptySet()));
     }
 
     @Test
     void shouldNotEqualsJudgeRole() {
-        Role role = Role.builder()
+        UserStateRole role = UserStateRole.builder()
             .roleId(JUDGE.getId())
             .roleName(JUDGE.toString())
             .globalAccess(false)
             .permissions(Collections.emptySet())
             .build();
 
-        assertNotEquals(role, new Role(REQUESTER.getId(), REQUESTER.toString(),false, Collections.emptySet(), Collections.emptySet()));
+        assertNotEquals(role, new UserStateRole(REQUESTER.getId(), REQUESTER.toString(), false, Collections.emptySet(), Collections.emptySet()));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/model/UserStateTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/model/UserStateTest.java
@@ -13,14 +13,14 @@ class UserStateTest {
 
     @Test
     void builder() {
-        Set<Role> newRoles = new HashSet<>();
-        newRoles.add(Role.builder()
+        Set<UserStateRole> newRoles = new HashSet<>();
+        newRoles.add(UserStateRole.builder()
                          .roleId(APPROVER.getId())
                          .roleName(APPROVER.toString())
                          .globalAccess(false)
                          .permissions(new HashSet<>())
                          .build());
-        newRoles.add(Role.builder()
+        newRoles.add(UserStateRole.builder()
                          .roleId(REQUESTER.getId())
                          .roleName(REQUESTER.toString())
                          .globalAccess(false)
@@ -35,7 +35,7 @@ class UserStateTest {
 
         assertEquals(123, userState.getUserId());
         assertEquals("UserName", userState.getUserName());
-        Set<Role> roles = userState.getRoles();
+        Set<UserStateRole> roles = userState.getRoles();
         assertEquals(newRoles, roles);
         assertEquals(2, roles.size());
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2750

### Change description ###

- renaming the `Role` class to `UserStateRole`
- this was incorrectly using another model class named Role which is created by OpenAPI

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
