### PR TITLE
DMP-2898 Add logging of ARM manifest contents

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmBatchProcessResponseFilesIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmBatchProcessResponseFilesIntTest.java
@@ -39,7 +39,6 @@ import uk.gov.hmcts.darts.testutils.stubs.TranscriptionStub;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -66,7 +65,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
     public static final String HASHCODE_2 = "7a374f19a9ce7dc9cc480ea8d4eca0fc";
     private static final String PREFIX = "DARTS";
     private static final LocalDateTime HEARING_DATETIME = LocalDateTime.of(2023, 6, 10, 10, 0, 0);
-    private static final LocalDate HEARING_DATE = LocalDate.of(2023, 6, 10);
     public static final String T_13_00_00_Z = "2023-06-10T13:00:00Z";
     public static final String T_13_45_00_Z = "2023-06-10T13:45:00Z";
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImpl.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.arm.component.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.arm.component.ArchiveRecordFileGenerator;
 import uk.gov.hmcts.darts.arm.enums.ArchiveRecordType;
@@ -53,7 +54,8 @@ public class ArchiveRecordFileGeneratorImpl implements ArchiveRecordFileGenerato
                     try {
                         String archiveRecordOperation = objectMapper.writeValueAsString(archiveRecord.getArchiveRecordOperation());
                         String uploadNewFileRecord = objectMapper.writeValueAsString(archiveRecord.getUploadNewFileRecord());
-                        log.debug("About to write {}{} to file {}", archiveRecordOperation, uploadNewFileRecord, archiveRecordsFile.getAbsolutePath());
+                        log.debug("About to write {}{} to file {} for EOD {}", archiveRecordOperation, uploadNewFileRecord,
+                                  archiveRecordsFile.getAbsolutePath(), archiveRecord.getArchiveRecordOperation().getRelationId());
                         printWriter.println(archiveRecordOperation);
                         printWriter.println(uploadNewFileRecord);
                     } catch (Exception e) {
@@ -64,9 +66,24 @@ public class ArchiveRecordFileGeneratorImpl implements ArchiveRecordFileGenerato
                     }
                 }
             } catch (IOException e) {
-                log.error("Unable to write ARM file {}", archiveRecordsFile.getAbsoluteFile(), e);
+                log.error("Unable to write ARM manifest file {}", archiveRecordsFile.getAbsoluteFile(), e);
                 throw new DartsException(e);
             }
+            logManifestFile(archiveRecords, archiveRecordsFile);
+        }
+    }
+
+    /*
+    TODO: This is a temporary method that is used to help debug issues with the manifest file and should be removed
+     */
+    private void logManifestFile(List<ArchiveRecord> archiveRecords, File archiveRecordsFile) {
+        try {
+            String contents = FileUtils.readFileToString(archiveRecordsFile.getAbsoluteFile(), "UTF-8");
+            log.info("Contents of manifest file {} for EOD {}\n{}", archiveRecordsFile.getAbsoluteFile(),
+                     archiveRecords.get(0).getArchiveRecordOperation().getRelationId(),
+                     contents);
+        } catch (Exception e) {
+            log.error("Unable to read ARM manifest file {}", archiveRecordsFile.getAbsoluteFile(), e);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImpl.java
@@ -17,6 +17,7 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.isNull;
 
 @Component
@@ -73,13 +74,13 @@ public class ArchiveRecordFileGeneratorImpl implements ArchiveRecordFileGenerato
         }
     }
 
-    /*
-    TODO: This is a temporary method that is used to help debug issues with the manifest file and should be removed
-     */
+    /* TODO: This is a temporary method that is used to help debug issues with the manifest file and should be removed */
+    @Deprecated
     private void logManifestFile(List<ArchiveRecord> archiveRecords, File archiveRecordsFile) {
         try {
-            String contents = FileUtils.readFileToString(archiveRecordsFile.getAbsoluteFile(), "UTF-8");
-            log.info("Contents of manifest file {} for EOD {}\n{}", archiveRecordsFile.getAbsoluteFile(),
+            String contents = FileUtils.readFileToString(archiveRecordsFile.getAbsoluteFile(), UTF_8);
+            log.info("Contents of manifest file {} for EOD {}\n{}",
+                     archiveRecordsFile.getAbsoluteFile(),
                      archiveRecords.get(0).getArchiveRecordOperation().getRelationId(),
                      contents);
         } catch (Exception e) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmBatchProcessResponseFilesImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmBatchProcessResponseFilesImpl.java
@@ -54,6 +54,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAttributes.ARM_CREATE_RECORD_FILENAME_KEY;
 import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAttributes.ARM_INVALID_LINE_FILENAME_KEY;
@@ -362,10 +363,12 @@ public class ArmBatchProcessResponseFilesImpl implements ArmResponseFilesProcess
 
     private void logResponseFileContents(Path jsonPath) {
         try {
-            String contents = FileUtils.readFileToString(jsonPath.toFile(), "UTF-8");
-            log.info("Contents of response file {} - \n{}", jsonPath.toFile().getAbsoluteFile(), contents);
+            String contents = FileUtils.readFileToString(jsonPath.toFile(), UTF_8);
+            log.info("Contents of ARM response file {} - \n{}",
+                     jsonPath.toFile().getAbsoluteFile(),
+                     contents);
         } catch (Exception e) {
-            log.error("Unable to ARM manifest file {}", jsonPath.toFile().getAbsoluteFile(), e);
+            log.error("Unable to ARM response file {}", jsonPath.toFile().getAbsoluteFile(), e);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmBatchProcessResponseFilesImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmBatchProcessResponseFilesImpl.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -284,6 +285,7 @@ public class ArmBatchProcessResponseFilesImpl implements ArmResponseFilesProcess
                 );
 
                 if (nonNull(jsonPath) && jsonPath.toFile().exists()) {
+                    logResponseFileContents(jsonPath);
                     ArmResponseCreateRecord armResponseCreateRecord = objectMapper.readValue(jsonPath.toFile(), ArmResponseCreateRecord.class);
                     UploadNewFileRecord uploadNewFileRecord = readInputJson(armResponseCreateRecord.getInput());
                     if (nonNull(uploadNewFileRecord)) {
@@ -335,6 +337,7 @@ public class ArmBatchProcessResponseFilesImpl implements ArmResponseFilesProcess
                 );
 
                 if (jsonPath.toFile().exists()) {
+                    logResponseFileContents(jsonPath);
                     ArmResponseUploadFileRecord armResponseUploadFileRecord = objectMapper.readValue(jsonPath.toFile(), ArmResponseUploadFileRecord.class);
                     UploadNewFileRecord uploadNewFileRecord = readInputJson(armResponseUploadFileRecord.getInput());
                     if (nonNull(uploadNewFileRecord)) {
@@ -354,6 +357,15 @@ public class ArmBatchProcessResponseFilesImpl implements ArmResponseFilesProcess
             }
         } else {
             log.warn("Failed to read upload file {}", uploadFileFilenameProcessor.getUploadFileFilenameAndPath());
+        }
+    }
+
+    private void logResponseFileContents(Path jsonPath) {
+        try {
+            String contents = FileUtils.readFileToString(jsonPath.toFile(), "UTF-8");
+            log.info("Contents of response file {} - \n{}", jsonPath.toFile().getAbsoluteFile(), contents);
+        } catch (Exception e) {
+            log.error("Unable to ARM manifest file {}", jsonPath.toFile().getAbsoluteFile(), e);
         }
     }
 
@@ -555,6 +567,7 @@ public class ArmBatchProcessResponseFilesImpl implements ArmResponseFilesProcess
                 );
 
                 if (jsonPath.toFile().exists()) {
+                    logResponseFileContents(jsonPath);
                     ArmResponseInvalidLineRecord armResponseInvalidLineRecord = objectMapper.readValue(jsonPath.toFile(), ArmResponseInvalidLineRecord.class);
                     UploadNewFileRecord uploadNewFileRecord = readInputJson(armResponseInvalidLineRecord.getInput());
                     if (nonNull(uploadNewFileRecord)) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmBatchProcessResponseFilesImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmBatchProcessResponseFilesImpl.java
@@ -368,7 +368,7 @@ public class ArmBatchProcessResponseFilesImpl implements ArmResponseFilesProcess
                      jsonPath.toFile().getAbsoluteFile(),
                      contents);
         } catch (Exception e) {
-            log.error("Unable to ARM response file {}", jsonPath.toFile().getAbsoluteFile(), e);
+            log.error("Unable to read ARM response file {}", jsonPath.toFile().getAbsoluteFile(), e);
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2898

### Change description ###

Added logging of manifest file which is currently a temporary fix and added loggin of ARM response files

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
