### PR TITLE
ATS status update fix

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Import;
+import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestType;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.notification.api.NotificationApi;
@@ -27,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.COMPLETED;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.FAILED;
@@ -37,7 +39,6 @@ import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMap
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.DEFENDANTS;
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.HEARING_DATE;
 import static uk.gov.hmcts.darts.notification.NotificationConstants.ParameterMapValues.REQUEST_ID;
-
 
 @Import(SystemCommandExecutorStubImpl.class)
 @Slf4j
@@ -53,9 +54,10 @@ class AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest extends
     private static final String MOCK_DOWNLOAD_REQUEST_ID = "2";
     public static final String TIME_12_00 = "12:00:00";
     public static final String TIME_13_00 = "13:00:00";
-    public static final String NOT_AVAILABLE = "N/A";
     private static final OffsetDateTime TIME_20_00 = OffsetDateTime.parse("2023-01-01T20:00Z");
     private static final OffsetDateTime TIME_20_30 = OffsetDateTime.parse("2023-01-01T20:30Z");
+    private static final OffsetDateTime TIME_12_01 = OffsetDateTime.parse("2023-01-01T12:01Z");
+    private static final OffsetDateTime TIME_14_00 = OffsetDateTime.parse("2023-01-01T14:00Z");
 
     @Autowired
     private AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder given;
@@ -103,6 +105,26 @@ class AudioTransformationServiceHandleKedaInvocationForMediaRequestsTest extends
         assertNull(notificationEntity.getTemplateValues());
         assertEquals(NotificationStatus.OPEN, notificationEntity.getStatus());
         assertEquals(EMAIL_ADDRESS, notificationEntity.getEmailAddress());
+    }
+
+    @Test
+    @SuppressWarnings("PMD.LawOfDemeter")
+    public void handleKedaInvocationForMediaRequestsShouldSucceedAndUpdateRequestStatusToCompletedOnlyOnce() {
+        given.aMediaEntityGraph();
+        var userAccountEntity = given.aUserAccount(EMAIL_ADDRESS);
+        // request time includes gap in audio, resulting in multiple generated files
+        given.aMediaRequestEntityForHearingWithRequestType(
+            hearing,
+            AudioRequestType.PLAYBACK,
+            userAccountEntity,
+            TIME_12_01,
+            TIME_14_00
+        );
+
+        audioTransformationService.handleKedaInvocationForMediaRequests();
+
+        // checking that the media request is only updated to COMPLETED once
+        verify(mediaRequestService, times(1)).updateAudioRequestCompleted(any(MediaRequestEntity.class));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
-import uk.gov.hmcts.darts.audio.enums.AudioRequestOutputFormat;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
@@ -177,9 +176,7 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
     @Test
 
     void shouldSetDownloadFileNameAndFormat() {
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(mediaRequestService.getMediaRequestById(1), TEST_FILENAME,
-                                                                                                AudioRequestOutputFormat.MP3
-        );
+        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(mediaRequestService.getMediaRequestById(1));
 
         assertEquals(COMPLETED, mediaRequestEntity.getStatus());
     }
@@ -187,9 +184,7 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
     @Test
 
     void shouldSetPlaybackFileNameAndFormat() {
-        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(mediaRequestService.getMediaRequestById(1), TEST_FILENAME,
-                                                                                                AudioRequestOutputFormat.ZIP
-        );
+        MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(mediaRequestService.getMediaRequestById(1));
 
         assertEquals(COMPLETED, mediaRequestEntity.getStatus());
     }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.audio.service;
 
 
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
-import uk.gov.hmcts.darts.audio.enums.AudioRequestOutputFormat;
 import uk.gov.hmcts.darts.audio.enums.MediaRequestStatus;
 import uk.gov.hmcts.darts.audiorequests.model.AudioNonAccessedResponse;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
@@ -41,6 +40,6 @@ public interface MediaRequestService {
 
     InputStream playback(Integer transformedMediaId);
 
-    MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity, String fileName, AudioRequestOutputFormat audioRequestOutputFormat);
+    MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -223,20 +223,16 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
                     log.error("No file found when trying to save to storage. {}", generatedAudioFile.getPath());
                     throw nsfe;
                 }
-
-                mediaRequestService.updateAudioRequestCompleted(mediaRequestEntity, fileName, audioRequestOutputFormat);
                 log.debug("Completed upload of file to storage for mediaRequestId {}. File ''{}'' successfully uploaded with blobId: {}",
                           requestId, fileName, blobId);
             }
-
+            mediaRequestService.updateAudioRequestCompleted(mediaRequestEntity);
             logApi.atsProcessingUpdate(mediaRequestEntity);
-
             transformedMediaHelper.notifyUser(
                 mediaRequestEntity,
                 hearingEntity.getCourtCase(),
                 NotificationApi.NotificationTemplate.REQUESTED_AUDIO_AVAILABLE.toString()
             );
-
         } catch (Exception e) {
             log.error("Exception occurred for request id {}.", requestId, e);
             var updatedMediaRequest = mediaRequestService.updateAudioRequestStatus(requestId, FAILED);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.component.AudioRequestBeingProcessedFromArchiveQuery;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity_;
-import uk.gov.hmcts.darts.audio.enums.AudioRequestOutputFormat;
 import uk.gov.hmcts.darts.audio.enums.MediaRequestStatus;
 import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.audio.exception.AudioRequestsApiError;
@@ -386,8 +385,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     }
 
     @Override
-    public MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity, String fileName,
-                                                          AudioRequestOutputFormat audioRequestOutputFormat) {
+    public MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity) {
 
         mediaRequestEntity.setStatus(MediaRequestStatus.COMPLETED);
         //todo update transformed media info


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- only update media request status to COMPLETED once all generated files have been saved to storage

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
