### PR TITLE
DMP-791 Removing usages of event.event_name column

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/data/EventTestData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/data/EventTestData.java
@@ -14,33 +14,27 @@ import java.util.Random;
 public class EventTestData {
 
     public static final int REPORTING_RESTRICTIONS_LIFTED_DB_ID = 192;
+
+    public static final int SECTION_4_1981_DB_ID = 183;
+    public static final int SECTION_11_1981_DB_ID = 184;
+    public static final int SECTION_39_1933_DB_ID = 185;
     public static final List<Integer> REPORTING_RESTRICTIONS_DB_IDS = List.of(54, 183, 184, 185, 186, 187, 188, 189, 190, 191);
+
+    private static final String LOG_ENTRY_EVENT_NAME = "LOG";
 
     public static EventEntity someMinimalEvent() {
         return new EventEntity();
     }
 
     public static EventEntity createEventWith(String eventName, String eventText, HearingEntity hearingEntity, OffsetDateTime eventTime) {
-        EventEntity event = someMinimalEvent();
-        event.setHearingEntities(List.of(hearingEntity));
-        event.setCourtroom(hearingEntity.getCourtroom());
-        event.setEventName(eventName);
-        event.setEventText(eventText);
-        event.setTimestamp(eventTime);
-        event.setIsLogEntry(false);
-        event.setEventType(createTestEventHandlerEntity());
-        return event;
-    }
 
-    public static EventEntity createEventWith(String eventName, String eventText, HearingEntity hearingEntity, OffsetDateTime eventTime,
-                                              EventHandlerEntity eventHandlerEntity) {
         EventEntity event = someMinimalEvent();
         event.setHearingEntities(List.of(hearingEntity));
         event.setCourtroom(hearingEntity.getCourtroom());
-        event.setEventName(eventName);
         event.setEventText(eventText);
         event.setTimestamp(eventTime);
-        event.setEventType(eventHandlerEntity);
+        event.setIsLogEntry(LOG_ENTRY_EVENT_NAME.equals(eventName));
+        event.setEventType(createTestEventHandlerEntity(eventName));
         return event;
     }
 
@@ -49,10 +43,10 @@ public class EventTestData {
             new Random().nextInt(REPORTING_RESTRICTIONS_DB_IDS.size()));
     }
 
-    private EventHandlerEntity createTestEventHandlerEntity() {
+    private EventHandlerEntity createTestEventHandlerEntity(String eventName) {
         EventHandlerEntity entity = new EventHandlerEntity();
         entity.setId(1);
-        entity.setEventName("Eventname");
+        entity.setEventName(eventName);
         entity.setType("Eventtype");
         return entity;
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/EventStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/EventStub.java
@@ -39,7 +39,6 @@ public class EventStub {
     public EventEntity createEvent(HearingEntity hearing, int eventHandlerId, OffsetDateTime eventTimestamp, String eventName) {
         EventEntity eventEntity = new EventEntity();
         eventEntity.setEventText("testEventText");
-        eventEntity.setEventName(eventName);
         EventHandlerEntity eventHandlerEntity = eventHandlerRepository.findById(eventHandlerId).get();
         eventEntity.setEventType(eventHandlerEntity);
         eventEntity.setTimestamp(eventTimestamp);
@@ -57,7 +56,6 @@ public class EventStub {
     public EventEntity createEvent(CourtroomEntity courtroom, int eventHandlerId, OffsetDateTime eventTimestamp, String eventName) {
         EventEntity eventEntity = new EventEntity();
         eventEntity.setEventText("testEventText");
-        eventEntity.setEventName(eventName);
         EventHandlerEntity eventHandlerEntity = eventHandlerRepository.findById(eventHandlerId).get();
         eventEntity.setEventType(eventHandlerEntity);
         eventEntity.setTimestamp(eventTimestamp);

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AnnotationXmlGeneratorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AnnotationXmlGeneratorImpl.java
@@ -110,7 +110,7 @@ public class AnnotationXmlGeneratorImpl extends AbstractDocumentGenerator {
                                    .getSeconds())
             );
 
-            eventElement.appendChild(document.createTextNode(event.getEventName()));
+            eventElement.appendChild(document.createTextNode(event.getEventType().getEventName()));
             annotations.appendChild(eventElement);
             eventCounter++;
         }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
@@ -44,9 +44,6 @@ public class EventEntity extends CreatedModifiedBaseEntity {
     @Column(name = "event_id")
     private Integer legacyEventId;
 
-    @Column(name = "event_name")
-    private String eventName;
-
     @Column(name = "event_text")
     private String eventText;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingReportingRestrictionsEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingReportingRestrictionsEntity.java
@@ -26,6 +26,9 @@ public class HearingReportingRestrictionsEntity {
     @Column(name = "hea_id")
     Integer hearingId;
 
+    @Column(name = "event_name")
+    String eventName;
+
     @Column(name = "event_type")
     String eventType;
 
@@ -49,9 +52,6 @@ public class HearingReportingRestrictionsEntity {
 
     @Column(name = "event_id")
     Integer mojEventId;
-
-    @Column(name = "event_name")
-    String eventName;
 
     @Column(name = "event_text")
     String eventText;

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CourtLogEventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CourtLogEventRepository.java
@@ -12,11 +12,12 @@ import java.util.List;
 public interface CourtLogEventRepository extends JpaRepository<EventEntity, Integer> {
 
     @Query("""
-           SELECT ee FROM EventEntity ee, CourtroomEntity cr, CourthouseEntity ch, CourtCaseEntity ce
+           SELECT ee
+           FROM EventEntity ee, CourtroomEntity cr, CourthouseEntity ch, CourtCaseEntity ce
            JOIN ee.hearingEntities hearing
            WHERE upper(ch.courthouseName) = upper(:courtHouse)
            AND upper(ce.caseNumber) = upper(:caseNumber)
-           AND ee.eventName = upper('LOG')
+           AND ee.isLogEntry = true
            AND ee.timestamp between :start AND :end
            AND cr.courthouse = ch
            AND hearing.courtroom = cr
@@ -29,7 +30,7 @@ public interface CourtLogEventRepository extends JpaRepository<EventEntity, Inte
            JOIN ee.hearingEntities hearing
            WHERE upper(ch.courthouseName) = upper(:courtHouse)
            AND upper(cr.name) = upper(:courtRoomName)
-           AND ee.eventName = upper('LOG')
+           AND ee.isLogEntry = true
            AND ee.timestamp between :start AND :end
            AND cr.courthouse = ch
            AND hearing.courtroom = cr

--- a/src/main/java/uk/gov/hmcts/darts/event/service/handler/base/EventHandlerBase.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/handler/base/EventHandlerBase.java
@@ -52,7 +52,6 @@ public abstract class EventHandlerBase implements EventHandler {
         var event = new EventEntity();
         event.setLegacyEventId(NumberUtils.createInteger(dartsEvent.getEventId()));
         event.setTimestamp(dartsEvent.getDateTime());
-        event.setEventName(eventHandler.getEventName());
         event.setEventText(dartsEvent.getEventText());
         event.setEventType(eventHandler);
         event.setMessageId(dartsEvent.getMessageId());

--- a/src/main/resources/db/migration/common/V1_296__fix_event_name_in_hearing_reporting_restrictions_view.sql
+++ b/src/main/resources/db/migration/common/V1_296__fix_event_name_in_hearing_reporting_restrictions_view.sql
@@ -1,0 +1,34 @@
+DROP VIEW IF EXISTS hearing_reporting_restrictions;
+
+CREATE VIEW hearing_reporting_restrictions AS
+SELECT
+  row_number() OVER () AS id,
+  h.cas_id,
+  he.hea_id,
+  eh.event_name,
+  eh.event_type,
+  eh.event_sub_type,
+  eh.active,
+  e.eve_id,
+  e.ctr_id,
+  e.evh_id,
+  e.event_object_id,
+  e.event_id,
+  e.event_text,
+  e.event_ts,
+  e.case_number,
+  e.version_label,
+  e.message_id,
+  e.created_ts,
+  e.created_by,
+  e.last_modified_ts,
+  e.last_modified_by,
+  e.is_log_entry,
+  e.chronicle_id,
+  e.antecedent_id
+FROM darts.event_handler eh
+JOIN darts.event e ON e.evh_id = eh.evh_id
+JOIN darts.hearing_event_ae he ON he.eve_id = e.eve_id
+JOIN darts.hearing h ON h.hea_id = he.hea_id
+WHERE eh.is_reporting_restriction = true
+ORDER BY h.cas_id, he.hea_id, e.event_ts;

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileZipGeneratorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileZipGeneratorImplTest.java
@@ -126,7 +126,6 @@ class OutboundFileZipGeneratorImplTest {
         EventHandlerEntity eventType = mock(EventHandlerEntity.class);
         eventEntity.setEventType(eventType);
         eventEntity.setLegacyEventId(1);
-        eventEntity.setEventName("Jury Returned");
         eventEntity.setEventText("Start Event");
         OffsetDateTime utcStartTime = OffsetDateTime.ofInstant(SOME_START_TIME, UTC);
         eventEntity.setTimestamp(utcStartTime.plusMinutes(5));

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -55,10 +55,13 @@ public class CommonTestDataUtil {
     public static EventEntity createEventWith(String eventName, String eventText,
                                               HearingEntity hearingEntity, OffsetDateTime eventTimestamp) {
 
+        EventHandlerEntity eventType = new EventHandlerEntity();
+        eventType.setEventName(eventName);
+
         EventEntity event = new EventEntity();
         event.setHearingEntities(List.of(hearingEntity));
         event.setCourtroom(hearingEntity.getCourtroom());
-        event.setEventName(eventName);
+        event.setEventType(eventType);
         event.setEventText(eventText);
         event.setId(1);
         event.setTimestamp(eventTimestamp);
@@ -81,7 +84,6 @@ public class CommonTestDataUtil {
         EventEntity event = new EventEntity();
         event.setHearingEntities(List.of(hearingEntity));
         event.setCourtroom(hearingEntity.getCourtroom());
-        event.setEventName(eventName);
         event.setEventText(eventText);
         event.setId(1);
         event.setTimestamp(eventTimestamp);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-791

### Change description ###

- amending "hearing_reporting_restrictions" view to include event_name from event_handler table
- fixing tests to use event name from associated event handler

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
