### PR TITLE
 DMP-3014 further cleanup after removing ARM_URL secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The required value of each variable is stored in Azure Key Vault as a Secret.
 | AZURE_AD_FUNCTIONAL_TEST_USERNAME        | AzureADFunctionalTestUsername             |
 | AZURE_AD_FUNCTIONAL_TEST_PASSWORD        | AzureADFunctionalTestPassword             |
 | ARM_SAS_ENDPOINT                         | ARMSasEndpoint                            |
-| ARM_URL                                  | ArmUrl                                    |
 | DETS_SAS_URL_ENDPOINT                    | DETSSasURLEndpoint                        |
 | ARM_USERNAME                             | ArmUsername                               |
 | ARM_PASSWORD                             | ArmPassword                               |
@@ -64,6 +63,7 @@ There are few attributes which doesn't use Azure Keyvault secrets. Those environ
 |-------------------------------|------------------------------------------------------------------|
 | ACTIVE_DIRECTORY_B2C_BASE_URI | https://hmctsstgextid.b2clogin.com                               |
 | ACTIVE_DIRECTORY_B2C_AUTH_URI | https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com |
+| ARM_URL                       |                                                                  |  
 
 To obtain the secret value, you may retrieve the keys from the Azure Vault by running the `az keyvault secret show`
 command in the terminal. E.g. to obtain the value for `GOVUK_NOTIFY_API_KEY`, you should run:

--- a/bin/secrets-stg.sh
+++ b/bin/secrets-stg.sh
@@ -30,7 +30,6 @@ export AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD="$(az keyvault secret show --vau
 export AZURE_AD_FUNCTIONAL_TEST_USERNAME="$(az keyvault secret show --vault-name darts-stg --name AzureADFunctionalTestUsername | jq .value -r)"
 export AZURE_AD_FUNCTIONAL_TEST_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name AzureADFunctionalTestPassword | jq .value -r)"
 export ARM_SAS_ENDPOINT="$(az keyvault secret show --vault-name darts-stg --name ARMSasEndpoint | jq .value -r)"
-export ARM_URL="$(az keyvault secret show --vault-name darts-stg --name ArmUrl | jq .value -r)"
 export ARM_USERNAME="$(az keyvault secret show --vault-name darts-stg --name ArmUsername | jq .value -r)"
 export ARM_PASSWORD="$(az keyvault secret show --vault-name darts-stg --name ArmPassword | jq .value -r)"
 export DETS_SAS_URL_ENDPOINT="$(az keyvault secret show --vault-name darts-stg --name DETSSasURLEndpoint | jq .value -r)"

--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.73
+version: 0.0.74
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -85,8 +85,6 @@ java:
           alias: ARM_SAS_ENDPOINT
         - name: DETSSasURLEndpoint
           alias: DETS_SAS_URL_ENDPOINT
-        - name: ArmUrl
-          alias: ARM_URL
         - name: ArmUsername
           alias: ARM_USERNAME
         - name: ArmPassword

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -187,8 +187,6 @@ function:
           alias: AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD
         - name: ARMSasEndpoint
           alias: ARM_SAS_ENDPOINT
-        - name: ArmUrl
-          alias: ARM_URL
         - name: ArmUsername
           alias: ARM_USERNAME
         - name: ArmPassword

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -215,7 +215,7 @@ darts:
       arm-username: ${ARM_USERNAME:}
       arm-password: ${ARM_PASSWORD:}
       cabinet-id: 100
-      url: ${ARM_URL:}
+      url: ${ARM_URL}
       token-path: /api/v1/token
       update-metadata-path: /api/v3/UpdateMetadata
       download-data-path: /api/v1/downloadBlob/{cabinet_id}/{record_id}/{file_id}


### PR DESCRIPTION
As part of DMP-3014 https://github.com/hmcts/darts-api/pull/1407/files we have removed ARM_URL from being populated by a secret. 
In this PR I'm doing some cleanup that I've missed to do in the previous PR