### PR TITLE
 DMP-3014 configure env var ARM_URL

### DIFF
--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.74
+version: 0.0.75
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.stg.template.yaml
+++ b/charts/darts-api/values.stg.template.yaml
@@ -5,3 +5,4 @@ java:
   environment:
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
     DARTS_GATEWAY_URL: https://darts-gateway.staging.platform.hmcts.net
+    ARM_URL: https://darts-stub-services.staging.platform.hmcts.net

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -101,6 +101,7 @@ java:
     API_MODE: true
     ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsstgextid.b2clogin.com
     ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
+    ARM_URL: https://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
 
 function:
   scaleType: Job


### PR DESCRIPTION
The `master` pipeline staging deployment needs the env vars defined in the chart for deploying a temporary `staging` pod, those are not picked up from flux so added `ARM_URL`