### PR TITLE
DMP-2571 Updating usages of DARTS stub services to HTTP

### DIFF
--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.76
+version: 0.0.77
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -97,7 +97,7 @@ java:
     DARTS_API_DB_USERNAME: "hmcts"
     spring.profiles.active: dev
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
-    DARTS_GATEWAY_URL: https://darts-gateway.staging.platform.hmcts.net
+    DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net
 
   secrets:
     DARTS_API_DB_PASSWORD:

--- a/charts/darts-api/values.stg.template.yaml
+++ b/charts/darts-api/values.stg.template.yaml
@@ -4,5 +4,5 @@ java:
   ingressHost: ${SERVICE_FQDN}
   environment:
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
-    DARTS_GATEWAY_URL: https://darts-gateway.staging.platform.hmcts.net
-    ARM_URL: https://darts-stub-services.staging.platform.hmcts.net
+    DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net
+    ARM_URL: http://darts-stub-services.staging.platform.hmcts.net

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -101,7 +101,7 @@ java:
     API_MODE: true
     ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsstgextid.b2clogin.com
     ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
-    ARM_URL: https://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
+    ARM_URL: http://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
 
 function:
   scaleType: Job
@@ -201,7 +201,7 @@ function:
     DARTS_GATEWAY_URL: http://darts-gateway.{{ .Values.global.environment }}.platform.hmcts.net
     ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsstgextid.b2clogin.com
     ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
-    ARM_URL: https://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
+    ARM_URL: http://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
 
   secrets:
     DARTS_API_DB_CONNECTION_STRING:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2571

### Change description ###

- also updating some misconfigured DARTS gateway URLs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
