### PR TITLE
Updating notification scheduler shedlock config

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/service/impl/NotificationServiceImpl.java
@@ -144,7 +144,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     @SchedulerLock(name = "NotificationService_sendNotificationToGovNotify",
-        lockAtLeastFor = "PT1M", lockAtMostFor = "PT5M")
+        lockAtLeastFor = "PT30S", lockAtMostFor = "PT5M")
     @Scheduled(cron = "${darts.notification.scheduler.cron}")
     public void sendNotificationToGovNotify() {
         if (notificationsEnabled && !atsMode) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- setting "lockAtLeastFor" to 30 seconds
- it was previously 1 minute, but the cron runs every minute
- theory is it's never unlocking

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
