### PR TITLE
DMP-3114 Populate has_events field for the GET /admin/event-mappings/id endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -19,10 +19,14 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
         """)
     List<EventEntity> findAllByHearingId(Integer hearingId);
 
-    @Query(value = """
-        SELECT * FROM darts.event e
-        where e.case_number = :caseNumber
-        order by e.created_ts
-        """, nativeQuery = true)
-    List<EventEntity> findAllByCaseNumberOrderByCreatedDate(String caseNumber);
+    @Query("""
+            SELECT EXISTS (
+                SELECT 1
+                FROM EventEntity ee, EventHandlerEntity ehe
+                WHERE ee.eventType = ehe
+                AND ehe.id = :eventHandlerId
+            )
+        """)
+    boolean doesEventHandlerHaveEvents(int eventHandlerId);
+
 }

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImplTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.darts.event.service.impl;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -11,6 +13,7 @@ import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventHandlerRepository;
+import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.event.mapper.EventHandlerMapper;
 import uk.gov.hmcts.darts.event.model.EventMapping;
 import uk.gov.hmcts.darts.event.service.handler.EventHandlerEnumerator;
@@ -37,6 +40,9 @@ class EventMappingServiceImplTest {
     private static final OffsetDateTime FIXED_DATETIME = OffsetDateTime.of(2024, 5, 01, 10, 0, 0, 0, ZoneOffset.UTC);
     @Mock
     EventHandlerRepository eventHandlerRepository;
+
+    @Mock
+    EventRepository eventRepository;
 
     @Mock
     private EventHandlerMapper eventHandlerMapper;
@@ -192,8 +198,9 @@ class EventMappingServiceImplTest {
         verify(eventHandlerRepository).findAll();
     }
 
-    @Test
-    void getEventMappingById() {
+    @ParameterizedTest
+    @ValueSource(strings = {"true", "false"})
+    void getEventMappingById(boolean hasEvents) {
         EventHandlerEntity eventHandlerEntity = new EventHandlerEntity();
         eventHandlerEntity.setId(1);
         eventHandlerEntity.setType("12345");
@@ -206,6 +213,7 @@ class EventMappingServiceImplTest {
         eventHandlerEntity.setCreatedDateTime(now);
 
         when(eventHandlerRepository.findById(anyInt())).thenReturn(Optional.of(eventHandlerEntity));
+        when(eventRepository.doesEventHandlerHaveEvents(anyInt())).thenReturn(hasEvents);
 
         EventMapping result = eventMappingServiceImpl.getEventMappingById(1);
 
@@ -217,6 +225,7 @@ class EventMappingServiceImplTest {
         assertEquals(eventHandlerEntity.getActive(), result.getIsActive());
         assertEquals(eventHandlerEntity.getIsReportingRestriction(), result.getHasRestrictions());
         assertEquals(eventHandlerEntity.getCreatedDateTime(), result.getCreatedAt());
+        assertEquals(hasEvents, result.getHasEvents());
 
         verify(eventHandlerRepository).findById(1);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3114


### Change description ###
The has_events field returned by the GET /admin/event-mappings/id endpoint is now populated, based on whether there are any events linked to this event handler. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
