### PR TITLE
DMP-3051 Updated /admin/transcription-workflows endpoint to return migrated comments

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
@@ -501,7 +501,7 @@ public class TranscriptionStub {
         transcriptionWorkflowRepository.saveAndFlush(requestedTranscriptionWorkflowEntity);
 
         if (nonNull(comment)) {
-            final var transcriptionComment = createTranscriptionComment(requestedTranscriptionWorkflowEntity, comment, userAccountEntity);
+            final var transcriptionComment = createTranscriptionWorkflowComment(requestedTranscriptionWorkflowEntity, comment, userAccountEntity);
             transcriptionCommentRepository.save(transcriptionComment);
 
             requestedTranscriptionWorkflowEntity.getTranscriptionComments().add(transcriptionComment);
@@ -520,8 +520,8 @@ public class TranscriptionStub {
         return transcriptionRepository.saveAndFlush(transcriptionEntity);
     }
 
-    public TranscriptionCommentEntity createTranscriptionComment(TranscriptionWorkflowEntity workflowEntity, String comment,
-                                                                 UserAccountEntity userAccountEntity) {
+    public TranscriptionCommentEntity createTranscriptionWorkflowComment(TranscriptionWorkflowEntity workflowEntity, String comment,
+                                                                         UserAccountEntity userAccountEntity) {
         TranscriptionCommentEntity transcriptionCommentEntity = new TranscriptionCommentEntity();
         transcriptionCommentEntity.setTranscription(workflowEntity.getTranscription());
         transcriptionCommentEntity.setTranscriptionWorkflow(workflowEntity);
@@ -533,8 +533,22 @@ public class TranscriptionStub {
         return transcriptionCommentEntity;
     }
 
-    public TranscriptionCommentEntity createAndSaveTranscriptionWorkflowComment(TranscriptionWorkflowEntity workflowEntity, String comment, UserAccountEntity userAccount) {
-        var transcriptionComment = createTranscriptionComment(workflowEntity, comment, userAccount);
+    public TranscriptionCommentEntity createAndSaveTranscriptionWorkflowComment(TranscriptionWorkflowEntity workflowEntity,
+                                                                                String comment, UserAccountEntity userAccount) {
+        var transcriptionComment = createTranscriptionWorkflowComment(workflowEntity, comment, userAccount);
+        return transcriptionCommentRepository.save(transcriptionComment);
+    }
+
+    public TranscriptionCommentEntity createAndSaveTranscriptionCommentNotAssociatedToWorkflow(TranscriptionEntity transcription,
+                                                                                               OffsetDateTime commentTimestamp,
+                                                                                               String comment) {
+        TranscriptionCommentEntity transcriptionComment = new TranscriptionCommentEntity();
+        transcriptionComment.setTranscription(transcription);
+        transcriptionComment.setComment(comment);
+        transcriptionComment.setCommentTimestamp(commentTimestamp);
+        transcriptionComment.setAuthorUserId(transcription.getCreatedBy().getId());
+        transcriptionComment.setLastModifiedBy(transcription.getCreatedBy());
+        transcriptionComment.setCreatedBy(transcription.getCreatedBy());
         return transcriptionCommentRepository.save(transcriptionComment);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
@@ -342,16 +342,25 @@ public class TranscriptionStub {
         return transcriptionRepository.saveAndFlush(transcriptionEntity);
     }
 
-    public TranscriptionWorkflowEntity createTranscriptionWorkflowEntity(TranscriptionEntity transcriptionEntity,
+    public TranscriptionWorkflowEntity createTranscriptionWorkflowEntity(TranscriptionEntity transcription,
                                                                          UserAccountEntity user,
-                                                                         OffsetDateTime timestamp,
+                                                                         OffsetDateTime workflowTimestamp,
                                                                          TranscriptionStatusEntity transcriptionStatus) {
-        TranscriptionWorkflowEntity transcriptionWorkflowEntity = new TranscriptionWorkflowEntity();
-        transcriptionWorkflowEntity.setTranscription(transcriptionEntity);
-        transcriptionWorkflowEntity.setTranscriptionStatus(transcriptionStatus);
-        transcriptionWorkflowEntity.setWorkflowActor(user);
-        transcriptionWorkflowEntity.setWorkflowTimestamp(timestamp);
-        return transcriptionWorkflowEntity;
+        TranscriptionWorkflowEntity transcriptionWorkflow = new TranscriptionWorkflowEntity();
+        transcriptionWorkflow.setTranscription(transcription);
+        transcriptionWorkflow.setTranscriptionStatus(transcriptionStatus);
+        transcriptionWorkflow.setWorkflowActor(user);
+        transcriptionWorkflow.setWorkflowTimestamp(workflowTimestamp);
+        return transcriptionWorkflow;
+    }
+
+    public TranscriptionWorkflowEntity createAndSaveTranscriptionWorkflow(TranscriptionEntity transcription,
+                                      OffsetDateTime workflowTimestamp,
+                                      TranscriptionStatusEntity transcriptionStatus) {
+
+        var transcriptionWorkflow = createTranscriptionWorkflowEntity(transcription, transcription.getCreatedBy(), workflowTimestamp, transcriptionStatus);
+
+        return transcriptionWorkflowRepository.save(transcriptionWorkflow);
     }
 
     public TranscriptionEntity updateTranscriptionWithDocument(TranscriptionEntity transcriptionEntity,
@@ -517,9 +526,16 @@ public class TranscriptionStub {
         transcriptionCommentEntity.setTranscription(workflowEntity.getTranscription());
         transcriptionCommentEntity.setTranscriptionWorkflow(workflowEntity);
         transcriptionCommentEntity.setComment(comment);
+        transcriptionCommentEntity.setCommentTimestamp(workflowEntity.getWorkflowTimestamp());
+        transcriptionCommentEntity.setAuthorUserId(userAccountEntity.getId());
         transcriptionCommentEntity.setLastModifiedBy(userAccountEntity);
         transcriptionCommentEntity.setCreatedBy(userAccountEntity);
         return transcriptionCommentEntity;
+    }
+
+    public TranscriptionCommentEntity createAndSaveTranscriptionWorkflowComment(TranscriptionWorkflowEntity workflowEntity, String comment, UserAccountEntity userAccount) {
+        var transcriptionComment = createTranscriptionComment(workflowEntity, comment, userAccount);
+        return transcriptionCommentRepository.save(transcriptionComment);
     }
 
     private ExternalLocationTypeEntity getLocationEntity(ExternalLocationTypeEnum externalLocationTypeEnum) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionWorkflowsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionWorkflowsIntTest.java
@@ -74,6 +74,11 @@ class TranscriptionControllerGetTranscriptionWorkflowsIntTest extends Integratio
                              OffsetDateTime.of(2024, 4, 24, 12, 0, 0, 0, ZoneOffset.UTC),
                              transcriptionStub.getTranscriptionStatusByEnum(TranscriptionStatusEnum.APPROVED));
         transcriptionStub.createAndSaveTranscriptionWorkflowComment(transcriptionWorkflow2, "comment2", transcription.getCreatedBy());
+
+        transcriptionStub.createAndSaveTranscriptionCommentNotAssociatedToWorkflow(transcription,
+            OffsetDateTime.of(2024, 4, 25, 12, 0, 0, 0, ZoneOffset.UTC),
+    "this is a migrated transcription comment that is not associated to a transcription workflow"
+        );
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionWorkflowsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionWorkflowsIntTest.java
@@ -13,14 +13,11 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionCommentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionStatusEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
-import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.util.DateConverterUtil;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.SuperAdminUserStub;
+import uk.gov.hmcts.darts.testutils.stubs.TranscriptionStub;
 import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum;
 
 import java.net.URI;
@@ -47,6 +44,8 @@ class TranscriptionControllerGetTranscriptionWorkflowsIntTest extends Integratio
     private UserIdentity mockUserIdentity;
     @Autowired
     private SuperAdminUserStub superAdminUserStub;
+    @Autowired
+    private TranscriptionStub transcriptionStub;
     private TranscriptionEntity transcription;
 
     @BeforeEach
@@ -66,15 +65,15 @@ class TranscriptionControllerGetTranscriptionWorkflowsIntTest extends Integratio
         transcription.setEndTime(SOME_DATE_TIME);
         transcription = dartsDatabase.save(transcription);
 
-        createWorkflowEntity(transcription,
+        var transcriptionWorkflow1 = transcriptionStub.createAndSaveTranscriptionWorkflow(transcription,
                              OffsetDateTime.of(2024, 4, 23, 10, 0, 0, 0, ZoneOffset.UTC),
-                             dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.REQUESTED),
-                             "comment1");
+                             transcriptionStub.getTranscriptionStatusByEnum(TranscriptionStatusEnum.REQUESTED));
+        transcriptionStub.createAndSaveTranscriptionWorkflowComment(transcriptionWorkflow1, "comment1", transcription.getCreatedBy());
 
-        createWorkflowEntity(transcription,
+        var transcriptionWorkflow2 = transcriptionStub.createAndSaveTranscriptionWorkflow(transcription,
                              OffsetDateTime.of(2024, 4, 24, 12, 0, 0, 0, ZoneOffset.UTC),
-                             dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.APPROVED),
-                             "comment2");
+                             transcriptionStub.getTranscriptionStatusByEnum(TranscriptionStatusEnum.APPROVED));
+        transcriptionStub.createAndSaveTranscriptionWorkflowComment(transcriptionWorkflow2, "comment2", transcription.getCreatedBy());
     }
 
     @Test
@@ -152,33 +151,5 @@ class TranscriptionControllerGetTranscriptionWorkflowsIntTest extends Integratio
             """;
 
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
-    }
-
-    private void createWorkflowEntity(TranscriptionEntity transcription,
-                                                             OffsetDateTime workflowTimestamp,
-                                                             TranscriptionStatusEntity status,
-                                                             String comment) {
-
-        TranscriptionWorkflowEntity workflowEntity = new TranscriptionWorkflowEntity();
-        workflowEntity.setTranscription(transcription);
-        workflowEntity.setWorkflowActor(transcription.getCreatedBy());
-        workflowEntity.setWorkflowTimestamp(workflowTimestamp);
-        workflowEntity.setTranscriptionStatus(status);
-
-        dartsDatabase.save(workflowEntity);
-
-        addCommentToWorkflow(workflowEntity, comment, transcription.getCreatedBy());
-    }
-
-    private void addCommentToWorkflow(TranscriptionWorkflowEntity workflowEntity, String comment, UserAccountEntity userAccount) {
-        TranscriptionCommentEntity commentEntity = new TranscriptionCommentEntity();
-        commentEntity.setTranscription(workflowEntity.getTranscription());
-        commentEntity.setTranscriptionWorkflow(workflowEntity);
-        commentEntity.setComment(comment);
-        commentEntity.setCommentTimestamp(workflowEntity.getWorkflowTimestamp());
-        commentEntity.setAuthorUserId(userAccount.getId());
-        commentEntity.setLastModifiedBy(userAccount);
-        commentEntity.setCreatedBy(userAccount);
-        dartsDatabase.save(commentEntity);
     }
 }

--- a/src/integrationTest/resources/tests/transcriptions/transcription_workflow/expectedAllWorkflowResponse.json
+++ b/src/integrationTest/resources/tests/transcriptions/transcription_workflow/expectedAllWorkflowResponse.json
@@ -1,5 +1,16 @@
 [
   {
+    "workflow_actor": 2,
+    "workflow_ts": "2024-04-25T12:00:00Z",
+    "comments": [
+      {
+        "comment": "this is a migrated transcription comment that is not associated to a transcription workflow",
+        "commented_at": "2024-04-25T12:00:00Z",
+        "author_id": 2
+      }
+    ]
+  },
+  {
     "workflow_actor":2,
     "status_id":3,
     "workflow_ts":"2024-04-24T12:00:00Z",

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionCommentRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionCommentRepository.java
@@ -4,7 +4,12 @@ package uk.gov.hmcts.darts.common.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.TranscriptionCommentEntity;
+import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
+
+import java.util.List;
 
 @Repository
 public interface TranscriptionCommentRepository extends JpaRepository<TranscriptionCommentEntity, Integer> {
+
+    List<TranscriptionCommentEntity> getByTranscriptionAndTranscriptionWorkflowIsNull(TranscriptionEntity transcription);
 }

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -489,10 +489,14 @@ public class TranscriptionServiceImpl implements TranscriptionService {
         var transcriptionWorkflows = transcriptionWorkflowRepository.findByTranscriptionOrderByWorkflowTimestampDesc(transcription.get());
 
         if (nonNull(isCurrent) && TRUE.equals(isCurrent)) {
-            return transcriptionResponseMapper.mapToTranscriptionWorkflowsResponse(List.of(transcriptionWorkflows.get(0)));
+            return transcriptionResponseMapper.mapToTranscriptionWorkflowsResponse(List.of(transcriptionWorkflows.get(0)), Collections.emptyList());
         }
 
-        return transcriptionResponseMapper.mapToTranscriptionWorkflowsResponse(transcriptionWorkflows);
+        // migrated transcription comments are not associated to a transcription workflow
+        List<TranscriptionCommentEntity> migratedTranscriptionComments =
+            transcriptionCommentRepository.getByTranscriptionAndTranscriptionWorkflowIsNull(transcription.get());
+
+        return transcriptionResponseMapper.mapToTranscriptionWorkflowsResponse(transcriptionWorkflows, migratedTranscriptionComments);
     }
 
     private ExternalObjectDirectoryEntity saveExternalObjectDirectory(UUID externalLocation,

--- a/src/main/resources/openapi/transcriptions.yaml
+++ b/src/main/resources/openapi/transcriptions.yaml
@@ -768,7 +768,7 @@ paths:
     get:
       tags:
         - Transcription
-      summary: Return all transcription workflow records in descending workflow timestamp chronological order
+      summary: Return the transcription history - all transcription workflow records with their comments and the transcription comments not associated to a workflow, in descending workflow timestamp chronological order
       parameters:
         - in: query
           name: is_current

--- a/src/main/resources/openapi/transcriptions.yaml
+++ b/src/main/resources/openapi/transcriptions.yaml
@@ -1309,15 +1309,19 @@ components:
 
     GetTranscriptionWorkflowsResponse:
       type: object
+      description: note - migrated transcription comments (which are not associated to a transcription workflow) have been "hacked" into this response
       properties:
         workflow_actor:
+          description: this corresponds to the transcription comment author for migrated comments
           type: integer
           example: 0
         status_id:
           type: integer
+          description: this is null for migrated comments
           example: 0
         workflow_ts:
           type: string
+          description: this corresponds to the transcription comment ts for migrated comments
           format: date-time
           example: 2024-0415T12:00:00Z
         comments:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3051


### Change description ###
Migrated comments are associated to a transcription but not associated to a transcription workflow. This change updates the `GET /admin/transcription-workflows` endpoint to return also these type of comments, which are currently ignored.
Because we didn't want to change the response schema, these new comments have been "hacked" into the existing response structure. This has been discussed with and approved by @davet1985 

Darts Portal handling of the endpoint response has been analysed with Dave and we believe it should not break when receiving the new data (migrated comments) returned by the endpoint

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
