### PR TITLE
Adding migration comments back in, broke the checksum in master

### DIFF
--- a/src/main/resources/db/migration/postgres/V1_0_0__create_schema.sql
+++ b/src/main/resources/db/migration/postgres/V1_0_0__create_schema.sql
@@ -1,1 +1,5 @@
 CREATE SCHEMA IF NOT EXISTS darts;
+-- DROP TABLESPACE IF EXISTS darts_tables;
+-- DROP TABLESPACE IF EXISTS darts_indexes;
+-- CREATE TABLESPACE darts_tables  location 'E:/PostgreSQL/Tables';
+-- CREATE TABLESPACE darts_indexes location 'E:/PostgreSQL/Indexes';


### PR DESCRIPTION
Adding migration comments back in, broke the checksum in master


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
