### PR TITLE
DMP-2765 Allowing spring graceful shutdown timeout to be configured

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,7 @@
 server:
   port: 4550
   max-http-request-header-size: 10MB
+  shutdown: graceful
 
 management:
   endpoint:
@@ -16,6 +17,8 @@ springdoc:
   packagesToScan: uk.gov.hmcts.darts
 
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: ${GRACEFUL_SHUTDOWN_TIMEOUT:30s}
   config:
     import: "optional:configtree:/mnt/secrets/darts/"
   application:


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2765

### Change description ###

- using `GRACEFUL_SHUTDOWN_TIMEOUT` env var

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
