### PR TITLE
DMP-3217 Remove seconds from the getCases response

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/CasesMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/CasesMapper.java
@@ -23,6 +23,8 @@ import uk.gov.hmcts.darts.common.repository.HearingReportingRestrictionsReposito
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
 
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -75,7 +77,7 @@ public class CasesMapper {
         CourtCaseEntity courtCase = hearing.getCourtCase();
         ScheduledCase scheduledCase = mapToScheduledCase(courtCase);
         scheduledCase.setHearingDate(hearing.getHearingDate());
-        scheduledCase.setScheduledStart(toStringOrDefaultTo(hearing.getScheduledStartTime(), ""));
+        scheduledCase.setScheduledStart(toStringOrDefaultTo(hearing.getScheduledStartTime()));
         scheduledCase.setCourtroom(hearing.getCourtroom().getName());
         return scheduledCase;
     }
@@ -195,10 +197,10 @@ public class CasesMapper {
     }
 
 
-    private String toStringOrDefaultTo(Object obj, String defaultStr) {
-        if (Objects.isNull(obj)) {
-            return defaultStr;
+    private String toStringOrDefaultTo(LocalTime time) {
+        if (Objects.isNull(time)) {
+            return "";
         }
-        return obj.toString();
+        return time.truncatedTo(ChronoUnit.MINUTES).toString();
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -373,7 +373,7 @@ public class CommonTestDataUtil {
 
     public List<HearingEntity> createHearings(int numOfHearings) {
         List<HearingEntity> returnList = new ArrayList<>();
-        LocalTime time = LocalTime.of(9, 0, 0);
+        LocalTime time = LocalTime.of(9, 0, 30);
         for (int counter = 1; counter <= numOfHearings; counter++) {
             returnList.add(createHearing("caseNum_" + counter, time));
             time = time.plusHours(1);


### PR DESCRIPTION
Remove seconds from the getCases response to match legacy.
Note, there are already tests to cover this scenario but the scheduled time was set to zero seconds. If the test data is changed to anything other than zero, it breaks the test as it starts using the seconds in the response. Therefore, the test data was changed to prove that this change has worked. 