### PR TITLE
DMP:3346: Pluralise transcription hide endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminPostTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminPostTranscriptionIntTest.java
@@ -43,7 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class TranscriptionControllerAdminPostTranscriptionIntTest extends IntegrationBase {
 
-    private static final String ENDPOINT_URL = "/admin/transcription-document/${TRANSACTION_DOCUMENT_ID}/hide";
+    private static final String ENDPOINT_URL = "/admin/transcription-documents/${TRANSACTION_DOCUMENT_ID}/hide";
 
     @Autowired
     private SuperAdminUserStub superAdminUserStub;

--- a/src/main/resources/openapi/transcriptions.yaml
+++ b/src/main/resources/openapi/transcriptions.yaml
@@ -904,7 +904,7 @@ paths:
                 allOf:
                   - $ref: './problem.yaml'
 
-  /admin/transcription-document/{transcription_document_id}/hide:
+  /admin/transcription-documents/{transcription_document_id}/hide:
     post:
       tags:
         - Transcription


### PR DESCRIPTION
# [DMP-3346](https://tools.hmcts.net/jira/browse/DMP-3346)

Rename endpoint to pluaralise the resource name, aligning with other APIs.

Note: FE already expects the pluralised resouce name.

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
