### PR TITLE
DMP-3276: Set interpreter flag true when creating TRANSLATION_QA groups

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostSecurityGroupIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostSecurityGroupIntTest.java
@@ -11,13 +11,12 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity_;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.testutils.TransactionalAssert;
 import uk.gov.hmcts.darts.testutils.stubs.SuperAdminUserStub;
 
 import java.util.List;
@@ -36,7 +35,7 @@ class PostSecurityGroupIntTest extends IntegrationBase {
     private static final String DESCRIPTION = "A test group";
 
     @Autowired
-    private PlatformTransactionManager transactionManager;
+    private TransactionalAssert transactionalAssert;
 
     @Autowired
     private SecurityGroupRepository securityGroupRepository;
@@ -50,13 +49,10 @@ class PostSecurityGroupIntTest extends IntegrationBase {
     @MockBean
     private UserIdentity userIdentity;
 
-    private TransactionTemplate transactionTemplate;
-
     private int maxSecurityGroupId;
 
     @BeforeEach
     void setUp() {
-        transactionTemplate = new TransactionTemplate(transactionManager);
         List<SecurityGroupEntity> securityGroupEntities = securityGroupRepository.findAll(Sort.by(SecurityGroupEntity_.ID).descending());
         maxSecurityGroupId = securityGroupEntities.get(0).getId();
     }
@@ -98,7 +94,7 @@ class PostSecurityGroupIntTest extends IntegrationBase {
         var id = new JSONObject(result.getResponse().getContentAsString())
             .getInt("id");
 
-        transactionTemplate.execute(status -> {
+        transactionalAssert.inTransaction(() -> {
             var createdSecurityGroupEntity = securityGroupRepository.findById(id)
                 .orElseThrow();
 
@@ -109,8 +105,6 @@ class PostSecurityGroupIntTest extends IntegrationBase {
             assertTrue(createdSecurityGroupEntity.getDisplayState());
             assertEquals("TRANSCRIBER", createdSecurityGroupEntity.getSecurityRoleEntity().getRoleName());
             assertFalse(createdSecurityGroupEntity.getUseInterpreter());
-
-            return null;
         });
     }
 
@@ -141,7 +135,7 @@ class PostSecurityGroupIntTest extends IntegrationBase {
         var id = new JSONObject(result.getResponse().getContentAsString())
             .getInt("id");
 
-        transactionTemplate.execute(status -> {
+        transactionalAssert.inTransaction(() -> {
             var createdSecurityGroupEntity = securityGroupRepository.findById(id)
                 .orElseThrow();
 
@@ -152,8 +146,6 @@ class PostSecurityGroupIntTest extends IntegrationBase {
             assertTrue(createdSecurityGroupEntity.getDisplayState());
             assertEquals("TRANSLATION_QA", createdSecurityGroupEntity.getSecurityRoleEntity().getRoleName());
             assertTrue(createdSecurityGroupEntity.getUseInterpreter());
-
-            return null;
         });
     }
 
@@ -185,7 +177,7 @@ class PostSecurityGroupIntTest extends IntegrationBase {
         var id = new JSONObject(result.getResponse().getContentAsString())
             .getInt("id");
 
-        transactionTemplate.execute(status -> {
+        transactionalAssert.inTransaction(() -> {
             var createdSecurityGroupEntity = securityGroupRepository.findById(id)
                 .orElseThrow();
 
@@ -195,8 +187,6 @@ class PostSecurityGroupIntTest extends IntegrationBase {
             assertFalse(createdSecurityGroupEntity.getGlobalAccess());
             assertTrue(createdSecurityGroupEntity.getDisplayState());
             assertEquals("TRANSCRIBER", createdSecurityGroupEntity.getSecurityRoleEntity().getRoleName());
-
-            return null;
         });
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/mapper/impl/SecurityGroupMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/mapper/impl/SecurityGroupMapper.java
@@ -3,12 +3,16 @@ package uk.gov.hmcts.darts.usermanagement.mapper.impl;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
+import org.mapstruct.Named;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
+import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.model.SecurityGroupModel;
 import uk.gov.hmcts.darts.usermanagement.model.SecurityGroupPostRequest;
 import uk.gov.hmcts.darts.usermanagement.model.SecurityGroupWithIdAndRole;
 import uk.gov.hmcts.darts.usermanagement.model.SecurityGroupWithIdAndRoleAndUsers;
+
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
 
 @Mapper(componentModel = "spring",
     unmappedSourcePolicy = ReportingPolicy.IGNORE,
@@ -22,6 +26,7 @@ public interface SecurityGroupMapper {
 
     @Mappings({
         @Mapping(source = "securityRoleId", target = "roleId"),
+        @Mapping(source = "securityRoleId", target = "useInterpreter", qualifiedByName = "toUseInterpreterFlag")
     })
     SecurityGroupModel mapToSecurityGroupModel(SecurityGroupPostRequest securityGroupPostRequest);
 
@@ -34,5 +39,10 @@ public interface SecurityGroupMapper {
         @Mapping(source = "groupName", target = "name"),
     })
     SecurityGroupWithIdAndRoleAndUsers mapToSecurityGroupWithIdAndRoleAndUsers(SecurityGroupEntity securityGroupEntity);
+
+    @Named("toUseInterpreterFlag")
+    default boolean toUseInterpreterFlag(int roleId) {
+        return TRANSLATION_QA.equals(SecurityRoleEnum.valueOfId(roleId));
+    }
 
 }


### PR DESCRIPTION
# [DMP-3276](https://tools.hmcts.net/jira/browse/DMP-3276)

Set interpreter flag true when creating security groups with TRANSLATION_QA role via the Admin API.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
