### PR TITLE
DMP-3305: Add DARTS role and group, rename JUDGE role and hide system…

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/SecurityGroupFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/SecurityGroupFunctionalTest.java
@@ -111,8 +111,8 @@ class SecurityGroupFunctionalTest extends FunctionalTest {
         Response response = buildRequestWithExternalGlobalAccessAuth()
             .baseUri(getUri("/admin/security-groups"))
             .contentType(ContentType.JSON)
-            .get()
-            .thenReturn();
+            .get();
+        assertEquals(200, response.getStatusCode());
 
         ObjectMapper objectMapper = new ObjectMapper();
         List<SecurityGroupWithIdAndRoleAndUsers> securityGroupWithIdAndRoles = objectMapper.readValue(response.asString(),
@@ -125,22 +125,24 @@ class SecurityGroupFunctionalTest extends FunctionalTest {
                 .filter(group -> group.getId() == 1
                     || group.getId() >= -6 && group.getId() <= -1
                     || group.getId() >= -17 && group.getId() <= -14
-                    || group.getSecurityRoleId().equals(SecurityRoleEnum.SUPER_USER.getId()))
+                    || group.getSecurityRoleId().equals(SecurityRoleEnum.SUPER_USER.getId())
+                    || group.getSecurityRoleId().equals(SecurityRoleEnum.DARTS.getId()))
                 .sorted(Comparator.comparingInt(SecurityGroupWithIdAndRoleAndUsers::getId).reversed())
                 .toList();
 
-        checkGroup(staticGroups.get(0), "SUPER_USER", true, 12, true, null);
-        checkGroup(staticGroups.get(1), "SUPER_ADMIN", true, 11, true, null);
-        checkGroup(staticGroups.get(2), "hmcts_staff_1", false, 1, true, 1);
-        checkGroup(staticGroups.get(3), "hmcts_staff_2", false, 2, true, 1);
-        checkGroup(staticGroups.get(4), "hmcts_staff_3", false, 3, true, 1);
-        checkGroup(staticGroups.get(5), "hmcts_staff_4", false, 4, true, 1);
-        checkGroup(staticGroups.get(6), "hmcts_staff_5", true, 5, true, 1);
-        checkGroup(staticGroups.get(7), "hmcts_staff_6", true, 6, true, 1);
-        checkGroup(staticGroups.get(8), "Xhibit Group", true, 7, true, 1);
-        checkGroup(staticGroups.get(9), "Cpp Group", true, 8, true, 1);
-        checkGroup(staticGroups.get(10), "Dar Pc Group", true, 9, true, 1);
-        checkGroup(staticGroups.get(11), "Mid Tier Group", true, 10, true, 1);
+        checkGroup(staticGroups.get(0), "DARTS", true, 13, false, null);
+        checkGroup(staticGroups.get(1), "SUPER_USER", true, 12, true, null);
+        checkGroup(staticGroups.get(2), "SUPER_ADMIN", true, 11, true, null);
+        checkGroup(staticGroups.get(3), "hmcts_staff_1", false, 1, true, 1);
+        checkGroup(staticGroups.get(4), "hmcts_staff_2", false, 2, true, 1);
+        checkGroup(staticGroups.get(5), "hmcts_staff_3", false, 3, true, 1);
+        checkGroup(staticGroups.get(6), "hmcts_staff_4", false, 4, true, 1);
+        checkGroup(staticGroups.get(7), "hmcts_staff_5", true, 5, true, 1);
+        checkGroup(staticGroups.get(8), "hmcts_staff_6", true, 6, true, 1);
+        checkGroup(staticGroups.get(9), "Xhibit Group", true, 7, false, 1);
+        checkGroup(staticGroups.get(10), "Cpp Group", true, 8, false, 1);
+        checkGroup(staticGroups.get(11), "Dar Pc Group", true, 9, false, 1);
+        checkGroup(staticGroups.get(12), "Mid Tier Group", true, 10, false, 1);
 
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/SecurityRoleFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/usermanagement/SecurityRoleFunctionalTest.java
@@ -42,8 +42,8 @@ class SecurityRoleFunctionalTest extends FunctionalTest {
                   },
                   {
                     "id": 3,
-                    "role_name": "JUDGE",
-                    "display_name": "Judge",
+                    "role_name": "JUDICIARY",
+                    "display_name": "Judiciary",
                     "display_state": true
                   },
                   {
@@ -68,25 +68,25 @@ class SecurityRoleFunctionalTest extends FunctionalTest {
                     "id": 7,
                     "role_name": "XHIBIT",
                     "display_name": "XHIBIT",
-                    "display_state": true
+                    "display_state": false
                   },
                   {
                     "id": 8,
                     "role_name": "CPP",
                     "display_name": "CPP",
-                    "display_state": true
+                    "display_state": false
                   },
                   {
                     "id": 9,
                     "role_name": "DAR_PC",
                     "display_name": "DAR PC",
-                    "display_state": true
+                    "display_state": false
                   },
                   {
                     "id": 10,
                     "role_name": "MID_TIER",
                     "display_name": "Mid Tier",
-                    "display_state": true
+                    "display_state": false
                   },
                   {
                     "id": 11,
@@ -99,6 +99,12 @@ class SecurityRoleFunctionalTest extends FunctionalTest {
                     "role_name": "SUPER_USER",
                     "display_name": "Super User",
                     "display_state": true
+                  },
+                  {
+                    "id": 13,
+                    "role_name": "DARTS",
+                    "display_name": "DARTS",
+                    "display_state": false
                   }
                 ]
                 """,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationDeleteTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationDeleteTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.EnumSource.Mode;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 import static uk.gov.hmcts.darts.test.common.data.AnnotationTestData.minimalAnnotationEntity;
 import static uk.gov.hmcts.darts.test.common.data.CourthouseTestData.someMinimalCourthouse;
@@ -40,7 +40,7 @@ class AnnotationDeleteTest extends IntegrationBase {
 
     @Test
     void judgeWithGlobalAccessCanDeleteTheirOwnAnnotation() throws Exception {
-        var judge = given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        var judge = given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY);
         var annotation = someAnnotationNotMarkedForDeletionCreatedBy(judge);
 
         mockMvc.perform(
@@ -57,7 +57,7 @@ class AnnotationDeleteTest extends IntegrationBase {
     @Test
     void judgeWithCourthouseAccessCanDeleteTheirOwnAnnotation() throws Exception {
         var hearing = dartsDatabase.save(createSomeMinimalHearing());
-        var judge = given.anAuthenticatedUserAuthorizedForCourthouse(JUDGE, hearing.getCourtroom().getCourthouse());
+        var judge = given.anAuthenticatedUserAuthorizedForCourthouse(JUDICIARY, hearing.getCourtroom().getCourthouse());
         var annotation = someAnnotationForHearingNotMarkedForDeletionCreatedBy(judge, hearing);
 
         mockMvc.perform(
@@ -70,7 +70,7 @@ class AnnotationDeleteTest extends IntegrationBase {
     void preventsJudgeNotAuthorizedForCourthouseDeletingAnnotationAssociatedWithThatCourthouse() throws Exception {
         var annotationHearing = dartsDatabase.save(createSomeMinimalHearing());
         var someOtherCourthouse = dartsDatabase.save(someMinimalCourthouse());
-        var judge = given.anAuthenticatedUserAuthorizedForCourthouse(JUDGE, someOtherCourthouse);
+        var judge = given.anAuthenticatedUserAuthorizedForCourthouse(JUDICIARY, someOtherCourthouse);
         var annotation = someAnnotationForHearingNotMarkedForDeletionCreatedBy(judge, annotationHearing);
 
         mockMvc.perform(
@@ -81,7 +81,7 @@ class AnnotationDeleteTest extends IntegrationBase {
 
     @Test
     void preventsJudgesFromDeletingAnotherJudgesAnnotations() throws Exception {
-        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY);
         var someOtherJudge = minimalUserAccount();
         var annotation = someAnnotationNotMarkedForDeletionCreatedBy(someOtherJudge);
 
@@ -104,7 +104,7 @@ class AnnotationDeleteTest extends IntegrationBase {
     }
 
     @ParameterizedTest
-    @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_ADMIN", "JUDGE"}, mode = Mode.EXCLUDE)
+    @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_ADMIN", "JUDICIARY" }, mode = Mode.EXCLUDE)
     void disallowsDeleteAnnotationByRolesOtherThanSuperAdminAndJudge(SecurityRoleEnum role) throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(role);
         var someJudge = minimalUserAccount();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationGetTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationGetTest.java
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.test.common.data.AnnotationTestData.minimalAnnotationEntity;
 import static uk.gov.hmcts.darts.test.common.data.HearingTestData.someMinimalHearing;
 
@@ -50,7 +50,7 @@ class AnnotationGetTest extends IntegrationBase {
     @Test
     void shouldThrowHttp404ForValidJudgeAndInvalidAnnotationDocumentEntity() throws Exception {
 
-        AnnotationEntity uae = someAnnotationCreatedBy(given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE));
+        AnnotationEntity uae = someAnnotationCreatedBy(given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY));
 
         MockHttpServletRequestBuilder requestBuilder = get(ANNOTATION_DOCUMENT_ENDPOINT, uae.getId(), -1);
 
@@ -67,7 +67,7 @@ class AnnotationGetTest extends IntegrationBase {
     @Test
     void shouldDownloadAnnotationDocument() throws Exception {
 
-        var judge = given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        var judge = given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY);
 
         when(downloadResponseMetaData.getInputStream()).thenReturn(inputStreamResource);
         when(dataManagementFacade.retrieveFileFromStorage(anyList())).thenReturn(downloadResponseMetaData);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationPostTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.test.common.data.HearingTestData.createSomeMinimalHearing;
 
 @AutoConfigureMockMvc
@@ -43,7 +43,7 @@ class AnnotationPostTest extends IntegrationBase {
 
     @Test
     void returnsAnnotationId() throws Exception {
-        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY);
         HearingEntity hearingEntity = createSomeMinimalHearing();
         hearingEntity = dartsDatabase.save(hearingEntity);
 
@@ -71,7 +71,7 @@ class AnnotationPostTest extends IntegrationBase {
 
     @Test
     void allowsJudgeWithGlobalAccessToUploadAnnotations() throws Exception {
-        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY);
         HearingEntity hearingEntity = createSomeMinimalHearing();
         hearingEntity = dartsDatabase.save(hearingEntity);
         mockMvc.perform(
@@ -85,7 +85,7 @@ class AnnotationPostTest extends IntegrationBase {
     @Test
     void allowsJudgeAuthorisedForCourthouseAccessToUploadAnnotations() throws Exception {
         var hearing = dartsDatabase.save(createSomeMinimalHearing());
-        given.anAuthenticatedUserAuthorizedForCourthouse(JUDGE, hearing.getCourtroom().getCourthouse());
+        given.anAuthenticatedUserAuthorizedForCourthouse(JUDICIARY, hearing.getCourtroom().getCourthouse());
 
         mockMvc.perform(
                 multipart(ENDPOINT)
@@ -97,7 +97,7 @@ class AnnotationPostTest extends IntegrationBase {
 
     @Test
     void returns400IfAnnotationDocumentMissing() throws Exception {
-        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY);
 
         mockMvc.perform(
                 multipart(ENDPOINT)
@@ -108,7 +108,7 @@ class AnnotationPostTest extends IntegrationBase {
 
     @Test
     void returns400IfPostBodyMissing() throws Exception {
-        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY);
 
         mockMvc.perform(
                 multipart(ENDPOINT)
@@ -119,7 +119,7 @@ class AnnotationPostTest extends IntegrationBase {
 
     @Test
     void returns400WhenHearingIdIsNull() throws Exception {
-        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDGE);
+        given.anAuthenticatedUserWithGlobalAccessAndRole(JUDICIARY);
 
         mockMvc.perform(
                 multipart(ENDPOINT)

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreviewIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreviewIntTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.audio.enums.AudioPreviewStatus.READY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
@@ -63,7 +63,7 @@ class AudioControllerPreviewIntTest extends IntegrationBase {
         given.externalObjectDirForMedia(mediaEntity);
         doNothing().when(authorisation).authoriseByMediaId(
             mediaEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
 
     }
@@ -87,7 +87,7 @@ class AudioControllerPreviewIntTest extends IntegrationBase {
 
         verify(authorisation, times(2)).authoriseByMediaId(
             mediaEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
     }
 
@@ -103,7 +103,7 @@ class AudioControllerPreviewIntTest extends IntegrationBase {
 
         verify(authorisation, times(2)).authoriseByMediaId(
             mediaEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
     }
 
@@ -119,7 +119,7 @@ class AudioControllerPreviewIntTest extends IntegrationBase {
 
         verify(authorisation, times(2)).authoriseByMediaId(
             mediaEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDeleteAudioRequestIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDeleteAudioRequestIntTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
@@ -55,7 +55,7 @@ class AudioRequestsControllerDeleteAudioRequestIntTest extends IntegrationBase {
 
         doNothing().when(authorisation).authoriseByMediaRequestId(
             mediaRequestEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
 
         MockHttpServletRequestBuilder requestBuilder = delete(URI.create(
@@ -66,7 +66,7 @@ class AudioRequestsControllerDeleteAudioRequestIntTest extends IntegrationBase {
 
         verify(authorisation).authoriseByMediaRequestId(
             mediaRequestEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDeleteTransformedMediaIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDeleteTransformedMediaIntTest.java
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
@@ -62,7 +62,7 @@ class AudioRequestsControllerDeleteTransformedMediaIntTest extends IntegrationBa
 
         doNothing().when(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaId,
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
 
         MockHttpServletRequestBuilder requestBuilder = delete(
@@ -81,7 +81,7 @@ class AudioRequestsControllerDeleteTransformedMediaIntTest extends IntegrationBa
 
         verify(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaId,
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
     }
 
@@ -105,7 +105,7 @@ class AudioRequestsControllerDeleteTransformedMediaIntTest extends IntegrationBa
 
         doNothing().when(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaId,
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
 
         MockHttpServletRequestBuilder requestBuilder = delete(
@@ -131,7 +131,7 @@ class AudioRequestsControllerDeleteTransformedMediaIntTest extends IntegrationBa
 
         verify(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaId,
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerPlaybackIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerPlaybackIntTest.java
@@ -41,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.darts.audiorequests.model.AudioRequestType.PLAYBACK;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
@@ -103,7 +103,7 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
         doNothing().when(mockAuthorisation)
             .authoriseByTransformedMediaId(
                 transformedMediaId,
-                Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+                Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
             );
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT)
@@ -116,7 +116,7 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
 
         verify(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaId,
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
 
         Integer courtCaseId = mediaRequestEntity.getHearing().getCourtCase().getId();
@@ -154,7 +154,7 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
         doNothing().when(mockAuthorisation)
             .authoriseByTransformedMediaId(
                 transformedMediaId,
-                Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+                Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
             );
 
         mockMvc.perform(requestBuilder)
@@ -164,7 +164,7 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
 
         verify(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaId,
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
     }
 
@@ -184,7 +184,7 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
         doNothing().when(mockAuthorisation)
             .authoriseByTransformedMediaId(
                 transformedMediaId,
-                Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+                Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
             );
 
         mockMvc.perform(requestBuilder)
@@ -194,7 +194,7 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
 
         verify(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaId,
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.audio.exception.AudioRequestsApiError.MEDIA_REQUEST_NOT_VALID_FOR_USER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
@@ -60,7 +60,7 @@ class AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest 
         Integer transformedMediaId = transformedMediaEntity.getId();
         doNothing().when(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaId,
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
         doNothing().when(mockAuthorisation).authoriseTransformedMediaAgainstUser(transformedMediaId);
         MockHttpServletRequestBuilder requestBuilder = patch(ENDPOINT_URL, transformedMediaId);
@@ -71,7 +71,7 @@ class AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest 
 
         verify(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
         verify(mockAuthorisation).authoriseTransformedMediaAgainstUser(transformedMediaId);
     }
@@ -94,7 +94,7 @@ class AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest 
         Integer transformedMediaId = transformedMediaEntity.getId();
         doNothing().when(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
 
         doThrow(new DartsApiException(MEDIA_REQUEST_NOT_VALID_FOR_USER))
@@ -118,7 +118,7 @@ class AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest 
 
         verify(mockAuthorisation).authoriseByTransformedMediaId(
             transformedMediaEntity.getId(),
-            Set.of(JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
+            Set.of(JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA)
         );
         verify(mockAuthorisation).authoriseTransformedMediaAgainstUser(transformedMediaId);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImplTest.java
@@ -26,7 +26,7 @@ import static uk.gov.hmcts.darts.audio.exception.AudioRequestsApiError.TRANSFORM
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.USER_NOT_AUTHORISED_FOR_COURTHOUSE;
 import static uk.gov.hmcts.darts.cases.exception.CaseApiError.CASE_NOT_FOUND;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.hearings.exception.HearingApiError.HEARING_NOT_FOUND;
 import static uk.gov.hmcts.darts.transcriptions.exception.TranscriptionApiError.TRANSCRIPTION_NOT_FOUND;
@@ -61,7 +61,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByCaseId(
-                authorisationStub.getCourtCaseEntity().getId(), Set.of(JUDGE))
+                authorisationStub.getCourtCaseEntity().getId(), Set.of(JUDICIARY))
         );
 
         assertEquals(USER_NOT_AUTHORISED_FOR_COURTHOUSE.getTitle(), exception.getMessage());
@@ -73,7 +73,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByCaseId(
-                -1, Set.of(JUDGE))
+                -1, Set.of(JUDICIARY))
         );
 
         assertEquals(CASE_NOT_FOUND.getTitle(), exception.getMessage());
@@ -91,7 +91,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByHearingId(
-                authorisationStub.getHearingEntity().getId(), Set.of(JUDGE))
+                authorisationStub.getHearingEntity().getId(), Set.of(JUDICIARY))
         );
 
         assertEquals(USER_NOT_AUTHORISED_FOR_COURTHOUSE.getTitle(), exception.getMessage());
@@ -103,7 +103,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByHearingId(
-                -1, Set.of(JUDGE))
+                -1, Set.of(JUDICIARY))
         );
 
         assertEquals(HEARING_NOT_FOUND.getTitle(), exception.getMessage());
@@ -121,7 +121,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByMediaRequestId(
-                authorisationStub.getMediaRequestEntity().getId(), Set.of(JUDGE))
+                authorisationStub.getMediaRequestEntity().getId(), Set.of(JUDICIARY))
         );
 
         assertEquals(USER_NOT_AUTHORISED_FOR_COURTHOUSE.getTitle(), exception.getMessage());
@@ -133,7 +133,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByMediaRequestId(
-                -1, Set.of(JUDGE))
+                -1, Set.of(JUDICIARY))
         );
 
         assertEquals(MEDIA_REQUEST_NOT_FOUND.getTitle(), exception.getMessage());
@@ -169,7 +169,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByMediaId(
-                authorisationStub.getMediaEntity().getId(), Set.of(JUDGE))
+                authorisationStub.getMediaEntity().getId(), Set.of(JUDICIARY))
         );
 
         assertEquals(USER_NOT_AUTHORISED_FOR_COURTHOUSE.getTitle(), exception.getMessage());
@@ -181,7 +181,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByMediaId(
-                -1, Set.of(JUDGE))
+                -1, Set.of(JUDICIARY))
         );
 
         assertEquals(MEDIA_NOT_FOUND.getTitle(), exception.getMessage());
@@ -199,7 +199,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByTranscriptionId(
-                authorisationStub.getTranscriptionEntity().getId(), Set.of(JUDGE))
+                authorisationStub.getTranscriptionEntity().getId(), Set.of(JUDICIARY))
         );
 
         assertEquals(USER_NOT_AUTHORISED_FOR_COURTHOUSE.getTitle(), exception.getMessage());
@@ -211,7 +211,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByTranscriptionId(
-                -1, Set.of(JUDGE))
+                -1, Set.of(JUDICIARY))
         );
 
         assertEquals(TRANSCRIPTION_NOT_FOUND.getTitle(), exception.getMessage());
@@ -229,7 +229,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByTransformedMediaId(
-                authorisationStub.getTransformedMediaEntity().getId(), Set.of(JUDGE))
+                authorisationStub.getTransformedMediaEntity().getId(), Set.of(JUDICIARY))
         );
 
         assertEquals(USER_NOT_AUTHORISED_FOR_COURTHOUSE.getTitle(), exception.getMessage());
@@ -241,7 +241,7 @@ class AuthorisationImplTest extends IntegrationBase {
         var exception = assertThrows(
             DartsApiException.class,
             () -> authorisationToTest.authoriseByTransformedMediaId(
-                -1, Set.of(JUDGE))
+                -1, Set.of(JUDICIARY))
         );
 
         assertEquals(TRANSFORMED_MEDIA_NOT_FOUND.getTitle(), exception.getMessage());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 
 @TestInstance(Lifecycle.PER_CLASS)
@@ -76,7 +76,7 @@ class AuthorisationServiceTest extends IntegrationBase {
         UserAccountRepository userAccountRepository = dartsDatabase.getUserAccountRepository();
         userAccountRepository.saveAndFlush(judgeUserAccount);
 
-        SecurityGroupEntity globalSecurityGroup = SecurityGroupTestData.buildGroupForRole(JUDGE);
+        SecurityGroupEntity globalSecurityGroup = SecurityGroupTestData.buildGroupForRole(JUDICIARY);
         globalSecurityGroup.setGlobalAccess(true);
         dartsDatabase.getSecurityGroupRepository().saveAndFlush(globalSecurityGroup);
 
@@ -142,7 +142,7 @@ class AuthorisationServiceTest extends IntegrationBase {
         assertEquals(1, judgeUserState.getRoles().size());
 
         UserStateRole judgeRole = judgeUserState.getRoles().iterator().next();
-        assertEquals(JUDGE.getId(), judgeRole.getRoleId());
+        assertEquals(JUDICIARY.getId(), judgeRole.getRoleId());
         assertFalse(judgeRole.getGlobalAccess());
 
         assertTrue(judgeRole.getCourthouseIds().contains(courthouseEntity.getId()));
@@ -166,7 +166,7 @@ class AuthorisationServiceTest extends IntegrationBase {
         assertEquals(1, judgeUserState.getRoles().size());
 
         UserStateRole judgeRole = judgeUserState.getRoles().iterator().next();
-        assertEquals(JUDGE.getId(), judgeRole.getRoleId());
+        assertEquals(JUDICIARY.getId(), judgeRole.getRoleId());
         assertTrue(judgeRole.getGlobalAccess());
 
         assertTrue(judgeRole.getCourthouseIds().isEmpty());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetAnnotationsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetAnnotationsIntTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 
 @Slf4j
@@ -177,7 +177,7 @@ class CaseControllerGetAnnotationsIntTest extends IntegrationBase {
             .andReturn();
 
         verify(mockUserIdentity).getUserAccount();
-        verify(mockUserIdentity).userHasGlobalAccess(Set.of(JUDGE, SUPER_ADMIN));
+        verify(mockUserIdentity).userHasGlobalAccess(Set.of(JUDICIARY, SUPER_ADMIN));
         verifyNoMoreInteractions(mockUserIdentity);
     }
 
@@ -203,7 +203,7 @@ class CaseControllerGetAnnotationsIntTest extends IntegrationBase {
             .andReturn();
 
         verify(mockUserIdentity).getUserAccount();
-        verify(mockUserIdentity).userHasGlobalAccess(Set.of(JUDGE, SUPER_ADMIN));
+        verify(mockUserIdentity).userHasGlobalAccess(Set.of(JUDICIARY, SUPER_ADMIN));
         verifyNoMoreInteractions(mockUserIdentity);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/SecurityRoleRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/SecurityRoleRepositoryTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.CPP;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.DAR_PC;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.MID_TIER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
@@ -33,7 +33,7 @@ class SecurityRoleRepositoryTest extends IntegrationBase {
     @Test
     void shouldFindAllSecurityRoles() {
         List<SecurityRoleEntity> securityRoleEntityList = securityRoleRepository.findAll();
-        assertEquals(12, securityRoleEntityList.size());
+        assertEquals(13, securityRoleEntityList.size());
     }
 
     @Test
@@ -52,7 +52,7 @@ class SecurityRoleRepositoryTest extends IntegrationBase {
 
     @Test
     void shouldFindAllJudgePermissions() {
-        SecurityRoleEntity judgeRole = securityRoleRepository.findById(JUDGE.getId()).orElseThrow();
+        SecurityRoleEntity judgeRole = securityRoleRepository.findById(JUDICIARY.getId()).orElseThrow();
         final Set<SecurityPermissionEntity> securityPermissionEntities = judgeRole.getSecurityPermissionEntities();
         assertEquals(12, securityPermissionEntities.size());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/retention/controller/RetentionControllerGetByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/retention/controller/RetentionControllerGetByCaseIdTest.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
 
@@ -93,7 +93,7 @@ class RetentionControllerGetByCaseIdTest extends IntegrationBase {
             .andExpect(MockMvcResultMatchers.jsonPath("$[2].comments", Matchers.is("a comment")))
             .andExpect(MockMvcResultMatchers.jsonPath("$[2].status", Matchers.is("c_state")));
 
-        verify(mockUserIdentity).userHasGlobalAccess(Set.of(JUDGE, SUPER_ADMIN, SUPER_USER));
+        verify(mockUserIdentity).userHasGlobalAccess(Set.of(JUDICIARY, SUPER_ADMIN, SUPER_USER));
     }
 
     @Test
@@ -107,7 +107,7 @@ class RetentionControllerGetByCaseIdTest extends IntegrationBase {
         String actualJson = mvcResult.getResponse().getContentAsString();
         JSONAssert.assertEquals("[]", actualJson, JSONCompareMode.NON_EXTENSIBLE);
 
-        verify(mockUserIdentity).userHasGlobalAccess(Set.of(JUDGE, SUPER_ADMIN, SUPER_USER));
+        verify(mockUserIdentity).userHasGlobalAccess(Set.of(JUDICIARY, SUPER_ADMIN, SUPER_USER));
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/GivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/GivenBuilder.java
@@ -13,7 +13,7 @@ import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
 import java.util.List;
 import java.util.UUID;
 
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.buildGroupForRole;
 import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.buildGroupForRoleAndCourthouse;
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;
@@ -44,7 +44,7 @@ public class GivenBuilder {
         var userEmail = role.name() + "@" + courthouse.getCourthouseName() + ".com";
         anAuthenticatedUserFor(userEmail);
 
-        var securityGroup = buildGroupForRoleAndCourthouse(JUDGE, courthouse);
+        var securityGroup = buildGroupForRoleAndCourthouse(JUDICIARY, courthouse);
 
         var judge = minimalUserAccount();
         judge.setEmailAddress(userEmail);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
@@ -347,7 +347,7 @@ public class UserAccountStub {
 
         Mockito.when(userIdentity.getUserAccount())
             .thenReturn(user);
-        Mockito.when(userIdentity.userHasGlobalAccess(argThat(t -> t.contains(SecurityRoleEnum.JUDGE))))
+        Mockito.when(userIdentity.userHasGlobalAccess(argThat(t -> t.contains(SecurityRoleEnum.JUDICIARY))))
             .thenReturn(true);
 
         return user;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/GetSecurityGroupsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/GetSecurityGroupsIntTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.usermanagement.controller;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -16,13 +15,8 @@ import uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.CourthouseStub;
 import uk.gov.hmcts.darts.testutils.stubs.SuperAdminUserStub;
-import uk.gov.hmcts.darts.usermanagement.model.SecurityGroupWithIdAndRole;
-
-import java.util.Comparator;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -44,43 +38,6 @@ class GetSecurityGroupsIntTest extends IntegrationBase {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Test
-    void shouldReturnAllSecurityGroupsWithCourthouseIds() throws Exception {
-        superAdminUserStub.givenUserIsAuthorised(userIdentity);
-
-        MvcResult mvcResult = mockMvc.perform(get(ENDPOINT_URL))
-            .andExpect(status().isOk())
-            .andReturn();
-
-        List<SecurityGroupWithIdAndRole> groups = objectMapper.readValue(mvcResult.getResponse().getContentAsString(),
-                                                                         new TypeReference<>() {
-                                                                         });
-
-        assertFalse(groups.isEmpty());
-
-        groups.sort(Comparator.comparingInt(SecurityGroupWithIdAndRole::getId).reversed());
-
-        checkGroup(groups.get(0), "SUPER_USER", true, 12, true);
-        checkGroup(groups.get(1), "SUPER_ADMIN", true, 11, true);
-        checkGroup(groups.get(2), "Test Approver", false, 1, true);
-        checkGroup(groups.get(3), "Test Requestor", false, 2, true);
-        checkGroup(groups.get(4), "Test Judge", false, 3, true);
-        checkGroup(groups.get(5), "Test Transcriber", false, 4, true);
-        checkGroup(groups.get(6), "Test Language Shop", true, 5, true);
-        checkGroup(groups.get(7), "Test RCJ Appeals", true, 6, true);
-        checkGroup(groups.get(8), "Xhibit Group", true, 7, true);
-        checkGroup(groups.get(9), "Cpp Group", true, 8, true);
-        checkGroup(groups.get(10), "Dar Pc Group", true, 9, true);
-        checkGroup(groups.get(11), "Mid Tier Group", true, 10, true);
-    }
-
-    private void checkGroup(SecurityGroupWithIdAndRole group, String name, boolean globalAccess, Integer roleId, boolean displayState) {
-        assertEquals(name, group.getName());
-        assertEquals(globalAccess, group.getGlobalAccess());
-        assertEquals(roleId, group.getSecurityRoleId());
-        assertEquals(displayState, group.getDisplayState());
-    }
 
     @Test
     void givenAUserNotAuthorisedThenReturnA403() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityGroupControllerIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityGroupControllerIntTest.java
@@ -166,7 +166,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                     "id":-17,
                     "security_role_id":10,
                     "global_access":true,
-                    "display_state":true,
+                    "display_state":false,
                     "courthouse_ids":[%s],
                     "name":"Mid Tier Group"
                   }
@@ -214,7 +214,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                     "id":-17,
                     "security_role_id":10,
                     "global_access":true,
-                    "display_state":true,
+                    "display_state":false,
                     "courthouse_ids":[%s],
                     "name":"Mid Tier Group"
                   }
@@ -243,7 +243,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                       "id":-17,
                       "security_role_id":10,
                       "global_access":true,
-                      "display_state":true,
+                      "display_state":false,
                       "courthouse_ids":[],
                       "name":"Mid Tier Group"
                     },
@@ -252,7 +252,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                       "id":-16,
                       "security_role_id":9,
                       "global_access":true,
-                      "display_state":true,
+                      "display_state":false,
                       "courthouse_ids":[],
                       "name":"Dar Pc Group"
                       },
@@ -261,7 +261,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                         "id":-15,
                         "security_role_id":8,
                         "global_access":true,
-                        "display_state":true,
+                        "display_state":false,
                         "courthouse_ids":[],
                         "name":"Cpp Group"
                       },
@@ -311,7 +311,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                     "id":-17,
                     "security_role_id":10,
                     "global_access":true,
-                    "display_state":true,
+                    "display_state":false,
                     "courthouse_ids":[],
                     "name":"Mid Tier Group"
                     },
@@ -320,7 +320,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                     "id":-16,
                     "security_role_id":9,
                     "global_access":true,
-                    "display_state":true,
+                    "display_state":false,
                     "courthouse_ids":[],
                     "name":"Dar Pc Group"
                     },
@@ -329,7 +329,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                     "id":-15,
                     "security_role_id":8,
                     "global_access":true,
-                    "display_state":true,
+                    "display_state":false,
                     "courthouse_ids":[],
                     "name":"Cpp Group"
                     },
@@ -399,7 +399,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                           "id":-17,
                           "security_role_id":10,
                           "global_access":true,
-                          "display_state":true,
+                          "display_state":false,
                           "courthouse_ids":[],
                           "name":"Mid Tier Group"
                       },
@@ -408,7 +408,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                           "id":-16,
                           "security_role_id":9,
                           "global_access":true,
-                          "display_state":true,
+                          "display_state":false,
                           "courthouse_ids":[],
                           "name":"Dar Pc Group"
                       },
@@ -417,7 +417,7 @@ class SecurityGroupControllerIntTest extends IntegrationBase {
                           "id":-15,
                           "security_role_id":8,
                           "global_access":true,
-                          "display_state":true,
+                          "display_state":false,
                           "courthouse_ids":[],
                           "name":"Cpp Group"
                       },

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityRoleControllerIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityRoleControllerIntTest.java
@@ -60,8 +60,8 @@ class SecurityRoleControllerIntTest extends IntegrationBase {
                   },
                   {
                     "id": 3,
-                    "role_name": "JUDGE",
-                    "display_name": "Judge",
+                    "role_name": "JUDICIARY",
+                    "display_name": "Judiciary",
                     "display_state": true
                   },
                   {
@@ -86,25 +86,25 @@ class SecurityRoleControllerIntTest extends IntegrationBase {
                     "id": 7,
                     "role_name": "XHIBIT",
                     "display_name": "XHIBIT",
-                    "display_state": true
+                    "display_state": false
                   },
                   {
                     "id": 8,
                     "role_name": "CPP",
                     "display_name": "CPP",
-                    "display_state": true
+                    "display_state": false
                   },
                   {
                     "id": 9,
                     "role_name": "DAR_PC",
                     "display_name": "DAR PC",
-                    "display_state": true
+                    "display_state": false
                   },
                   {
                     "id": 10,
                     "role_name": "MID_TIER",
                     "display_name": "Mid Tier",
-                    "display_state": true
+                    "display_state": false
                   },
                   {
                     "id": 11,
@@ -117,6 +117,12 @@ class SecurityRoleControllerIntTest extends IntegrationBase {
                     "role_name": "SUPER_USER",
                     "display_name": "Super User",
                     "display_state": true
+                  },
+                  {
+                    "id": 13,
+                    "role_name": "DARTS",
+                    "display_name": "DARTS",
+                    "display_state": false
                   }
                 ]
             """;

--- a/src/integrationTest/resources/tests/usermanagement/SecurityGroupControllerGetTest/securityGroupsGetEndpointAllReturned.json
+++ b/src/integrationTest/resources/tests/usermanagement/SecurityGroupControllerGetTest/securityGroupsGetEndpointAllReturned.json
@@ -4,7 +4,7 @@
     "id": -17,
     "security_role_id": 10,
     "global_access": true,
-    "display_state": true,
+    "display_state": false,
     "courthouse_ids": [],
     "name": "Mid Tier Group"
   },
@@ -13,7 +13,7 @@
     "id": -16,
     "security_role_id": 9,
     "global_access": true,
-    "display_state": true,
+    "display_state": false,
     "courthouse_ids": [],
     "name": "Dar Pc Group"
   },
@@ -22,7 +22,7 @@
     "id": -15,
     "security_role_id": 8,
     "global_access": true,
-    "display_state": true,
+    "display_state": false,
     "courthouse_ids": [],
     "name": "Cpp Group"
   },
@@ -31,7 +31,7 @@
     "id": -14,
     "security_role_id": 7,
     "global_access": true,
-    "display_state": true,
+    "display_state": false,
     "courthouse_ids": [],
     "name": "Xhibit Group"
   },
@@ -108,5 +108,15 @@
     "courthouse_ids": [],
     "name": "SUPER_USER",
     "display_name": "Super User"
+  },
+  {
+    "user_ids": [],
+    "id": 3,
+    "security_role_id": 13,
+    "global_access": true,
+    "display_state": false,
+    "courthouse_ids": [],
+    "name": "DARTS",
+    "display_name": "DARTS"
   }
 ]

--- a/src/main/java/uk/gov/hmcts/darts/annotation/controller/AnnotationController.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/controller/AnnotationController.java
@@ -21,7 +21,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_DISPOSITION;
 import static uk.gov.hmcts.darts.authorisation.constants.AuthorisationConstants.SECURITY_SCHEMES_BEARER_AUTH;
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANNOTATION_ID;
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.HEARING_ID;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 
 @RestController
@@ -38,8 +38,8 @@ public class AnnotationController implements AnnotationsApi {
     @Authorisation(
         bodyAuthorisation = true,
         contextId = HEARING_ID,
-        securityRoles = {JUDGE},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN})
+        securityRoles = {JUDICIARY},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN})
     @Override
     public ResponseEntity<PostAnnotationResponse> postAnnotation(MultipartFile file, Annotation annotation) {
         var annotationId = uploadService.upload(file, annotation);
@@ -49,8 +49,8 @@ public class AnnotationController implements AnnotationsApi {
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(
         contextId = ANNOTATION_ID,
-        securityRoles = {JUDGE},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN})
+        securityRoles = {JUDICIARY},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN})
     @Override
     public ResponseEntity<Void> deleteAnnotation(Integer annotationId) {
         deleteService.delete(annotationId);
@@ -60,8 +60,8 @@ public class AnnotationController implements AnnotationsApi {
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(
         contextId = ANNOTATION_ID,
-        securityRoles = {JUDGE},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN})
+        securityRoles = {JUDICIARY},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN})
     @Override
     public ResponseEntity<Resource> downloadAnnotation(Integer annotationId, Integer annotationDocumentId) {
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -42,7 +42,7 @@ import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANY_ENTITY_ID
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.HEARING_ID;
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.MEDIA_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.MID_TIER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
@@ -70,8 +70,8 @@ public class AudioController implements AudioApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = HEARING_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<List<AudioMetadata>> getAudioMetadata(Integer hearingId) {
         List<MediaEntity> mediaEntities = audioService.getAudioMetadata(hearingId, 1);
         List<AudioMetadata> audioMetadata = audioResponseMapper.mapToAudioMetadata(mediaEntities);
@@ -99,8 +99,8 @@ public class AudioController implements AudioApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = MEDIA_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<byte[]> preview(Integer mediaId, String httpRangeList) {
         AudioPreview audioPreview = audioPreviewService.getOrCreateAudioPreview(mediaId);
         if (audioPreview.getStatus().equals(FAILED)) {

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -39,7 +39,7 @@ import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.DOWNLOAD_HEAR
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.MEDIA_REQUEST_ID;
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.TRANSFORMED_MEDIA_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
@@ -68,8 +68,8 @@ public class AudioRequestsController implements AudioRequestsApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = MEDIA_REQUEST_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<Void> deleteAudioRequest(Integer mediaRequestId) {
         mediaRequestService.deleteAudioRequest(mediaRequestId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -92,8 +92,8 @@ public class AudioRequestsController implements AudioRequestsApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(bodyAuthorisation = true, contextId = DOWNLOAD_HEARING_ID_TRANSCRIBER,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<AddAudioResponse> addAudioRequest(AudioRequestDetails audioRequestDetails) {
         if (mediaRequestService.isUserDuplicateAudioRequest(audioRequestDetails)) {
             throw new DartsApiException(AudioRequestsApiError.DUPLICATE_MEDIA_REQUEST);
@@ -112,8 +112,8 @@ public class AudioRequestsController implements AudioRequestsApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(bodyAuthorisation = true, contextId = DOWNLOAD_HEARING_ID_TRANSCRIBER,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<AddAudioResponse> addAudioRequestPlayback(AudioRequestDetails audioRequestDetails) {
         audioRequestDetails.setRequestType(AudioRequestType.PLAYBACK);
         return addAudioRequest(audioRequestDetails);
@@ -133,8 +133,8 @@ public class AudioRequestsController implements AudioRequestsApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = TRANSFORMED_MEDIA_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<byte[]> playback(Integer transformedMediaId, String httpRangeList) {
         InputStream audioFileStream = mediaRequestService.playback(transformedMediaId);
 
@@ -144,8 +144,8 @@ public class AudioRequestsController implements AudioRequestsApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = TRANSFORMED_MEDIA_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<Void> updateTransformedMediaLastAccessedTimestamp(Integer transformedMediaId) {
         mediaRequestService.updateTransformedMediaLastAccessedTimestamp(transformedMediaId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
@@ -154,8 +154,8 @@ public class AudioRequestsController implements AudioRequestsApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = TRANSFORMED_MEDIA_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<Void> deleteTransformedMedia(Integer transformedMediaId) {
         mediaRequestService.deleteTransformedMedia(transformedMediaId);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
@@ -37,7 +37,7 @@ import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANY_ENTITY_ID
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.CASE_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.DAR_PC;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.MID_TIER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
@@ -119,8 +119,8 @@ public class CaseController implements CasesApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = CASE_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<List<Hearing>> casesCaseIdHearingsGet(Integer caseId) {
 
         return new ResponseEntity<>(caseService.getCaseHearings(caseId), HttpStatus.OK);
@@ -129,8 +129,8 @@ public class CaseController implements CasesApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = CASE_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     public ResponseEntity<SingleCase> casesCaseIdGet(Integer caseId) {
 
         return new ResponseEntity<>(caseService.getCasesById(caseId), HttpStatus.OK);
@@ -140,8 +140,8 @@ public class CaseController implements CasesApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = CASE_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS})
     public ResponseEntity<List<Transcript>> casesCaseIdTranscriptsGet(Integer caseId) {
         return new ResponseEntity<>(caseService.getTranscriptsByCaseId(caseId), HttpStatus.OK);
     }
@@ -149,8 +149,8 @@ public class CaseController implements CasesApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = CASE_ID,
-        securityRoles = {JUDGE},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN})
+        securityRoles = {JUDICIARY},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN})
     public ResponseEntity<List<Annotation>> getYourAnnotationsByCaseId(Integer caseId) {
         return new ResponseEntity<>(caseService.getAnnotations(caseId), HttpStatus.OK);
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/enums/SecurityRoleEnum.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/enums/SecurityRoleEnum.java
@@ -12,7 +12,7 @@ public enum SecurityRoleEnum {
 
     APPROVER(1),
     REQUESTER(2),
-    JUDGE(3),
+    JUDICIARY(3),
     TRANSCRIBER(4),
     TRANSLATION_QA(5),
     RCJ_APPEALS(6),
@@ -21,7 +21,8 @@ public enum SecurityRoleEnum {
     DAR_PC(9),
     MID_TIER(10),
     SUPER_ADMIN(11),
-    SUPER_USER(12);
+    SUPER_USER(12),
+    DARTS(13);
 
     private final Integer id;
 

--- a/src/main/java/uk/gov/hmcts/darts/hearings/controller/HearingsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/controller/HearingsController.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static uk.gov.hmcts.darts.authorisation.constants.AuthorisationConstants.SECURITY_SCHEMES_BEARER_AUTH;
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.HEARING_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
@@ -36,8 +36,8 @@ public class HearingsController implements HearingsApi {
 
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = HEARING_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     @Override
     public ResponseEntity<GetHearingResponse> getHearing(Integer hearingId) {
         return new ResponseEntity<>(hearingsService.getHearings(hearingId), HttpStatus.OK);
@@ -45,8 +45,8 @@ public class HearingsController implements HearingsApi {
 
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = HEARING_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA})
     @Override
     public ResponseEntity<List<EventResponse>> getEvents(Integer hearingId) {
         return new ResponseEntity<>(hearingsService.getEvents(hearingId), HttpStatus.OK);
@@ -55,8 +55,8 @@ public class HearingsController implements HearingsApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = HEARING_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER, RCJ_APPEALS},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, RCJ_APPEALS},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS})
     public ResponseEntity<List<Transcript>> hearingsHearingIdTranscriptsGet(Integer hearingId) {
         return new ResponseEntity<>(hearingsService.getTranscriptsByHearingId(hearingId), HttpStatus.OK);
     }
@@ -64,8 +64,8 @@ public class HearingsController implements HearingsApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = HEARING_ID,
-        securityRoles = {JUDGE},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN})
+        securityRoles = {JUDICIARY},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN})
     public ResponseEntity<List<Annotation>> getHearingAnnotations(Integer hearingId) {
         return new ResponseEntity<>(hearingsService.getAnnotationsByHearingId(hearingId), HttpStatus.OK);
     }

--- a/src/main/java/uk/gov/hmcts/darts/retention/controller/RetentionController.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/controller/RetentionController.java
@@ -25,7 +25,7 @@ import static uk.gov.hmcts.darts.authorisation.constants.AuthorisationConstants.
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANY_ENTITY_ID;
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.CASE_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
@@ -42,8 +42,8 @@ public class RetentionController implements RetentionApi {
 
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = CASE_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER})
     @Override
     public ResponseEntity<List<GetCaseRetentionsResponse>> retentionsGet(Integer caseId) {
         return new ResponseEntity<>(retentionService.getCaseRetentions(caseId), HttpStatus.OK);
@@ -51,8 +51,8 @@ public class RetentionController implements RetentionApi {
 
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = CASE_ID, bodyAuthorisation = true,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER})
     @Override
     public ResponseEntity<PostRetentionResponse> retentionsPost(Boolean validateOnly,
                                                                 PostRetentionRequest postRetentionRequest) {

--- a/src/main/java/uk/gov/hmcts/darts/retention/service/impl/RetentionPostServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/service/impl/RetentionPostServiceImpl.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
 
@@ -43,7 +43,7 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
 @Slf4j
 public class RetentionPostServiceImpl implements RetentionPostService {
 
-    private static final List<SecurityRoleEnum> JUDGE_AND_SUPER_ADMIN_USER_ROLES = List.of(JUDGE, SUPER_ADMIN, SUPER_USER);
+    private static final List<SecurityRoleEnum> JUDGE_AND_SUPER_ADMIN_USER_ROLES = List.of(JUDICIARY, SUPER_ADMIN, SUPER_USER);
 
     private final CaseRepository caseRepository;
     private final CaseRetentionRepository caseRetentionRepository;

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionController.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionController.java
@@ -52,7 +52,7 @@ import static uk.gov.hmcts.darts.authorisation.constants.AuthorisationConstants.
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANY_ENTITY_ID;
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.TRANSCRIPTION_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
@@ -83,8 +83,8 @@ public class TranscriptionController implements TranscriptionApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(bodyAuthorisation = true, contextId = ANY_ENTITY_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER})
     public ResponseEntity<RequestTranscriptionResponse> requestTranscription(TranscriptionRequestDetails transcriptionRequestDetails) {
         transcriptionRequestDetailsValidator.validate(transcriptionRequestDetails);
 
@@ -128,8 +128,8 @@ public class TranscriptionController implements TranscriptionApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = TRANSCRIPTION_ID,
-        securityRoles = {JUDGE, REQUESTER, APPROVER, TRANSCRIBER},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS})
+        securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS})
     public ResponseEntity<Resource> downloadTranscript(Integer transcriptionId) {
         final DownloadTranscriptResponse downloadTranscriptResponse = transcriptionService.downloadTranscript(
             transcriptionId);
@@ -179,8 +179,8 @@ public class TranscriptionController implements TranscriptionApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = TRANSCRIPTION_ID,
-        securityRoles = {JUDGE, APPROVER, REQUESTER, TRANSCRIBER},
-        globalAccessSecurityRoles = {JUDGE, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS})
+        securityRoles = {JUDICIARY, APPROVER, REQUESTER, TRANSCRIBER},
+        globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS})
     public ResponseEntity<GetTranscriptionByIdResponse> getTranscription(Integer transcriptionId) {
         return new ResponseEntity<>(
             transcriptionService.getTranscription(transcriptionId),
@@ -200,7 +200,7 @@ public class TranscriptionController implements TranscriptionApi {
         // we authorise the transcription ids
         authorisation.authoriseWithIdsForTranscription(request,
                                                        e -> e.getTranscriptionId().toString(),
-                                                       new SecurityRoleEnum[]{JUDGE, REQUESTER, APPROVER},
+                                                       new SecurityRoleEnum[]{JUDICIARY, REQUESTER, APPROVER},
                                                        executeOnAuth
         );
 

--- a/src/main/resources/db/migration/common/V1_322__insert_darts_role_and_group.sql
+++ b/src/main/resources/db/migration/common/V1_322__insert_darts_role_and_group.sql
@@ -1,0 +1,6 @@
+INSERT INTO security_role (rol_id, role_name, display_name, display_state)
+VALUES (13, 'DARTS', 'DARTS', false);
+ALTER SEQUENCE rol_seq RESTART WITH 14;
+
+INSERT INTO security_group (grp_id, rol_id, group_name, global_access, display_state, use_interpreter, display_name, created_ts, created_by, last_modified_ts, last_modified_by)
+VALUES (nextval('grp_seq'), 13, 'DARTS', true, false, false, 'DARTS', CURRENT_TIMESTAMP, 0, CURRENT_TIMESTAMP, 0);

--- a/src/main/resources/db/migration/common/V1_323__rename_judge_role.sql
+++ b/src/main/resources/db/migration/common/V1_323__rename_judge_role.sql
@@ -1,0 +1,3 @@
+UPDATE security_role
+SET role_name = 'JUDICIARY', display_name = 'Judiciary'
+WHERE role_name = 'JUDGE';

--- a/src/main/resources/db/migration/common/V1_324__hide_roles_and_groups.sql
+++ b/src/main/resources/db/migration/common/V1_324__hide_roles_and_groups.sql
@@ -1,13 +1,7 @@
 UPDATE security_role
 SET display_state = false
-WHERE role_name = 'XHIBIT'
-   OR role_name = 'CPP'
-   OR role_name = 'DAR_PC'
-   OR role_name = 'MID_TIER';
+WHERE role_name IN ('XHIBIT', 'CPP', 'DAR_PC', 'MID_TIER');
 
 UPDATE security_group
 SET display_state = false
-WHERE group_name = 'Xhibit Group'
-   OR group_name = 'Cpp Group'
-   OR group_name = 'Dar Pc Group'
-   OR group_name = 'Mid Tier Group';
+WHERE group_name IN ('Xhibit Group', 'Cpp Group', 'Dar Pc Group', 'Mid Tier Group')

--- a/src/main/resources/db/migration/common/V1_324__hide_roles_and_groups.sql
+++ b/src/main/resources/db/migration/common/V1_324__hide_roles_and_groups.sql
@@ -1,0 +1,13 @@
+UPDATE security_role
+SET display_state = false
+WHERE role_name = 'XHIBIT'
+   OR role_name = 'CPP'
+   OR role_name = 'DAR_PC'
+   OR role_name = 'MID_TIER';
+
+UPDATE security_group
+SET display_state = false
+WHERE group_name = 'Xhibit Group'
+   OR group_name = 'Cpp Group'
+   OR group_name = 'Dar Pc Group'
+   OR group_name = 'Mid Tier Group';

--- a/src/main/resources/db/reference/modernised_darts_standing_data.sql
+++ b/src/main/resources/db/reference/modernised_darts_standing_data.sql
@@ -475,16 +475,17 @@ INSERT INTO security_permission (per_id, permission_name) VALUES (23, 'ADD_AUDIO
 
 INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (1, 'APPROVER', 'Approver', true);
 INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (2, 'REQUESTER', 'Requester', true);
-INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (3, 'JUDGE', 'Judge', true);
+INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (3, 'JUDICIARY', 'Judiciary', true);
 INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (4, 'TRANSCRIBER', 'Transcriber', true);
 INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (5, 'TRANSLATION_QA', 'Translation QA', true);
 INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (6, 'RCJ_APPEALS', 'RCJ Appeals', true);
-INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (7, 'XHIBIT', 'XHIBIT', true);
-INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (8, 'CPP', 'CPP', true);
-INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (9, 'DAR_PC', 'DAR PC', true);
-INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (10, 'MID_TIER', 'Mid Tier', true);
+INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (7, 'XHIBIT', 'XHIBIT', false);
+INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (8, 'CPP', 'CPP', false);
+INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (9, 'DAR_PC', 'DAR PC', false);
+INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (10, 'MID_TIER', 'Mid Tier', false);
 INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (11, 'SUPER_ADMIN', 'Super Admin', true);
 INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (12, 'SUPER_USER', 'Super User', true);
+INSERT INTO security_role (rol_id, role_name, display_name, display_state) VALUES (13, 'DARTS', 'DARTS', false);
 
 INSERT INTO security_role_permission_ae (rol_id, per_id) VALUES (1, 2);
 INSERT INTO security_role_permission_ae (rol_id, per_id) VALUES (1, 4);
@@ -586,6 +587,8 @@ INSERT INTO security_group (grp_id, rol_id, group_name, global_access, display_s
 VALUES (nextval('grp_seq'), 11, 'SUPER_ADMIN', true, true, false, 'Super Admin', CURRENT_TIMESTAMP, 0, CURRENT_TIMESTAMP, 0);
 INSERT INTO security_group (grp_id, rol_id, group_name, global_access, display_state, use_interpreter, display_name, created_ts, created_by, last_modified_ts, last_modified_by)
 VALUES (nextval('grp_seq'), 12, 'SUPER_USER', true, true, false, 'Super User', CURRENT_TIMESTAMP, 0, CURRENT_TIMESTAMP, 0);
+INSERT INTO security_group (grp_id, rol_id, group_name, global_access, display_state, use_interpreter, display_name, created_ts, created_by, last_modified_ts, last_modified_by)
+VALUES (nextval('grp_seq'), 13, 'DARTS', true, false, false, 'DARTS', CURRENT_TIMESTAMP, 0, CURRENT_TIMESTAMP, 0);
 
 INSERT INTO transcription_status (trs_id, status_type, display_name) VALUES (1, 'Requested', 'Requested');
 INSERT INTO transcription_status (trs_id, status_type, display_name) VALUES (2, 'Awaiting Authorisation', 'Awaiting Authorisation');

--- a/src/test/java/uk/gov/hmcts/darts/annotation/validators/UserAuthorisedToDeleteAnnotationValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/annotation/validators/UserAuthorisedToDeleteAnnotationValidatorTest.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,7 +47,7 @@ class UserAuthorisedToDeleteAnnotationValidatorTest {
 
     @Test
     void doesntThrowIfUserIsJudgeAndCreatedTheAnnotation() {
-        var judge = userWithRole(JUDGE);
+        var judge = userWithRole(JUDICIARY);
         when(authorisationApi.getCurrentUser()).thenReturn(judge);
         when(annotationRepository.findById(1)).thenReturn(Optional.of(annotationCreatedBy(judge)));
 

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/AnnotationIdControllerAuthorisationImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/AnnotationIdControllerAuthorisationImplTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.authorisation.component.impl.AnnotationIdContro
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANNOTATION_ID;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_ANNOTATION_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
@@ -53,7 +53,7 @@ class AnnotationIdControllerAuthorisationImplTest {
     @BeforeEach
     void setUp() {
         roles = Set.of(
-            JUDGE,
+            JUDICIARY,
             REQUESTER,
             APPROVER,
             TRANSCRIBER,

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/AnyEntityIdControllerAuthorisationImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/AnyEntityIdControllerAuthorisationImplTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANY_ENTITY_ID
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_ANY_ID;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_CASE_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
@@ -53,7 +53,7 @@ class AnyEntityIdControllerAuthorisationImplTest {
     @BeforeEach
     void setUp() {
         roles = Set.of(
-            JUDGE,
+            JUDICIARY,
             REQUESTER,
             APPROVER,
             TRANSCRIBER,

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/CaseIdControllerAuthorisationImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/CaseIdControllerAuthorisationImplTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.authorisation.component.impl.CaseIdControllerAu
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.CASE_ID;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_CASE_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
@@ -53,7 +53,7 @@ class CaseIdControllerAuthorisationImplTest {
     @BeforeEach
     void setUp() {
         roles = Set.of(
-            JUDGE,
+            JUDICIARY,
             REQUESTER,
             APPROVER,
             TRANSCRIBER,

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/HearingIdControllerAuthorisationImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/HearingIdControllerAuthorisationImplTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.authorisation.component.impl.HearingIdControlle
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.HEARING_ID;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_HEARING_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
@@ -53,7 +53,7 @@ class HearingIdControllerAuthorisationImplTest {
     @BeforeEach
     void setUp() {
         roles = Set.of(
-            JUDGE,
+            JUDICIARY,
             REQUESTER,
             APPROVER,
             TRANSCRIBER,

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/MediaIdControllerAuthorisationImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/MediaIdControllerAuthorisationImplTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.authorisation.component.impl.MediaIdControllerA
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.MEDIA_ID;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_MEDIA_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
@@ -53,7 +53,7 @@ class MediaIdControllerAuthorisationImplTest {
     @BeforeEach
     void setUp() {
         roles = Set.of(
-            JUDGE,
+            JUDICIARY,
             REQUESTER,
             APPROVER,
             TRANSCRIBER,

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/MediaRequestIdControllerAuthorisationImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/MediaRequestIdControllerAuthorisationImplTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.authorisation.component.impl.MediaRequestIdCont
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.MEDIA_REQUEST_ID;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_MEDIA_REQUEST_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
@@ -53,7 +53,7 @@ class MediaRequestIdControllerAuthorisationImplTest {
     @BeforeEach
     void setUp() {
         roles = Set.of(
-            JUDGE,
+            JUDICIARY,
             REQUESTER,
             APPROVER,
             TRANSCRIBER,

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/TranscriptionIdControllerAuthorisationImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/TranscriptionIdControllerAuthorisationImplTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.authorisation.component.impl.TranscriptionIdCon
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.TRANSCRIPTION_ID;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_TRANSCRIPTION_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
@@ -53,7 +53,7 @@ class TranscriptionIdControllerAuthorisationImplTest {
     @BeforeEach
     void setUp() {
         roles = Set.of(
-            JUDGE,
+            JUDICIARY,
             REQUESTER,
             APPROVER,
             TRANSCRIBER,

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/TransformedMediaIdControllerAuthorisationImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/component/impl/TransformedMediaIdControllerAuthorisationImplTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.authorisation.component.impl.TransformedMediaId
 import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.TRANSFORMED_MEDIA_ID;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.BAD_REQUEST_TRANSFORMED_MEDIA_ID;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.RCJ_APPEALS;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
@@ -53,7 +53,7 @@ class TransformedMediaIdControllerAuthorisationImplTest {
     @BeforeEach
     void setUp() {
         roles = Set.of(
-            JUDGE,
+            JUDICIARY,
             REQUESTER,
             APPROVER,
             TRANSCRIBER,

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/model/UserStateRoleTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/model/UserStateRoleTest.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDGE;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 
 class UserStateRoleTest {
@@ -31,20 +31,20 @@ class UserStateRoleTest {
     @Test
     void shouldEqualsJudgeRole() {
         UserStateRole role = UserStateRole.builder()
-            .roleId(JUDGE.getId())
-            .roleName(JUDGE.toString())
+            .roleId(JUDICIARY.getId())
+            .roleName(JUDICIARY.toString())
             .globalAccess(false)
             .permissions(Collections.emptySet())
             .build();
 
-        assertEquals(role, new UserStateRole(JUDGE.getId(), JUDGE.toString(), false, Collections.emptySet(), Collections.emptySet()));
+        assertEquals(role, new UserStateRole(JUDICIARY.getId(), JUDICIARY.toString(), false, Collections.emptySet(), Collections.emptySet()));
     }
 
     @Test
     void shouldNotEqualsJudgeRole() {
         UserStateRole role = UserStateRole.builder()
-            .roleId(JUDGE.getId())
-            .roleName(JUDGE.toString())
+            .roleId(JUDICIARY.getId())
+            .roleName(JUDICIARY.toString())
             .globalAccess(false)
             .permissions(Collections.emptySet())
             .build();

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/util/SecurityGroupUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/util/SecurityGroupUtilTest.java
@@ -34,7 +34,7 @@ class SecurityGroupUtilTest {
 
 
         List<SecurityRoleEnum> securityRoles = new ArrayList<>();
-        securityRoles.add(SecurityRoleEnum.JUDGE);
+        securityRoles.add(SecurityRoleEnum.JUDICIARY);
 
         assertTrue(SecurityGroupUtil.matchesAtLeastOneSecurityGroup(securityGroupEntities, securityRoles));
     }
@@ -46,7 +46,7 @@ class SecurityGroupUtilTest {
 
 
         List<SecurityRoleEnum> securityRoles = new ArrayList<>();
-        securityRoles.add(SecurityRoleEnum.JUDGE);
+        securityRoles.add(SecurityRoleEnum.JUDICIARY);
         securityRoles.add(SecurityRoleEnum.SUPER_ADMIN);
 
         assertTrue(SecurityGroupUtil.matchesAtLeastOneSecurityGroup(securityGroupEntities, securityRoles));


### PR DESCRIPTION
# [DMP-3305](https://tools.hmcts.net/jira/browse/DMP-3305)

Part 1 of DMP-3305, covering:

- Addition of new role `DARTS`
- Addition of new group `DARTS`
- Renaming existing `JUDGE` role to `JUDICIARY`.
- Changing `XHIBIT`, `CPP`, `DAR_PC` and `MID_TIER` roles and groups to `display_state=false`

Part 2 will follow as a separate PR which will cover adding the `DARTS` role to the `@Authrorisation` of various controller methods.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
