### PR TITLE
Attempting to fix flakey test

### DIFF
--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/AwaitabilityUtil.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/AwaitabilityUtil.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.test.common;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 
+import static org.apache.commons.lang3.RandomStringUtils.random;
 import static org.awaitility.Awaitility.await;
 
 public final class AwaitabilityUtil {
@@ -16,7 +17,8 @@ public final class AwaitabilityUtil {
     }
 
     public static void waitForMaxWithOneSecondPoll(Callable<Boolean> callable, Duration duration) {
-        await().atMost(duration)
+        var awaitAlias = random(4);
+        await(awaitAlias).atMost(duration)
             .with().pollInterval(Duration.ofSeconds(1))
             .until(() -> {
                 boolean verified;


### PR DESCRIPTION
`StopAndCloseHandlerTest.givenDarStopAndCloseEventReceivedAndHearingDoesNotExist_thenNotifyDarUpdateAndNotifyDarStopRecording` sometime fails on `dartsGateway.verifyReceivedNotificationType(3);`   it seems to be only finding the previous notification type 2.  The `await()` function can be given an alias so this PR just a stab in the dark to see if providing an alias fixes the issue.


```
[ ] Yes
[x] No
```
