### PR TITLE
Attempting to improve event tests which verify DAR notifications

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStartHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStartHandlerTest.java
@@ -80,7 +80,6 @@ class DarStartHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -107,7 +106,6 @@ class DarStartHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -140,7 +138,6 @@ class DarStartHandlerTest extends HandlerTestData {
 
         assertTrue(dartsDatabase.findByCourthouseCourtroomAndDate(SOME_COURTHOUSE, SOME_ROOM, HEARING_DATE_ODT.toLocalDate()).isEmpty());
 
-        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -171,7 +168,6 @@ class DarStartHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(1);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStartHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStartHandlerTest.java
@@ -80,6 +80,7 @@ class DarStartHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -106,6 +107,7 @@ class DarStartHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -138,6 +140,7 @@ class DarStartHandlerTest extends HandlerTestData {
 
         assertTrue(dartsDatabase.findByCourthouseCourtroomAndDate(SOME_COURTHOUSE, SOME_ROOM, HEARING_DATE_ODT.toLocalDate()).isEmpty());
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -168,6 +171,7 @@ class DarStartHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(1);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStopHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStopHandlerTest.java
@@ -72,6 +72,7 @@ class DarStopHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -98,6 +99,7 @@ class DarStopHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -130,6 +132,7 @@ class DarStopHandlerTest extends HandlerTestData {
 
         assertTrue(dartsDatabase.findByCourthouseCourtroomAndDate(SOME_COURTHOUSE, SOME_ROOM, HEARING_DATE_ODT.toLocalDate()).isEmpty());
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -161,6 +164,7 @@ class DarStopHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStopHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStopHandlerTest.java
@@ -72,7 +72,6 @@ class DarStopHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -99,7 +98,6 @@ class DarStopHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -132,7 +130,6 @@ class DarStopHandlerTest extends HandlerTestData {
 
         assertTrue(dartsDatabase.findByCourthouseCourtroomAndDate(SOME_COURTHOUSE, SOME_ROOM, HEARING_DATE_ODT.toLocalDate()).isEmpty());
 
-        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -164,7 +161,6 @@ class DarStopHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/HandlerTestData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/HandlerTestData.java
@@ -26,7 +26,7 @@ class HandlerTestData extends IntegrationBaseWithGatewayStub {
 
     protected final OffsetDateTime today = now();
 
-    protected final String DAR_NOTIFY_URL = "http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx";
+    protected static final String DAR_NOTIFY_URL = "http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx";
 
     protected void verifyDarNotification(DarNotifyEvent darNotifyEvent,
                                          DarNotifyType type,
@@ -40,7 +40,9 @@ class HandlerTestData extends IntegrationBaseWithGatewayStub {
 
     protected void verifyDarNotifications(List<DarNotifyEvent> actualNotifications, List<DarNotifyType> expectedTypes, String courtroom) {
         for (DarNotifyType darNotifyType : expectedTypes) {
-            var foundNotification = actualNotifications.stream().filter(notification -> notification.getNotificationType().equals(darNotifyType.getNotificationType())).findFirst();
+            var foundNotification = actualNotifications.stream()
+                .filter(notification -> notification.getNotificationType().equals(darNotifyType.getNotificationType()))
+                .findFirst();
             assertTrue(foundNotification.isPresent());
             verifyDarNotification(foundNotification.get(), darNotifyType, SOME_COURTHOUSE, courtroom);
         }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/HandlerTestData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/HandlerTestData.java
@@ -19,6 +19,7 @@ import static java.time.OffsetDateTime.now;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
 class HandlerTestData extends IntegrationBaseWithGatewayStub {
@@ -41,6 +42,12 @@ class HandlerTestData extends IntegrationBaseWithGatewayStub {
 
     @Captor
     protected ArgumentCaptor<DarNotifyEvent> darNotifyEventArgumentCaptor;
+
+    @SuppressWarnings("PMD.DoNotUseThreads")
+    protected void verifyDarNotificationNotReceived() throws InterruptedException {
+        Thread.sleep(1000);
+        Mockito.verify(dartsGatewayClient, times(0)).darNotify(any(DarNotifyEvent.class));
+    }
 
     protected void verifyDarNotificationCount(int count) {
         await().until(() -> {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/HandlerTestData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/HandlerTestData.java
@@ -1,12 +1,17 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
+import uk.gov.hmcts.darts.event.enums.DarNotifyType;
+import uk.gov.hmcts.darts.event.model.DarNotifyEvent;
 import uk.gov.hmcts.darts.testutils.IntegrationBaseWithGatewayStub;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import static java.time.OffsetDateTime.now;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HandlerTestData extends IntegrationBaseWithGatewayStub {
 
@@ -20,4 +25,24 @@ class HandlerTestData extends IntegrationBaseWithGatewayStub {
     protected static final OffsetDateTime HEARING_DATE_ODT = HEARING_DATE.atOffset(ZoneOffset.UTC);
 
     protected final OffsetDateTime today = now();
+
+    protected final String DAR_NOTIFY_URL = "http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx";
+
+    protected void verifyDarNotification(DarNotifyEvent darNotifyEvent,
+                                         DarNotifyType type,
+                                         String courthouse,
+                                         String courtroom) {
+        assertEquals(type.getNotificationType(), darNotifyEvent.getNotificationType());
+        assertEquals(DAR_NOTIFY_URL, darNotifyEvent.getNotificationUrl());
+        assertEquals(courthouse, darNotifyEvent.getCourthouse());
+        assertEquals(courtroom, darNotifyEvent.getCourtroom());
+    }
+
+    protected void verifyDarNotifications(List<DarNotifyEvent> actualNotifications, List<DarNotifyType> expectedTypes, String courtroom) {
+        for (DarNotifyType darNotifyType : expectedTypes) {
+            var foundNotification = actualNotifications.stream().filter(notification -> notification.getNotificationType().equals(darNotifyType.getNotificationType())).findFirst();
+            assertTrue(foundNotification.isPresent());
+            verifyDarNotification(foundNotification.get(), darNotifyType, SOME_COURTHOUSE, courtroom);
+        }
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/InterpreterUsedHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/InterpreterUsedHandlerTest.java
@@ -66,6 +66,7 @@ class InterpreterUsedHandlerTest extends HandlerTestData {
                                     .courtroom(SOME_ROOM)
                                     .dateTime(HEARING_DATE_ODT));
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
 
@@ -101,6 +102,7 @@ class InterpreterUsedHandlerTest extends HandlerTestData {
                                     .courtroom(SOME_ROOM)
                                     .dateTime(HEARING_DATE_ODT));
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
 
@@ -139,6 +141,7 @@ class InterpreterUsedHandlerTest extends HandlerTestData {
                                     .courtroom(SOME_OTHER_ROOM)
                                     .dateTime(HEARING_DATE_ODT));
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/InterpreterUsedHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/InterpreterUsedHandlerTest.java
@@ -66,7 +66,6 @@ class InterpreterUsedHandlerTest extends HandlerTestData {
                                     .courtroom(SOME_ROOM)
                                     .dateTime(HEARING_DATE_ODT));
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
 
@@ -102,7 +101,6 @@ class InterpreterUsedHandlerTest extends HandlerTestData {
                                     .courtroom(SOME_ROOM)
                                     .dateTime(HEARING_DATE_ODT));
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
 
@@ -141,7 +139,6 @@ class InterpreterUsedHandlerTest extends HandlerTestData {
                                     .courtroom(SOME_OTHER_ROOM)
                                     .dateTime(HEARING_DATE_ODT));
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
@@ -66,6 +66,7 @@ class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -87,6 +88,7 @@ class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -114,6 +116,7 @@ class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
 
         assertTrue(dartsDatabase.findByCourthouseCourtroomAndDate(SOME_COURTHOUSE, SOME_ROOM, HEARING_DATE_ODT.toLocalDate()).isEmpty());
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
@@ -66,7 +66,6 @@ class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -88,7 +87,6 @@ class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -116,7 +114,6 @@ class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
 
         assertTrue(dartsDatabase.findByCourthouseCourtroomAndDate(SOME_COURTHOUSE, SOME_ROOM, HEARING_DATE_ODT.toLocalDate()).isEmpty());
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SetReportingRestrictionEventHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SetReportingRestrictionEventHandlerTest.java
@@ -70,6 +70,7 @@ class SetReportingRestrictionEventHandlerTest extends HandlerTestData {
             persistedCase.getReportingRestrictions().getEventName()
         );
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -108,6 +109,7 @@ class SetReportingRestrictionEventHandlerTest extends HandlerTestData {
             persistedCase.getReportingRestrictions().getEventName()
         );
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -151,6 +153,7 @@ class SetReportingRestrictionEventHandlerTest extends HandlerTestData {
             persistedCase.getReportingRestrictions().getEventName()
         );
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -223,6 +226,7 @@ class SetReportingRestrictionEventHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
         assertEquals("Restrictions lifted", persistedCase.getReportingRestrictions().getEventName());
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SetReportingRestrictionEventHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SetReportingRestrictionEventHandlerTest.java
@@ -70,7 +70,6 @@ class SetReportingRestrictionEventHandlerTest extends HandlerTestData {
             persistedCase.getReportingRestrictions().getEventName()
         );
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -109,7 +108,6 @@ class SetReportingRestrictionEventHandlerTest extends HandlerTestData {
             persistedCase.getReportingRestrictions().getEventName()
         );
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -153,7 +151,6 @@ class SetReportingRestrictionEventHandlerTest extends HandlerTestData {
             persistedCase.getReportingRestrictions().getEventName()
         );
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -226,7 +223,6 @@ class SetReportingRestrictionEventHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
         assertEquals("Restrictions lifted", persistedCase.getReportingRestrictions().getEventName());
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StandardEventHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StandardEventHandlerTest.java
@@ -86,6 +86,7 @@ class StandardEventHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -121,6 +122,7 @@ class StandardEventHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -160,6 +162,7 @@ class StandardEventHandlerTest extends HandlerTestData {
 
         assertTrue(dartsDatabase.findByCourthouseCourtroomAndDate(SOME_COURTHOUSE, SOME_ROOM, HEARING_DATE_ODT.toLocalDate()).isEmpty());
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StandardEventHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StandardEventHandlerTest.java
@@ -86,7 +86,6 @@ class StandardEventHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -122,7 +121,6 @@ class StandardEventHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -162,7 +160,6 @@ class StandardEventHandlerTest extends HandlerTestData {
 
         assertTrue(dartsDatabase.findByCourthouseCourtroomAndDate(SOME_COURTHOUSE, SOME_ROOM, HEARING_DATE_ODT.toLocalDate()).isEmpty());
 
-        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StopAndCloseHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StopAndCloseHandlerTest.java
@@ -2,8 +2,6 @@ package uk.gov.hmcts.darts.event.service.impl;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -20,7 +18,6 @@ import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.CaseRetentionRepository;
 import uk.gov.hmcts.darts.common.util.DateConverterUtil;
-import uk.gov.hmcts.darts.event.client.DartsGatewayClient;
 import uk.gov.hmcts.darts.event.model.DarNotifyEvent;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.model.DartsEventRetentionPolicy;
@@ -44,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.event.enums.DarNotifyType.CASE_UPDATE;
@@ -72,12 +68,6 @@ class StopAndCloseHandlerTest extends HandlerTestData {
 
     @Mock
     private CaseRetentionRepository caseRetentionRepository;
-
-    @MockBean
-    private DartsGatewayClient dartsGatewayClient;
-
-    @Captor
-    private ArgumentCaptor<DarNotifyEvent> darNotifyEventArgumentCaptor;
 
     @BeforeEach
     public void setupStubs() {
@@ -120,7 +110,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertThat(hearingsForCase.size()).isEqualTo(1);
         assertThat(hearingsForCase.get(0).getHearingIsActual()).isEqualTo(true);
 
-        verify(dartsGatewayClient, times(2)).darNotify(darNotifyEventArgumentCaptor.capture());
+        verifyDarNotificationCount(2);
         verifyDarNotifications(darNotifyEventArgumentCaptor.getAllValues(), List.of(STOP_RECORDING, CASE_UPDATE), SOME_ROOM);
     }
 
@@ -149,7 +139,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertThat(persistedCase.getClosed()).isTrue();
         assertEquals(HEARING_DATE_ODT, persistedCase.getCaseClosedTimestamp());
 
-        verify(dartsGatewayClient, times(2)).darNotify(darNotifyEventArgumentCaptor.capture());
+        verifyDarNotificationCount(2);
         verifyDarNotifications(darNotifyEventArgumentCaptor.getAllValues(), List.of(STOP_RECORDING, CASE_UPDATE), SOME_ROOM);
     }
 
@@ -184,7 +174,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertThat(persistedCase.getClosed()).isTrue();
         assertEquals(HEARING_DATE_ODT, persistedCase.getCaseClosedTimestamp());
 
-        verify(dartsGatewayClient, times(2)).darNotify(darNotifyEventArgumentCaptor.capture());
+        verifyDarNotificationCount(2);
         verifyDarNotifications(darNotifyEventArgumentCaptor.getAllValues(), List.of(STOP_RECORDING, CASE_UPDATE), SOME_OTHER_ROOM);
     }
 
@@ -215,7 +205,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertThat(persistedCase.getClosed()).isTrue();
         assertEquals(HEARING_DATE_ODT, persistedCase.getCaseClosedTimestamp());
 
-        verify(dartsGatewayClient, times(1)).darNotify(darNotifyEventArgumentCaptor.capture());
+        verifyDarNotificationCount(1);
         verifyDarNotification(darNotifyEventArgumentCaptor.getValue(), STOP_RECORDING, SOME_COURTHOUSE, SOME_ROOM);
     }
 
@@ -242,7 +232,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         var persistedEvent = allEvents.get(0);
         assertThat(persistedEvent.getCourtroom().getName()).isEqualTo(SOME_ROOM);
 
-        verify(dartsGatewayClient, times(1)).darNotify(darNotifyEventArgumentCaptor.capture());
+        verifyDarNotificationCount(1);
         verifyDarNotification(darNotifyEventArgumentCaptor.getValue(), STOP_RECORDING, SOME_COURTHOUSE, SOME_ROOM);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StopAndCloseHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StopAndCloseHandlerTest.java
@@ -110,6 +110,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertThat(persistedCase.getClosed()).isTrue();
         assertEquals(HEARING_DATE_ODT, persistedCase.getCaseClosedTimestamp());
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -142,6 +143,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertThat(persistedCase.getClosed()).isTrue();
         assertEquals(HEARING_DATE_ODT, persistedCase.getCaseClosedTimestamp());
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -180,6 +182,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertThat(persistedCase.getClosed()).isTrue();
         assertEquals(HEARING_DATE_ODT, persistedCase.getCaseClosedTimestamp());
 
+        dartsGateway.waitForRequestCount(2);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyReceivedNotificationType(3);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 2);
@@ -214,6 +217,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertThat(persistedCase.getClosed()).isTrue();
         assertEquals(HEARING_DATE_ODT, persistedCase.getCaseClosedTimestamp());
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }
@@ -241,6 +245,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         var persistedEvent = allEvents.get(0);
         assertThat(persistedEvent.getCourtroom().getName()).isEqualTo(SOME_ROOM);
 
+        dartsGateway.waitForRequestCount(1);
         dartsGateway.verifyReceivedNotificationType(2);
         dartsGateway.verifyNotificationUrl("http://1.2.3.4/VIQDARNotifyEvent/DARNotifyEvent.asmx", 1);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/DartsGatewayStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/DartsGatewayStub.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.testutils.stubs.wiremock;
 
+import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -10,7 +11,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static uk.gov.hmcts.darts.test.common.AwaitabilityUtil.waitForMax10SecondsWithOneSecondPoll;
+import static org.awaitility.Awaitility.await;
 
 @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
 public class DartsGatewayStub {
@@ -31,22 +32,27 @@ public class DartsGatewayStub {
         verify(exactly(0), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH)));
     }
 
-    public void verifyReceivedNotificationType(int type) {
-        var notificationType = "\"notification_type\":\"" + type + "\"";
-        waitForMax10SecondsWithOneSecondPoll(() -> {
-            verify(exactly(1), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH))
-                    .withRequestBody(containing(notificationType)));
-            return true;
+    public void waitForRequestCount(int count) {
+        await().until(() -> {
+            try {
+                verify(exactly(count), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH)));
+                return true;
+            } catch (VerificationException ex) {
+                return false;
+            }
         });
     }
 
+    public void verifyReceivedNotificationType(int type) {
+        var notificationType = "\"notification_type\":\"" + type + "\"";
+        verify(exactly(1), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH))
+                .withRequestBody(containing(notificationType)));
+    }
+
     public void verifyNotificationUrl(String url, int count) {
-        var notificationType = "\"notification_url\":\"" + url + "\"";
-        waitForMax10SecondsWithOneSecondPoll(() -> {
-            verify(exactly(count), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH))
-                    .withRequestBody(containing(notificationType)));
-            return true;
-        });
+        var notificationUrl = "\"notification_url\":\"" + url + "\"";
+        verify(exactly(count), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH))
+                .withRequestBody(containing(notificationUrl)));
     }
 
     public void clearStubs() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/DartsGatewayStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/wiremock/DartsGatewayStub.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.testutils.stubs.wiremock;
 
-import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.client.WireMock;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -11,7 +10,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.awaitility.Awaitility.await;
+import static uk.gov.hmcts.darts.test.common.AwaitabilityUtil.waitForMax10SecondsWithOneSecondPoll;
 
 @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
 public class DartsGatewayStub {
@@ -32,27 +31,22 @@ public class DartsGatewayStub {
         verify(exactly(0), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH)));
     }
 
-    public void waitForRequestCount(int count) {
-        await().until(() -> {
-            try {
-                verify(exactly(count), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH)));
-                return true;
-            } catch (VerificationException ex) {
-                return false;
-            }
+    public void verifyReceivedNotificationType(int type) {
+        var notificationType = "\"notification_type\":\"" + type + "\"";
+        waitForMax10SecondsWithOneSecondPoll(() -> {
+            verify(exactly(1), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH))
+                    .withRequestBody(containing(notificationType)));
+            return true;
         });
     }
 
-    public void verifyReceivedNotificationType(int type) {
-        var notificationType = "\"notification_type\":\"" + type + "\"";
-        verify(exactly(1), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH))
-                .withRequestBody(containing(notificationType)));
-    }
-
     public void verifyNotificationUrl(String url, int count) {
-        var notificationUrl = "\"notification_url\":\"" + url + "\"";
-        verify(exactly(count), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH))
-                .withRequestBody(containing(notificationUrl)));
+        var notificationType = "\"notification_url\":\"" + url + "\"";
+        waitForMax10SecondsWithOneSecondPoll(() -> {
+            verify(exactly(count), postRequestedFor(urlEqualTo(DAR_NOTIFY_PATH))
+                    .withRequestBody(containing(notificationType)));
+            return true;
+        });
     }
 
     public void clearStubs() {


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- removing use of wiremock
- using Mockito to verify the calls to `dartsGateway.darNotify`
- adding a verify method which ignores the order of notifications when asserting
- this makes the tests more stable and the assertions easier

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
