### PR TITLE
DMP-3368 Improved misleading task execution logs. Fixed bug in task e…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AutomatedTaskServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AutomatedTaskServiceTest.java
@@ -115,7 +115,7 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
     private DailyListService dailyListService;
 
     @SpyBean
-    private CaseRepository generateCaseDocumentProcessor;
+    private CaseRepository caseRepository;
 
     @Autowired
     private ArmRetentionEventDateProcessor armRetentionEventDateProcessor;
@@ -159,7 +159,7 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
     void givenSuccessfullyStartedTaskFailsDuringExecutionThenStatusIsSetToFailed() {
         GenerateCaseDocumentAutomatedTask automatedTask = new GenerateCaseDocumentAutomatedTask(automatedTaskRepository, lockProvider,
                                                                                         automatedTaskConfigurationProperties, taskProcessorFactory, logApi);
-        doThrow(ArithmeticException.class).when(generateCaseDocumentProcessor).findCasesNeedingCaseDocumentGenerated(any(), any());
+        doThrow(ArithmeticException.class).when(caseRepository).findCasesNeedingCaseDocumentGenerated(any(), any());
 
         automatedTaskService.cancelAutomatedTaskAndUpdateCronExpression(automatedTask.getTaskName(), true, "*/7 * * * * *");
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AutomatedTaskServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AutomatedTaskServiceTest.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.scheduling.config.CronTask;
 import org.springframework.scheduling.config.FixedDelayTask;
 import org.springframework.scheduling.config.FixedRateTask;
@@ -24,6 +25,7 @@ import uk.gov.hmcts.darts.cases.service.CloseOldCasesProcessor;
 import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.common.repository.CaseRepository;
 import uk.gov.hmcts.darts.dailylist.service.DailyListService;
 import uk.gov.hmcts.darts.datamanagement.service.InboundToUnstructuredProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
@@ -57,6 +59,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static uk.gov.hmcts.darts.task.status.AutomatedTaskStatus.COMPLETED;
+import static uk.gov.hmcts.darts.task.status.AutomatedTaskStatus.FAILED;
+import static uk.gov.hmcts.darts.task.status.AutomatedTaskStatus.NOT_STARTED;
 import static uk.gov.hmcts.darts.test.common.AwaitabilityUtil.waitForMax10SecondsWithOneSecondPoll;
 
 @Slf4j
@@ -107,6 +114,9 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
     @Autowired
     private DailyListService dailyListService;
 
+    @SpyBean
+    private CaseRepository generateCaseDocumentProcessor;
+
     @Autowired
     private ArmRetentionEventDateProcessor armRetentionEventDateProcessor;
 
@@ -146,6 +156,20 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
     }
 
     @Test
+    void givenSuccessfullyStartedTaskFailsDuringExecutionThenStatusIsSetToFailed() {
+        GenerateCaseDocumentAutomatedTask automatedTask = new GenerateCaseDocumentAutomatedTask(automatedTaskRepository, lockProvider,
+                                                                                        automatedTaskConfigurationProperties, taskProcessorFactory, logApi);
+        doThrow(ArithmeticException.class).when(generateCaseDocumentProcessor).findCasesNeedingCaseDocumentGenerated(any(), any());
+
+        automatedTaskService.cancelAutomatedTaskAndUpdateCronExpression(automatedTask.getTaskName(), true, "*/7 * * * * *");
+
+        waitForMax10SecondsWithOneSecondPoll(() -> {
+            AutomatedTaskStatus newAutomatedTaskStatus = automatedTaskService.getAutomatedTaskStatus(automatedTask.getTaskName());
+            return newAutomatedTaskStatus == FAILED;
+        });
+    }
+
+    @Test
     void givenAutomatedTaskVerifyStatusBeforeAndAfterRunning() {
         ProcessDailyListAutomatedTask automatedTask = new ProcessDailyListAutomatedTask(automatedTaskRepository, lockProvider,
                                                                                         automatedTaskConfigurationProperties, logApi
@@ -157,7 +181,7 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
 
         // this may have transitioned to complete. Let's check the history to ensure that
         // we started with NOT_STARTED state
-        assertTrue(automatedTask.hasTransitionState(AutomatedTaskStatus.NOT_STARTED));
+        assertTrue(automatedTask.hasTransitionState(NOT_STARTED));
 
         boolean result1 = automatedTaskService.cancelAutomatedTaskAndUpdateCronExpression(
             automatedTask.getTaskName(), true, "*/7 * * * * *");
@@ -165,7 +189,7 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
 
         waitForMax10SecondsWithOneSecondPoll(() -> {
             AutomatedTaskStatus newAutomatedTaskStatus = automatedTaskService.getAutomatedTaskStatus(automatedTask.getTaskName());
-            return AutomatedTaskStatus.COMPLETED.equals(newAutomatedTaskStatus);
+            return COMPLETED.equals(newAutomatedTaskStatus);
         });
 
         boolean result2 = automatedTaskService.cancelAutomatedTaskAndUpdateCronExpression(
@@ -307,7 +331,7 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
 
         waitForMax10SecondsWithOneSecondPoll(() -> {
             AutomatedTaskStatus newAutomatedTaskStatus = automatedTaskService.getAutomatedTaskStatus(automatedTask.getTaskName());
-            return AutomatedTaskStatus.COMPLETED.equals(newAutomatedTaskStatus);
+            return COMPLETED.equals(newAutomatedTaskStatus);
         });
 
         automatedTaskService.updateAutomatedTaskCronExpression(

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionAutomatedTask.java
@@ -31,9 +31,4 @@ public class ApplyRetentionAutomatedTask extends AbstractLockableAutomatedTask {
     protected void runTask() {
         applyRetentionProcessor.processApplyRetention();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionCaseAssociatedObjectsAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionCaseAssociatedObjectsAutomatedTask.java
@@ -34,10 +34,4 @@ public class ApplyRetentionCaseAssociatedObjectsAutomatedTask extends AbstractLo
     protected void runTask() {
         processor.processApplyRetentionToCaseAssociatedObjects();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ArmRetentionEventDateCalculatorAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ArmRetentionEventDateCalculatorAutomatedTask.java
@@ -32,10 +32,5 @@ public class ArmRetentionEventDateCalculatorAutomatedTask extends AbstractLockab
     protected void runTask() {
         armRetentionEventDateProcessor.calculateEventDates();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
 }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTask.java
@@ -32,9 +32,4 @@ public class BatchCleanupArmResponseFilesAutomatedTask extends AbstractLockableA
         Integer batchSize = getAutomatedTaskBatchSize(taskName);
         batchCleanupArmResponseFilesService.cleanupResponseFiles(batchSize);
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CleanupArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CleanupArmResponseFilesAutomatedTask.java
@@ -31,9 +31,4 @@ public class CleanupArmResponseFilesAutomatedTask extends AbstractLockableAutoma
     protected void runTask() {
         cleanupArmResponseFilesService.cleanupResponseFiles();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CloseOldCasesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CloseOldCasesAutomatedTask.java
@@ -31,9 +31,4 @@ public class CloseOldCasesAutomatedTask extends AbstractLockableAutomatedTask {
     protected void runTask() {
         closeOldCasesProcessor.closeCases();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Error attempting to close cases: {}", exception.getMessage(), exception);
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CloseUnfinishedTranscriptionsAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CloseUnfinishedTranscriptionsAutomatedTask.java
@@ -34,9 +34,4 @@ public class CloseUnfinishedTranscriptionsAutomatedTask extends AbstractLockable
     protected void runTask() {
         transcriptionsProcessor.closeTranscriptions();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Error attempting to close transcriptions: {}", exception.getMessage());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DailyListAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DailyListAutomatedTask.java
@@ -32,9 +32,4 @@ public class DailyListAutomatedTask extends AbstractLockableAutomatedTask {
     protected void runTask() {
         dailyListService.runHouseKeeping();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Error attempting to run daily list housekeeping: {}", exception.getMessage(), exception);
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ExternalDataStoreDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ExternalDataStoreDeleterAutomatedTask.java
@@ -45,9 +45,4 @@ public class ExternalDataStoreDeleterAutomatedTask extends AbstractLockableAutom
         unstructuredDeleter.delete();
         outboundDeleter.delete();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCaseDocumentAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCaseDocumentAutomatedTask.java
@@ -37,10 +37,4 @@ public class GenerateCaseDocumentAutomatedTask extends AbstractLockableAutomated
         GenerateCaseDocumentProcessor processor = automatedTaskProcessorFactory.createGenerateCaseDocumentProcessor(batchSize);
         processor.processGenerateCaseDocument();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundAudioDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundAudioDeleterAutomatedTask.java
@@ -32,9 +32,4 @@ public class InboundAudioDeleterAutomatedTask extends AbstractLockableAutomatedT
     protected void runTask() {
         inboundAudioDeleterProcessor.markForDeletion();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundToUnstructuredAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundToUnstructuredAutomatedTask.java
@@ -34,10 +34,4 @@ public class InboundToUnstructuredAutomatedTask extends AbstractLockableAutomate
     protected void runTask() {
         inboundToUnstructuredProcessor.processInboundToUnstructured();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/OutboundAudioDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/OutboundAudioDeleterAutomatedTask.java
@@ -32,9 +32,4 @@ public class OutboundAudioDeleterAutomatedTask extends AbstractLockableAutomated
     protected void runTask() {
         outboundAudioDeleterProcessor.markForDeletion();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ProcessArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ProcessArmResponseFilesAutomatedTask.java
@@ -35,9 +35,4 @@ public class ProcessArmResponseFilesAutomatedTask extends AbstractLockableAutoma
         ArmResponseFilesProcessor armResponseFilesProcessor = automatedTaskProcessorFactory.createArmResponseFilesProcessor(batchSize);
         armResponseFilesProcessor.processResponseFiles();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception ", exception);
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ProcessDailyListAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ProcessDailyListAutomatedTask.java
@@ -40,18 +40,13 @@ public class ProcessDailyListAutomatedTask extends AbstractLockableAutomatedTask
     }
 
     @Override
-    protected void runTask() {
+    public void runTask() {
         dailyListProcessor.processAllDailyLists();
     }
 
     @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
-
-
-    @Override
     protected void setAutomatedTaskStatus(AutomatedTaskStatus automatedTaskStatus) {
+        //TODO remove override of exceptions handling on the various tasks
         super.setAutomatedTaskStatus(automatedTaskStatus);
         trackedStateChanges.add(automatedTaskStatus);
     }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredAudioDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredAudioDeleterAutomatedTask.java
@@ -35,9 +35,4 @@ public class UnstructuredAudioDeleterAutomatedTask extends AbstractLockableAutom
     protected void runTask() {
         unstructuredAudioDeleterProcessor.markForDeletion();
     }
-
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("Exception: {}", exception.getMessage());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredToArmAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredToArmAutomatedTask.java
@@ -36,10 +36,4 @@ public class UnstructuredToArmAutomatedTask extends AbstractLockableAutomatedTas
         UnstructuredToArmProcessor unstructuredToArmProcessor = automatedTaskProcessorFactory.createUnstructuredToArmProcessor(batchSize);
         unstructuredToArmProcessor.processUnstructuredToArm();
     }
-
-    @SuppressWarnings("java:S4507")
-    @Override
-    protected void handleException(Exception exception) {
-        log.error("{} Exception", getTaskName(), exception);
-    }
 }


### PR DESCRIPTION
…xecution status

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3368


### Change description ###
- improved misleading error messages related to task execution - logs where giving the impression that a task was started even though it never acquired the log and execution didn't happen
- fixed bug in task failed state - state was set to `LOCK_FAILED` in case of successful lock acquisition but exception during actual task execution. Changed the state to `FAILED`
- added missing test for error during actual task execution
- fixed false positive/bugged unit test
- various refactoring


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
