### PR TITLE
DMP-3027 Schedule notifications for active users only

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/TransformedMediaHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/TransformedMediaHelper.java
@@ -28,6 +28,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -148,7 +149,7 @@ public class TransformedMediaHelper {
             var saveNotificationToDbRequest = SaveNotificationToDbRequest.builder()
                 .eventId(notificationTemplateName)
                 .caseId(courtCase.getId())
-                .emailAddresses(userAccount.get().getEmailAddress())
+                .userAccountsToEmail(List.of(userAccount.get()))
                 .templateValues(templateParams)
                 .build();
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -197,7 +197,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
             var saveNotificationToDbRequest = SaveNotificationToDbRequest.builder()
                 .eventId(notificationTemplate.toString())
                 .caseId(mediaRequest.getHearing().getCourtCase().getId())
-                .emailAddresses(mediaRequest.getRequestor().getEmailAddress())
+                .userAccountsToEmail(List.of(mediaRequest.getRequestor()))
                 .build();
             notificationApi.scheduleNotification(saveNotificationToDbRequest);
         } catch (Exception e) {

--- a/src/main/java/uk/gov/hmcts/darts/notification/dto/SaveNotificationToDbRequest.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/dto/SaveNotificationToDbRequest.java
@@ -7,6 +7,18 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Data Transfer Object (DTO) used to specify data for saving a notification to the database.
+ *
+ * <p>This DTO offers two ways to define notification recipients:
+ *  - **`userAccountsToEmail`**: This list of {@link UserAccountEntity} objects is preferred as it
+ *    allows verification of user account activity before scheduling notifications.
+ *  - **`emailAddresses`**: This property accepts a comma-separated string of email addresses.
+ *    Use this option only when notifying users without associated user accounts is necessary.
+ *
+ * <p>It's recommended to prioritize `userAccountsToEmail` for better notification management
+ * and to ensure notifications reach active users.
+ */
 @Data
 @Builder
 public class SaveNotificationToDbRequest {

--- a/src/main/java/uk/gov/hmcts/darts/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/service/impl/NotificationServiceImpl.java
@@ -122,6 +122,7 @@ public class NotificationServiceImpl implements NotificationService {
             CollectionUtils.addAll(
                 emailAddressList,
                 request.getUserAccountsToEmail().stream()
+                    .filter(UserAccountEntity::isActive)
                     .map(UserAccountEntity::getEmailAddress)
                     .toList()
             );

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
@@ -409,7 +409,7 @@ class AudioTransformationServiceImplTest {
         assertEquals(MOCK_HEARING_DATE_FORMATTED, actual.getTemplateValues().get(HEARING_DATE));
         assertEquals(MOCK_COURTHOUSE_NAME, actual.getTemplateValues().get(COURTHOUSE));
         assertEquals(MOCK_DEFENDANT_LIST, actual.getTemplateValues().get(DEFENDANTS));
-        assertEquals(MOCK_EMAIL, actual.getEmailAddresses());
+        assertEquals(mockUserAccountEntity, actual.getUserAccountsToEmail().get(0));
         assertEquals(actual.getEventId(), NotificationApi.NotificationTemplate.ERROR_PROCESSING_AUDIO.toString());
         assertEquals(MOCK_CASEID, actual.getCaseId());
     }
@@ -507,7 +507,6 @@ class AudioTransformationServiceImplTest {
         when(mockMediaRequestEntity.getEndTime()).thenReturn(endTime);
         when(mockMediaRequestEntity.getRequestor()).thenReturn(mockUserAccountEntity);
         when(mockUserAccountEntity.getId()).thenReturn(1);
-        when(mockUserAccountEntity.getEmailAddress()).thenReturn(MOCK_EMAIL);
         when(mockHearing.getHearingDate()).thenReturn(hearingDate);
         when(mockHearing.getCourtCase()).thenReturn(mockCourtCase);
         when(mockCourtCase.getId()).thenReturn(MOCK_CASEID);

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
@@ -260,7 +260,7 @@ class MediaRequestServiceImplTest {
         var saveNotificationToDbRequest = SaveNotificationToDbRequest.builder()
             .eventId(AUDIO_REQUEST_PROCESSING.toString())
             .caseId(1001)
-            .emailAddresses("test@test.com")
+            .userAccountsToEmail(List.of(mockUserAccountEntity))
             .build();
         verify(audioRequestBeingProcessedFromArchiveQuery).getResults(mediaRequestId);
         verify(notificationApi).scheduleNotification(saveNotificationToDbRequest);
@@ -290,7 +290,7 @@ class MediaRequestServiceImplTest {
         var saveNotificationToDbRequest = SaveNotificationToDbRequest.builder()
             .eventId(AUDIO_REQUEST_PROCESSING_ARCHIVE.toString())
             .caseId(1001)
-            .emailAddresses("test@test.com")
+            .userAccountsToEmail(List.of(mockUserAccountEntity))
             .build();
         verify(audioRequestBeingProcessedFromArchiveQuery).getResults(mediaRequestId);
         verify(notificationApi).scheduleNotification(saveNotificationToDbRequest);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3027

### Change description ###

[Do not schedule notifications for inactive users](https://github.com/hmcts/darts-api/commit/2175e4361c45517cc96d13030fad9f64d7849f12) 

- only check when user accounts are specified
- if email addresses are used no check for active accounts will happen
- minor test refactor

[Amending usages of SaveNotificationToDbRequest](https://github.com/hmcts/darts-api/commit/2baf5ba1656b8cbb922004e742d3b49a19c799a6) 

- to use "userAccountsToEmail" wherever possible
- to ensure that the active account check will be used

[Adding some JavaDoc to SaveNotificationToDbRequest](https://github.com/hmcts/darts-api/commit/fa0434e763e19215f674962ebfb5991cdd2245a4) 

- to make it clear that "userAccountsToEmail" should be used whenever possible

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
