### PR TITLE
DMP-3406 Adding `hide_request_from_requestor` to get transcription by ID response

### DIFF
--- a/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponse.json
+++ b/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponse.json
@@ -25,5 +25,6 @@
       "priority_order": 999
   },
   "courtroom":"some-courtroom",
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "hide_request_from_requestor": false
 }

--- a/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponseNoCourtroom.json
+++ b/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponseNoCourtroom.json
@@ -23,5 +23,6 @@
       "description": "Standard",
       "priority_order": 999
   },
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "hide_request_from_requestor": false
 }

--- a/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponseNoHearing.json
+++ b/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponseNoHearing.json
@@ -24,5 +24,6 @@
       "priority_order": 999
   },
   "courtroom":"some-courtroom",
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "hide_request_from_requestor": false
 }

--- a/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponseNoUrgency.json
+++ b/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponseNoUrgency.json
@@ -18,5 +18,6 @@
   "transcription_start_ts" : "2023-01-01T12:00:00Z",
   "transcription_end_ts" : "2023-01-01T12:00:00Z",
   "courtroom" : "some-courtroom",
-  "transcription_object_id" : "legacyObjectId"
+  "transcription_object_id" : "legacyObjectId",
+  "hide_request_from_requestor": false
 }

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -209,6 +209,7 @@ public class TranscriptionResponseMapper {
         transcriptionResponse.setTranscriptionStartTs(transcriptionEntity.getStartTime());
         transcriptionResponse.setTranscriptionEndTs(transcriptionEntity.getEndTime());
         transcriptionResponse.setIsManual(transcriptionEntity.getIsManualTranscription());
+        transcriptionResponse.setHideRequestFromRequestor(transcriptionEntity.getHideRequestFromRequestor());
 
         mapReportingRestrictions(courtCase, transcriptionResponse);
 

--- a/src/main/resources/openapi/transcriptions.yaml
+++ b/src/main/resources/openapi/transcriptions.yaml
@@ -1409,6 +1409,9 @@ components:
         transcription_object_id:
           type: string
           example: 1
+        hide_request_from_requestor:
+          type: boolean
+          example: false
     defendant:
       type: string
       example: Joe Bloggs

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
@@ -272,6 +272,18 @@ class TranscriptionResponseMapperTest {
     }
 
     @Test
+    void mapToTranscriptionResponseWithHideFromRequestor() throws Exception {
+        HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
+        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = transcriptionList.get(0);
+        transcriptionEntity.setHideRequestFromRequestor(true);
+
+        GetTranscriptionByIdResponse transcriptionResponse =
+            transcriptionResponseMapper.mapToTranscriptionResponse(transcriptionEntity);
+        assertEquals(true, transcriptionResponse.getHideRequestFromRequestor());
+    }
+
+    @Test
     void mapTransactionEntityToTransactionDetails() {
 
         LocalDate hearingDate = LocalDate.now();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3406

### Change description ###

Adding `hide_request_from_requestor` to get transcription by ID response, it's required for the screen changes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
