### PR TITLE
DMP-2723 GET /userstate to return 403 for users without an email address

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/authorisation/controller/AuthorisationController.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/controller/AuthorisationController.java
@@ -1,16 +1,16 @@
-package uk.gov.hmcts.darts.authentication.controller;
+package uk.gov.hmcts.darts.authorisation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.GetMapping;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
 
-public interface AuthenticationCommonController {
+public interface AuthorisationController {
 
     @Operation(
         summary = "Gets the User State for the currently logged in user",
         description = "Gets the User State for the currently logged in user. The User State details the Users roles and permissions. " +
             "This allows the screen to refresh the roles and permissions of a user easily.",
-        tags = {"Authentication"}
+        tags = {"Authorisation"}
     )
     @GetMapping(value = "/userstate", produces = "application/json")
     UserState getUserState();

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/controller/impl/AuthorisationControllerImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/controller/impl/AuthorisationControllerImpl.java
@@ -1,13 +1,15 @@
-package uk.gov.hmcts.darts.authentication.controller.impl;
+package uk.gov.hmcts.darts.authorisation.controller.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.hmcts.darts.authentication.controller.AuthenticationCommonController;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.authorisation.controller.AuthorisationController;
+import uk.gov.hmcts.darts.authorisation.exception.AuthorisationError;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
 
 import java.util.Optional;
 
@@ -15,7 +17,7 @@ import java.util.Optional;
 @RestController
 @ConditionalOnProperty(prefix = "darts", name = "api-pod", havingValue = "true")
 @RequiredArgsConstructor
-public class AuthenticationCommonControllerImpl implements AuthenticationCommonController {
+public class AuthorisationControllerImpl implements AuthorisationController {
 
     private final AuthorisationApi authorisationApi;
 
@@ -23,6 +25,9 @@ public class AuthenticationCommonControllerImpl implements AuthenticationCommonC
     public UserState getUserState() {
         UserAccountEntity currentUser = authorisationApi.getCurrentUser();
         Optional<UserState> userStateOptional = authorisationApi.getAuthorisation(currentUser.getEmailAddress());
-        return userStateOptional.orElse(null);
+        if (userStateOptional.isEmpty()) {
+            throw new DartsApiException(AuthorisationError.USER_NOT_AUTHORISED_FOR_ENDPOINT);
+        }
+        return userStateOptional.get();
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/authorisation/controller/impl/AuthorisationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/authorisation/controller/impl/AuthorisationControllerTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.darts.authentication.controller.impl;
+package uk.gov.hmcts.darts.authorisation.controller.impl;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -6,9 +6,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.authorisation.exception.AuthorisationError;
 import uk.gov.hmcts.darts.authorisation.model.UserState;
 import uk.gov.hmcts.darts.authorisation.model.UserStateRole;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
 
 import java.util.HashSet;
@@ -17,16 +19,16 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings({"PMD.ExcessiveImports"})
-class AuthenticationCommonControllerTest {
+class AuthorisationControllerTest {
     @InjectMocks
-    private AuthenticationCommonControllerImpl controller;
+    private AuthorisationControllerImpl controller;
 
     @Mock
     private AuthorisationApi authorisationApi;
@@ -58,11 +60,19 @@ class AuthenticationCommonControllerTest {
             .build();
         when(authorisationApi.getAuthorisation(userAccountEntity.getEmailAddress())).thenReturn(Optional.of(userState));
 
-
         UserState userStateResponse = controller.getUserState();
 
         assertNotNull(userStateResponse);
         assertEquals("UserName", userStateResponse.getUserName());
         assertTrue(userStateResponse.getIsActive());
+    }
+
+    @Test
+    void getUserStateForbiddenWhenNoEmailAddress() {
+        UserAccountEntity userAccountEntity = CommonTestDataUtil.createUserAccount();
+        when(authorisationApi.getCurrentUser()).thenReturn(userAccountEntity);
+        when(authorisationApi.getAuthorisation(userAccountEntity.getEmailAddress())).thenReturn(Optional.empty());
+        var exception = assertThrows(DartsApiException.class, () -> controller.getUserState());
+        assertEquals(AuthorisationError.USER_NOT_AUTHORISED_FOR_ENDPOINT, exception.getError());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-2723

### Change description ###

- renaming and moving class from authentication package into authorisation package

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
