### PR TITLE
DMP-3388: Correct the title for error AUDIO_REQUESTS_102

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioRequestsApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioRequestsApiError.java
@@ -24,7 +24,7 @@ public enum AudioRequestsApiError implements DartsApiError {
     MEDIA_REQUEST_TYPE_IS_INVALID_FOR_ENDPOINT(
         AudioRequestsErrorCode.MEDIA_REQUEST_TYPE_IS_INVALID_FOR_ENDPOINT.getValue(),
         HttpStatus.BAD_REQUEST,
-        AudioRequestsErrorCode.MEDIA_REQUEST_TYPE_IS_INVALID_FOR_ENDPOINT.toString()
+        AudioRequestsTitleErrors.MEDIA_REQUEST_TYPE_IS_INVALID_FOR_ENDPOINT.toString()
     ),
     TRANSFORMED_MEDIA_NOT_FOUND(
         AudioRequestsErrorCode.TRANSFORMED_MEDIA_NOT_FOUND.getValue(),


### PR DESCRIPTION
# [DMP-3388](https://tools.hmcts.net/jira/browse/DMP-3388)

Small change to correct the title displayed in the API response for an `AUDIO_REQUESTS_102` error.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
