### PR TITLE
DMP-3345 Fixing concurrent daily list processing

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorTest.java
@@ -324,4 +324,17 @@ class DailyListProcessorTest extends IntegrationBase {
 
         Assertions.assertThat(dailyListStatus).isEqualTo(IGNORED);
     }
+
+    @Test
+    void dailyListProcessorWithLock() throws IOException {
+        CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
+        dartsDatabase.createDailyLists(swanseaCourtEntity.getCourthouseName());
+
+        dailyListProcessor.processAllDailyListsWithLock(null);
+
+        List<DailyListEntity> savedDailyLists = dailyListRepository.findAll();
+        List<JobStatusType> dailyListStatuses = savedDailyLists.stream().map(dailyList -> dailyList.getStatus()).toList();
+        long countOfProcessed = dailyListStatuses.stream().filter(status -> status.equals(PROCESSED)).count();
+        assertEquals(2, countOfProcessed);
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AutomatedTaskServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AutomatedTaskServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.task.service;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,10 +41,10 @@ import uk.gov.hmcts.darts.datamanagement.service.InboundToUnstructuredProcessor;
 import uk.gov.hmcts.darts.event.service.RemoveDuplicateEventsProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.retention.service.ApplyRetentionCaseAssociatedObjectsProcessor;
+import uk.gov.hmcts.darts.task.api.AutomatedTaskName;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
 import uk.gov.hmcts.darts.task.exception.AutomatedTaskSetupError;
 import uk.gov.hmcts.darts.task.runner.AutomatedTask;
-import uk.gov.hmcts.darts.task.runner.AutomatedTaskName;
 import uk.gov.hmcts.darts.task.runner.impl.ApplyRetentionCaseAssociatedObjectsAutomatedTask;
 import uk.gov.hmcts.darts.task.runner.impl.ArmRetentionEventDateCalculatorAutomatedTask;
 import uk.gov.hmcts.darts.task.runner.impl.CleanupArmResponseFilesAutomatedTask;
@@ -938,10 +937,10 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
         AutomatedTask automatedTask =
             new RemoveDuplicatedEventsAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 removeDuplicateEventsProcessor,
-                logApi
+                logApi,
+                lockService
             );
 
         Optional<AutomatedTaskEntity> originalAutomatedTaskEntity =
@@ -972,10 +971,10 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
         AutomatedTask automatedTask =
             new RemoveDuplicatedEventsAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 removeDuplicateEventsProcessor,
-                logApi
+                logApi,
+                lockService
             );
 
         Set<ScheduledTask> scheduledTasks = scheduledTaskHolder.getScheduledTasks();
@@ -1213,10 +1212,10 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
         AutomatedTask automatedTask =
             new GenerateCaseDocumentForRetentionDateAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 taskProcessorFactory,
-                logApi
+                logApi,
+                lockService
             );
 
         Optional<AutomatedTaskEntity> originalAutomatedTaskEntity =
@@ -1247,10 +1246,10 @@ class AutomatedTaskServiceTest extends IntegrationPerClassBase {
         AutomatedTask automatedTask =
             new GenerateCaseDocumentForRetentionDateAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 taskProcessorFactory,
-                logApi
+                logApi,
+                lockService
             );
 
         Set<ScheduledTask> scheduledTasks = scheduledTaskHolder.getScheduledTasks();

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceImpl.java
@@ -32,7 +32,7 @@ import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONS
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_MANIFEST_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_PROCESSING_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdvancedSearchResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdvancedSearchResponseMapper.java
@@ -33,10 +33,10 @@ public class AdvancedSearchResponseMapper {
             }
         }
         //case not already in response, so add it.
-        advancedSearchResults.add(maptToAdvancedSearchResult(hearing));
+        advancedSearchResults.add(mapToAdvancedSearchResult(hearing));
     }
 
-    private AdvancedSearchResult maptToAdvancedSearchResult(HearingEntity hearing) {
+    private AdvancedSearchResult mapToAdvancedSearchResult(HearingEntity hearing) {
         AdvancedSearchResult advancedSearchResult = new AdvancedSearchResult();
         CourtCaseEntity courtCase = hearing.getCourtCase();
         advancedSearchResult.setCaseId(courtCase.getId());

--- a/src/main/java/uk/gov/hmcts/darts/common/helper/SystemUserHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/helper/SystemUserHelper.java
@@ -16,6 +16,8 @@ import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 
 @Component
@@ -30,7 +32,7 @@ public class SystemUserHelper {
     public static final String DAILYLIST_PROCESSOR = "dailylist-processor";
     private final UserAccountRepository userAccountRepository;
     private Map<String, String> systemUserGuidMap;
-    private Map<String, UserAccountEntity> systemUserNameToEntityMap = new HashMap<>();
+    private ConcurrentMap<String, UserAccountEntity> systemUserNameToEntityMap = new ConcurrentHashMap<>();
     private final AutomatedTaskConfigurationProperties properties;
 
     public String findSystemUserGuid(String configKey) {

--- a/src/main/java/uk/gov/hmcts/darts/common/helper/SystemUserHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/helper/SystemUserHelper.java
@@ -13,12 +13,10 @@ import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.dailylist.exception.DailyListError;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/controller/DailyListController.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/controller/DailyListController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.common.config.ObjectMapperConfig;
+import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.dailylist.exception.DailyListError;
 import uk.gov.hmcts.darts.dailylist.http.api.DailyListsApi;
@@ -25,7 +26,9 @@ import uk.gov.hmcts.darts.dailylist.model.PostDailyListResponse;
 import uk.gov.hmcts.darts.dailylist.service.DailyListProcessor;
 import uk.gov.hmcts.darts.dailylist.service.DailyListService;
 import uk.gov.hmcts.darts.dailylist.validation.DailyListPostValidator;
+import uk.gov.hmcts.darts.task.api.AutomatedTasksApi;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static uk.gov.hmcts.darts.authorisation.constants.AuthorisationConstants.SECURITY_SCHEMES_BEARER_AUTH;
@@ -33,11 +36,9 @@ import static uk.gov.hmcts.darts.authorisation.enums.ContextIdEnum.ANY_ENTITY_ID
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.CPP;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.XHIBIT;
+import static uk.gov.hmcts.darts.dailylist.exception.DailyListError.DAILY_LIST_ALREADY_PROCESSING;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.PROCESS_DAILY_LIST_TASK_NAME;
 
-/**
- * Default endpoints per application.
- */
-@SuppressWarnings({"checkstyle.LineLengthCheck"})
 @RestController
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "darts", name = "api-pod", havingValue = "true")
@@ -46,6 +47,7 @@ public class DailyListController implements DailyListsApi {
     private final DailyListService dailyListService;
     private final DailyListProcessor processor;
     private final DailyListPostRequestMapper dailyListPostRequestMapper;
+    private final AutomatedTasksApi automatedTasksApi;
 
     ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig();
     ObjectMapper objectMapper = objectMapperConfig.objectMapper();
@@ -93,12 +95,12 @@ public class DailyListController implements DailyListsApi {
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_USER})
     public ResponseEntity<Void> dailylistsRunPost(String listingCourthouse) {
-        if (listingCourthouse == null) {
-            CompletableFuture.runAsync(processor::processAllDailyLists);
-        } else {
-            CompletableFuture.runAsync(() -> processor.processAllDailyListForListingCourthouse(listingCourthouse));
+        var taskName = PROCESS_DAILY_LIST_TASK_NAME.getTaskName();
+        Optional<AutomatedTaskEntity> automatedTaskEntity = automatedTasksApi.getTaskByName(taskName);
+        if (automatedTaskEntity.isPresent() && automatedTasksApi.isLocked(automatedTaskEntity.get())) {
+            throw new DartsApiException(DAILY_LIST_ALREADY_PROCESSING);
         }
-
+        CompletableFuture.runAsync(() -> processor.processAllDailyListsWithLock(listingCourthouse));
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/exception/DailyListError.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/exception/DailyListError.java
@@ -45,6 +45,11 @@ public enum DailyListError implements DartsApiError {
         DailyListErrorCode.MISSING_SYSTEM_USER.getValue(),
         HttpStatus.INTERNAL_SERVER_ERROR,
         DailyListTitleErrors.MISSING_SYSTEM_USER.toString()
+    ),
+    DAILY_LIST_ALREADY_PROCESSING(
+        DailyListErrorCode.DAILY_LIST_ALREADY_PROCESSING.getValue(),
+        HttpStatus.CONFLICT,
+        DailyListTitleErrors.DAILY_LIST_ALREADY_PROCESSING.getValue()
     );
 
     private static final String ERROR_TYPE_PREFIX = "DAILYLIST";

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessor.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessor.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.darts.dailylist.service;
 
 public interface DailyListProcessor {
 
+    void processAllDailyListsWithLock(String listingCourthouse);
+
     void processAllDailyLists();
 
     void processAllDailyListForListingCourthouse(String listingCourthouse);

--- a/src/main/java/uk/gov/hmcts/darts/event/exception/DarNotifyError.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/exception/DarNotifyError.java
@@ -2,5 +2,6 @@ package uk.gov.hmcts.darts.event.exception;
 
 public class DarNotifyError extends Exception {
     public DarNotifyError(Exception ex) {
+        super(ex);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.darts.task.runner;
+package uk.gov.hmcts.darts.task.api;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTasksApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTasksApi.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.darts.task.api;
+
+import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface AutomatedTasksApi {
+
+    Optional<AutomatedTaskEntity> getTaskByName(String taskName);
+
+    boolean isLocked(AutomatedTaskEntity automatedTaskEntity);
+
+    LockingTaskExecutor getLockingTaskExecutor();
+
+    Duration getLockAtMostFor();
+
+    Duration getLockAtLeastFor();
+}

--- a/src/main/java/uk/gov/hmcts/darts/task/api/impl/AutomatedTasksApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/api/impl/AutomatedTasksApiImpl.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.darts.task.api.impl;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.task.api.AutomatedTasksApi;
+import uk.gov.hmcts.darts.task.service.LockService;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AutomatedTasksApiImpl implements AutomatedTasksApi {
+
+    private final AutomatedTaskRepository automatedTaskRepository;
+    private final LockService lockService;
+
+    @Override
+    public Optional<AutomatedTaskEntity> getTaskByName(String taskName) {
+        return automatedTaskRepository.findByTaskName(taskName);
+    }
+
+    @Override
+    public boolean isLocked(AutomatedTaskEntity automatedTaskEntity) {
+        return lockService.isLocked(automatedTaskEntity);
+    }
+
+    @Override
+    public LockingTaskExecutor getLockingTaskExecutor() {
+        return lockService.getLockingTaskExecutor();
+    }
+
+    @Override
+    public Duration getLockAtMostFor() {
+        return lockService.getLockAtMostFor();
+    }
+
+    @Override
+    public Duration getLockAtLeastFor() {
+        return lockService.getLockAtLeastFor();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/AutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/AutomatedTask.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner;
 
-import net.javacrumbs.shedlock.core.LockConfiguration;
 import uk.gov.hmcts.darts.task.status.AutomatedTaskStatus;
 
 public interface AutomatedTask extends Runnable {
@@ -8,8 +7,6 @@ public interface AutomatedTask extends Runnable {
     String getTaskName();
 
     AutomatedTaskStatus getAutomatedTaskStatus();
-
-    LockConfiguration getLockConfiguration();
 
     String getLastCronExpression();
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.retention.service.ApplyRetentionProcessor;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.APPLY_RETENTION_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.APPLY_RETENTION_TASK_NAME;
 
 @Slf4j
 public class ApplyRetentionAutomatedTask extends AbstractLockableAutomatedTask {
@@ -15,10 +15,10 @@ public class ApplyRetentionAutomatedTask extends AbstractLockableAutomatedTask {
     protected String taskName = APPLY_RETENTION_TASK_NAME.getTaskName();
     ApplyRetentionProcessor applyRetentionProcessor;
 
-    public ApplyRetentionAutomatedTask(AutomatedTaskRepository automatedTaskRepository, LockProvider lockProvider,
+    public ApplyRetentionAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
                                        AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
-                                       ApplyRetentionProcessor applyRetentionProcessor, LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                       ApplyRetentionProcessor applyRetentionProcessor, LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.applyRetentionProcessor = applyRetentionProcessor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionCaseAssociatedObjectsAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionCaseAssociatedObjectsAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.retention.service.ApplyRetentionCaseAssociatedObjectsProcessor;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.APPLY_RETENTION_CASE_ASSOCIATED_OBJECTS_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.APPLY_RETENTION_CASE_ASSOCIATED_OBJECTS_TASK_NAME;
 
 @Slf4j
 @SuppressWarnings({"squid:S1135"})
@@ -17,11 +17,10 @@ public class ApplyRetentionCaseAssociatedObjectsAutomatedTask extends AbstractLo
     private final ApplyRetentionCaseAssociatedObjectsProcessor processor;
 
     public ApplyRetentionCaseAssociatedObjectsAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                            LockProvider lockProvider,
                                                             AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                             ApplyRetentionCaseAssociatedObjectsProcessor processor,
-                                                            LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                            LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.processor = processor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ArmRetentionEventDateCalculatorAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ArmRetentionEventDateCalculatorAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.service.ArmRetentionEventDateProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.ARM_RETENTION_EVENT_DATE_CALCULATOR_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.ARM_RETENTION_EVENT_DATE_CALCULATOR_TASK_NAME;
 
 @Slf4j
 public class ArmRetentionEventDateCalculatorAutomatedTask extends AbstractLockableAutomatedTask {
@@ -15,11 +15,10 @@ public class ArmRetentionEventDateCalculatorAutomatedTask extends AbstractLockab
     private final ArmRetentionEventDateProcessor armRetentionEventDateProcessor;
 
     public ArmRetentionEventDateCalculatorAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                        LockProvider lockProvider,
                                                         AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                         ArmRetentionEventDateProcessor armRetentionEventDateProcessor,
-                                                        LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                        LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.armRetentionEventDateProcessor = armRetentionEventDateProcessor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.service.BatchCleanupArmResponseFilesService;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
 
 @Slf4j
 public class BatchCleanupArmResponseFilesAutomatedTask extends AbstractLockableAutomatedTask {
@@ -15,10 +15,10 @@ public class BatchCleanupArmResponseFilesAutomatedTask extends AbstractLockableA
     private final BatchCleanupArmResponseFilesService batchCleanupArmResponseFilesService;
 
     public BatchCleanupArmResponseFilesAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                     LockProvider lockProvider,
                                                      AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
-                                                     BatchCleanupArmResponseFilesService batchCleanupArmResponseFilesService, LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                     BatchCleanupArmResponseFilesService batchCleanupArmResponseFilesService,
+                                                     LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.batchCleanupArmResponseFilesService = batchCleanupArmResponseFilesService;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CleanupArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CleanupArmResponseFilesAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.service.CleanupArmResponseFilesService;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
 
 @Slf4j
 public class CleanupArmResponseFilesAutomatedTask extends AbstractLockableAutomatedTask {
@@ -15,10 +15,10 @@ public class CleanupArmResponseFilesAutomatedTask extends AbstractLockableAutoma
     private final CleanupArmResponseFilesService cleanupArmResponseFilesService;
 
     public CleanupArmResponseFilesAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                LockProvider lockProvider,
                                                 AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
-                                                CleanupArmResponseFilesService cleanupArmResponseFilesService, LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                CleanupArmResponseFilesService cleanupArmResponseFilesService,
+                                                LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.cleanupArmResponseFilesService = cleanupArmResponseFilesService;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CleanupCurrentEventTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CleanupCurrentEventTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.component.AutomatedTaskProcessorFactory;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.event.service.CleanupCurrentFlagEventProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.EVENT_CLEANUP_CURRENT_TASK;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.EVENT_CLEANUP_CURRENT_TASK;
 
 public class CleanupCurrentEventTask extends AbstractLockableAutomatedTask {
 
@@ -15,11 +15,10 @@ public class CleanupCurrentEventTask extends AbstractLockableAutomatedTask {
     private AutomatedTaskProcessorFactory automatedTaskProcessorFactory;
 
     public CleanupCurrentEventTask(AutomatedTaskRepository automatedTaskRepository,
-                                   LockProvider lockProvider,
                                    AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                    AutomatedTaskProcessorFactory automatedTaskProcessorFactory,
-                                   LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                   LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi,lockService);
         this.automatedTaskProcessorFactory = automatedTaskProcessorFactory;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CloseOldCasesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CloseOldCasesAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.cases.service.CloseOldCasesProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.CLOSE_OLD_CASES_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.CLOSE_OLD_CASES_TASK_NAME;
 
 @Slf4j
 public class CloseOldCasesAutomatedTask extends AbstractLockableAutomatedTask {
@@ -15,10 +15,9 @@ public class CloseOldCasesAutomatedTask extends AbstractLockableAutomatedTask {
     CloseOldCasesProcessor closeOldCasesProcessor;
 
     public CloseOldCasesAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                      LockProvider lockProvider,
                                       AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
-                                      CloseOldCasesProcessor closeOldCasesProcessor, LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                      CloseOldCasesProcessor closeOldCasesProcessor, LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.closeOldCasesProcessor = closeOldCasesProcessor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CloseUnfinishedTranscriptionsAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CloseUnfinishedTranscriptionsAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 import uk.gov.hmcts.darts.transcriptions.service.TranscriptionsProcessor;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.CLOSE_OLD_UNFINISHED_TRANSCRIPTIONS_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.CLOSE_OLD_UNFINISHED_TRANSCRIPTIONS_TASK_NAME;
 
 @Slf4j
 public class CloseUnfinishedTranscriptionsAutomatedTask extends AbstractLockableAutomatedTask {
@@ -17,11 +17,10 @@ public class CloseUnfinishedTranscriptionsAutomatedTask extends AbstractLockable
     protected String taskName = CLOSE_OLD_UNFINISHED_TRANSCRIPTIONS_TASK_NAME.getTaskName();
 
     public CloseUnfinishedTranscriptionsAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                      LockProvider lockProvider,
                                                       AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                       TranscriptionsProcessor transcriptionsProcessor,
-                                                      LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                      LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.transcriptionsProcessor = transcriptionsProcessor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DailyListAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DailyListAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.dailylist.service.DailyListService;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.DAILY_LIST_HOUSEKEEPING_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.DAILY_LIST_HOUSEKEEPING_TASK_NAME;
 
 @Slf4j
 public class DailyListAutomatedTask extends AbstractLockableAutomatedTask {
@@ -15,11 +15,10 @@ public class DailyListAutomatedTask extends AbstractLockableAutomatedTask {
     private final DailyListService dailyListService;
 
     public DailyListAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                  LockProvider lockProvider,
                                   AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                   DailyListService dailyListService,
-                                  LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                  LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.dailyListService = dailyListService;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ExternalDataStoreDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ExternalDataStoreDeleterAutomatedTask.java
@@ -1,15 +1,15 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.audio.deleter.impl.inbound.ExternalInboundDataStoreDeleter;
 import uk.gov.hmcts.darts.audio.deleter.impl.outbound.ExternalOutboundDataStoreDeleter;
 import uk.gov.hmcts.darts.audio.deleter.impl.unstructured.ExternalUnstructuredDataStoreDeleter;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.EXTERNAL_DATASTORE_DELETER_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.EXTERNAL_DATASTORE_DELETER_TASK_NAME;
 
 @Slf4j
 public class ExternalDataStoreDeleterAutomatedTask extends AbstractLockableAutomatedTask {
@@ -21,13 +21,13 @@ public class ExternalDataStoreDeleterAutomatedTask extends AbstractLockableAutom
 
     protected String taskName = EXTERNAL_DATASTORE_DELETER_TASK_NAME.getTaskName();
 
-    public ExternalDataStoreDeleterAutomatedTask(AutomatedTaskRepository automatedTaskRepository, LockProvider lockProvider,
+    public ExternalDataStoreDeleterAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
                                                  AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                  ExternalInboundDataStoreDeleter inboundDeleter,
                                                  ExternalUnstructuredDataStoreDeleter unstructuredDeleter,
                                                  ExternalOutboundDataStoreDeleter outboundDeleter,
-                                                 LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                 LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.inboundDeleter = inboundDeleter;
         this.unstructuredDeleter = unstructuredDeleter;
         this.outboundDeleter = outboundDeleter;

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCaseDocumentAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCaseDocumentAutomatedTask.java
@@ -1,14 +1,14 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.component.AutomatedTaskProcessorFactory;
 import uk.gov.hmcts.darts.casedocument.service.GenerateCaseDocumentProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.GENERATE_CASE_DOCUMENT_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.GENERATE_CASE_DOCUMENT_TASK_NAME;
 
 @Slf4j
 @SuppressWarnings({"squid:S1135"})
@@ -18,11 +18,10 @@ public class GenerateCaseDocumentAutomatedTask extends AbstractLockableAutomated
     private final AutomatedTaskProcessorFactory automatedTaskProcessorFactory;
 
     public GenerateCaseDocumentAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                             LockProvider lockProvider,
                                              AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                              AutomatedTaskProcessorFactory automatedTaskProcessorFactory,
-                                             LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                             LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.automatedTaskProcessorFactory = automatedTaskProcessorFactory;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCaseDocumentForRetentionDateAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCaseDocumentForRetentionDateAutomatedTask.java
@@ -1,14 +1,14 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.component.AutomatedTaskProcessorFactory;
 import uk.gov.hmcts.darts.casedocument.service.GenerateCaseDocumentForRetentionDateProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.GENERATE_CASE_DOCUMENT_FOR_RETENTION_DATE_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.GENERATE_CASE_DOCUMENT_FOR_RETENTION_DATE_TASK_NAME;
 
 @Slf4j
 @SuppressWarnings({"squid:S1135"})
@@ -18,11 +18,11 @@ public class GenerateCaseDocumentForRetentionDateAutomatedTask extends AbstractL
     private final AutomatedTaskProcessorFactory automatedTaskProcessorFactory;
 
     public GenerateCaseDocumentForRetentionDateAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                             LockProvider lockProvider,
                                                              AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                              AutomatedTaskProcessorFactory automatedTaskProcessorFactory,
-                                                             LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                             LogApi logApi,
+                                                             LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.automatedTaskProcessorFactory = automatedTaskProcessorFactory;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundAnnotationTranscriptionDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundAnnotationTranscriptionDeleterAutomatedTask.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.service.InboundAnnotationTranscriptionDeleterProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.INBOUND_TRANSCRIPTION_ANNOTATION_DELETER_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.INBOUND_TRANSCRIPTION_ANNOTATION_DELETER_TASK_NAME;
 
 public class InboundAnnotationTranscriptionDeleterAutomatedTask extends AbstractLockableAutomatedTask {
 
@@ -14,11 +14,11 @@ public class InboundAnnotationTranscriptionDeleterAutomatedTask extends Abstract
     private InboundAnnotationTranscriptionDeleterProcessor armDeletionProcessor;
 
     public InboundAnnotationTranscriptionDeleterAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                              LockProvider lockProvider,
                                                               AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                               InboundAnnotationTranscriptionDeleterProcessor armDeletionProcessor,
-                                                              LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                              LogApi logApi,
+                                                              LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.armDeletionProcessor = armDeletionProcessor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundAudioDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundAudioDeleterAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.audio.service.InboundAudioDeleterProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.INBOUND_AUDIO_DELETER_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.INBOUND_AUDIO_DELETER_TASK_NAME;
 
 @Slf4j
 public class InboundAudioDeleterAutomatedTask extends AbstractLockableAutomatedTask {
@@ -15,11 +15,11 @@ public class InboundAudioDeleterAutomatedTask extends AbstractLockableAutomatedT
     protected String taskName = INBOUND_AUDIO_DELETER_TASK_NAME.getTaskName();
     private final InboundAudioDeleterProcessor inboundAudioDeleterProcessor;
 
-    public InboundAudioDeleterAutomatedTask(AutomatedTaskRepository automatedTaskRepository, LockProvider lockProvider,
+    public InboundAudioDeleterAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
                                             AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                             InboundAudioDeleterProcessor processor,
-                                            LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                            LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.inboundAudioDeleterProcessor = processor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundToUnstructuredAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/InboundToUnstructuredAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.datamanagement.service.InboundToUnstructuredProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.INBOUND_TO_UNSTRUCTURED_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.INBOUND_TO_UNSTRUCTURED_TASK_NAME;
 
 @Slf4j
 @SuppressWarnings({"squid:S1135"})
@@ -17,11 +17,10 @@ public class InboundToUnstructuredAutomatedTask extends AbstractLockableAutomate
     private final InboundToUnstructuredProcessor inboundToUnstructuredProcessor;
 
     public InboundToUnstructuredAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                              LockProvider lockProvider,
                                               AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                               InboundToUnstructuredProcessor processor,
-                                              LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                              LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.inboundToUnstructuredProcessor = processor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/OutboundAudioDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/OutboundAudioDeleterAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.audio.service.OutboundAudioDeleterProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.OUTBOUND_AUDIO_DELETER_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.OUTBOUND_AUDIO_DELETER_TASK_NAME;
 
 @Slf4j
 public class OutboundAudioDeleterAutomatedTask extends AbstractLockableAutomatedTask {
@@ -15,11 +15,11 @@ public class OutboundAudioDeleterAutomatedTask extends AbstractLockableAutomated
     protected String taskName = OUTBOUND_AUDIO_DELETER_TASK_NAME.getTaskName();
     private final OutboundAudioDeleterProcessor outboundAudioDeleterProcessor;
 
-    public OutboundAudioDeleterAutomatedTask(AutomatedTaskRepository automatedTaskRepository, LockProvider lockProvider,
+    public OutboundAudioDeleterAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
                                              AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                              OutboundAudioDeleterProcessor processor,
-                                             LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                             LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.outboundAudioDeleterProcessor = processor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ProcessArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ProcessArmResponseFilesAutomatedTask.java
@@ -1,14 +1,14 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.component.AutomatedTaskProcessorFactory;
 import uk.gov.hmcts.darts.arm.service.ArmResponseFilesProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.PROCESS_ARM_RESPONSE_FILES_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.PROCESS_ARM_RESPONSE_FILES_TASK_NAME;
 
 @Slf4j
 public class ProcessArmResponseFilesAutomatedTask extends AbstractLockableAutomatedTask {
@@ -16,11 +16,10 @@ public class ProcessArmResponseFilesAutomatedTask extends AbstractLockableAutoma
     private final AutomatedTaskProcessorFactory automatedTaskProcessorFactory;
 
     public ProcessArmResponseFilesAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                LockProvider lockProvider,
                                                 AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                 AutomatedTaskProcessorFactory automatedTaskProcessorFactory,
-                                                LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.automatedTaskProcessorFactory = automatedTaskProcessorFactory;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ProcessDailyListAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ProcessDailyListAutomatedTask.java
@@ -1,17 +1,17 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.dailylist.service.DailyListProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 import uk.gov.hmcts.darts.task.status.AutomatedTaskStatus;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.PROCESS_DAILY_LIST_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.PROCESS_DAILY_LIST_TASK_NAME;
 
 @Slf4j
 @SuppressWarnings({"squid:S1135"})
@@ -22,15 +22,16 @@ public class ProcessDailyListAutomatedTask extends AbstractLockableAutomatedTask
 
     private final List<AutomatedTaskStatus> trackedStateChanges = new ArrayList<>();
 
-    public ProcessDailyListAutomatedTask(AutomatedTaskRepository automatedTaskRepository, LockProvider lockProvider,
-                                         AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties, LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+    public ProcessDailyListAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
+                                         AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
+                                         LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
     }
 
-    public ProcessDailyListAutomatedTask(AutomatedTaskRepository automatedTaskRepository, LockProvider lockProvider,
+    public ProcessDailyListAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
                                          AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
-                                         DailyListProcessor processor, LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                         DailyListProcessor processor, LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.dailyListProcessor = processor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/RemoveDuplicatedEventsAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/RemoveDuplicatedEventsAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.event.service.RemoveDuplicateEventsProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.REMOVE_DUPLICATED_EVENTS_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.REMOVE_DUPLICATED_EVENTS_TASK_NAME;
 
 @Slf4j
 @SuppressWarnings({"squid:S1135"})
@@ -18,11 +18,11 @@ public class RemoveDuplicatedEventsAutomatedTask extends AbstractLockableAutomat
     private final RemoveDuplicateEventsProcessor removeDuplicateEventsProcessor;
 
     public RemoveDuplicatedEventsAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                               LockProvider lockProvider,
                                                AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                RemoveDuplicateEventsProcessor removeDuplicateEventsProcessor,
-                                               LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                               LogApi logApi,
+                                               LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.removeDuplicateEventsProcessor = removeDuplicateEventsProcessor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredAnnotationTranscriptionDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredAnnotationTranscriptionDeleterAutomatedTask.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.service.UnstructuredTranscriptionAndAnnotationDeleterProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.UNSTRUCTURED_TRANSCRIPTION_ANNOTATION_DELETER_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.UNSTRUCTURED_TRANSCRIPTION_ANNOTATION_DELETER_TASK_NAME;
 
 public class UnstructuredAnnotationTranscriptionDeleterAutomatedTask extends AbstractLockableAutomatedTask {
 
@@ -14,11 +14,11 @@ public class UnstructuredAnnotationTranscriptionDeleterAutomatedTask extends Abs
     private UnstructuredTranscriptionAndAnnotationDeleterProcessor armDeletionProcessor;
 
     public UnstructuredAnnotationTranscriptionDeleterAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                              LockProvider lockProvider,
-                                                              AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
+                                                                   AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                                                    UnstructuredTranscriptionAndAnnotationDeleterProcessor armDeletionProcessor,
-                                                              LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                                                   LogApi logApi,
+                                                                   LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.armDeletionProcessor = armDeletionProcessor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredAudioDeleterAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredAudioDeleterAutomatedTask.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.audio.service.UnstructuredAudioDeleterProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.UNSTRUCTURED_AUDIO_DELETER_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.UNSTRUCTURED_AUDIO_DELETER_TASK_NAME;
 
 @Slf4j
 public class UnstructuredAudioDeleterAutomatedTask extends AbstractLockableAutomatedTask {
@@ -18,11 +18,10 @@ public class UnstructuredAudioDeleterAutomatedTask extends AbstractLockableAutom
 
     public UnstructuredAudioDeleterAutomatedTask(
         AutomatedTaskRepository automatedTaskRepository,
-        LockProvider lockProvider,
         AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
         UnstructuredAudioDeleterProcessor unstructuredAudioDeleterProcessor,
-        LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+        LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.unstructuredAudioDeleterProcessor = unstructuredAudioDeleterProcessor;
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredToArmAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredToArmAutomatedTask.java
@@ -1,14 +1,14 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import uk.gov.hmcts.darts.arm.service.UnstructuredToArmBatchProcessor;
 import uk.gov.hmcts.darts.arm.service.UnstructuredToArmProcessor;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.UNSTRUCTURED_TO_ARM_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.UNSTRUCTURED_TO_ARM_TASK_NAME;
 
 @Slf4j
 public class UnstructuredToArmAutomatedTask extends AbstractLockableAutomatedTask {
@@ -18,12 +18,11 @@ public class UnstructuredToArmAutomatedTask extends AbstractLockableAutomatedTas
     private final UnstructuredToArmProcessor unstructuredToArmProcessor;
 
     public UnstructuredToArmAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                          LockProvider lockProvider,
                                           AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties,
                                           UnstructuredToArmBatchProcessor unstructuredToArmBatchProcessor,
                                           UnstructuredToArmProcessor unstructuredToArmProcessor,
-                                          LogApi logApi) {
-        super(automatedTaskRepository, lockProvider, automatedTaskConfigurationProperties, logApi);
+                                          LogApi logApi, LockService lockService) {
+        super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.unstructuredToArmBatchProcessor = unstructuredToArmBatchProcessor;
         this.unstructuredToArmProcessor = unstructuredToArmProcessor;
     }

--- a/src/main/java/uk/gov/hmcts/darts/task/service/LockService.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/LockService.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.darts.task.service;
+
+import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
+
+import java.time.Duration;
+
+public interface LockService {
+    boolean isLocked(AutomatedTaskEntity automatedTask);
+
+    LockingTaskExecutor getLockingTaskExecutor();
+
+    Duration getLockAtMostFor();
+
+    Duration getLockAtLeastFor();
+}

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
@@ -90,7 +90,7 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
         return mapper.mapEntityToDetailedAutomatedTask(updatedTask);
     }
 
-    private boolean isLocked(AutomatedTaskEntity automatedTask) {
+    public boolean isLocked(AutomatedTaskEntity automatedTask) {
         var lockedUntil = automatedTaskRepository.findLockedUntilForTask(automatedTask.getTaskName());
         return !lockedUntil.isEmpty() && isInFuture(lockedUntil);
     }

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
@@ -4,19 +4,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
-import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
-import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.task.exception.AutomatedTaskApiError;
 import uk.gov.hmcts.darts.task.service.AdminAutomatedTaskService;
+import uk.gov.hmcts.darts.task.service.LockService;
 import uk.gov.hmcts.darts.tasks.model.AutomatedTaskPatch;
 import uk.gov.hmcts.darts.tasks.model.AutomatedTaskSummary;
 import uk.gov.hmcts.darts.tasks.model.DetailedAutomatedTask;
 
-import java.sql.Timestamp;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 
 import static uk.gov.hmcts.darts.audit.api.AuditActivity.ENABLE_DISABLE_JOB;
@@ -33,8 +29,8 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
     private final AutomatedTasksMapper mapper;
     private final ManualTaskService manualTaskService;
     private final AutomatedTaskRunner automatedTaskRunner;
-    private final CurrentTimeHelper currentTimeHelper;
     private final AuditApi auditApi;
+    private final LockService lockService;
 
     @Override
     public List<AutomatedTaskSummary> getAllAutomatedTasks() {
@@ -57,7 +53,7 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
         var automatedTaskEntity = automatedTaskRepository.findById(taskId)
             .orElseThrow(() -> new DartsApiException(AUTOMATED_TASK_NOT_FOUND));
 
-        if (isLocked(automatedTaskEntity)) {
+        if (lockService.isLocked(automatedTaskEntity)) {
             log.info("Manual running of {} failed as it is locked", automatedTaskEntity.getTaskName());
             throw new DartsApiException(AUTOMATED_TASK_ALREADY_RUNNING);
         }
@@ -89,19 +85,4 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
 
         return mapper.mapEntityToDetailedAutomatedTask(updatedTask);
     }
-
-    public boolean isLocked(AutomatedTaskEntity automatedTask) {
-        var lockedUntil = automatedTaskRepository.findLockedUntilForTask(automatedTask.getTaskName());
-        return !lockedUntil.isEmpty() && isInFuture(lockedUntil);
-    }
-
-    private boolean isInFuture(List<Timestamp> lockedUntil) {
-        // There should only ever be one item in the list as we search by primary key
-        return toOffsetDateTime(lockedUntil.get(0)).isAfter(currentTimeHelper.currentOffsetDateTime());
-    }
-
-    private OffsetDateTime toOffsetDateTime(Timestamp timestamp) {
-        return timestamp.toLocalDateTime().atOffset(ZoneOffset.UTC);
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AutomatedTaskServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AutomatedTaskServiceImpl.java
@@ -86,39 +86,20 @@ import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.CLOSE_OLD_UNFINISHED
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.DAILY_LIST_HOUSEKEEPING_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.EVENT_CLEANUP_CURRENT_TASK;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.EXTERNAL_DATASTORE_DELETER_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.GENERATE_CASE_DOCUMENT_FOR_RETENTION_DATE_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.GENERATE_CASE_DOCUMENT_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.INBOUND_AUDIO_DELETER_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.INBOUND_TO_UNSTRUCTURED_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.INBOUND_TRANSCRIPTION_ANNOTATION_DELETER_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.OUTBOUND_AUDIO_DELETER_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.PROCESS_ARM_RESPONSE_FILES_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.PROCESS_DAILY_LIST_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.REMOVE_DUPLICATED_EVENTS_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.UNSTRUCTURED_AUDIO_DELETER_TASK_NAME;
 import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.UNSTRUCTURED_TO_ARM_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.UNSTRUCTURED_TRANSCRIPTION_ANNOTATION_DELETER_TASK_NAME;
 import static uk.gov.hmcts.darts.task.exception.AutomatedTaskSetupError.FAILED_TO_FIND_AUTOMATED_TASK;
 import static uk.gov.hmcts.darts.task.exception.AutomatedTaskSetupError.INVALID_CRON_EXPRESSION;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.APPLY_RETENTION_CASE_ASSOCIATED_OBJECTS_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.APPLY_RETENTION_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.ARM_RETENTION_EVENT_DATE_CALCULATOR_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.CLOSE_OLD_CASES_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.CLOSE_OLD_UNFINISHED_TRANSCRIPTIONS_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.DAILY_LIST_HOUSEKEEPING_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.EVENT_CLEANUP_CURRENT_TASK;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.EXTERNAL_DATASTORE_DELETER_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.GENERATE_CASE_DOCUMENT_FOR_RETENTION_DATE_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.GENERATE_CASE_DOCUMENT_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.INBOUND_AUDIO_DELETER_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.INBOUND_TO_UNSTRUCTURED_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.INBOUND_TRANSCRIPTION_ANNOTATION_DELETER_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.OUTBOUND_AUDIO_DELETER_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.PROCESS_ARM_RESPONSE_FILES_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.PROCESS_DAILY_LIST_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.REMOVE_DUPLICATED_EVENTS_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.UNSTRUCTURED_AUDIO_DELETER_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.UNSTRUCTURED_TO_ARM_TASK_NAME;
-import static uk.gov.hmcts.darts.task.runner.AutomatedTaskName.UNSTRUCTURED_TRANSCRIPTION_ANNOTATION_DELETER_TASK_NAME;
-
 
 /**
  * Refer to <a href="https://docs.spring.io/spring-framework/reference/integration/scheduling.html#scheduling-cron-expression">...</a>
@@ -603,10 +584,10 @@ public class AutomatedTaskServiceImpl implements AutomatedTaskService {
 
     private void addInboundTranscriptionAndAnnotationDeleterToTaskRegistrar(ScheduledTaskRegistrar taskRegistrar) {
         var eventCleanupTask = new InboundAnnotationTranscriptionDeleterAutomatedTask(automatedTaskRepository,
-                                                                                      lockProvider,
                                                                                       automatedTaskConfigurationProperties,
                                                                                       inboundTranscriptionAndAnnotationDeleterProcessor,
-                                                                                      logApi);
+                                                                                      logApi,
+                                                                                      lockService);
         eventCleanupTask.setLastCronExpression(getAutomatedTaskCronExpression(eventCleanupTask));
         Trigger trigger = createAutomatedTaskTrigger(eventCleanupTask);
         taskRegistrar.addTriggerTask(eventCleanupTask, trigger);
@@ -615,10 +596,10 @@ public class AutomatedTaskServiceImpl implements AutomatedTaskService {
     private void addUnstructuredTranscriptionAndAnnotationDeleterToTaskRegistrar(ScheduledTaskRegistrar taskRegistrar) {
         var unstructuredAnnotationTranscriptionDeleterAutomatedTask = new
             UnstructuredAnnotationTranscriptionDeleterAutomatedTask(automatedTaskRepository,
-                                                                    lockProvider,
                                                                     automatedTaskConfigurationProperties,
                                                                     unstructuredTranscriptionAndAnnotationDeleterProcessor,
-                                                                    logApi);
+                                                                    logApi,
+                                                                    lockService);
         unstructuredAnnotationTranscriptionDeleterAutomatedTask
             .setLastCronExpression(getAutomatedTaskCronExpression(unstructuredAnnotationTranscriptionDeleterAutomatedTask));
         Trigger trigger = createAutomatedTaskTrigger(unstructuredAnnotationTranscriptionDeleterAutomatedTask);
@@ -628,10 +609,10 @@ public class AutomatedTaskServiceImpl implements AutomatedTaskService {
     private void addRemoveDuplicateEventsToTaskRegistrar(ScheduledTaskRegistrar taskRegistrar) {
         var removeDuplicateEventsAutomatedTask = new RemoveDuplicatedEventsAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             removeDuplicateEventsProcessor,
-            logApi
+            logApi,
+            lockService
         );
         removeDuplicateEventsAutomatedTask.setLastCronExpression(getAutomatedTaskCronExpression(removeDuplicateEventsAutomatedTask));
         Trigger trigger = createAutomatedTaskTrigger(removeDuplicateEventsAutomatedTask);
@@ -640,10 +621,10 @@ public class AutomatedTaskServiceImpl implements AutomatedTaskService {
 
     private void addGenerateCaseDocumentForRetentionDateToTaskRegistrar(ScheduledTaskRegistrar taskRegistrar) {
         var generateCaseDocumentForRetentionDateAutomatedTask = new GenerateCaseDocumentForRetentionDateAutomatedTask(automatedTaskRepository,
-                                                                                                                      lockProvider,
                                                                                                                       automatedTaskConfigurationProperties,
                                                                                                                       automatedTaskProcessorFactory,
-                                                                                                                      logApi);
+                                                                                                                      logApi,
+                                                                                                                      lockService);
         generateCaseDocumentForRetentionDateAutomatedTask.setLastCronExpression(
             getAutomatedTaskCronExpression(generateCaseDocumentForRetentionDateAutomatedTask));
         Trigger trigger = createAutomatedTaskTrigger(generateCaseDocumentForRetentionDateAutomatedTask);
@@ -979,10 +960,10 @@ public class AutomatedTaskServiceImpl implements AutomatedTaskService {
         if (triggerAndAutomatedTask == null) {
             var generateInboundAnnotationTranscriptionTask = new InboundAnnotationTranscriptionDeleterAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 inboundTranscriptionAndAnnotationDeleterProcessor,
-                logApi
+                logApi,
+                lockService
             );
             Trigger trigger = createAutomatedTaskTrigger(generateInboundAnnotationTranscriptionTask);
             taskScheduler.schedule(generateInboundAnnotationTranscriptionTask, trigger);
@@ -996,10 +977,10 @@ public class AutomatedTaskServiceImpl implements AutomatedTaskService {
         if (triggerAndAutomatedTask == null) {
             var unstructuredAnnotationTranscriptionDeleterAutomatedTask = new UnstructuredAnnotationTranscriptionDeleterAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 unstructuredTranscriptionAndAnnotationDeleterProcessor,
-                logApi
+                logApi,
+                lockService
             );
             Trigger trigger = createAutomatedTaskTrigger(unstructuredAnnotationTranscriptionDeleterAutomatedTask);
             taskScheduler.schedule(unstructuredAnnotationTranscriptionDeleterAutomatedTask, trigger);
@@ -1013,10 +994,10 @@ public class AutomatedTaskServiceImpl implements AutomatedTaskService {
         if (triggerAndAutomatedTask == null) {
             var removeDuplicatedEventsAutomatedTask = new RemoveDuplicatedEventsAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 removeDuplicateEventsProcessor,
-                logApi
+                logApi,
+                lockService
             );
             Trigger trigger = createAutomatedTaskTrigger(removeDuplicatedEventsAutomatedTask);
             taskScheduler.schedule(removeDuplicatedEventsAutomatedTask, trigger);
@@ -1030,10 +1011,10 @@ public class AutomatedTaskServiceImpl implements AutomatedTaskService {
         if (triggerAndAutomatedTask == null) {
             var generateCaseDocumentForRetentionDateAutomatedTask = new GenerateCaseDocumentForRetentionDateAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 automatedTaskProcessorFactory,
-                logApi
+                logApi,
+                lockService
             );
             Trigger trigger = createAutomatedTaskTrigger(generateCaseDocumentForRetentionDateAutomatedTask);
             taskScheduler.schedule(generateCaseDocumentForRetentionDateAutomatedTask, trigger);

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImpl.java
@@ -20,8 +20,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LockServiceImpl implements LockService {
 
-    private static final int DEFAULT_LOCK_AT_MOST_SECONDS = 600;
-    private static final int DEFAULT_LOCK_AT_LEAST_SECONDS = 20;
+    private static final Duration DEFAULT_LOCK_AT_MOST = Duration.ofSeconds(600);
+    private static final Duration DEFAULT_LOCK_AT_LEAST = Duration.ofSeconds(20);
 
     private final AutomatedTaskRepository automatedTaskRepository;
     private final CurrentTimeHelper currentTimeHelper;
@@ -39,12 +39,12 @@ public class LockServiceImpl implements LockService {
 
     @Override
     public Duration getLockAtMostFor() {
-        return Duration.ofSeconds(DEFAULT_LOCK_AT_MOST_SECONDS);
+        return DEFAULT_LOCK_AT_MOST;
     }
 
     @Override
     public Duration getLockAtLeastFor() {
-        return Duration.ofSeconds(DEFAULT_LOCK_AT_LEAST_SECONDS);
+        return DEFAULT_LOCK_AT_LEAST;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImpl.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.darts.task.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.core.DefaultLockingTaskExecutor;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.task.service.LockService;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LockServiceImpl implements LockService {
+
+    private static final int DEFAULT_LOCK_AT_MOST_SECONDS = 600;
+    private static final int DEFAULT_LOCK_AT_LEAST_SECONDS = 20;
+
+    private final AutomatedTaskRepository automatedTaskRepository;
+    private final CurrentTimeHelper currentTimeHelper;
+    private final LockProvider lockProvider;
+
+    private LockingTaskExecutor lockingTaskExecutor;
+
+    @Override
+    public LockingTaskExecutor getLockingTaskExecutor() {
+        if (lockingTaskExecutor == null) {
+            lockingTaskExecutor = new DefaultLockingTaskExecutor(lockProvider);
+        }
+        return lockingTaskExecutor;
+    }
+
+    @Override
+    public Duration getLockAtMostFor() {
+        return Duration.ofSeconds(DEFAULT_LOCK_AT_MOST_SECONDS);
+    }
+
+    @Override
+    public Duration getLockAtLeastFor() {
+        return Duration.ofSeconds(DEFAULT_LOCK_AT_LEAST_SECONDS);
+    }
+
+    @Override
+    public boolean isLocked(AutomatedTaskEntity automatedTask) {
+        List<Timestamp> lockedUntil = automatedTaskRepository.findLockedUntilForTask(automatedTask.getTaskName());
+        return !lockedUntil.isEmpty() && isInFuture(lockedUntil);
+    }
+
+    private boolean isInFuture(List<Timestamp> lockedUntil) {
+        // There should only ever be one item in the list as we search by primary key
+        return toOffsetDateTime(lockedUntil.get(0)).isAfter(currentTimeHelper.currentOffsetDateTime());
+    }
+
+    private OffsetDateTime toOffsetDateTime(Timestamp timestamp) {
+        return timestamp.toLocalDateTime().atOffset(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/ManualTaskService.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/ManualTaskService.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.task.service.impl;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.arm.component.AutomatedTaskProcessorFactory;
 import uk.gov.hmcts.darts.arm.service.ArmRetentionEventDateProcessor;
@@ -52,6 +51,7 @@ import uk.gov.hmcts.darts.task.runner.impl.RemoveDuplicatedEventsAutomatedTask;
 import uk.gov.hmcts.darts.task.runner.impl.UnstructuredAnnotationTranscriptionDeleterAutomatedTask;
 import uk.gov.hmcts.darts.task.runner.impl.UnstructuredAudioDeleterAutomatedTask;
 import uk.gov.hmcts.darts.task.runner.impl.UnstructuredToArmAutomatedTask;
+import uk.gov.hmcts.darts.task.service.LockService;
 import uk.gov.hmcts.darts.transcriptions.service.TranscriptionsProcessor;
 
 import java.util.ArrayList;
@@ -87,6 +87,7 @@ public class ManualTaskService {
 
     private final LockProvider lockProvider;
     private final LogApi logApi;
+    private final LockService lockService;
 
     private InboundAnnotationTranscriptionDeleterProcessor inboundAnnotationTranscriptionDeleterProcessor;
     private UnstructuredTranscriptionAndAnnotationDeleterProcessor unstructuredTranscriptionAndAnnotationDeleterProcessor;
@@ -127,10 +128,10 @@ public class ManualTaskService {
     private void addProcessDailyListToTaskRegistrar() {
         var manualTask = new ProcessDailyListAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             dailyListProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -139,10 +140,10 @@ public class ManualTaskService {
     private void addInboundAudioDeleterToTaskRegistrar() {
         var manualTask = new InboundAudioDeleterAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             inboundAudioDeleterProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -151,10 +152,10 @@ public class ManualTaskService {
     private void addOutboundAudioDeleterToTaskRegistrar() {
         var manualTask = new OutboundAudioDeleterAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             outboundAudioDeleterProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -163,10 +164,10 @@ public class ManualTaskService {
     private void addInboundToUnstructuredTaskRegistrar() {
         var manualTask = new InboundToUnstructuredAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             inboundToUnstructuredProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -175,12 +176,12 @@ public class ManualTaskService {
     private void addExternalDataStoreDeleterToTaskRegistrar() {
         var manualTask = new ExternalDataStoreDeleterAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             inboundDataStoreDeleter,
             unstructuredDataStoreDeleter,
             outboundDataStoreDeleter,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -189,10 +190,10 @@ public class ManualTaskService {
     private void addCloseNonCompletedTranscriptionsAutomatedTaskToTaskRegistrar() {
         var manualTask = new CloseUnfinishedTranscriptionsAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             transcriptionsProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -201,10 +202,10 @@ public class ManualTaskService {
     private void addUnstructuredAudioDeleterAutomatedTaskToTaskRegistrar() {
         var manualTask = new UnstructuredAudioDeleterAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             unstructuredAudioDeleterProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -213,11 +214,11 @@ public class ManualTaskService {
     private void addUnstructuredToArmTaskRegistrar() {
         var manualTask = new UnstructuredToArmAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             unstructuredToArmBatchProcessor,
             unstructuredToArmProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -226,10 +227,10 @@ public class ManualTaskService {
     private void addProcessArmResponseFilesTaskRegistrar() {
         var manualTask = new ProcessArmResponseFilesAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             automatedTaskProcessorFactory,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -238,10 +239,10 @@ public class ManualTaskService {
     private void addApplyRetentionToTaskRegistrar() {
         var manualTask = new ApplyRetentionAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             applyRetentionProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -250,10 +251,10 @@ public class ManualTaskService {
     private void addCaseObjectApplyRetentionToTaskRegistrar() {
         var manualTask = new ApplyRetentionCaseAssociatedObjectsAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             applyRetentionCaseAssociatedObjectsProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -262,10 +263,10 @@ public class ManualTaskService {
     private void addCleanupArmResponseFilesTaskRegistrar() {
         var manualTask = new CleanupArmResponseFilesAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             cleanupArmResponseFilesService,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -274,10 +275,10 @@ public class ManualTaskService {
     private void addBatchCleanupArmResponseFilesTaskRegistrar() {
         var manualTask = new BatchCleanupArmResponseFilesAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             batchCleanupArmResponseFilesService,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -285,20 +286,20 @@ public class ManualTaskService {
 
     private void addCloseOldCasesTaskRegistrar() {
         var manualTask = new CloseOldCasesAutomatedTask(automatedTaskRepository,
-                                                        lockProvider,
                                                         automatedTaskConfigurationProperties,
                                                         closeOldCasesProcessor,
-                                                        logApi);
+                                                        logApi,
+                                                        lockService);
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
     }
 
     private void addDailyListHouseKeepingToTaskRegistrar() {
         var manualTask = new DailyListAutomatedTask(automatedTaskRepository,
-                                                    lockProvider,
                                                     automatedTaskConfigurationProperties,
                                                     dailyListService,
-                                                    logApi);
+                                                    logApi,
+                                                    lockService);
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
     }
@@ -306,10 +307,10 @@ public class ManualTaskService {
 
     private void addArmRetentionEventDateCalculatorToTaskRegister() {
         var manualTask = new ArmRetentionEventDateCalculatorAutomatedTask(automatedTaskRepository,
-                                                                          lockProvider,
                                                                           automatedTaskConfigurationProperties,
                                                                           armRetentionEventDateProcessor,
-                                                                          logApi);
+                                                                          logApi,
+                                                                          lockService);
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
     }
@@ -317,10 +318,10 @@ public class ManualTaskService {
     private void addGenerateCaseDocumentToTaskRegistrar() {
         var manualTask = new GenerateCaseDocumentAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             automatedTaskProcessorFactory,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -341,10 +342,10 @@ public class ManualTaskService {
     private void addEventHandler() {
         var manualTask = new CleanupCurrentEventTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             automatedTaskProcessorFactory,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/ManualTaskService.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/ManualTaskService.java
@@ -85,7 +85,6 @@ public class ManualTaskService {
     private final UnstructuredToArmBatchProcessor unstructuredToArmBatchProcessor;
     private final UnstructuredToArmProcessor unstructuredToArmProcessor;
 
-    private final LockProvider lockProvider;
     private final LogApi logApi;
     private final LockService lockService;
 
@@ -330,10 +329,10 @@ public class ManualTaskService {
     private void addRemoveDuplicateEventsToTaskRegistrar() {
         var manualTask = new RemoveDuplicatedEventsAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             removeDuplicateEventsProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -354,10 +353,10 @@ public class ManualTaskService {
     private void addInboundTranscriptionAndAnnotationDeleterRegistrar() {
         var manualTask = new InboundAnnotationTranscriptionDeleterAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             inboundAnnotationTranscriptionDeleterProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -366,10 +365,10 @@ public class ManualTaskService {
     private void addUnstructuredTranscriptionAndAnnotationDeleterRegistrar() {
         var manualTask = new UnstructuredAnnotationTranscriptionDeleterAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             unstructuredTranscriptionAndAnnotationDeleterProcessor,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);
@@ -378,10 +377,10 @@ public class ManualTaskService {
     private void addGenerateCaseDocumentForRetentionDateToTaskRegistrar() {
         var manualTask = new GenerateCaseDocumentForRetentionDateAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             automatedTaskConfigurationProperties,
             automatedTaskProcessorFactory,
-            logApi
+            logApi,
+            lockService
         );
         manualTask.setManualTask();
         automatedTasks.add(manualTask);

--- a/src/main/resources/openapi/dailylist.yaml
+++ b/src/main/resources/openapi/dailylist.yaml
@@ -470,6 +470,7 @@ components:
         - "DAILYLIST_104"
         - "DAILYLIST_105"
         - "DAILYLIST_106"
+        - "DAILYLIST_107"
       x-enum-varnames: [
         FAILED_TO_PROCESS_DAILYLIST,
         XML_OR_JSON_NEEDS_TO_BE_PROVIDED,

--- a/src/main/resources/openapi/dailylist.yaml
+++ b/src/main/resources/openapi/dailylist.yaml
@@ -98,6 +98,16 @@ paths:
                 type: "COMMON_100"
                 title: "Provided courthouse does not exist"
                 status: 400
+        '409':
+          description: Daily list already processing
+          content:
+            application/json+problem:
+              schema:
+                $ref: './problem.yaml'
+              example:
+                type: "DAILYLIST_106"
+                title: "Daily list already processing"
+                status: 400
         '500':
           description: Internal Server Error
           content:
@@ -467,7 +477,8 @@ components:
         DAILY_LIST_NOT_FOUND,
         INTERNAL_ERROR,
         INVALID_SOURCE_SYSTEM,
-        MISSING_SYSTEM_USER ]
+        MISSING_SYSTEM_USER,
+        DAILY_LIST_ALREADY_PROCESSING ]
 
     DailyListTitleErrors:
       type: string
@@ -479,6 +490,7 @@ components:
         - "An Internal Server Error has occurred."
         - "Invalid source system. Should be CPP or XHB."
         - "Failed to find user to process daily list."
+        - "Daily list already processing"
       x-enum-varnames: [
         FAILED_TO_PROCESS_DAILYLIST,
         XML_OR_JSON_NEEDS_TO_BE_PROVIDED,
@@ -486,4 +498,5 @@ components:
         DAILY_LIST_NOT_FOUND,
         INTERNAL_ERROR,
         INVALID_SOURCE_SYSTEM,
-        MISSING_SYSTEM_USER ]
+        MISSING_SYSTEM_USER,
+        DAILY_LIST_ALREADY_PROCESSING ]

--- a/src/test/java/uk/gov/hmcts/darts/dailylist/controller/DailyListProcessEndpointTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/dailylist/controller/DailyListProcessEndpointTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.darts.dailylist.service.DailyListProcessor;
+import uk.gov.hmcts.darts.task.api.AutomatedTasksApi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -19,18 +20,20 @@ class DailyListProcessEndpointTest {
     private DailyListController controller;
     @Mock
     private DailyListProcessor processor;
+    @Mock
+    private AutomatedTasksApi automatedTasksApi;
 
     @Test
     void dailyListRun() {
         ResponseEntity<Void> response = controller.dailylistsRunPost(null);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        Mockito.verify(processor, Mockito.timeout(100).times(1)).processAllDailyLists();
+        Mockito.verify(processor, Mockito.timeout(100).times(1)).processAllDailyListsWithLock(null);
     }
 
     @Test
     void dailyListRunWithCourthouse() {
         ResponseEntity<Void> response = controller.dailylistsRunPost("Swansea");
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        Mockito.verify(processor, Mockito.timeout(100).times(1)).processAllDailyListForListingCourthouse("Swansea");
+        Mockito.verify(processor, Mockito.timeout(100).times(1)).processAllDailyListsWithLock("Swansea");
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListProcessorImplTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.dailylist.enums.JobStatusType;
 import uk.gov.hmcts.darts.dailylist.enums.SourceType;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.log.util.DailyListLogJobReport;
+import uk.gov.hmcts.darts.task.api.AutomatedTasksApi;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -49,12 +50,14 @@ class DailyListProcessorImplTest {
     private DailyListEntity latestDailyListEntityForLeeds;
     @Mock
     private LogApi logApi;
+    @Mock
+    private AutomatedTasksApi automatedTasksApi;
 
     private DailyListProcessorImpl dailyListProcessor;
 
     @BeforeEach
     void setUp() {
-        dailyListProcessor = new DailyListProcessorImpl(dailyListRepository, dailyListUpdater, logApi);
+        dailyListProcessor = new DailyListProcessorImpl(dailyListRepository, dailyListUpdater, logApi, automatedTasksApi);
         setCourthouseForStubs("Swansea", dailyListEntityForSwansea);
         setCourthouseForStubs(
             "Leeds",

--- a/src/test/java/uk/gov/hmcts/darts/dailylist/service/impl/ProcessAllDailyListsTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/dailylist/service/impl/ProcessAllDailyListsTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.common.entity.DailyListEntity;
 import uk.gov.hmcts.darts.common.repository.DailyListRepository;
 import uk.gov.hmcts.darts.dailylist.enums.SourceType;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.api.AutomatedTasksApi;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -47,10 +48,12 @@ class ProcessAllDailyListsTest {
     private DailyListEntity latestDailyListForLeeds;
     @Mock
     private LogApi logApi;
+    @Mock
+    private AutomatedTasksApi automatedTasksApi;
 
     @BeforeEach
     void setUp() {
-        dailyListProcessor = new DailyListProcessorImpl(dailyListRepository, dailyListUpdater, logApi);
+        dailyListProcessor = new DailyListProcessorImpl(dailyListRepository, dailyListUpdater, logApi, automatedTasksApi);
         setCourthouseForStubs("Swansea", dailyListForSwansea);
         setCourthouseForStubs("Leeds",
                               oldestDailyListForLeeds,

--- a/src/test/java/uk/gov/hmcts/darts/task/api/impl/AutomatedTasksApiImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/api/impl/AutomatedTasksApiImplTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.darts.task.api.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.task.service.LockService;
+
+@ExtendWith(MockitoExtension.class)
+class AutomatedTasksApiImplTest {
+
+    @InjectMocks
+    private AutomatedTasksApiImpl automatedTasksApi;
+
+    @Mock
+    private AutomatedTaskRepository automatedTaskRepository;
+
+    @Mock
+    private LockService lockService;
+
+    @Test
+    void getTaskByName() {
+        var taskName = "TestTask";
+        automatedTasksApi.getTaskByName(taskName);
+        Mockito.verify(automatedTaskRepository).findByTaskName(taskName);
+    }
+
+    @Test
+    void isLocked() {
+        AutomatedTaskEntity automatedTaskEntity = new AutomatedTaskEntity();
+        automatedTasksApi.isLocked(automatedTaskEntity);
+        Mockito.verify(lockService).isLocked(automatedTaskEntity);
+    }
+
+    @Test
+    void getLockingTaskExecutor() {
+        automatedTasksApi.getLockingTaskExecutor();
+        Mockito.verify(lockService).getLockingTaskExecutor();
+    }
+
+    @Test
+    void getLockAtMostFor() {
+        automatedTasksApi.getLockAtMostFor();
+        Mockito.verify(lockService).getLockAtMostFor();
+    }
+
+    @Test
+    void getLockAtLeastFor() {
+        automatedTasksApi.getLockAtLeastFor();
+        Mockito.verify(lockService).getLockAtLeastFor();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,25 +7,26 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.retention.service.ApplyRetentionProcessor;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 @ExtendWith(MockitoExtension.class)
 class ApplyRetentionAutomatedTaskTest {
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private ApplyRetentionProcessor applyRetentionProcessor;
     @Mock
     private LogApi logApi;
+    @Mock
+    private LockService lockService;
 
     @Test
     void runTask() {
         ApplyRetentionAutomatedTask applyRetentionAutomatedTaskTest =
             new ApplyRetentionAutomatedTask(
                 null,
-                lockProvider,
                 null,
                 applyRetentionProcessor,
-                logApi
+                logApi,
+                lockService
             );
 
         applyRetentionAutomatedTaskTest.runTask();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionCaseAssociatedObjectsAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ApplyRetentionCaseAssociatedObjectsAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,16 +7,17 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.retention.service.ApplyRetentionCaseAssociatedObjectsProcessor;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 @ExtendWith(MockitoExtension.class)
 class ApplyRetentionCaseAssociatedObjectsAutomatedTaskTest {
 
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private ApplyRetentionCaseAssociatedObjectsProcessor applyRetentionCaseAssociatedObjectsProcessor;
     @Mock
     private LogApi logApi;
+    @Mock
+    private LockService lockService;
 
 
     @Test
@@ -25,10 +25,10 @@ class ApplyRetentionCaseAssociatedObjectsAutomatedTaskTest {
         ApplyRetentionCaseAssociatedObjectsAutomatedTask task =
             new ApplyRetentionCaseAssociatedObjectsAutomatedTask(
                 null,
-                lockProvider,
                 null,
                 applyRetentionCaseAssociatedObjectsProcessor,
-                logApi
+                logApi,
+                lockService
             );
 
         task.runTask();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ArmRetentionEventDateCalculatorAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ArmRetentionEventDateCalculatorAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,26 +7,27 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.arm.service.ArmRetentionEventDateProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 @ExtendWith(MockitoExtension.class)
 class ArmRetentionEventDateCalculatorAutomatedTaskTest {
 
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private ArmRetentionEventDateProcessor armRetentionEventDateProcessor;
     @Mock
     private LogApi logApi;
+    @Mock
+    private LockService lockService;
 
     @Test
     void runTask() {
         ArmRetentionEventDateCalculatorAutomatedTask armRetentionEventDateCalculatorAutomatedTask =
             new ArmRetentionEventDateCalculatorAutomatedTask(
                 null,
-                lockProvider,
                 null,
                 armRetentionEventDateProcessor,
-                logApi
+                logApi,
+                lockService
             );
 
         armRetentionEventDateCalculatorAutomatedTask.runTask();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CleanCurrentEventTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CleanCurrentEventTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,6 +9,7 @@ import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.event.service.CleanupCurrentFlagEventProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 import java.util.Optional;
 
@@ -22,13 +22,13 @@ class CleanCurrentEventTaskTest {
 
     public static final int BATCH_SIZE = 50;
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private AutomatedTaskProcessorFactory factory;
     @Mock
     private CleanupCurrentFlagEventProcessor processor;
     @Mock
     private LogApi logApi;
+    @Mock
+    private LockService lockService;
     @Mock
     private AutomatedTaskRepository automatedTaskRepository;
 
@@ -40,10 +40,10 @@ class CleanCurrentEventTaskTest {
         when(factory.createCleanupCurrentFlagEventProcessor(BATCH_SIZE)).thenReturn(processor);
         CleanupCurrentEventTask task = new CleanupCurrentEventTask(
             automatedTaskRepository,
-            lockProvider,
             null,
             factory,
-            logApi
+            logApi,
+            lockService
         );
 
         task.runTask();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CleanupArmResponseFilesAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CleanupArmResponseFilesAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,26 +7,27 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.arm.service.CleanupArmResponseFilesService;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 @ExtendWith(MockitoExtension.class)
 class CleanupArmResponseFilesAutomatedTaskTest {
 
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private CleanupArmResponseFilesService cleanupArmResponseFilesService;
     @Mock
     private LogApi logApi;
+    @Mock
+    private LockService lockService;
 
 
     @Test
     void runTask() {
         CleanupArmResponseFilesAutomatedTask cleanupArmResponseFilesAutomatedTask = new CleanupArmResponseFilesAutomatedTask(
                 null,
-                lockProvider,
                 null,
                 cleanupArmResponseFilesService,
-                logApi
+                logApi,
+                lockService
         );
 
         cleanupArmResponseFilesAutomatedTask.runTask();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/DailyListHouseKeepingAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/DailyListHouseKeepingAutomatedTaskTest.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.dailylist.service.DailyListService;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,21 +15,22 @@ import static org.mockito.Mockito.verify;
 class DailyListHouseKeepingAutomatedTaskTest {
 
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private DailyListService dailyListService;
 
     @Mock
     private LogApi logApi;
 
+    @Mock
+    private LockService lockService;
+
     @Test
     void runTask() {
         var dailyListAutomatedTask = new DailyListAutomatedTask(
                 null,
-                lockProvider,
                 null,
                 dailyListService,
-                logApi
+                logApi,
+                lockService
         );
 
         dailyListAutomatedTask.runTask();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ExternalDataStoreDeleterAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ExternalDataStoreDeleterAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,13 +9,10 @@ import uk.gov.hmcts.darts.audio.deleter.impl.inbound.ExternalInboundDataStoreDel
 import uk.gov.hmcts.darts.audio.deleter.impl.outbound.ExternalOutboundDataStoreDeleter;
 import uk.gov.hmcts.darts.audio.deleter.impl.unstructured.ExternalUnstructuredDataStoreDeleter;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 @ExtendWith(MockitoExtension.class)
 class ExternalDataStoreDeleterAutomatedTaskTest {
-
-
-    @Mock
-    LockProvider provider;
 
     @Mock
     private ExternalInboundDataStoreDeleter inboundDeleter;
@@ -30,11 +26,16 @@ class ExternalDataStoreDeleterAutomatedTaskTest {
     @Mock
     private LogApi logApi;
 
+    @Mock
+    private LockService lockService;
+
     @Test
     void runTask() {
         ExternalDataStoreDeleterAutomatedTask externalDataStoreDeleterAutomatedTask =
             new ExternalDataStoreDeleterAutomatedTask(
-                null, provider, null, inboundDeleter, unstructuredDeleter, outboundDeleter, logApi);
+                null,null, inboundDeleter,
+                unstructuredDeleter, outboundDeleter, logApi, lockService
+            );
 
         externalDataStoreDeleterAutomatedTask.runTask();
 

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCourtCaseDocumentAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCourtCaseDocumentAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,6 +9,7 @@ import uk.gov.hmcts.darts.casedocument.service.GenerateCaseDocumentProcessor;
 import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 import java.util.Optional;
 
@@ -22,13 +22,13 @@ class GenerateCourtCaseDocumentAutomatedTaskTest {
 
     public static final int BATCH_SIZE = 50;
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private AutomatedTaskProcessorFactory factory;
     @Mock
     private GenerateCaseDocumentProcessor processor;
     @Mock
     private LogApi logApi;
+    @Mock
+    private LockService lockService;
     @Mock
     private AutomatedTaskRepository automatedTaskRepository;
 
@@ -40,10 +40,10 @@ class GenerateCourtCaseDocumentAutomatedTaskTest {
         when(factory.createGenerateCaseDocumentProcessor(BATCH_SIZE)).thenReturn(processor);
         GenerateCaseDocumentAutomatedTask task = new GenerateCaseDocumentAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 null,
                 factory,
-                logApi
+                logApi,
+                lockService
         );
 
         task.runTask();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCourtCaseDocumentForRetentionDateAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/GenerateCourtCaseDocumentForRetentionDateAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,6 +9,7 @@ import uk.gov.hmcts.darts.casedocument.service.GenerateCaseDocumentForRetentionD
 import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 import java.util.Optional;
 
@@ -22,13 +22,13 @@ class GenerateCourtCaseDocumentForRetentionDateAutomatedTaskTest {
 
     public static final int BATCH_SIZE = 50;
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private AutomatedTaskProcessorFactory factory;
     @Mock
     private GenerateCaseDocumentForRetentionDateProcessor processor;
     @Mock
     private LogApi logApi;
+    @Mock
+    private LockService lockService;
     @Mock
     private AutomatedTaskRepository automatedTaskRepository;
 
@@ -40,10 +40,10 @@ class GenerateCourtCaseDocumentForRetentionDateAutomatedTaskTest {
         when(factory.createGenerateCaseDocumentForRetentionDateProcessor(BATCH_SIZE)).thenReturn(processor);
         GenerateCaseDocumentForRetentionDateAutomatedTask task = new GenerateCaseDocumentForRetentionDateAutomatedTask(
             automatedTaskRepository,
-            lockProvider,
             null,
             factory,
-            logApi
+            logApi,
+            lockService
         );
 
         task.runTask();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/InboundAnnotationTranscriptionDeleterAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/InboundAnnotationTranscriptionDeleterAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,17 +9,19 @@ import uk.gov.hmcts.darts.arm.service.InboundAnnotationTranscriptionDeleterProce
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 @ExtendWith(MockitoExtension.class)
 class InboundAnnotationTranscriptionDeleterAutomatedTaskTest {
-    @Mock
-    private LockProvider lockProvider;
 
     @Mock
     private InboundAnnotationTranscriptionDeleterProcessor armResponseFilesProcessor;
 
     @Mock
     private LogApi logApi;
+
+    @Mock
+    private LockService lockService;
 
     @Mock
     private AutomatedTaskRepository automatedTaskRepository;
@@ -33,10 +34,10 @@ class InboundAnnotationTranscriptionDeleterAutomatedTaskTest {
         // given
         InboundAnnotationTranscriptionDeleterAutomatedTask unstructuredAnnotationTranscriptionDeleterAutomatedTask
             = new InboundAnnotationTranscriptionDeleterAutomatedTask(automatedTaskRepository,
-                                                                          lockProvider,
-                                                                          automatedTaskConfigurationProperties,
-                                                                          armResponseFilesProcessor,
-                                                                          logApi);
+                                                                     automatedTaskConfigurationProperties,
+                                                                     armResponseFilesProcessor,
+                                                                     logApi,
+                                                                     lockService);
         // when
         unstructuredAnnotationTranscriptionDeleterAutomatedTask.runTask();
 

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/OutboundAudioDeleterAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/OutboundAudioDeleterAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -8,6 +7,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.audio.service.OutboundAudioDeleterProcessor;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 @ExtendWith(MockitoExtension.class)
 class OutboundAudioDeleterAutomatedTaskTest {
@@ -16,15 +16,15 @@ class OutboundAudioDeleterAutomatedTaskTest {
     OutboundAudioDeleterProcessor processor;
 
     @Mock
-    LockProvider provider;
+    private LogApi logApi;
 
     @Mock
-    private LogApi logApi;
+    private LockService lockService;
 
     @Test
     void runTask() {
         OutboundAudioDeleterAutomatedTask outboundAudioDeleterAutomatedTask =
-            new OutboundAudioDeleterAutomatedTask(null, provider, null, processor, logApi);
+            new OutboundAudioDeleterAutomatedTask(null, null, processor, logApi, lockService);
 
         outboundAudioDeleterAutomatedTask.runTask();
 

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ProcessArmResponseFilesAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ProcessArmResponseFilesAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -11,6 +10,7 @@ import uk.gov.hmcts.darts.arm.service.impl.ArmResponseFilesProcessorImpl;
 import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 import java.util.Optional;
 
@@ -19,8 +19,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ProcessArmResponseFilesAutomatedTaskTest {
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private ArmResponseFilesProcessorImpl armResponseFilesProcessor;
     @Mock
     private LogApi logApi;
@@ -28,6 +26,8 @@ class ProcessArmResponseFilesAutomatedTaskTest {
     private AutomatedTaskRepository automatedTaskRepository;
     @Mock
     private AutomatedTaskProcessorFactory processorFactory;
+    @Mock
+    private LockService lockService;
 
     @Test
     void runTask() {
@@ -39,10 +39,10 @@ class ProcessArmResponseFilesAutomatedTaskTest {
         ProcessArmResponseFilesAutomatedTask processArmResponseFilesAutomatedTask =
             new ProcessArmResponseFilesAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 null,
                 processorFactory,
-                logApi
+                logApi,
+                lockService
             );
 
         when(automatedTaskRepository.findByTaskName("ProcessArmResponseFiles")).thenReturn(Optional.of(automatedTask));

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredAnnotationTranscriptionDeleterAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredAnnotationTranscriptionDeleterAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,17 +9,18 @@ import uk.gov.hmcts.darts.arm.service.UnstructuredTranscriptionAndAnnotationDele
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 @ExtendWith(MockitoExtension.class)
 class UnstructuredAnnotationTranscriptionDeleterAutomatedTaskTest {
-    @Mock
-    private LockProvider lockProvider;
-
     @Mock
     private UnstructuredTranscriptionAndAnnotationDeleterProcessor armResponseFilesProcessor;
 
     @Mock
     private LogApi logApi;
+
+    @Mock
+    private LockService lockService;
 
     @Mock
     private AutomatedTaskRepository automatedTaskRepository;
@@ -34,10 +34,10 @@ class UnstructuredAnnotationTranscriptionDeleterAutomatedTaskTest {
         // given
         UnstructuredAnnotationTranscriptionDeleterAutomatedTask unstructuredAnnotationTranscriptionDeleterAutomatedTask
             = new UnstructuredAnnotationTranscriptionDeleterAutomatedTask(automatedTaskRepository,
-                                                                          lockProvider,
                                                                           automatedTaskConfigurationProperties,
                                                                           armResponseFilesProcessor,
-                                                                          logApi);
+                                                                          logApi,
+                                                                          lockService);
         // when
         unstructuredAnnotationTranscriptionDeleterAutomatedTask.runTask();
 

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredToArmAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/UnstructuredToArmAutomatedTaskTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.runner.impl;
 
-import net.javacrumbs.shedlock.core.LockProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -12,6 +11,7 @@ import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
+import uk.gov.hmcts.darts.task.service.LockService;
 
 import java.util.Optional;
 
@@ -22,11 +22,11 @@ class UnstructuredToArmAutomatedTaskTest {
     @Mock
     private AutomatedTaskRepository automatedTaskRepository;
     @Mock
-    private LockProvider lockProvider;
-    @Mock
     private AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties;
     @Mock
     private LogApi logApi;
+    @Mock
+    private LockService lockService;
     @Mock
     UnstructuredToArmProcessorImpl unstructuredToArmProcessor;
     @Mock
@@ -41,11 +41,11 @@ class UnstructuredToArmAutomatedTaskTest {
         UnstructuredToArmAutomatedTask unstructuredToArmAutomatedTask =
             new UnstructuredToArmAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 unstructuredToArmBatchProcessor,
                 unstructuredToArmProcessor,
-                logApi
+                logApi,
+                lockService
             );
 
         when(automatedTaskRepository.findByTaskName("UnstructuredToArmDataStore")).thenReturn(Optional.of(automatedTask));
@@ -66,11 +66,11 @@ class UnstructuredToArmAutomatedTaskTest {
         UnstructuredToArmAutomatedTask unstructuredToArmAutomatedTask =
             new UnstructuredToArmAutomatedTask(
                 automatedTaskRepository,
-                lockProvider,
                 automatedTaskConfigurationProperties,
                 unstructuredToArmBatchProcessor,
                 unstructuredToArmProcessor,
-                logApi
+                logApi,
+                lockService
             );
 
         when(automatedTaskRepository.findByTaskName("UnstructuredToArmDataStore")).thenReturn(Optional.of(automatedTask));

--- a/src/test/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImplTest.java
@@ -1,0 +1,87 @@
+package uk.gov.hmcts.darts.task.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LockServiceImplTest {
+
+    @InjectMocks
+    private LockServiceImpl lockService;
+
+    @Mock
+    private AutomatedTaskRepository automatedTaskRepository;
+    @Mock
+    private CurrentTimeHelper currentTimeHelper;
+
+    @Test
+    void getLockingTaskExecutor() {
+    }
+
+    @Test
+    void getLockAtMostFor() {
+        assertEquals(Duration.ofSeconds(600), lockService.getLockAtMostFor());
+    }
+
+    @Test
+    void getLockAtLeastFor() {
+        assertEquals(Duration.ofSeconds(20), lockService.getLockAtLeastFor());
+    }
+
+    @Test
+    void isLockedTrue() {
+        OffsetDateTime someHoursAgo = OffsetDateTime.now().minusHours(5);
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(someHoursAgo);
+
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        when(automatedTaskRepository.findLockedUntilForTask(anyString())).thenReturn(List.of(timestamp));
+
+        var taskName = "TestTask";
+        var automatedTaskEntity = new AutomatedTaskEntity();
+        automatedTaskEntity.setTaskName(taskName);
+
+        assertTrue(lockService.isLocked(automatedTaskEntity));
+    }
+
+    @Test
+    void isLockedFalse() {
+        OffsetDateTime someHoursAhead = OffsetDateTime.now().plusHours(5);
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(someHoursAhead);
+
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+        when(automatedTaskRepository.findLockedUntilForTask(anyString())).thenReturn(List.of(timestamp));
+
+        var taskName = "TestTask";
+        var automatedTaskEntity = new AutomatedTaskEntity();
+        automatedTaskEntity.setTaskName(taskName);
+
+        assertFalse(lockService.isLocked(automatedTaskEntity));
+    }
+
+    @Test
+    void isLockedWhenNotSet() {
+        var taskName = "TestTask";
+        var automatedTaskEntity = new AutomatedTaskEntity();
+        automatedTaskEntity.setTaskName(taskName);
+        when(automatedTaskRepository.findLockedUntilForTask(anyString())).thenReturn(Collections.emptyList());
+        assertFalse(lockService.isLocked(automatedTaskEntity));
+    }
+}


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###

**Problem:**
The daily list can be trigger using the POST /dailylists/run endpoint. This endpoint is useful for running daily lists for a specific listing courthouse and is (or will be) locked down to SUPER_ADMIN only.

**Solution:**
Utilise the automated tasks locking mechanism when running the daily list processing, to ensure that it's not already locked by the automated task running on schedule or another manual execution.
- the results in calls to POST /dailylists/run getting a 409 response if the task is already locked, preventing concurrent executions.

**Implementation:**
Exposing some methods from the automated task package through an "api" interface.
Adding a LockService, exposed within the "api" package.
- used by the daily list controller to check if the task is locked
- used by the daily list processor to execute the task with a lock

Using the new LockService within the automated tasks
- to get the locking task executor
- to get the default lock times

**Additionally:**
- updating DarNotifyError constructor to call super
- using ConcurrentMap in SystemUserHelper - to fix a ConcurrentModificationException that was seen in the logs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
