### PR TITLE
DMP-3174: Align POST /admin/events/search response with LLD

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
@@ -99,11 +99,11 @@ class EventSearchControllerTest extends IntegrationBase {
             .andReturn();
 
         var response = json.from(mvcResult.getResponse().getContentAsString());
-        assertThat(response).hasJsonPathNumberValue("events[0].id");
-        assertThat(response).hasJsonPathStringValue("events[0].created_at");
-        assertThat(response).hasJsonPathNumberValue("events[0].courthouse.id");
-        assertThat(response).hasJsonPathStringValue("events[0].courthouse.display_name");
-        assertThat(response).hasJsonPathNumberValue("events[0].courtroom.id");
-        assertThat(response).hasJsonPathStringValue("events[0].courtroom.name");
+        assertThat(response).hasJsonPathNumberValue("[0].id");
+        assertThat(response).hasJsonPathStringValue("[0].created_at");
+        assertThat(response).hasJsonPathNumberValue("[0].courthouse.id");
+        assertThat(response).hasJsonPathStringValue("[0].courthouse.display_name");
+        assertThat(response).hasJsonPathNumberValue("[0].courtroom.id");
+        assertThat(response).hasJsonPathStringValue("[0].courtroom.name");
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/AdminEventSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/AdminEventSearchTest.java
@@ -44,7 +44,7 @@ class AdminEventSearchTest extends IntegrationBase {
             new AdminEventSearch()
                 .courthouseIds(courthouseIdsAssociatedWithEvents(persistedEvents)));
 
-        assertThat(eventSearchResults.getEvents())
+        assertThat(eventSearchResults)
             .extracting("id")
             .isEqualTo(idsOf(persistedEvents));
     }
@@ -59,7 +59,7 @@ class AdminEventSearchTest extends IntegrationBase {
             new AdminEventSearch()
                 .caseNumber(hearing.getCourtCase().getCaseNumber()));
 
-        assertThat(eventSearchResults.getEvents())
+        assertThat(eventSearchResults)
             .extracting("id")
             .isEqualTo(idsOf(persistedEventsForHearing));
     }
@@ -74,7 +74,7 @@ class AdminEventSearchTest extends IntegrationBase {
             new AdminEventSearch()
                 .courtroomName(courtRoom.getName()));
 
-        assertThat(eventSearchResults.getEvents())
+        assertThat(eventSearchResults)
             .extracting("id")
             .isEqualTo(idsOf(persistedEventsForCourtroom));
     }
@@ -92,7 +92,7 @@ class AdminEventSearchTest extends IntegrationBase {
                 .hearingStartAt(parse("2020-02-28")));
 
 
-        assertThat(eventSearchResults.getEvents())
+        assertThat(eventSearchResults)
             .extracting("id")
             .containsExactly(persistedEvents.get(2).getId());
     }
@@ -110,7 +110,7 @@ class AdminEventSearchTest extends IntegrationBase {
                 .hearingEndAt(parse("2020-01-28")));
 
 
-        assertThat(eventSearchResults.getEvents())
+        assertThat(eventSearchResults)
             .extracting("id")
             .containsExactly(persistedEvents.get(0).getId());
     }

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -17,7 +17,7 @@ import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.http.api.EventApi;
 import uk.gov.hmcts.darts.event.model.AdminEventSearch;
-import uk.gov.hmcts.darts.event.model.AdminSearchEventResponse;
+import uk.gov.hmcts.darts.event.model.AdminSearchEventResponseResult;
 import uk.gov.hmcts.darts.event.model.CourtLog;
 import uk.gov.hmcts.darts.event.model.CourtLogsPostRequestBody;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
@@ -156,7 +156,7 @@ public class EventsController implements EventApi {
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
-    public ResponseEntity<AdminSearchEventResponse> adminSearchEvents(AdminEventSearch adminEventSearch) {
+    public ResponseEntity<List<AdminSearchEventResponseResult>> adminSearchEvents(AdminEventSearch adminEventSearch) {
         var adminSearchEventResponse = eventSearchService.searchForEvents(adminEventSearch);
         return new ResponseEntity<>(adminSearchEventResponse, HttpStatus.OK);
     }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/EventSearchService.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/EventSearchService.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.darts.event.service;
 
 import uk.gov.hmcts.darts.event.model.AdminEventSearch;
-import uk.gov.hmcts.darts.event.model.AdminSearchEventResponse;
+import uk.gov.hmcts.darts.event.model.AdminSearchEventResponseResult;
+
+import java.util.List;
 
 public interface EventSearchService {
-    AdminSearchEventResponse searchForEvents(AdminEventSearch adminEventSearch);
+    List<AdminSearchEventResponseResult> searchForEvents(AdminEventSearch adminEventSearch);
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventSearchServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventSearchServiceImpl.java
@@ -3,14 +3,18 @@ package uk.gov.hmcts.darts.event.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.event.mapper.EventSearchMapper;
 import uk.gov.hmcts.darts.event.model.AdminEventSearch;
-import uk.gov.hmcts.darts.event.model.AdminSearchEventResponse;
+import uk.gov.hmcts.darts.event.model.AdminSearchEventResponseResult;
+import uk.gov.hmcts.darts.event.model.EventSearchResult;
 import uk.gov.hmcts.darts.event.service.EventSearchService;
+
+import java.util.List;
 
 import static uk.gov.hmcts.darts.event.exception.EventError.TOO_MANY_SEARCH_RESULTS;
 
@@ -26,8 +30,8 @@ public class EventSearchServiceImpl implements EventSearchService {
     private Integer maxResults;
 
     @Override
-    public AdminSearchEventResponse searchForEvents(AdminEventSearch adminEventSearch) {
-        var eventSearchResults = eventRepository.searchEventsFilteringOn(
+    public List<AdminSearchEventResponseResult> searchForEvents(AdminEventSearch adminEventSearch) {
+        Page<EventSearchResult> eventSearchResults = eventRepository.searchEventsFilteringOn(
             adminEventSearch.getCourthouseIds(),
             adminEventSearch.getCaseNumber(),
             adminEventSearch.getCourtroomName(),
@@ -43,10 +47,8 @@ public class EventSearchServiceImpl implements EventSearchService {
             );
         }
 
-        var adminSearchEventResponseResults = eventSearchResults.stream()
-            .map(evr -> eventSearchMapper.adminSearchEventResponseResultFrom(evr))
+        return eventSearchResults.stream()
+            .map(eventSearchMapper::adminSearchEventResponseResultFrom)
             .toList();
-
-        return new AdminSearchEventResponse().events(adminSearchEventResponseResults);
     }
 }

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -490,7 +490,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AdminSearchEventResponse'
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminSearchEventResponseResult'
 
         '400':
           description: Too many results
@@ -675,14 +677,6 @@ components:
           type: string
           format: date
           example: "2024-05-09"
-
-    AdminSearchEventResponse:
-      type: object
-      properties:
-        events:
-          type: array
-          items:
-            $ref: '#/components/schemas/AdminSearchEventResponseResult'
 
     AdminSearchEventResponseResult:
       type: object


### PR DESCRIPTION
# [DMP-3593](https://tools.hmcts.net/jira/browse/DMP-3593)

Align the POST /admin/events/search response with the [LLD](https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1739306630#AdminPortalLLDRetentionManagement-PATCH/admin/retention-policy-types/{id}) by eliminating the top-level "events" attribute.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
