### PR TITLE
DMP-3312: Simplify computing a checksum for streams that can be fully…

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/util/FileContentChecksum.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/util/FileContentChecksum.java
@@ -1,16 +1,12 @@
 package uk.gov.hmcts.darts.common.util;
 
-import com.google.common.hash.HashCode;
-import com.google.common.hash.Hashing;
-import com.google.common.io.ByteSource;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
+import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.security.DigestInputStream;
 
 import static org.apache.commons.codec.digest.DigestUtils.md5;
 
@@ -28,7 +24,7 @@ import static org.apache.commons.codec.digest.DigestUtils.md5;
 public class FileContentChecksum {
 
     /**
-     * @deprecated This implementation is not memory-efficient with large files, use calculate(DigestInputStream digestInputStream) instead.
+     * @deprecated This implementation is not memory-efficient with large files, use calculate(InputStream inputStream) instead.
      */
     @Deprecated
     public String calculate(byte[] bytes) {
@@ -40,18 +36,9 @@ public class FileContentChecksum {
         return encodeToString(md5(inputStream));
     }
 
-    /**
-     * Calculates the digest when the source data has already been consumed.
-     */
-    public String calculate(DigestInputStream digestInputStream) throws IOException {
-        return encodeToString(digestInputStream.getMessageDigest().digest());
-    }
-
     @SneakyThrows
     public String calculate(Path filePath) {
-        ByteSource byteSource = com.google.common.io.Files.asByteSource(filePath.toFile());
-        HashCode hc = byteSource.hash(Hashing.md5());
-        return encodeToString(hc.asBytes());
+        return calculate(new FileInputStream(filePath.toFile()));
     }
 
     protected String encodeToString(byte[] bytes) {

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.darts.audio.component.AddAudioRequestMapper;
 import uk.gov.hmcts.darts.audio.component.AudioBeingProcessedFromArchiveQuery;
 import uk.gov.hmcts.darts.audio.component.AudioMessageDigest;
 import uk.gov.hmcts.darts.audio.component.impl.AddAudioRequestMapperImpl;
-import uk.gov.hmcts.darts.audio.config.AudioConfiguration;
 import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
 import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.audio.service.AudioOperationService;
@@ -26,7 +25,6 @@ import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.MediaLinkedCaseHelper;
 import uk.gov.hmcts.darts.common.repository.CourtLogEventRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
@@ -43,8 +41,6 @@ import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.test.common.data.HearingTestData;
 
 import java.io.InputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -58,7 +54,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.darts.audio.exception.AudioApiError.FAILED_TO_UPLOAD_AUDIO_FILE;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings({"PMD.ExcessiveImports"})
@@ -133,24 +128,13 @@ class AudioUploadServiceImplTest {
             logApi,
             audioDigest,
             mediaLinkedCaseRepository);
-
     }
 
     @Test
     void addAudio() {
-
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance(AudioConfiguration.DEFAULT_ALGORITHM);
-        } catch (NoSuchAlgorithmException e) {
-            throw new DartsApiException(FAILED_TO_UPLOAD_AUDIO_FILE, e);
-        }
-        when(audioDigest.getMessageDigest()).thenReturn(digest);
-
         UserAccountEntity userAccount = new UserAccountEntity();
         userAccount.setId(10);
         when(userIdentity.getUserAccount()).thenReturn(userAccount);
-
 
         // Given
         HearingEntity hearingEntity = new HearingEntity();
@@ -375,15 +359,6 @@ class AudioUploadServiceImplTest {
         UserAccountEntity userAccount = new UserAccountEntity();
         userAccount.setId(10);
         when(userIdentity.getUserAccount()).thenReturn(userAccount);
-
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance(AudioConfiguration.DEFAULT_ALGORITHM);
-        } catch (NoSuchAlgorithmException e) {
-            throw new DartsApiException(FAILED_TO_UPLOAD_AUDIO_FILE, e);
-        }
-        when(audioDigest.getMessageDigest()).thenReturn(digest);
-
 
         MockMultipartFile audioFile = new MockMultipartFile(
             "addAudio",

--- a/src/test/java/uk/gov/hmcts/darts/common/util/FileContentChecksumTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/FileContentChecksumTest.java
@@ -5,12 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,13 +14,12 @@ import static uk.gov.hmcts.darts.test.common.TestUtils.getFile;
 @Slf4j
 class FileContentChecksumTest {
 
-    private static final String MD_5 = "MD5";
     private final FileContentChecksum checksum = new FileContentChecksum();
+
     private static final byte[] TEST_DATA = "test".getBytes(StandardCharsets.UTF_8);
     private static final String EXPECTED_STRING_MD5_CHECKSUM = "098f6bcd4621d373cade4e832627b4f6";
     private static final String EXPECTED_AUDIO_FILE_MD5_CHECKSUM = "3fb4b2be0d3c015a6532d02d464c4262";
     private static final String EXPECTED_AZURE_AUDIO_FILE_CHECKSUM = "4d544cc2ad7a6f899c6703d29598ff89";
-
 
     @Test
     void calculateFromBytes() {
@@ -33,43 +27,18 @@ class FileContentChecksumTest {
     }
 
     @Test
-    void calculateFromDigestInputStream() throws NoSuchAlgorithmException, IOException {
-        var md5Digest = MessageDigest.getInstance(MD_5);
-
-        ByteArrayInputStream testDataInputStream = new ByteArrayInputStream(TEST_DATA);
-
-        try (var digestInputStream = new DigestInputStream(testDataInputStream, md5Digest)) {
-            // The digest is based on what has been consumed from the stream, so we must first consume the entire stream before computing the digest.
-            digestInputStream.readAllBytes();
-            assertEquals(EXPECTED_STRING_MD5_CHECKSUM, checksum.calculate(digestInputStream));
-        }
-    }
-
-    @Test
-    void calculateFromDigestInputStreamUsingAudioFile() throws IOException, NoSuchAlgorithmException {
-        var md5Digest = MessageDigest.getInstance(MD_5);
+    void calculateFromInputStreamUsingAudioFile() {
         File audioFileTest = getFile("Tests/common/util/FileContentChecksum/testAudio.mp2");
-        String audioFileChecksum;
-        // file hashing with DigestInputStream
-        try (DigestInputStream digestInputStream = new DigestInputStream(Files.newInputStream(audioFileTest.toPath()), md5Digest)) {
-            digestInputStream.readAllBytes();
-            audioFileChecksum = checksum.calculate(digestInputStream);
-            log.info("audioFileChecksum {}", audioFileChecksum);
-        }
+        String audioFileChecksum = checksum.calculate(audioFileTest.toPath());
+
         assertEquals(EXPECTED_AUDIO_FILE_MD5_CHECKSUM, audioFileChecksum);
     }
 
     @Test
-    void calculateFromDigestInputStreamUsingAudioFileFromAzure() throws IOException, NoSuchAlgorithmException {
-        var md5Digest = MessageDigest.getInstance(MD_5);
+    void calculateFromInputStreamUsingAudioFileFromAzure() {
         File audioFileTest = getFile("Tests/common/util/FileContentChecksum/001b1423-1f94-4ce7-b3a8-1534eb18eb06");
-        String audioFileChecksum;
-        // file hashing with DigestInputStream
-        try (DigestInputStream digestInputStream = new DigestInputStream(Files.newInputStream(audioFileTest.toPath()), md5Digest)) {
-            digestInputStream.readAllBytes();
-            audioFileChecksum = checksum.calculate(digestInputStream);
-        }
-        log.info("audioFileChecksum 2 {}", audioFileChecksum);
+        String audioFileChecksum = checksum.calculate(audioFileTest.toPath());
+
         assertEquals(EXPECTED_AZURE_AUDIO_FILE_CHECKSUM, audioFileChecksum);
     }
 


### PR DESCRIPTION
This change is related to DMP-3312 and has arisen after a discussion with @mario-paniccia.

An `InputStream` may be wrapped with a `DigestInputStream`. This is convienient if we wish to compute a checkum at the same time as reading the stream for some other purpose (e.g. uploading the data to server).

However, for applications where it is acceptable to consume the entire stream only for the purpose of computing a checksum (e.g. in a verification check), then a simpler approach can be taken that avoids the boilerplate of wrapping the stream with a `DigestInputStream`.

This PR implements that simplification, and removes methods that accept a `DigestInputStream` as there are no current usages.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
