### PR TITLE
DMP-3649: Fixing event search 

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/AdminEventSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/AdminEventSearchTest.java
@@ -115,6 +115,19 @@ class AdminEventSearchTest extends IntegrationBase {
             .containsExactly(persistedEvents.get(0).getId());
     }
 
+    @Test
+    void treatsEmptyCourthouseIdListAsNull() {
+        var persistedEvents = given.persistedEvents(3);
+
+        var eventSearchResults = eventSearchService.searchForEvents(
+            new AdminEventSearch()
+                .courthouseIds(List.of()));
+
+        assertThat(eventSearchResults)
+            .extracting("id")
+            .isEqualTo(idsOf(persistedEvents));
+    }
+
 
     private static List<Integer> idsOf(List<EventEntity> persistedEvents) {
         return persistedEvents.stream().map(EventEntity::getId).toList();

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventSearchServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventSearchServiceImpl.java
@@ -21,6 +21,7 @@ import static uk.gov.hmcts.darts.event.exception.EventError.TOO_MANY_SEARCH_RESU
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@SuppressWarnings({"squid:S1168"})
 public class EventSearchServiceImpl implements EventSearchService {
 
     private final EventRepository eventRepository;

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventSearchServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventSearchServiceImpl.java
@@ -32,7 +32,7 @@ public class EventSearchServiceImpl implements EventSearchService {
     @Override
     public List<AdminSearchEventResponseResult> searchForEvents(AdminEventSearch adminEventSearch) {
         Page<EventSearchResult> eventSearchResults = eventRepository.searchEventsFilteringOn(
-            adminEventSearch.getCourthouseIds(),
+            getNonEmptyOrNull(adminEventSearch.getCourthouseIds()),
             adminEventSearch.getCaseNumber(),
             adminEventSearch.getCourtroomName(),
             adminEventSearch.getHearingStartAt(),
@@ -50,5 +50,12 @@ public class EventSearchServiceImpl implements EventSearchService {
         return eventSearchResults.stream()
             .map(eventSearchMapper::adminSearchEventResponseResultFrom)
             .toList();
+    }
+
+    private static List<Integer> getNonEmptyOrNull(List<Integer> integerList) {
+        if (integerList != null && integerList.isEmpty()) {
+           return null;
+        }
+        return integerList;
     }
 }


### PR DESCRIPTION
Fixing event search when the courthouse id array is empty in the request 

https://tools.hmcts.net/jira/browse/DMP-3649


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
