### PR TITLE
DMP-3614: Utilise io streams for file upload to outbound storage for ATS

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/datamanagement/DataManagementServiceTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/datamanagement/DataManagementServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.datamanagement;
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.models.BlobStorageException;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,6 +16,7 @@ import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.exception.FileNotDownloadedException;
+import uk.gov.hmcts.darts.datamanagement.model.BlobClientUploadResponse;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
 
 import java.io.ByteArrayInputStream;
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -117,10 +118,10 @@ class DataManagementServiceTest {
         byte[] testStringInBytes = TEST_BINARY_STRING.getBytes(StandardCharsets.UTF_8);
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(testStringInBytes);
 
-        var uuid = dataManagementService.saveBlobData(unstructuredStorageContainerName, byteArrayInputStream);
+        BlobClientUploadResponse blobClientUploadResponse = dataManagementService.saveBlobData(unstructuredStorageContainerName, byteArrayInputStream);
 
-        assertTrue(uuid instanceof UUID);
-        assertTrue(StringUtils.isNotEmpty(uuid.toString()));
+        assertNotNull(blobClientUploadResponse.getBlobName());
+        assertNotNull(blobClientUploadResponse.getBlobSize());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/service/TransientObjectDirectoryServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/service/TransientObjectDirectoryServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.common.service;
 
-import com.azure.storage.blob.BlobClientBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
@@ -12,6 +11,7 @@ import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,10 +36,7 @@ class TransientObjectDirectoryServiceTest extends IntegrationBase {
         var mediaRequestEntity1 = dartsDatabase.createAndLoadOpenMediaRequestEntity(requestor, AudioRequestType.DOWNLOAD);
 
         MediaRequestEntity mediaRequestEntity = mediaRequestService.getMediaRequestEntityById(mediaRequestEntity1.getId());
-        String blodId = "f744a74f-83c0-47e4-8bb2-2fd4d2b68647";
-        BlobClientBuilder blobClientBuilder = new BlobClientBuilder();
-        blobClientBuilder.blobName(blodId);
-        blobClientBuilder.endpoint("http://127.0.0.1:10000/devstoreaccount1");
+        UUID blobId = UUID.fromString("f744a74f-83c0-47e4-8bb2-2fd4d2b68647");
 
         TransformedMediaEntity transformedMediaEntity = transformedMediaHelper.createTransformedMediaEntity(
             mediaRequestEntity,
@@ -50,14 +47,14 @@ class TransientObjectDirectoryServiceTest extends IntegrationBase {
         );
         TransientObjectDirectoryEntity transientObjectDirectoryEntity = transientObjectDirectoryService.saveTransientObjectDirectoryEntity(
             transformedMediaEntity,
-            blobClientBuilder.buildClient()
+            blobId
         );
 
         assertNotNull(transientObjectDirectoryEntity);
         assertTrue(transientObjectDirectoryEntity.getId() > 0);
         assertEquals(mediaRequestEntity1.getId(), transientObjectDirectoryEntity.getTransformedMedia().getMediaRequest().getId());
         assertEquals(STORED.getId(), transientObjectDirectoryEntity.getStatus().getId());
-        assertEquals(blodId, transientObjectDirectoryEntity.getExternalLocation().toString());
+        assertEquals(blobId, transientObjectDirectoryEntity.getExternalLocation());
         assertNull(transientObjectDirectoryEntity.getChecksum());
         assertTrue(transientObjectDirectoryEntity.getCreatedDateTime()
                        .isAfter(OffsetDateTime.parse("2023-07-06T16:00:00.000Z")));

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
@@ -4,6 +4,7 @@ import com.azure.core.http.rest.Response;
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobClientBuilder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,7 @@ import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.exception.DartsException;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.exception.FileNotDownloadedException;
+import uk.gov.hmcts.darts.datamanagement.model.BlobClientUploadResponse;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
 
 import java.io.File;
@@ -72,8 +74,16 @@ public class DataManagementServiceStubImpl implements DataManagementService {
     }
 
     @Override
-    public UUID saveBlobData(String containerName, InputStream inputStream) {
-        return saveBlobData();
+    public BlobClientUploadResponse saveBlobData(String containerName, InputStream inputStream, Map<String, String> metadata) {
+        return saveBlobData(containerName, inputStream);
+    }
+
+    @Override
+    public BlobClientUploadResponse saveBlobData(String containerName, InputStream inputStream) {
+        UUID blobName = saveBlobData();
+        long blobSize = 1000L; // Some arbitrary value
+
+        return new BlobClientUploadResponseStub(blobName, blobSize);
     }
 
     private UUID saveBlobData() {
@@ -152,4 +162,19 @@ public class DataManagementServiceStubImpl implements DataManagementService {
         log.warn("### This implementation is intended only for integration tests. If you see this log message elsewhere"
                      + " you should ask questions! ###");
     }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class BlobClientUploadResponseStub implements BlobClientUploadResponse {
+
+        private final UUID blobName;
+        private final Long blobSize;
+
+        @Override
+        public Map<String, String> addMetadata(Map<String, String> additionalMetadata) {
+            return additionalMetadata;
+        }
+
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
@@ -73,7 +73,8 @@ public class UnstructuredDataHelper {
     private UUID saveToUnstructuredDataStore(ExternalObjectDirectoryEntity eodEntity, InputStream inputStream) {
         UUID uuid = null;
         try {
-            uuid = dataManagementService.saveBlobData(dataManagementConfiguration.getUnstructuredContainerName(), inputStream);
+            uuid = dataManagementService.saveBlobData(dataManagementConfiguration.getUnstructuredContainerName(), inputStream)
+                .getBlobName();
             log.debug(
                 "Completed upload to unstructured data store for EOD {}. Successfully uploaded with blobId: {}",
                 eodEntity.getId(),

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -218,7 +218,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
                 );
 
                 try (InputStream inputStream = Files.newInputStream(generatedAudioFile.getPath())) {
-                    blobId = transformedMediaHelper.saveToStorage(mediaRequestEntity, BinaryData.fromStream(inputStream), fileName, generatedAudioFile);
+                    blobId = transformedMediaHelper.saveToStorage(mediaRequestEntity, inputStream, fileName, generatedAudioFile);
                 } catch (NoSuchFileException nsfe) {
                     log.error("No file found when trying to save to storage. {}", generatedAudioFile.getPath());
                     throw nsfe;

--- a/src/main/java/uk/gov/hmcts/darts/common/service/TransientObjectDirectoryService.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/TransientObjectDirectoryService.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.darts.common.service;
 
-import com.azure.storage.blob.BlobClient;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
+
+import java.util.UUID;
 
 public interface TransientObjectDirectoryService {
 
     TransientObjectDirectoryEntity saveTransientObjectDirectoryEntity(TransformedMediaEntity transformedMediaEntity,
-                                                                      BlobClient blobClient);
+                                                                      UUID blobName);
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/TransientObjectDirectoryServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/TransientObjectDirectoryServiceImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.common.service.impl;
 
-import com.azure.storage.blob.BlobClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
@@ -25,12 +24,12 @@ public class TransientObjectDirectoryServiceImpl implements TransientObjectDirec
 
     @Override
     public TransientObjectDirectoryEntity saveTransientObjectDirectoryEntity(TransformedMediaEntity transformedMediaEntity,
-                                                                             BlobClient blobClient) {
+                                                                             UUID blobName) {
 
         TransientObjectDirectoryEntity transientObjectDirectoryEntity = new TransientObjectDirectoryEntity();
         transientObjectDirectoryEntity.setTransformedMedia(transformedMediaEntity);
         transientObjectDirectoryEntity.setStatus(objectRecordStatusRepository.getReferenceById(STORED.getId()));
-        transientObjectDirectoryEntity.setExternalLocation(UUID.fromString(blobClient.getBlobName()));
+        transientObjectDirectoryEntity.setExternalLocation(blobName);
         transientObjectDirectoryEntity.setTransferAttempts(null);
         var systemUser = userAccountRepository.getReferenceById(SystemUsersEnum.DEFAULT.getId());
         transientObjectDirectoryEntity.setCreatedBy(systemUser);

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/api/DataManagementApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/api/DataManagementApi.java
@@ -5,6 +5,7 @@ import com.azure.storage.blob.BlobClient;
 import uk.gov.hmcts.darts.common.datamanagement.api.BlobContainerDownloadable;
 import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
+import uk.gov.hmcts.darts.datamanagement.model.BlobClientUploadResponse;
 
 import java.io.InputStream;
 import java.util.Map;
@@ -20,9 +21,9 @@ public interface DataManagementApi extends BlobContainerDownloadable {
 
     BlobClient saveBlobDataToContainer(BinaryData binaryData, DatastoreContainerType container, Map<String, String> metadata);
 
-    void addMetadata(BlobClient client, Map<String, String> metadata);
+    BlobClientUploadResponse saveBlobToContainer(InputStream inputStream, DatastoreContainerType container, Map<String, String> metadata);
 
-    void addMetadata(BlobClient client, String key, String value);
+    BlobClientUploadResponse saveBlobToContainer(InputStream inputStream, DatastoreContainerType container);
 
     void deleteBlobDataFromOutboundContainer(UUID blobId) throws AzureDeleteBlobException;
 

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/api/impl/DataManagementApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/api/impl/DataManagementApiImpl.java
@@ -12,10 +12,10 @@ import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.exception.FileNotDownloadedException;
+import uk.gov.hmcts.darts.datamanagement.model.BlobClientUploadResponse;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
 
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,19 +47,19 @@ public class DataManagementApiImpl implements DataManagementApi {
     public BlobClient saveBlobDataToContainer(BinaryData binaryData, DatastoreContainerType container, Map<String, String> metadata) {
         Optional<String> containerName = getContainerName(container);
         return containerName.map(s -> dataManagementService.saveBlobData(s, binaryData, metadata)).orElse(null);
-
     }
 
     @Override
-    public void addMetadata(BlobClient client, Map<String, String> metadata) {
-        dataManagementService.addMetaData(client, metadata);
+    public BlobClientUploadResponse saveBlobToContainer(InputStream inputStream, DatastoreContainerType container, Map<String, String> metadata) {
+        String containerName = getContainerName(container)
+            .orElseThrow(() -> new IllegalArgumentException("Container name cannot be resolved"));
+
+        return dataManagementService.saveBlobData(containerName, inputStream, metadata);
     }
 
     @Override
-    public void addMetadata(BlobClient client, String key, String value) {
-        Map<String, String> newMetadata = new HashMap<>();
-        newMetadata.put(key, value);
-        addMetadata(client, newMetadata);
+    public BlobClientUploadResponse saveBlobToContainer(InputStream inputStream, DatastoreContainerType container) {
+        return saveBlobToContainer(inputStream, container, null);
     }
 
     @Override
@@ -79,7 +79,7 @@ public class DataManagementApiImpl implements DataManagementApi {
 
     @Override
     public UUID saveBlobDataToInboundContainer(InputStream inputStream) {
-        return dataManagementService.saveBlobData(getInboundContainerName(), inputStream);
+        return dataManagementService.saveBlobData(getInboundContainerName(), inputStream).getBlobName();
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/model/BlobClientUploadResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/model/BlobClientUploadResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.darts.datamanagement.model;
+
+import java.util.Map;
+import java.util.UUID;
+
+public interface BlobClientUploadResponse {
+
+    UUID getBlobName();
+
+    Long getBlobSize();
+
+    Map<String, String> addMetadata(Map<String, String> additionalMetadata);
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/model/BlobClientUploadResponseImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/model/BlobClientUploadResponseImpl.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.darts.datamanagement.model;
+
+import com.azure.storage.blob.BlobClient;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A wrapper/facade around BlobClient to expose properties useful to upload callers.
+ */
+public class BlobClientUploadResponseImpl implements BlobClientUploadResponse {
+
+    private final BlobClient blobClient;
+
+    private Long blobSize;
+
+    public BlobClientUploadResponseImpl(BlobClient blobClient) {
+        this.blobClient = blobClient;
+    }
+
+    @Override
+    public UUID getBlobName() {
+        return UUID.fromString(blobClient.getBlobName());
+    }
+
+    @Override
+    public Long getBlobSize() {
+        // This triggers a network call via blobClient, so we only fetch it if we need to
+        if (blobSize == null) {
+            blobSize = blobClient.getProperties().getBlobSize();
+        }
+        return blobSize;
+    }
+
+    /**
+     * Retrospectively adds additional metadata to the uploaded blob.
+     *
+     * @param additionalMetadata Metadata to add to the blob
+     * @return A map containing all metadata applied to the blob.
+     */
+    public Map<String, String> addMetadata(Map<String, String> additionalMetadata) {
+        var metadata = new HashMap<>(blobClient.getProperties().getMetadata());
+        metadata.putAll(additionalMetadata);
+
+        // Triggers a network call via blobClient
+        blobClient.setMetadata(metadata);
+
+        return metadata;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementService.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.darts.common.datamanagement.component.impl.DownloadResponseM
 import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.datamanagement.exception.FileNotDownloadedException;
+import uk.gov.hmcts.darts.datamanagement.model.BlobClientUploadResponse;
 
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -20,7 +21,9 @@ public interface DataManagementService {
 
     UUID saveBlobData(String containerName, BinaryData binaryData);
 
-    UUID saveBlobData(String containerName, InputStream inputStream);
+    BlobClientUploadResponse saveBlobData(String containerName, InputStream inputStream, Map<String, String> metadata);
+
+    BlobClientUploadResponse saveBlobData(String containerName, InputStream inputStream);
 
     BlobClient saveBlobData(String containerName, BinaryData binaryData, Map<String, String> metadata);
 

--- a/src/test/java/uk/gov/hmcts/darts/casedocument/service/impl/GenerateCaseDocumentSingleCaseProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/casedocument/service/impl/GenerateCaseDocumentSingleCaseProcessorImplTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.arm.service.ExternalObjectDirectoryService;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.casedocument.model.CourtCaseDocument;
 import uk.gov.hmcts.darts.casedocument.service.CaseDocumentService;
+import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -24,8 +25,8 @@ import uk.gov.hmcts.darts.common.repository.CaseRepository;
 import uk.gov.hmcts.darts.common.service.impl.EodHelperMocks;
 import uk.gov.hmcts.darts.common.util.EodHelper;
 import uk.gov.hmcts.darts.common.util.FileContentChecksum;
-import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
-import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
+import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
+import uk.gov.hmcts.darts.datamanagement.model.BlobClientUploadResponseImpl;
 
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -61,9 +62,7 @@ class GenerateCaseDocumentSingleCaseProcessorImplTest {
     @Mock
     CaseDocumentService caseDocumentService;
     @Mock
-    DataManagementService dataManagementService;
-    @Mock
-    DataManagementConfiguration configuration;
+    DataManagementApi dataManagementApi;
     @Mock
     ExternalObjectDirectoryService externalObjectDirectoryService;
     @Mock
@@ -82,6 +81,8 @@ class GenerateCaseDocumentSingleCaseProcessorImplTest {
     CaseDocumentEntity caseDocumentEntity;
     @Mock
     CourtCaseEntity caseEntity;
+    @Mock
+    BlobClientUploadResponseImpl blobClientUploadResponseImpl;
 
     @Captor
     ArgumentCaptor<CaseDocumentEntity> caseDocumentCaptor;
@@ -95,7 +96,6 @@ class GenerateCaseDocumentSingleCaseProcessorImplTest {
 
     @BeforeEach
     void setup() {
-        when(configuration.getUnstructuredContainerName()).thenReturn(UNSTRUCTURED_CONTAINER_NAME);
         ReflectionTestUtils.setField(processor, "caseDocumentFilenamePrefix", FILE_NAME_PREFIX);
         ReflectionTestUtils.setField(processor, "caseDocumentFileExtension", FILE_EXTENSION);
     }
@@ -107,7 +107,8 @@ class GenerateCaseDocumentSingleCaseProcessorImplTest {
         // given
         when(caseDocumentService.generateCaseDocument(CASE_ID)).thenReturn(courtCaseDocument);
         when(objectMapper.writeValueAsString(courtCaseDocument)).thenReturn(CASE_DOCUMENT_JSON);
-        when(dataManagementService.saveBlobData(eq(UNSTRUCTURED_CONTAINER_NAME), any(InputStream.class))).thenReturn(UNSTRUCTURED_BLOB_UUID);
+        when(blobClientUploadResponseImpl.getBlobName()).thenReturn(UNSTRUCTURED_BLOB_UUID);
+        when(dataManagementApi.saveBlobToContainer(any(InputStream.class), eq(DatastoreContainerType.UNSTRUCTURED))).thenReturn(blobClientUploadResponseImpl);
         when(userIdentity.getUserAccount()).thenReturn(user);
         when(caseDocumentRepository.save(any())).thenReturn(caseDocumentEntity);
         when(checksumCalculator.calculate(any(InputStream.class))).thenReturn(CHECKSUM);

--- a/src/test/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImplTest.java
@@ -37,6 +37,7 @@ import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
 import uk.gov.hmcts.darts.datamanagement.exception.FileNotDownloadedException;
+import uk.gov.hmcts.darts.datamanagement.model.BlobClientUploadResponseImpl;
 import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
 
 import java.io.File;
@@ -93,6 +94,8 @@ class DataManagementFacadeImplTest {
     private BlobClient blobClient;
     @Mock
     private DownloadResponseMetaData downloadResponseMetaDataMock;
+    @Mock
+    private BlobClientUploadResponseImpl blobClientUploadResponseImpl;
 
     private ExternalLocationTypeEntity inboundLocationEntity;
     private ExternalLocationTypeEntity unstructuredLocationEntity;
@@ -573,9 +576,10 @@ class DataManagementFacadeImplTest {
 
     @Test
     void testUnstructuredDataHelperCreate() throws Exception {
+        when(blobClientUploadResponseImpl.getBlobName()).thenReturn(UUID.randomUUID());
 
         when(dataManagementConfiguration.getUnstructuredContainerName()).thenReturn("unstructured");
-        when(dataManagementService.saveBlobData((String) any(), (InputStream) any())).thenReturn(UUID.randomUUID());
+        when(dataManagementService.saveBlobData((String) any(), (InputStream) any())).thenReturn(blobClientUploadResponseImpl);
 
         UnstructuredDataHelper unstructuredDataHelperTest = getUnstructuredDataHelper();
 

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/model/BlobClientUploadResponseImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/model/BlobClientUploadResponseImplTest.java
@@ -1,0 +1,93 @@
+package uk.gov.hmcts.darts.datamanagement.model;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobProperties;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@ExtendWith(MockitoExtension.class)
+class BlobClientUploadResponseImplTest {
+
+    private BlobClientUploadResponseImpl blobClientUploadResponse;
+
+    @Mock
+    private BlobClient blobClient;
+    @Mock
+    private BlobProperties blobProperties;
+
+    @BeforeEach
+    void setUp() {
+        blobClientUploadResponse = new BlobClientUploadResponseImpl(blobClient);
+    }
+
+    @Test
+    void shouldReturnExpectedBlobName() {
+        // Given
+        final UUID someName = UUID.randomUUID();
+        Mockito.when(blobClient.getBlobName())
+            .thenReturn(someName.toString());
+
+        // When
+        UUID blobName = blobClientUploadResponse.getBlobName();
+
+        // Then
+        assertEquals(someName, blobName);
+    }
+
+    @Test
+    void shouldReturnExpectedBlobSizeAndOnlyInvokeClientOnce() {
+        // Given
+        Mockito.when(blobClient.getProperties())
+            .thenReturn(blobProperties);
+
+        final long someSize = 1000L;
+        Mockito.when(blobProperties.getBlobSize())
+            .thenReturn(someSize);
+
+        // When invoked multiple times
+        for (int i = 0; i < 2; i++) {
+            Long blobSize = blobClientUploadResponse.getBlobSize();
+
+            // Then
+            assertEquals(someSize, blobSize);
+        }
+
+        // And
+        Mockito.verify(blobClient, Mockito.times(1))
+            .getProperties();
+    }
+
+    @Test
+    void shouldAppendMetadataToExistingMetadataAndInvokeClient() {
+        // Given
+        Mockito.when(blobClient.getProperties())
+            .thenReturn(blobProperties);
+
+        Mockito.when(blobProperties.getMetadata())
+            .thenReturn(Map.of("someExistingKey", "someExistingValue"));
+
+        // When
+        Map<String, String> metadata = blobClientUploadResponse.addMetadata(Map.of("someAdditionalKey", "someAdditionalValue"));
+
+        // Then
+        Mockito.verify(blobClient, Mockito.times(1))
+            .setMetadata(metadata);
+
+        assertEquals(2, metadata.size());
+        MatcherAssert.assertThat(metadata, Matchers.hasEntry("someExistingKey", "someExistingValue"));
+        MatcherAssert.assertThat(metadata, Matchers.hasEntry("someAdditionalKey", "someAdditionalValue"));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.common.exception.DartsException;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
+import uk.gov.hmcts.darts.datamanagement.model.BlobClientUploadResponseImpl;
 import uk.gov.hmcts.darts.datamanagement.service.impl.DataManagementServiceImpl;
 import uk.gov.hmcts.darts.util.AzureCopyUtil;
 
@@ -89,15 +90,26 @@ class DataManagementServiceImplTest {
 
     @Test
     void testSaveBlobDataViaInputStream() {
-        when(dataManagementConfiguration.getBlobClientBlockSizeBytes()).thenReturn(1L);
-        when(dataManagementConfiguration.getBlobClientMaxSingleUploadSizeBytes()).thenReturn(1L);
-        when(dataManagementConfiguration.getBlobClientMaxConcurrency()).thenReturn(1);
-        when(dataManagementConfiguration.getBlobClientTimeout()).thenReturn(Duration.ofMinutes(1));
+        // Given
+        when(dataManagementConfiguration.getBlobClientBlockSizeBytes())
+            .thenReturn(1L);
+        when(dataManagementConfiguration.getBlobClientMaxSingleUploadSizeBytes())
+            .thenReturn(1L);
+        when(dataManagementConfiguration.getBlobClientMaxConcurrency())
+            .thenReturn(1);
+        when(dataManagementConfiguration.getBlobClientTimeout())
+            .thenReturn(Duration.ofMinutes(1));
+        when(dataManagementFactory.getBlobClient(any(), any()))
+            .thenReturn(blobClient);
+        when(blobClient.getBlobName())
+            .thenReturn(BLOB_ID.toString());
 
-        when(dataManagementFactory.getBlobContainerClient(BLOB_CONTAINER_NAME, serviceClient)).thenReturn(blobContainerClient);
-        when(dataManagementFactory.getBlobClient(any(), any())).thenReturn(blobClient);
-        UUID blobId = dataManagementService.saveBlobData(BLOB_CONTAINER_NAME, new ByteArrayInputStream(TEST_BINARY_STRING.getBytes()));
-        assertNotNull(blobId);
+        // When
+        BlobClientUploadResponseImpl blobClientUploadResponse = dataManagementService.saveBlobData(BLOB_CONTAINER_NAME,
+                                                                                                   new ByteArrayInputStream(TEST_BINARY_STRING.getBytes()));
+
+        // Then
+        assertEquals(BLOB_ID, blobClientUploadResponse.getBlobName());
     }
 
     @Test


### PR DESCRIPTION
# [DMP-3614](https://tools.hmcts.net/jira/browse/DMP-3614)

The root cause of this bug is an out of memory condition that occurs during ATS processing when transferring the processed audio file to outbound storage. This is due to usage of `BinaryData.fromStream()`, which reads the entire stream into memory.

`master` branch was locally profiled whilst ATS was processing a media file. For convenience, a low memory ceiling of 250MB (`-Xmx250m`) was set such that large objects on the heap would cause the application to OOM.

![Screenshot 2024-07-23 at 10 21 12](https://github.com/user-attachments/assets/db846938-1b1d-4102-9f26-bb68c847c504)

At the far right of the chart, the application fails with `java.lang.OutOfMemoryError: Java heap space` at the moment `BinaryData.fromStream()` is invoked, and the associated `media_request` remains "stuck" with `request_status==PROCESSING`.

`dmp-3614-ats-large-file-fix` was then profiled with the same memory constraint.

![Screenshot 2024-07-23 at 10 26 40](https://github.com/user-attachments/assets/4bc148cd-8164-4d6f-aa4e-3e0c212350c7)

The complete ATS flow succeeds, and the associated `media_request` progresses to `COMPLETED`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
