### PR TITLE
DMP-3673

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
@@ -81,7 +81,7 @@ class AuthorisationServiceTest extends IntegrationBase {
         dartsDatabase.getSecurityGroupRepository().saveAndFlush(globalSecurityGroup);
 
         UserAccountEntity judgeUserAccountGlobal = new UserAccountEntity();
-        judgeUserAccountGlobal.setSecurityGroupEntities(Set.of(globalSecurityGroup));
+        judgeUserAccountGlobal.setSecurityGroupEntities(Set.of(globalSecurityGroup, judgesSecurityGroup));
         judgeUserAccountGlobal.setUserName("Test Judge Global");
         judgeUserAccountGlobal.setUserFullName("Test Judge Global");
         judgeUserAccountGlobal.setEmailAddress(TEST_JUDGE_GLOBAL_EMAIL);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3673

### Change description ###

- globalAccess not set correctly if a non-global security group is associated with the role first
- to demonstrate the bug described in DMP-3673

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
