### PR TITLE
 DMP-3571-part2 removed no longer needed manual cleanup of test data …

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/AuthenticationControllerTest.java
@@ -42,7 +42,6 @@ class AuthenticationControllerTest extends IntegrationBase {
     @Test
     void testGetUserStateIsActive() throws Exception {
         UserAccountEntity userAccountEntity = superAdminUserStub.givenUserIsAuthorised(mockUserIdentity);
-        dartsDatabase.addToUserAccountTrash(userAccountEntity.getEmailAddress());
 
         MvcResult mvcResult = mockMvc.perform(
             get(ENDPOINT))
@@ -62,7 +61,6 @@ class AuthenticationControllerTest extends IntegrationBase {
     @Test
     void testGetUserStateAccountNotActive() throws Exception {
         UserAccountEntity userAccountEntity = superAdminUserStub.givenUserIsAuthorisedButInactive(mockUserIdentity);
-        dartsDatabase.addToUserAccountTrash(userAccountEntity.getEmailAddress());
 
         MvcResult mvcResult = mockMvc.perform(
                 get(ENDPOINT))

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.cases.controller;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -147,11 +146,6 @@ class CaseControllerAdminSearchTest extends IntegrationBase {
         setupUserAccountAndSecurityGroup();
 
 
-    }
-
-    @AfterEach
-    void deleteUser() {
-        dartsDatabase.addToUserAccountTrash(INTEGRATION_TEST_USER_EMAIL);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.cases.controller;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -142,11 +141,6 @@ class CaseControllerSearchPostTest extends IntegrationBase {
         dartsDatabase.saveAll(event4a, event5b);
 
         givenBearerTokenExists(INTEGRATION_TEST_USER_EMAIL);
-    }
-
-    @AfterEach
-    void deleteUser() {
-        dartsDatabase.addToUserAccountTrash(INTEGRATION_TEST_USER_EMAIL);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.cases.service;
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -41,7 +40,6 @@ import static uk.gov.hmcts.darts.test.common.data.DefendantTestData.createDefend
 import static uk.gov.hmcts.darts.test.common.data.EventTestData.createEventWith;
 import static uk.gov.hmcts.darts.test.common.data.HearingTestData.createHearingWithDefaults;
 import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createJudgeWithName;
-import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TEST_USER_EMAIL;
 
 @Slf4j
 @TestPropertySource(properties = {
@@ -174,11 +172,6 @@ class CaseServiceAdminSearchTest extends IntegrationBase {
         EventEntity event5b = createEventWith("eventName", "event5b", hearing5b, OffsetDateTime.now());
         dartsDatabase.saveAll(event4a, event5b);
         user = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
-    }
-
-    @AfterEach
-    void deleteUser() {
-        dartsDatabase.addToUserAccountTrash(INTEGRATION_TEST_USER_EMAIL);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.cases.service;
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -171,11 +170,6 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
 
         givenBearerTokenExists(INTEGRATION_TEST_USER_EMAIL);
         user = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
-    }
-
-    @AfterEach
-    void deleteUser() {
-        dartsDatabase.addToUserAccountTrash(INTEGRATION_TEST_USER_EMAIL);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchUseInterpreterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchUseInterpreterTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.cases.service;
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,11 +87,6 @@ class CaseServiceAdvancedSearchUseInterpreterTest extends IntegrationBase {
         givenBearerTokenExists(INTEGRATION_TEST_USER_EMAIL);
         user = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         user.getSecurityGroupEntities().clear();
-    }
-
-    @AfterEach
-    void deleteUser() {
-        dartsDatabase.addToUserAccountTrash(INTEGRATION_TEST_USER_EMAIL);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/CourthouseApiTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/CourthouseApiTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.common.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -50,7 +49,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
@@ -144,16 +142,6 @@ class CourthouseApiTest extends IntegrationBase {
         transactionTemplate = new TransactionTemplate(transactionManager);
         SecurityContextHolder.getContext()
             .setAuthentication(authentication);
-    }
-
-    @AfterEach
-    void tearDown() {
-        Set<SecurityGroupEntity> securityGroupsToBeDeleted = dartsDatabase.getSecurityGroupRepository()
-            .findAll()
-            .stream()
-            .filter(securityGroupEntity -> securityGroupEntity.getGroupName().contains("INT-TEST"))
-            .collect(Collectors.toSet());
-        dartsDatabase.addToTrash(securityGroupsToBeDeleted);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerPostEventsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerPostEventsTest.java
@@ -103,8 +103,6 @@ class EventsControllerPostEventsTest extends IntegrationBase {
 
         EventHandlerEntity eventType = persistedEvent.getEventType();
         Assertions.assertEquals("New Description", eventType.getEventName());
-
-        dartsDatabase.addToTrash(activeHandler, inactiveHandler);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
@@ -233,8 +233,6 @@ class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
     private UserAccountEntity givenATranscriberIsAuthorisedFor(CourthouseEntity courthouse) {
         var transcriber = buildUserWithRoleFor(TRANSCRIBER, courthouse);
         dartsDatabase.saveUserWithGroup(transcriber);
-        dartsDatabase.addToUserAccountTrash(transcriber.getEmailAddress());
-        dartsDatabase.addToTrash(transcriber.getSecurityGroupEntities());
         return transcriber;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/GivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/GivenBuilder.java
@@ -35,7 +35,6 @@ public class GivenBuilder {
         user.setEmailAddress(userEmail);
 
         dartsDatabase.addUserToGroup(user, securityGroup);
-        dartsDatabase.addToUserAccountTrash(userEmail);
 
         return user;
     }
@@ -48,7 +47,6 @@ public class GivenBuilder {
 
         var judge = minimalUserAccount();
         judge.setEmailAddress(userEmail);
-        dartsDatabase.addToUserAccountTrash(userEmail);
 
         dartsDatabase.addUserToGroup(judge, securityGroup);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -91,7 +91,6 @@ import uk.gov.hmcts.darts.dailylist.enums.SourceType;
 import uk.gov.hmcts.darts.notification.entity.NotificationEntity;
 import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
 import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
-import uk.gov.hmcts.darts.retentions.model.RetentionPolicyType;
 import uk.gov.hmcts.darts.test.common.data.AudioTestData;
 import uk.gov.hmcts.darts.test.common.data.CourthouseTestData;
 import uk.gov.hmcts.darts.test.common.data.DailyListTestData;
@@ -105,10 +104,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import static java.time.LocalDateTime.now;
@@ -207,11 +204,6 @@ public class DartsDatabaseStub {
     private final TranscriptionDocumentStub transcriptionDocumentStub;
     private final TransformedMediaStub transformedMediaStub;
     private final UserAccountStub userAccountStub;
-
-    private final List<EventHandlerEntity> eventHandlerBin = new ArrayList<>();
-    private final List<UserAccountEntity> userAccountBin = new ArrayList<>();
-    private final List<SecurityGroupEntity> securityGroupBin = new ArrayList<>();
-    private final List<RetentionPolicyTypeEntity> retentionPolicyTypeBin = new ArrayList<>();
 
     private final EntityManager entityManager;
     private final CurrentTimeHelper currentTimeHelper;
@@ -676,34 +668,6 @@ public class DartsDatabaseStub {
         save(mediaRequestEntity.getRequestor());
         save(mediaRequestEntity.getCurrentOwner());
         return save(mediaRequestEntity);
-    }
-
-    public void addToTrash(EventHandlerEntity... eventHandlerEntities) {
-        this.eventHandlerBin.addAll(asList(eventHandlerEntities));
-    }
-
-    public void addToTrash(RetentionPolicyType retentionPolicy) {
-        this.retentionPolicyTypeBin.add(
-            retentionPolicyTypeRepository.getReferenceById(retentionPolicy.getId()));
-    }
-
-    public void addToTrash(RetentionPolicyTypeEntity... retentionPolicyTypeEntities) {
-        this.retentionPolicyTypeBin.addAll(asList(retentionPolicyTypeEntities));
-    }
-
-    public void addToTrash(Set<SecurityGroupEntity> securityGroupEntities) {
-        this.securityGroupBin.addAll(securityGroupEntities);
-    }
-
-    public void addSecurityGroupToTrashById(Integer id) {
-        this.securityGroupBin.add(securityGroupRepository.getReferenceById(id));
-    }
-
-    //TODO remove
-    public void addToUserAccountTrash(String... emailAddresses) {
-        stream(emailAddresses)
-            .flatMap(email -> userAccountRepository.findByEmailAddressIgnoreCase(email).stream())
-            .forEach(userAccountBin::add);
     }
 
     public void createTestUserAccount() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchUserIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.usermanagement.controller;
 
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,11 +70,6 @@ class PatchUserIntTest extends IntegrationBase {
     @BeforeEach
     void setUp() {
         transactionTemplate = new TransactionTemplate(transactionManager);
-    }
-
-    @AfterEach
-    void deleteUser() {
-        dartsDatabase.addToUserAccountTrash(ORIGINAL_EMAIL_ADDRESS);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostUserIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PostUserIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.usermanagement.controller;
 
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -70,11 +69,6 @@ class PostUserIntTest extends IntegrationBase {
             .getIntegrationTestUserAccountEntity();
         Mockito.when(authorisationApi.getCurrentUser())
             .thenReturn(integrationTestUser);
-    }
-
-    @AfterEach
-    void deleteUser() {
-        dartsDatabase.addToUserAccountTrash(EMAIL_ADDRESS);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerSearchIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerSearchIntTest.java
@@ -232,8 +232,6 @@ class UserControllerSearchIntTest extends IntegrationBase {
 
         verify(userIdentity).userHasGlobalAccess(Set.of(SUPER_ADMIN, SUPER_USER));
         verifyNoMoreInteractions(userIdentity);
-
-        dartsDatabaseStub.addToUserAccountTrash(username1 + "@ex.com", username2 + "@ex.com");
     }
 
     @Test
@@ -262,8 +260,6 @@ class UserControllerSearchIntTest extends IntegrationBase {
 
         verify(userIdentity).userHasGlobalAccess(Set.of(SUPER_ADMIN, SUPER_USER));
         verifyNoMoreInteractions(userIdentity);
-
-        dartsDatabaseStub.addToUserAccountTrash(username1 + "@ex.com", username2 + "@ex.com");
     }
 
     @Test
@@ -292,8 +288,6 @@ class UserControllerSearchIntTest extends IntegrationBase {
 
         verify(userIdentity).userHasGlobalAccess(Set.of(SUPER_ADMIN, SUPER_USER));
         verifyNoMoreInteractions(userIdentity);
-
-        dartsDatabaseStub.addToUserAccountTrash(username1 + "@ex.com", username2 + "@ex.com");
     }
 
     private UserAccountEntity activeUserWithName(String name) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/RetentionPolicyAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/RetentionPolicyAuditTest.java
@@ -40,9 +40,6 @@ class RetentionPolicyAuditTest extends IntegrationBase {
 
         var retentionPolicyRevisions = dartsDatabase.findRetentionPolicyRevisionsFor(retentionPolicy.getId());
         assertThat(retentionPolicyRevisions.getLatestRevision().getMetadata().getRevisionType()).isEqualTo(INSERT);
-
-        // clean up
-        dartsDatabase.addToTrash(retentionPolicy);
     }
 
     @Test
@@ -70,10 +67,6 @@ class RetentionPolicyAuditTest extends IntegrationBase {
 
         var priorPolicyRevisions = dartsDatabase.findRetentionPolicyRevisionsFor(priorPolicyEntity.getId());
         assertThat(priorPolicyRevisions.getLatestRevision().getMetadata().getRevisionType()).isEqualTo(UPDATE);
-
-        // clean up
-        dartsDatabase.addToTrash(retentionPolicy);
-        dartsDatabase.addToTrash(priorPolicyEntity);
     }
 
     @Test
@@ -96,9 +89,6 @@ class RetentionPolicyAuditTest extends IntegrationBase {
 
         var retentionPolicyRevisions = dartsDatabase.findRetentionPolicyRevisionsFor(retentionPolicyType.getId());
         assertThat(retentionPolicyRevisions.getLatestRevision().getMetadata().getRevisionType()).isEqualTo(UPDATE);
-
-        // clean up
-        dartsDatabase.addToTrash(retentionPolicyType);
     }
 
     private static AdminPostRetentionRequest adminPostRetentionRequestWithDefaults() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/SecurityGroupManagementAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/SecurityGroupManagementAuditTest.java
@@ -71,13 +71,11 @@ class SecurityGroupManagementAuditTest extends IntegrationBase {
     }
 
     private SecurityGroupWithIdAndRole createSecurityGroup() {
-        var securityGroup = securityGroupService.createSecurityGroup(
+        return securityGroupService.createSecurityGroup(
             new SecurityGroupPostRequest()
                 .name("some-security-group-name")
                 .displayName("some-security-group-display-name")
                 .securityRoleId(4));
-        dartsDatabase.addSecurityGroupToTrashById(securityGroup.getId());
-        return securityGroup;
     }
 
     private AuditEntity findAuditActivity(String activity, List<AuditEntity> audits) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementAuditTest.java
@@ -92,15 +92,13 @@ class UserManagementAuditTest extends IntegrationBase {
     }
 
     private UserWithId createUser(boolean active) {
-        var user = userManagementService.createUser(
+
+        return userManagementService.createUser(
             new User()
                 .fullName("some-full-name")
                 .emailAddress("someone@hmcts.net")
                 .description("some-description")
                 .active(active));
-        dartsDatabase.addToUserAccountTrash(user.getEmailAddress());
-
-        return user;
 
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserQueryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserQueryTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.usermanagement.service;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -17,20 +16,12 @@ class UserQueryTest extends IntegrationBase {
 
     @Autowired
     private UserManagementQuery userManagementQuery;
-    private UserAccountEntity user1;
-    private UserAccountEntity user2;
-    private UserAccountEntity user3;
-
-    @AfterEach
-    void tearDown() {
-        dartsDatabase.addToUserAccountTrash(user1.getEmailAddress(), user2.getEmailAddress(), user3.getEmailAddress());
-    }
 
     @Test
     void searchWithAllOptionalFieldsBlank() {
-        user1 = minimalUserAccount();
-        user2 = minimalUserAccount();
-        user3 = minimalUserAccount();
+        UserAccountEntity user1 = minimalUserAccount();
+        UserAccountEntity user2 = minimalUserAccount();
+        UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
         var users = userManagementQuery.getUsers(null, null);
@@ -41,10 +32,10 @@ class UserQueryTest extends IntegrationBase {
 
     @Test
     void searchWithOnlyEmailSpecified() {
-        user1 = minimalUserAccount();
+        UserAccountEntity user1 = minimalUserAccount();
         user1.setEmailAddress("some-user-email");
-        user2 = minimalUserAccount();
-        user3 = minimalUserAccount();
+        UserAccountEntity user2 = minimalUserAccount();
+        UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
         var users = userManagementQuery.getUsers(user1.getEmailAddress(), null);
@@ -54,9 +45,9 @@ class UserQueryTest extends IntegrationBase {
 
     @Test
     void searchWithOneUserIdSpecified() {
-        user1 = minimalUserAccount();
-        user2 = minimalUserAccount();
-        user3 = minimalUserAccount();
+        UserAccountEntity user1 = minimalUserAccount();
+        UserAccountEntity user2 = minimalUserAccount();
+        UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
         var users = userManagementQuery.getUsers(null, List.of(user1.getId()));
@@ -66,9 +57,9 @@ class UserQueryTest extends IntegrationBase {
 
     @Test
     void searchWithMultipleUserIdsSpecified() {
-        user1 = minimalUserAccount();
-        user2 = minimalUserAccount();
-        user3 = minimalUserAccount();
+        UserAccountEntity user1 = minimalUserAccount();
+        UserAccountEntity user2 = minimalUserAccount();
+        UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
         var users = userManagementQuery.getUsers(null, List.of(user1.getId(), user3.getId()));
@@ -79,10 +70,10 @@ class UserQueryTest extends IntegrationBase {
 
     @Test
     void returnsEmptyListIfNoUsersMatchOnMultiplePredicates() {
-        user1 = minimalUserAccount();
+        UserAccountEntity user1 = minimalUserAccount();
         user1.setEmailAddress("some-user-email");
-        user2 = minimalUserAccount();
-        user3 = minimalUserAccount();
+        UserAccountEntity user2 = minimalUserAccount();
+        UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
         var users = userManagementQuery.getUsers(user1.getEmailAddress(), List.of(user3.getId()));


### PR DESCRIPTION
…via bin

since now any test data created by tests is automatically deleted before each test executes. See changes introduced in the previous PR: https://github.com/hmcts/darts-api/pull/1754


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3571

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
