### PR TITLE
DMP-3613 Timestamp an hour out on e-mail notification

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/TransformedMediaHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/TransformedMediaHelper.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.common.service.TransientObjectDirectoryService;
+import uk.gov.hmcts.darts.common.util.DateConverterUtil;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 import uk.gov.hmcts.darts.notification.api.NotificationApi;
 import uk.gov.hmcts.darts.notification.dto.SaveNotificationToDbRequest;
@@ -133,10 +134,10 @@ public class TransformedMediaHelper {
                 String hearingDate = getFormattedHearingDate(mediaRequestEntity.getHearing().getHearingDate());
 
                 String audioStartTime = mediaRequestEntity.getStartTime() != null
-                    ? mediaRequestEntity.getStartTime().format(formatter) : NOT_AVAILABLE;
+                    ? DateConverterUtil.toLocalDateTime(mediaRequestEntity.getStartTime()).format(formatter) : NOT_AVAILABLE;
 
                 String audioEndTime = mediaRequestEntity.getEndTime() != null
-                    ? mediaRequestEntity.getEndTime().format(formatter) : NOT_AVAILABLE;
+                    ? DateConverterUtil.toLocalDateTime(mediaRequestEntity.getEndTime()).format(formatter) : NOT_AVAILABLE;
 
                 templateParams.put(REQUEST_ID, String.valueOf(mediaRequestEntity.getId()));
                 templateParams.put(COURTHOUSE, courthouseName);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3613

### Change description ###

Changed the media request start date time from UTC as stored in the DB to local time (BST) for the notification templates.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
