### PR TITLE
DMP-3303 Hide isHearingActual false cases from darts portal

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -151,6 +151,7 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
 
         CourtroomEntity courtroom4 = createCourtRoomWithNameAtCourthouse(swanseaCourthouse, "courtroom4");
         HearingEntity hearing10a = createHearingWithDefaults(case10, courtroom4, LocalDate.of(2023, 10, 23), judge);
+        HearingEntity hearing10b = createHearingWithDefaults(case10, courtroom4, LocalDate.of(2023, 10, 24), judge, false);
 
         dartsDatabase.saveAll(hearing1a, hearing1b, hearing1c,
                               hearing2a, hearing2b, hearing2c,
@@ -161,7 +162,7 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
                               hearing7a, hearing7b,
                               hearing8,
                               hearing9,
-                              hearing10a
+                              hearing10a, hearing10b
         );
 
         EventEntity event4a = createEventWith("eventName", "event4a", hearing4a, OffsetDateTime.now());

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -102,11 +102,15 @@ public class CaseServiceImpl implements CaseService {
 
         List<HearingEntity> hearingList = hearingRepository.findByCaseIds(List.of(caseId));
 
-        if (hearingList.isEmpty()) {
-            getCourtCaseById(caseId);
+        if (hearingList.isEmpty() && !caseRepository.existsById(caseId)) {
+            throw new DartsApiException(CaseApiError.CASE_NOT_FOUND);
         }
 
-        return HearingEntityToCaseHearing.mapToHearingList(hearingList);
+        List<HearingEntity> filteredHearings = hearingList.stream()
+            .filter(HearingEntity::getHearingIsActual)
+            .toList();
+
+        return HearingEntityToCaseHearing.mapToHearingList(filteredHearings);
 
     }
 
@@ -162,7 +166,10 @@ public class CaseServiceImpl implements CaseService {
         if (caseIds.isEmpty()) {
             return new ArrayList<>();
         }
-        List<HearingEntity> hearings = hearingRepository.findByCaseIds(caseIds);
+        List<HearingEntity> hearings = hearingRepository.findByCaseIds(caseIds).stream()
+            .filter(HearingEntity::getHearingIsActual)
+            .toList();
+
         return AdvancedSearchResponseMapper.mapResponse(hearings);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/CasesMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/CasesMapperTest.java
@@ -87,7 +87,7 @@ class CasesMapperTest {
         CourtroomEntity courtroomEntity = CommonTestDataUtil.createCourtroom(courthouse, "1");
 
         HearingEntity hearing = CommonTestDataUtil.createHearing(caseEntity, courtroomEntity,
-                                                                 LocalDate.of(2023, Month.JULY, 7)
+                                                                 LocalDate.of(2023, Month.JULY, 7), true
         );
 
         ScheduledCase scheduledCases = caseMapper.mapToScheduledCase(hearing);

--- a/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
@@ -287,7 +287,7 @@ class CaseServiceImplTest {
     }
 
     @Test
-    void testGetCaseHearings() {
+    void testGetCaseHearingsWhenHearingIsActualTrue() {
         CourthouseEntity courthouseEntity = CommonTestDataUtil.createCourthouse(SWANSEA);
         CourtroomEntity courtroomEntity = CommonTestDataUtil.createCourtroom(courthouseEntity, "1");
         CourtCaseEntity existingCaseEntity = CommonTestDataUtil.createCase("case1", courthouseEntity);
@@ -296,7 +296,8 @@ class CaseServiceImplTest {
         List<HearingEntity> existingHearings = Lists.newArrayList(CommonTestDataUtil.createHearing(
             existingCaseEntity,
             courtroomEntity,
-            LocalDate.now()
+            LocalDate.now(),
+            true
         ));
 
         when(hearingRepository.findByCaseIds(List.of(existingCaseEntity.getId()))).thenReturn(existingHearings);
@@ -310,6 +311,37 @@ class CaseServiceImplTest {
     }
 
     @Test
+    void testGetCaseHearingsWhenHearingIsActualFalse() {
+        CourthouseEntity courthouseEntity = CommonTestDataUtil.createCourthouse(SWANSEA);
+        CourtroomEntity courtroomEntity = CommonTestDataUtil.createCourtroom(courthouseEntity, "1");
+        CourtCaseEntity existingCaseEntity = CommonTestDataUtil.createCase("case1", courthouseEntity);
+        existingCaseEntity.setId(1);
+
+        List<HearingEntity> existingHearings = Lists.newArrayList(CommonTestDataUtil.createHearing(
+            existingCaseEntity,
+            courtroomEntity,
+            LocalDate.now(),
+            false
+        ));
+
+        when(hearingRepository.findByCaseIds(List.of(existingCaseEntity.getId()))).thenReturn(existingHearings);
+
+        List<Hearing> caseHearings = service.getCaseHearings(existingCaseEntity.getId());
+
+        assertEquals(0, caseHearings.size());
+    }
+
+    @Test
+    void testGetCaseHearingsWhenCaseDoesNotExistThrowsException() {
+        when(hearingRepository.findByCaseIds(any())).thenReturn(Collections.emptyList());
+
+        var exception = assertThrows(DartsApiException.class, () ->
+            service.getCaseHearings(1));
+
+        assertEquals("The requested case cannot be found", exception.getMessage());
+    }
+
+    @Test
     void testGetEventsByCaseId() throws Exception {
         CourthouseEntity courthouseEntity = CommonTestDataUtil.createCourthouse(SWANSEA);
         CourtroomEntity courtroomEntity = CommonTestDataUtil.createCourtroom(courthouseEntity, "1");
@@ -319,7 +351,8 @@ class CaseServiceImplTest {
         HearingEntity hearing = CommonTestDataUtil.createHearing(
             courtCaseEntity,
             courtroomEntity,
-            hearingDate.toLocalDate()
+            hearingDate.toLocalDate(),
+            true
         );
 
         List<EventEntity> events = Lists.newArrayList(createEventWith("eventName", "event", hearing, hearingDate));
@@ -460,6 +493,6 @@ class CaseServiceImplTest {
         CourthouseEntity courthouseEntity = CommonTestDataUtil.createCourthouse(SWANSEA);
         CourtroomEntity courtroomEntity = CommonTestDataUtil.createCourtroom(courthouseEntity, "2");
         CourtCaseEntity caseEntity = CommonTestDataUtil.createCase("Case0000009", courthouseEntity);
-        return CommonTestDataUtil.createHearing(caseEntity, courtroomEntity, LocalDate.of(2023, Month.JULY, 20));
+        return CommonTestDataUtil.createHearing(caseEntity, courtroomEntity, LocalDate.of(2023, Month.JULY, 20), true);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -202,13 +202,14 @@ public class CommonTestDataUtil {
         return prosecutorEntity;
     }
 
-    public HearingEntity createHearing(CourtCaseEntity courtcase, CourtroomEntity courtroom, LocalDate date) {
+    public HearingEntity createHearing(CourtCaseEntity courtcase, CourtroomEntity courtroom, LocalDate date, boolean isHearingActual) {
         HearingEntity hearing1 = new HearingEntity();
         hearing1.setId(1);
         hearing1.setCourtCase(courtcase);
         hearing1.setCourtroom(courtroom);
         hearing1.setHearingDate(date);
         hearing1.setCreatedDateTime(createOffsetDateTime("2024-03-25T10:00:00"));
+        hearing1.setHearingIsActual(isHearingActual);
         return hearing1;
     }
 
@@ -430,7 +431,7 @@ public class CommonTestDataUtil {
         for (int courtroomCounter = 1; courtroomCounter <= numOfCourtrooms; courtroomCounter++) {
             CourtroomEntity courtroom = createCourtroom("courtroom" + courtroomCounter);
             for (int hearingCounter = 1; hearingCounter <= numOfHearingsPerCourtroom; hearingCounter++) {
-                HearingEntity hearing = createHearing(courtCase, courtroom, startDate);
+                HearingEntity hearing = createHearing(courtCase, courtroom, startDate, true);
                 hearings.add(hearing);
                 startDate = startDate.plusDays(1);
             }

--- a/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
@@ -77,7 +77,8 @@ class HearingsServiceImplTest {
         HearingEntity hearingEntity = CommonTestDataUtil.createHearing(
             caseEntity,
             courtroomEntity,
-            LocalDate.now()
+            LocalDate.now(),
+            true
         );
 
         EventHandlerEntity eventType = mock(EventHandlerEntity.class);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/HearingTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/HearingTestData.java
@@ -67,6 +67,12 @@ public class HearingTestData {
     }
 
     public static HearingEntity createHearingWithDefaults(CourtCaseEntity courtCase, CourtroomEntity courtroom, LocalDate hearingDate, JudgeEntity judge) {
+        return createHearingWithDefaults(courtCase, courtroom, hearingDate, judge, true);
+    }
+
+
+    public static HearingEntity createHearingWithDefaults(CourtCaseEntity courtCase, CourtroomEntity courtroom, LocalDate hearingDate, JudgeEntity judge,
+                                                          boolean isHearingActual) {
         HearingEntity hearing = new HearingEntity();
         hearing.setCourtCase(Objects.requireNonNullElseGet(courtCase, CaseTestData::someMinimalCase));
 
@@ -74,7 +80,7 @@ public class HearingTestData {
 
         hearing.setHearingDate(Objects.requireNonNullElseGet(hearingDate, LocalDate::now));
 
-        hearing.setHearingIsActual(false);
+        hearing.setHearingIsActual(isHearingActual);
         hearing.addJudge(judge);
 
         return hearing;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3303


### Change description ###
Hide isHearingActual false cases from darts portal in search results and on hearings on case screen


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
