### PR TITLE
DMP-3252 Return 404 error when hearing is actual false

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/hearings/exception/HearingApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/exception/HearingApiError.java
@@ -20,7 +20,12 @@ public enum HearingApiError implements DartsApiError {
         HttpStatus.BAD_REQUEST,
         HearingsTitleErrors.TOO_MANY_RESULTS.toString()
 
-    );
+    ),
+    HEARING_NOT_ACTUAL(
+        HearingsErrorCode.HEARING_NOT_ACTUAL.getValue(),
+        HttpStatus.NOT_FOUND,
+        HearingsTitleErrors.HEARING_NOT_ACTUAL.toString()
+    ),;
 
     private static final String ERROR_TYPE_PREFIX = "HEARING";
 

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
-import uk.gov.hmcts.darts.common.model.TranscriptModel;
 import uk.gov.hmcts.darts.common.repository.AnnotationRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
@@ -27,7 +26,6 @@ import uk.gov.hmcts.darts.hearings.model.HearingTranscriptModel;
 import uk.gov.hmcts.darts.hearings.model.Transcript;
 import uk.gov.hmcts.darts.hearings.service.HearingsService;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,6 +56,8 @@ public class HearingsServiceImpl implements HearingsService {
         Optional<HearingEntity> foundHearingOpt = hearingRepository.findById(hearingId);
         if (foundHearingOpt.isEmpty()) {
             throw new DartsApiException(HearingApiError.HEARING_NOT_FOUND);
+        } else if (!foundHearingOpt.get().getHearingIsActual()) {
+            throw new DartsApiException(HearingApiError.HEARING_NOT_ACTUAL);
         }
         return foundHearingOpt.get();
     }
@@ -73,17 +73,6 @@ public class HearingsServiceImpl implements HearingsService {
         List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByHearingIdManualOrLegacy(hearingId);
         List<HearingTranscriptModel> hearingTranscriptModel =  transcriptionMapper.mapResponse(transcriptionEntities);
         return transcriptionMapper.getTranscriptList(hearingTranscriptModel);
-    }
-
-    private <T extends TranscriptModel> List<Transcript> getTranscriptList(List<T> modelLst) {
-        List<Transcript> transcriptList = new ArrayList<>();
-        for (T model : modelLst) {
-            if (model instanceof Transcript) {
-                transcriptList.add((Transcript) model);
-            }
-        }
-
-        return transcriptList;
     }
 
     @Override

--- a/src/main/resources/openapi/hearings.yaml
+++ b/src/main/resources/openapi/hearings.yaml
@@ -428,11 +428,13 @@ components:
       enum:
         - "HEARING_100"
         - "HEARING_101"
-      x-enum-varnames: [HEARING_NOT_FOUND, TOO_MANY_RESULTS]
+        - "HEARING_102"
+      x-enum-varnames: [HEARING_NOT_FOUND, TOO_MANY_RESULTS, HEARING_NOT_ACTUAL]
 
     HearingsTitleErrors:
       type: string
       enum:
         - "The requested hearing cannot be found"
         - "Too many results have been returned. Please change search criteria."
-      x-enum-varnames: [HEARING_NOT_FOUND, TOO_MANY_RESULTS]
+        - "The requested hearing is not an actual hearing."
+      x-enum-varnames: [HEARING_NOT_FOUND, TOO_MANY_RESULTS, HEARING_NOT_ACTUAL]

--- a/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.AnnotationRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.HearingReportingRestrictionsRepository;
@@ -24,9 +25,11 @@ import uk.gov.hmcts.darts.hearings.model.EventResponse;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -68,18 +71,36 @@ class HearingsServiceImplTest {
     }
 
     @Test
-    void testGetEventsResponse() {
-        CourthouseEntity courthouseEntity = CommonTestDataUtil.createCourthouse("swansea");
-        CourtroomEntity courtroomEntity = CommonTestDataUtil.createCourtroom(courthouseEntity, "1");
-        CourtCaseEntity caseEntity = CommonTestDataUtil.createCase("case1", courthouseEntity);
-        caseEntity.setId(1);
+    void testGetHearingsById() {
+        HearingEntity hearingEntity = createHearingEntity(true);
+        when(hearingRepository.findById(hearingEntity.getId())).thenReturn(Optional.of(hearingEntity));
 
-        HearingEntity hearingEntity = CommonTestDataUtil.createHearing(
-            caseEntity,
-            courtroomEntity,
-            LocalDate.now(),
-            true
-        );
+        HearingEntity result = service.getHearingById(hearingEntity.getId());
+        assertEquals(1, result.getId());
+    }
+
+    @Test
+    void testGetHearingsByIdHearingNotFound() {
+        when(hearingRepository.findById(1)).thenReturn(Optional.empty());
+
+        DartsApiException exception = assertThrows(DartsApiException.class, () -> service.getHearingById(1));
+
+        assertEquals("HEARING_100", exception.getError().getErrorTypeNumeric());
+    }
+
+    @Test
+    void testGetHearingsByIdHearingNotActual() {
+        HearingEntity hearingEntity = createHearingEntity(false);
+        when(hearingRepository.findById(hearingEntity.getId())).thenReturn(Optional.of(hearingEntity));
+
+        DartsApiException exception = assertThrows(DartsApiException.class, () -> service.getHearingById(hearingEntity.getId()));
+
+        assertEquals("HEARING_102", exception.getError().getErrorTypeNumeric());
+    }
+
+    @Test
+    void testGetEventsResponse() {
+        HearingEntity hearingEntity = createHearingEntity(true);
 
         EventHandlerEntity eventType = mock(EventHandlerEntity.class);
         when(eventType.getEventName()).thenReturn("TestEvent");
@@ -95,6 +116,15 @@ class HearingsServiceImplTest {
         assertEquals("TestEvent", eventResponses.get(0).getName());
         assertNotNull(eventResponses.get(0).getTimestamp());
 
+    }
+
+    private HearingEntity createHearingEntity(boolean isHearingActual) {
+        CourthouseEntity courthouseEntity = CommonTestDataUtil.createCourthouse("swansea");
+        CourtroomEntity courtroomEntity = CommonTestDataUtil.createCourtroom(courthouseEntity, "1");
+        CourtCaseEntity caseEntity = CommonTestDataUtil.createCase("case1", courthouseEntity);
+        caseEntity.setId(1);
+
+        return CommonTestDataUtil.createHearing(caseEntity, courtroomEntity, LocalDate.now(), isHearingActual);
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3252


### Change description ###
When a user tries to access a hearing where the hearing is actual is false, return a 404 error.

Also, added some missing unit tests covering scenarios not covered anywhere else in codebase.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
