### PR TITLE
DMP-3632 Fix index out of bounds error on empty transcription workflows

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -496,7 +496,9 @@ public class TranscriptionServiceImpl implements TranscriptionService {
         var transcriptionWorkflows = transcriptionWorkflowRepository.findByTranscriptionOrderByWorkflowTimestampDesc(transcription.get());
 
         if (nonNull(isCurrent) && TRUE.equals(isCurrent)) {
-            return transcriptionResponseMapper.mapToTranscriptionWorkflowsResponse(List.of(transcriptionWorkflows.get(0)), Collections.emptyList());
+            List<TranscriptionWorkflowEntity> workflow =
+                !transcriptionWorkflows.isEmpty() ? List.of(transcriptionWorkflows.getFirst()) : Collections.emptyList();
+            return transcriptionResponseMapper.mapToTranscriptionWorkflowsResponse(workflow, Collections.emptyList());
         }
 
         // migrated transcription comments are not associated to a transcription workflow

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceGetWorkflowsTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceGetWorkflowsTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.darts.transcriptions.mapper.TranscriptionResponseMapper;
 import uk.gov.hmcts.darts.transcriptions.model.GetTranscriptionWorkflowsResponse;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -78,6 +79,20 @@ class TranscriptionServiceGetWorkflowsTest {
         verify(transcriptionRepository, times(1)).findById(anyInt());
         verify(transcriptionWorkflowRepository, times(1)).findByTranscriptionOrderByWorkflowTimestampDesc(any());
         verify(transcriptionCommentRepository).getByTranscriptionAndTranscriptionWorkflowIsNull(transcription);
+    }
+
+    @Test
+    void handleNoTranscriptionWorkflows() {
+        when(transcriptionRepository.findById(anyInt())).thenReturn(Optional.of(new TranscriptionEntity()));
+        when(transcriptionWorkflowRepository.findByTranscriptionOrderByWorkflowTimestampDesc(any())).thenReturn(Collections.emptyList());
+        when(transcriptionResponseMapper.mapToTranscriptionWorkflowsResponse(List.of(), List.of()))
+            .thenReturn(List.of(mockTranscriptionWorkflowResponse));
+
+        List<GetTranscriptionWorkflowsResponse> transcriptionWorkflows = transcriptionService.getTranscriptionWorkflows(1, true);
+
+        assertEquals(1, transcriptionWorkflows.size());
+        verify(transcriptionRepository, times(1)).findById(anyInt());
+        verify(transcriptionWorkflowRepository, times(1)).findByTranscriptionOrderByWorkflowTimestampDesc(any());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3632


### Change description ###
Fix for when a transcription contains no workflows and an admin tries to load the transcription. 
Looking at the code, this should never actually happen on prod as a transcription will always have a workflow. However, on the lower environments, it appears there are some test transcriptions without workflows. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
