### PR TITLE
Possible Refactor related to DMP-3713

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/AtsModeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/AtsModeTest.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.darts;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.authorisation.component.impl.AtsUserIdentityImpl;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"ATS_MODE = true"})
+class AtsModeTest extends IntegrationBase {
+
+    @Autowired
+    private UserIdentity userIdentity;
+
+    @Test
+    void testAtsIjection() {
+        Assertions.assertTrue(userIdentity instanceof AtsUserIdentityImpl);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/DefaultModeTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/DefaultModeTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.darts;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.authorisation.component.impl.UserIdentityImpl;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+
+@AutoConfigureMockMvc
+class DefaultModeTest extends IntegrationBase {
+    @Autowired
+    private UserIdentity userIdentity;
+
+    @Test
+    void testUserInjection() {
+        Assertions.assertTrue(userIdentity instanceof UserIdentityImpl);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.audio.service;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
@@ -11,6 +12,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
 import uk.gov.hmcts.darts.testutils.IntegrationPerClassBase;
 import uk.gov.hmcts.darts.testutils.stubs.SuperAdminUserStub;
@@ -55,6 +57,9 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
 
     @MockBean
     private UserIdentity mockUserIdentity;
+
+    @Autowired
+    private SystemUserHelper systemUserHelper;
 
     @BeforeAll
     void beforeAll() {
@@ -199,9 +204,6 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
 
         assertNull(mediaRequestEntityBeforeCompleted.getLastModifiedBy());
 
-        UserAccountEntity testUser = superAdminUserStub.givenUserIsAuthorised(mockUserIdentity);
-        when(mockUserIdentity.getUserAccount()).thenReturn(testUser);
-
         MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(mediaRequestService.getMediaRequestEntityById(1));
 
         // assert the date and user is set
@@ -209,7 +211,7 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
         assertNotEquals(mediaRequestEntityBeforeCompleted
                                        .getLastModifiedDateTime()
                                        .atZoneSameInstant(ZoneOffset.UTC), mediaRequestEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC));
-        assertEquals(testUser.getId(), mediaRequestEntity.getLastModifiedBy().getId());
+        assertEquals(systemUserHelper.getSystemUser().getId(), mediaRequestEntity.getLastModifiedBy().getId());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/MediaRequestServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.audio.service;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
@@ -204,6 +203,9 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
 
         assertNull(mediaRequestEntityBeforeCompleted.getLastModifiedBy());
 
+        UserAccountEntity testUser = superAdminUserStub.givenUserIsAuthorised(mockUserIdentity);
+        when(mockUserIdentity.getUserAccount()).thenReturn(testUser);
+
         MediaRequestEntity mediaRequestEntity = mediaRequestService.updateAudioRequestCompleted(mediaRequestService.getMediaRequestEntityById(1));
 
         // assert the date and user is set
@@ -211,7 +213,7 @@ class MediaRequestServiceTest extends IntegrationPerClassBase {
         assertNotEquals(mediaRequestEntityBeforeCompleted
                                        .getLastModifiedDateTime()
                                        .atZoneSameInstant(ZoneOffset.UTC), mediaRequestEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC));
-        assertEquals(systemUserHelper.getSystemUser().getId(), mediaRequestEntity.getLastModifiedBy().getId());
+        assertEquals(testUser.getId(), mediaRequestEntity.getLastModifiedBy().getId());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
@@ -32,6 +32,7 @@ import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.enums.SystemUsersAccountUUIDEnum;
 import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
+import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
 import uk.gov.hmcts.darts.test.common.data.AudioTestData;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.TransientObjectDirectoryStub;
@@ -96,6 +97,9 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
     private ExternalUnstructuredDataStoreDeleter externalUnstructuredDataStoreDeleter;
     private ExternalOutboundDataStoreDeleter externalOutboundDataStoreDeleter;
 
+    @Mock
+    private AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties;
+
     @BeforeEach
     void setUp() {
         this.requestor = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
@@ -106,7 +110,7 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
             LocalDateTime.now()
         );
 
-        SystemUserHelper systemUserHelper = new SystemUserHelper(dartsDatabase.getUserAccountRepository());
+        SystemUserHelper systemUserHelper = new SystemUserHelper(dartsDatabase.getUserAccountRepository(), automatedTaskConfigurationProperties);
         systemUserHelper.setSystemUserGuidMap(Collections.singletonMap(
             "housekeeping",
             SystemUsersAccountUUIDEnum.HOUSE_KEEPING.getUuid()

--- a/src/integrationTest/resources/application-intTest.yaml
+++ b/src/integrationTest/resources/application-intTest.yaml
@@ -80,6 +80,9 @@ darts:
       url: http://localhost:4551
   transcription:
     max-file-size: 20
+  automated:
+    task:
+      system-user-email: dartssystemuser@hmcts.net
 logging:
   level:
     root: DEBUG

--- a/src/main/java/uk/gov/hmcts/darts/Application.java
+++ b/src/main/java/uk/gov/hmcts/darts/Application.java
@@ -38,7 +38,6 @@ public class Application implements CommandLineRunner {
             log.info("ATS_MODE found, closing instance");
             instance.close();
         }
-
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/DartsMode.java
+++ b/src/main/java/uk/gov/hmcts/darts/DartsMode.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.darts;
+
+public enum DartsMode {
+    ATS_MODE("ATS_MODE");
+
+    private String mode;
+
+    DartsMode(String mode) {
+        this.mode = mode;
+    }
+
+    public String getModeStr() {
+        return mode;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -60,7 +60,6 @@ import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.exception.DartsException;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
-import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
@@ -126,7 +125,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     private final MediaHideOrShowValidator mediaHideOrShowValidator;
     private final ObjectAdminActionRepository objectAdminActionRepository;
     private final ObjectHiddenReasonRepository objectHiddenReasonRepository;
-    private final SystemUserHelper systemUserHelper;
+    private final UserIdentity systemUserHelper;
 
     @Override
     public Optional<MediaRequestEntity> getOldestMediaRequestByStatus(MediaRequestStatus status) {
@@ -135,7 +134,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
 
     @Override
     public Optional<MediaRequestEntity> retrieveMediaRequestForProcessing() {
-        return Optional.ofNullable(mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(systemUserHelper.getSystemUser().getId()));
+        return Optional.ofNullable(mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(systemUserHelper.getUserAccount().getId()));
     }
 
     @Override
@@ -481,7 +480,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     public MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity) {
 
         mediaRequestEntity.setStatus(COMPLETED);
-        mediaRequestEntity.setLastModifiedBy(systemUserHelper.getSystemUser());
+        mediaRequestEntity.setLastModifiedBy(systemUserHelper.getUserAccount());
 
         //todo update transformed media info
         return mediaRequestRepository.saveAndFlush(mediaRequestEntity);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -60,6 +60,7 @@ import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.exception.DartsException;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
@@ -125,6 +126,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     private final MediaHideOrShowValidator mediaHideOrShowValidator;
     private final ObjectAdminActionRepository objectAdminActionRepository;
     private final ObjectHiddenReasonRepository objectHiddenReasonRepository;
+    private final SystemUserHelper systemUserHelper;
 
     @Override
     public Optional<MediaRequestEntity> getOldestMediaRequestByStatus(MediaRequestStatus status) {
@@ -133,7 +135,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
 
     @Override
     public Optional<MediaRequestEntity> retrieveMediaRequestForProcessing() {
-        return Optional.ofNullable(mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(userIdentity.getUserAccount().getId()));
+        return Optional.ofNullable(mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(systemUserHelper.getSystemUser().getId()));
     }
 
     @Override
@@ -479,7 +481,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     public MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity) {
 
         mediaRequestEntity.setStatus(COMPLETED);
-        mediaRequestEntity.setLastModifiedBy(userIdentity.getUserAccount());
+        mediaRequestEntity.setLastModifiedBy(systemUserHelper.getSystemUser());
 
         //todo update transformed media info
         return mediaRequestRepository.saveAndFlush(mediaRequestEntity);

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AtsUserIdentityImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AtsUserIdentityImpl.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.darts.authorisation.component.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
+import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.common.repository.UserRolesCourthousesRepository;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.nonNull;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AtsUserIdentityImpl implements UserIdentity {
+
+    private final SystemUserHelper systemUserHelper;
+
+    private final UserAccountRepository userAccountRepository;
+
+    private final UserRolesCourthousesRepository userRolesCourthousesRepository;
+
+    @Override
+    public UserAccountEntity getUserAccount() {
+        return systemUserHelper.getSystemUser();
+    }
+
+    @Override
+    public boolean userHasGlobalAccess(Set<SecurityRoleEnum> globalAccessRoles) {
+        boolean userHasGlobalAccess = false;
+        String emailAddress = null;
+
+        emailAddress = getUserAccount().getEmailAddress();
+
+
+        if (nonNull(emailAddress)) {
+            List<UserAccountEntity> userAccountEntities =
+                userAccountRepository.findByEmailAddressOrAccountGuidForRolesAndGlobalAccessIsTrue(
+                    emailAddress, null,
+                    globalAccessRoles.stream().map(SecurityRoleEnum::getId).collect(Collectors.toUnmodifiableSet())
+                );
+            if (!userAccountEntities.isEmpty()) {
+                userHasGlobalAccess = true;
+            }
+        }
+        return userHasGlobalAccess;
+    }
+
+    @Override
+    public List<Integer> getListOfCourthouseIdsUserHasAccessTo() {
+        UserAccountEntity userAccount = getUserAccount();
+        return userRolesCourthousesRepository.findAllCourthouseIdsByUserAccount(userAccount);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AtsUserIdentityImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AtsUserIdentityImpl.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.darts.authorisation.component.impl;
 
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
@@ -17,8 +15,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
 
-@Component
-@RequiredArgsConstructor
+@AllArgsConstructor
 @Slf4j
 public class AtsUserIdentityImpl implements UserIdentity {
 

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
@@ -21,7 +21,6 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.USER_DETAILS_INVALID;
 
-@Component
 @AllArgsConstructor
 @Slf4j
 public class UserIdentityImpl implements UserIdentity {

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;

--- a/src/main/java/uk/gov/hmcts/darts/common/config/mode/ConditionOnAts.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/mode/ConditionOnAts.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.darts.common.config.mode;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import uk.gov.hmcts.darts.DartsMode;
+
+public class ConditionOnAts implements Condition {
+    public ConditionOnAts() {
+    }
+
+    @Override
+    public boolean matches(ConditionContext context,
+                           AnnotatedTypeMetadata metadata) {
+        Environment env = context.getEnvironment();
+        return env.getProperty(DartsMode.ATS_MODE.getModeStr()) != null;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/config/mode/ConditionOnNotAts.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/mode/ConditionOnNotAts.java
@@ -1,0 +1,18 @@
+package uk.gov.hmcts.darts.common.config.mode;
+
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class ConditionOnNotAts implements Condition {
+    private final ConditionOnAts conditionOnAts = new ConditionOnAts();
+
+    public ConditionOnNotAts() {
+    }
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return !conditionOnAts.matches(context, metadata);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
@@ -7,13 +7,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Condition;
-import org.springframework.context.annotation.ConditionContext;
-import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.env.Environment;
-import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -34,15 +29,8 @@ import uk.gov.hmcts.darts.authentication.config.external.ExternalAuthConfigurati
 import uk.gov.hmcts.darts.authentication.config.external.ExternalAuthProviderConfigurationProperties;
 import uk.gov.hmcts.darts.authentication.config.internal.InternalAuthConfigurationProperties;
 import uk.gov.hmcts.darts.authentication.config.internal.InternalAuthProviderConfigurationProperties;
-import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
-import uk.gov.hmcts.darts.authorisation.component.impl.AtsUserIdentityImpl;
-import uk.gov.hmcts.darts.authorisation.component.impl.UserIdentityImpl;
-import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
-import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
-import uk.gov.hmcts.darts.common.repository.UserRolesCourthousesRepository;
 
 import java.io.IOException;
-import java.lang.annotation.Annotation;
 import java.util.Map;
 
 
@@ -147,35 +135,6 @@ public class SecurityConfig {
             }
 
             response.sendRedirect(locator.locateAuthenticationConfiguration(req -> fallbackConfiguration).getLoginUri(null).toString());
-        }
-    }
-
-    @Bean
-    @Conditional(ConditionOnAts.class)
-    public UserIdentity getATSIdentity (SystemUserHelper systemUserHelper, UserAccountRepository userAccountRepository, UserRolesCourthousesRepository userRolesCourthousesRepository) {
-        return new AtsUserIdentityImpl(systemUserHelper, userAccountRepository, userRolesCourthousesRepository);
-    }
-
-    @Bean
-    @Conditional(ConditionOnNotAts.class)
-    public UserIdentity geIdentity (UserAccountRepository userAccountRepository, UserRolesCourthousesRepository userRolesCourthousesRepository) {
-        return new UserIdentityImpl(userAccountRepository, userRolesCourthousesRepository);
-    }
-
-    class ConditionOnAts implements Condition {
-        @Override
-        public boolean matches(ConditionContext context,
-                               AnnotatedTypeMetadata metadata) {
-                Environment env = context.getEnvironment();
-            return System.getenv("ATS_MODE") != null;
-        }
-    }
-
-    class ConditionOnNotAts implements Condition {
-        private final ConditionOnAts conditionOnAts = new ConditionOnAts();
-        @Override
-        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
-            return !conditionOnAts.matches(context, metadata);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
@@ -7,8 +7,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -29,8 +34,15 @@ import uk.gov.hmcts.darts.authentication.config.external.ExternalAuthConfigurati
 import uk.gov.hmcts.darts.authentication.config.external.ExternalAuthProviderConfigurationProperties;
 import uk.gov.hmcts.darts.authentication.config.internal.InternalAuthConfigurationProperties;
 import uk.gov.hmcts.darts.authentication.config.internal.InternalAuthProviderConfigurationProperties;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.authorisation.component.impl.AtsUserIdentityImpl;
+import uk.gov.hmcts.darts.authorisation.component.impl.UserIdentityImpl;
+import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.common.repository.UserRolesCourthousesRepository;
 
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.util.Map;
 
 
@@ -138,4 +150,32 @@ public class SecurityConfig {
         }
     }
 
+    @Bean
+    @Conditional(ConditionOnAts.class)
+    public UserIdentity getATSIdentity (SystemUserHelper systemUserHelper, UserAccountRepository userAccountRepository, UserRolesCourthousesRepository userRolesCourthousesRepository) {
+        return new AtsUserIdentityImpl(systemUserHelper, userAccountRepository, userRolesCourthousesRepository);
+    }
+
+    @Bean
+    @Conditional(ConditionOnNotAts.class)
+    public UserIdentity geIdentity (UserAccountRepository userAccountRepository, UserRolesCourthousesRepository userRolesCourthousesRepository) {
+        return new UserIdentityImpl(userAccountRepository, userRolesCourthousesRepository);
+    }
+
+    class ConditionOnAts implements Condition {
+        @Override
+        public boolean matches(ConditionContext context,
+                               AnnotatedTypeMetadata metadata) {
+                Environment env = context.getEnvironment();
+            return System.getenv("ATS_MODE") != null;
+        }
+    }
+
+    class ConditionOnNotAts implements Condition {
+        private final ConditionOnAts conditionOnAts = new ConditionOnAts();
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            return !conditionOnAts.matches(context, metadata);
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/config/security/UserIdentityConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/security/UserIdentityConfig.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.darts.common.config.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.authorisation.component.impl.AtsUserIdentityImpl;
+import uk.gov.hmcts.darts.authorisation.component.impl.UserIdentityImpl;
+import uk.gov.hmcts.darts.common.config.mode.ConditionOnAts;
+import uk.gov.hmcts.darts.common.config.mode.ConditionOnNotAts;
+import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.common.repository.UserRolesCourthousesRepository;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class UserIdentityConfig {
+    @Bean
+    @Conditional(ConditionOnAts.class)
+    public UserIdentity getAtsIdentity(SystemUserHelper systemUserHelper,
+                                       UserAccountRepository userAccountRepository, UserRolesCourthousesRepository userRolesCourthousesRepository) {
+        return new AtsUserIdentityImpl(systemUserHelper, userAccountRepository, userRolesCourthousesRepository);
+    }
+
+    @Bean
+    @Conditional(ConditionOnNotAts.class)
+    public UserIdentity getIdentity(UserAccountRepository userAccountRepository,
+                                    UserRolesCourthousesRepository userRolesCourthousesRepository) {
+        return new UserIdentityImpl(userAccountRepository, userRolesCourthousesRepository);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/common/helper/SystemUserHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/helper/SystemUserHelper.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
 
 import java.util.HashMap;
 import java.util.List;
@@ -25,11 +26,11 @@ import java.util.Map;
 public class SystemUserHelper {
 
     public static final String HOUSEKEEPING = "housekeeping";
-    public static final String SYSTEM_EMAIL_ADDRESS = "dartssystemuser@hmcts.net";
     public static final String DAILYLIST_PROCESSOR = "dailylist-processor";
     private final UserAccountRepository userAccountRepository;
     private Map<String, String> systemUserGuidMap;
     private Map<String, UserAccountEntity> systemUserNameToEntityMap = new HashMap<>();
+    private final AutomatedTaskConfigurationProperties properties;
 
     public String findSystemUserGuid(String configKey) {
         return systemUserGuidMap.get(configKey);
@@ -58,7 +59,7 @@ public class SystemUserHelper {
     }
 
     public UserAccountEntity getSystemUser() {
-        List<UserAccountEntity> userList = userAccountRepository.findByEmailAddressIgnoreCase(SystemUserHelper.SYSTEM_EMAIL_ADDRESS);
+        List<UserAccountEntity> userList = userAccountRepository.findByEmailAddressIgnoreCase(properties.getSystemUserEmail());
 
         if (userList.isEmpty()) {
             throw new DartsApiException(AudioApiError.MISSING_SYSTEM_USER);

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/ExternalOutboundDataStoreDeleterImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/ExternalOutboundDataStoreDeleterImplTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.common.helper.SystemUserHelper;
 import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,10 +45,12 @@ class ExternalOutboundDataStoreDeleterImplTest {
     private OutboundDataStoreDeleter outboundDataStoreDeleter;
     @Mock
     private TransformedMediaRepository transformedMediaRepository;
+    @Mock
+    private AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties;
 
     @BeforeEach
     void setUp() {
-        SystemUserHelper systemUserHelper = new SystemUserHelper(userAccountRepository);
+        SystemUserHelper systemUserHelper = new SystemUserHelper(userAccountRepository, automatedTaskConfigurationProperties);
         Map<String, String> systemUserGuidMap = new HashMap<>();
         systemUserGuidMap.put("housekeeping", "123");
         systemUserHelper.setSystemUserGuidMap(systemUserGuidMap);

--- a/src/test/java/uk/gov/hmcts/darts/common/helper/SystemUserHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/helper/SystemUserHelperTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.task.config.AutomatedTaskConfigurationProperties;
 
 import java.util.HashMap;
 import java.util.List;
@@ -30,11 +31,14 @@ class SystemUserHelperTest {
     @Mock
     private UserAccountRepository userAccountRepository;
 
+    @Mock
+    private AutomatedTaskConfigurationProperties automatedTaskConfigurationProperties;
+
     private SystemUserHelper systemUserHelper;
 
     @BeforeEach
     void setUp() {
-        systemUserHelper = new SystemUserHelper(userAccountRepository);
+        systemUserHelper = new SystemUserHelper(userAccountRepository, automatedTaskConfigurationProperties);
 
         Map<String, String> guidMap = new HashMap<>();
         guidMap.put("housekeeping", HOUSEKEEPING_GUID);
@@ -79,10 +83,13 @@ class SystemUserHelperTest {
         UserAccountEntity coreSystemUser = new UserAccountEntity();
         coreSystemUser.setAccountGuid(CORE_SYSTEM_USER);
 
-        when(userAccountRepository.findByEmailAddressIgnoreCase(SystemUserHelper.SYSTEM_EMAIL_ADDRESS)).thenReturn(List.of(coreSystemUser));
+        String email = "test@email.com";
+        when(automatedTaskConfigurationProperties.getSystemUserEmail()).thenReturn(email);
+
+        when(userAccountRepository.findByEmailAddressIgnoreCase(email)).thenReturn(List.of(coreSystemUser));
 
         UserAccountEntity user = systemUserHelper.getSystemUser();
-        verify(userAccountRepository, times(1)).findByEmailAddressIgnoreCase(SystemUserHelper.SYSTEM_EMAIL_ADDRESS);
+        verify(userAccountRepository, times(1)).findByEmailAddressIgnoreCase(email);
         assertEquals(CORE_SYSTEM_USER, user.getAccountGuid());
     }
 
@@ -91,7 +98,10 @@ class SystemUserHelperTest {
         UserAccountEntity coreSystemUser = new UserAccountEntity();
         coreSystemUser.setAccountGuid(CORE_SYSTEM_USER);
 
-        when(userAccountRepository.findByEmailAddressIgnoreCase(SystemUserHelper.SYSTEM_EMAIL_ADDRESS)).thenReturn(List.of());
+        String email = "test@email.com";
+        when(automatedTaskConfigurationProperties.getSystemUserEmail()).thenReturn(email);
+
+        when(userAccountRepository.findByEmailAddressIgnoreCase(email)).thenReturn(List.of());
 
         DartsApiException exception = Assertions.assertThrows(DartsApiException.class, () -> systemUserHelper.getSystemUser());
         assertEquals(AudioApiError.MISSING_SYSTEM_USER, exception.getError());


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

This spike has fallen out of bug https://tools.hmcts.net/jira/browse/DMP-3713. 

_**Problem**_

There are many pieces of logic within the darts codebase that have to be context aware i.e. the logic has to understand how it is being executed e.g. in ATS or default (user mode). As such, certain methods have to explicitly by pass the use of the user identity when in ATS mode. 

A better pattern would be for the implementation to always be user agnostic leaving the user identity injection up to the Di framework. This will allow the associated darts logic to be more reusable than it would otherwise be.

**_Solution_**

Introduce the concept a darts mode and load an alternative user identity if we are running in ATS mode. In this manner the underlying code that gets executed does not need to care about its execution context. This naturally promotes reuse of methods as well as reducing the scope for bugs occurring when executing those methods.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
