### PR TITLE
DMP-1036: replace hearingRepository.getReferenceById with service call

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
@@ -228,6 +228,24 @@ class AudioRequestsControllerAddAudioRequestIntTest extends IntegrationBase {
     }
 
     @Test
+    void addAudioRequestWhenHearingNotFoundShouldThrow404() throws Exception {
+        var audioRequestDetails = new AudioRequestDetails();
+        audioRequestDetails.setHearingId(9999); // Set to invalid hearing id
+        audioRequestDetails.setStartTime(START_TIME);
+        audioRequestDetails.setEndTime(END_TIME);
+        audioRequestDetails.setRequestor(testUser.getId());
+        audioRequestDetails.setRequestType(AUDIO_REQUEST_TYPE_DOWNLOAD);
+
+        MockHttpServletRequestBuilder requestBuilder = post(ENDPOINT)
+            .header("Content-Type", "application/json")
+            .content(objectMapper.writeValueAsString(audioRequestDetails));
+
+        mockMvc.perform(requestBuilder)
+            .andExpect(status().isNotFound())
+            .andReturn();
+    }
+
+    @Test
     void duplicateAddAudioRequestShouldThrowConflictError() throws Exception {
         var requestor = dartsDatabase.getUserAccountStub()
             .createAuthorisedIntegrationTestUser("NEWCASTLE");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
@@ -230,7 +230,7 @@ class AudioRequestsControllerAddAudioRequestIntTest extends IntegrationBase {
     @Test
     void addAudioRequestWhenHearingNotFoundShouldThrow404() throws Exception {
         var audioRequestDetails = new AudioRequestDetails();
-        audioRequestDetails.setHearingId(9999); // Set to invalid hearing id
+        audioRequestDetails.setHearingId(9999); // Set to not existing hearing id
         audioRequestDetails.setStartTime(START_TIME);
         audioRequestDetails.setEndTime(END_TIME);
         audioRequestDetails.setRequestor(testUser.getId());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
@@ -228,24 +228,6 @@ class AudioRequestsControllerAddAudioRequestIntTest extends IntegrationBase {
     }
 
     @Test
-    void addAudioRequestWhenHearingNotFoundShouldThrow404() throws Exception {
-        var audioRequestDetails = new AudioRequestDetails();
-        audioRequestDetails.setHearingId(9999); // Set to invalid hearing id
-        audioRequestDetails.setStartTime(START_TIME);
-        audioRequestDetails.setEndTime(END_TIME);
-        audioRequestDetails.setRequestor(testUser.getId());
-        audioRequestDetails.setRequestType(AUDIO_REQUEST_TYPE_DOWNLOAD);
-
-        MockHttpServletRequestBuilder requestBuilder = post(ENDPOINT)
-            .header("Content-Type", "application/json")
-            .content(objectMapper.writeValueAsString(audioRequestDetails));
-
-        mockMvc.perform(requestBuilder)
-            .andExpect(status().isNotFound())
-            .andReturn();
-    }
-
-    @Test
     void duplicateAddAudioRequestShouldThrowConflictError() throws Exception {
         var requestor = dartsDatabase.getUserAccountStub()
             .createAuthorisedIntegrationTestUser("NEWCASTLE");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -375,13 +375,15 @@ public class DartsDatabaseStub {
     public HearingEntity createHearing(String courthouseName, String courtroomName, String caseNumber,
                                        LocalDateTime hearingDate) {
         createCourthouseUnlessExists(courthouseName);
-        return retrieveCoreObjectService.retrieveOrCreateHearing(
+        var hearingEntity =  retrieveCoreObjectService.retrieveOrCreateHearing(
             courthouseName,
             courtroomName,
             caseNumber,
             hearingDate,
             userAccountRepository.getReferenceById(0)
         );
+        hearingEntity.setHearingIsActual(true);
+        return hearingEntity;
     }
 
     public CourthouseEntity createCourthouseUnlessExists(String courthouseName) {

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -58,7 +58,6 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
-import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
 import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectAdminActionRepository;
@@ -68,6 +67,7 @@ import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.common.validation.IdRequest;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
+import uk.gov.hmcts.darts.hearings.service.HearingsService;
 import uk.gov.hmcts.darts.notification.api.NotificationApi;
 import uk.gov.hmcts.darts.notification.dto.SaveNotificationToDbRequest;
 
@@ -100,7 +100,7 @@ import static uk.gov.hmcts.darts.notification.api.NotificationApi.NotificationTe
 @SuppressWarnings({"PMD.CouplingBetweenObjects"})
 public class MediaRequestServiceImpl implements MediaRequestService {
 
-    private final HearingRepository hearingRepository;
+    private final HearingsService hearingsService;
     private final UserAccountRepository userAccountRepository;
     private final UserIdentity userIdentity;
     private final MediaRequestRepository mediaRequestRepository;
@@ -164,7 +164,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     public boolean isUserDuplicateAudioRequest(AudioRequestDetails audioRequestDetails) {
 
         var duplicateUserMediaRequests = mediaRequestRepository.findDuplicateUserMediaRequests(
-            hearingRepository.getReferenceById(audioRequestDetails.getHearingId()),
+            hearingsService.getHearingById(audioRequestDetails.getHearingId()),
             userAccountRepository.getReferenceById(audioRequestDetails.getRequestor()),
             audioRequestDetails.getStartTime(),
             audioRequestDetails.getEndTime(),
@@ -179,7 +179,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     @Override
     public MediaRequestEntity saveAudioRequest(AudioRequestDetails request) {
         MediaRequestEntity mediaRequest = saveAudioRequestToDb(
-            hearingRepository.getReferenceById(request.getHearingId()),
+            hearingsService.getHearingById(request.getHearingId()),
             userAccountRepository.getReferenceById(request.getRequestor()),
             request.getStartTime(),
             request.getEndTime(),

--- a/src/main/resources/openapi/audiorequests.yaml
+++ b/src/main/resources/openapi/audiorequests.yaml
@@ -67,6 +67,8 @@ paths:
           description: 'invalid input, object invalid'
         '401':
           description: Unauthorised Error
+        '404':
+          description: Hearing Not Found
         '409':
           description: audio request item already exists
       requestBody:

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
@@ -219,7 +219,7 @@ class MediaRequestServiceImplTest {
     }
 
     @Test
-    void saveAudioRequest_whenHearingNotFound_shouldThrowException() {
+    void whenSavingAudioAndHearingNotFoundShouldThrowException() {
         Integer hearingId = 4567;
         mockHearingEntity.setId(hearingId);
         mockMediaRequestEntity.setId(1);

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
@@ -42,6 +42,7 @@ import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
+import uk.gov.hmcts.darts.hearings.service.HearingsService;
 import uk.gov.hmcts.darts.notification.api.NotificationApi;
 import uk.gov.hmcts.darts.notification.dto.SaveNotificationToDbRequest;
 
@@ -103,7 +104,7 @@ class MediaRequestServiceImplTest {
     private MediaRequestServiceImpl mediaRequestService;
 
     @Mock
-    private HearingRepository mockHearingRepository;
+    private HearingsService mockHearingService;
     @Mock
     private UserAccountRepository mockUserAccountRepository;
     @Mock
@@ -200,14 +201,14 @@ class MediaRequestServiceImplTest {
         requestDetails.setEndTime(OffsetDateTime.parse(OFFSET_T_12_00_00_Z));
         requestDetails.setRequestType(DOWNLOAD);
 
-        when(mockHearingRepository.getReferenceById(hearingId)).thenReturn(mockHearingEntity);
+        when(mockHearingService.getHearingById(hearingId)).thenReturn(mockHearingEntity);
         when(mockMediaRequestRepository.saveAndFlush(any(MediaRequestEntity.class))).thenReturn(mockMediaRequestEntity);
         when(mockUserAccountRepository.getReferenceById(TEST_REQUESTER)).thenReturn(mockUserAccountEntity);
         doNothing().when(auditApi).record(any(), any(), any());
         var request = mediaRequestService.saveAudioRequest(requestDetails);
 
         assertEquals(request.getId(), mockMediaRequestEntity.getId());
-        verify(mockHearingRepository).getReferenceById(hearingId);
+        verify(mockHearingService).getHearingById(hearingId);
         verify(mockMediaRequestRepository).saveAndFlush(any(MediaRequestEntity.class));
         verify(mockUserAccountRepository).getReferenceById(TEST_REQUESTER);
         verify(auditApi).record(REQUEST_AUDIO, mockUserAccountEntity, mockCourtCaseEntity);
@@ -226,7 +227,7 @@ class MediaRequestServiceImplTest {
         requestDetails.setEndTime(OffsetDateTime.parse(OFFSET_T_12_00_00_Z));
         requestDetails.setRequestType(DOWNLOAD);
 
-        when(mockHearingRepository.getReferenceById(hearingId)).thenReturn(mockHearingEntity);
+        when(mockHearingService.getHearingById(hearingId)).thenReturn(mockHearingEntity);
         when(mockUserAccountRepository.getReferenceById(TEST_REQUESTER)).thenReturn(mockUserAccountEntity);
         when(mockMediaRequestRepository.findDuplicateUserMediaRequests(
             mockHearingEntity,
@@ -255,7 +256,7 @@ class MediaRequestServiceImplTest {
         requestDetails.setEndTime(OffsetDateTime.parse(OFFSET_T_12_00_00_Z));
         requestDetails.setRequestType(DOWNLOAD);
 
-        when(mockHearingRepository.getReferenceById(hearingId)).thenReturn(mockHearingEntity);
+        when(mockHearingService.getHearingById(hearingId)).thenReturn(mockHearingEntity);
         when(mockUserAccountRepository.getReferenceById(TEST_REQUESTER)).thenReturn(mockUserAccountEntity);
         when(mockMediaRequestRepository.findDuplicateUserMediaRequests(
             mockHearingEntity,


### PR DESCRIPTION
### JIRA link (if applicable) ###
DMP-1036


### Change description ###
Replace hearingRepository.getReferenceById with service call


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
