### PR TITLE
DMP-3623 Only display transcriptions where is_current = true

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
@@ -231,6 +231,7 @@ public class TranscriptionStub {
         transcription.setLastModifiedBy(testUser);
         transcription.setIsManualTranscription(true);
         transcription.setHideRequestFromRequestor(false);
+        transcription.setIsCurrent(true);
 
         if (hearing != null) {
             hearing.getTranscriptions().add(transcription);
@@ -280,6 +281,7 @@ public class TranscriptionStub {
         transcription.setLastModifiedBy(testUser);
         transcription.setIsManualTranscription(isManualTranscription);
         transcription.setHideRequestFromRequestor(false);
+        transcription.setIsCurrent(true);
         return transcriptionRepository.saveAndFlush(transcription);
     }
 
@@ -298,6 +300,7 @@ public class TranscriptionStub {
         transcription.setLastModifiedBy(testUser);
         transcription.setIsManualTranscription(true);
         transcription.setHideRequestFromRequestor(false);
+        transcription.setIsCurrent(true);
         return transcriptionRepository.saveAndFlush(transcription);
     }
 
@@ -340,16 +343,26 @@ public class TranscriptionStub {
                                                                                HearingEntity hearingEntity,
                                                                                OffsetDateTime workflowTimestamp,
                                                                                boolean associatedUrgency) {
-        var transcriptionEntity = this.createTranscriptionWithStatus(
+        return createAndSaveAwaitingAuthorisationTranscription(userAccountEntity, courtCaseEntity,
+                                                               hearingEntity, workflowTimestamp, associatedUrgency,true);
+    }
+
+    @Transactional
+    public TranscriptionEntity createAndSaveAwaitingAuthorisationTranscription(UserAccountEntity userAccountEntity,
+                                                                               CourtCaseEntity courtCaseEntity,
+                                                                               HearingEntity hearingEntity,
+                                                                               OffsetDateTime workflowTimestamp,
+                                                                               boolean associatedUrgency, boolean isCurrent) {
+        return this.createTranscriptionWithStatus(
             userAccountEntity,
             courtCaseEntity,
             hearingEntity,
             workflowTimestamp,
             getTranscriptionStatusByEnum(AWAITING_AUTHORISATION),
             null,
-            associatedUrgency
+            associatedUrgency,
+            isCurrent
         );
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
     }
 
     @Transactional
@@ -431,6 +444,7 @@ public class TranscriptionStub {
         transcriptionEntity.setStartTime(startDate);
         transcriptionEntity.setEndTime(endDate);
         transcriptionEntity.setTranscriptionType(transcriptionType);
+        transcriptionEntity.setIsCurrent(true);
         return transcriptionRepository.saveAndFlush(transcriptionEntity);
     }
 
@@ -625,6 +639,17 @@ public class TranscriptionStub {
                                                               OffsetDateTime workflowTimestamp,
                                                               TranscriptionStatusEntity status,
                                                               String comment, boolean associateUrgency) {
+
+        return createTranscriptionWithStatus(userAccountEntity, courtCaseEntity, hearingEntity, workflowTimestamp,
+                                      status, comment, associateUrgency, true);
+    }
+
+    private TranscriptionEntity createTranscriptionWithStatus(UserAccountEntity userAccountEntity,
+                                                              CourtCaseEntity courtCaseEntity,
+                                                              HearingEntity hearingEntity,
+                                                              OffsetDateTime workflowTimestamp,
+                                                              TranscriptionStatusEntity status,
+                                                              String comment, boolean associateUrgency, boolean isCurrent) {
         final var transcriptionEntity = new TranscriptionEntity();
         transcriptionEntity.addCase(courtCaseEntity);
         transcriptionEntity.addHearing(hearingEntity);
@@ -644,6 +669,7 @@ public class TranscriptionStub {
         transcriptionEntity.setLastModifiedBy(userAccountEntity);
         transcriptionEntity.setIsManualTranscription(true);
         transcriptionEntity.setHideRequestFromRequestor(false);
+        transcriptionEntity.setIsCurrent(isCurrent);
         transcriptionRepository.save(transcriptionEntity);
 
         final var requestedTranscriptionWorkflowEntity = createTranscriptionWorkflowEntity(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStubComposable.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStubComposable.java
@@ -93,6 +93,7 @@ public class TranscriptionStubComposable {
         transcription.setLastModifiedBy(testUser);
         transcription.setIsManualTranscription(true);
         transcription.setHideRequestFromRequestor(false);
+        transcription.setIsCurrent(true);
 
         if (hearing != null) {
             hearing.getTranscriptions().add(transcription);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriberTranscriptsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriberTranscriptsIntTest.java
@@ -364,9 +364,9 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 -- Transcript Requests: Approved (after status rollback from WITH_TRANSCRIBER)
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
-                                is_manual_transcription, hide_request_from_requestor)
+                                is_manual_transcription, hide_request_from_requestor, is_current)
                                 VALUES (41, NULL, 9, NULL, NULL, '2023-11-23 09:00:00+00', '2023-11-23 09:30:00+00', '2023-11-23 16:25:55.297666+00',
-                                '2023-11-23 16:26:20.451054+00', -10, -10, $URGENCY, 3, NULL, true, false);
+                                '2023-11-23 16:26:20.451054+00', -10, -10, $URGENCY, 3, NULL, true, false, true);
                                 INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (41,-1);
                                 INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (41,-1);
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
@@ -383,9 +383,9 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 -- Add transcript request to test transcriptions do not show after 90 days
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
-                                is_manual_transcription, hide_request_from_requestor)
+                                is_manual_transcription, hide_request_from_requestor, is_current)
                                 VALUES (602, NULL, 9, NULL, NULL, '2023-11-23 09:00:00+00', '2023-11-23 09:30:00+00', '2023-11-23 16:25:55.297666+00',
-                                '2023-11-23 16:26:20.451054+00', -10, -10, $URGENCY, 3, NULL, true, false);
+                                '2023-11-23 16:26:20.451054+00', -10, -10, $URGENCY, 3, NULL, true, false, true);
                                 INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (602,-1);
                                 INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (602,-1);
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
@@ -394,9 +394,9 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 -- Your work > To do: With Transcriber
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
-                                is_manual_transcription, hide_request_from_requestor)
+                                is_manual_transcription, hide_request_from_requestor, is_current)
                                 VALUES (81, NULL, 9, NULL, NULL, '2023-11-23 09:20:00+00', '2023-11-23 09:30:00+00', '2023-11-23 17:45:14.938855+00',
-                                '2023-11-23 17:45:51.1549+00', -10, -10, $URGENCY, 5, NULL, true, false);
+                                '2023-11-23 17:45:51.1549+00', -10, -10, $URGENCY, 5, NULL, true, false, true);
                                 INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (81,-1);
                                 INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (81,-1);
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
@@ -411,9 +411,9 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 -- Add additional Your work transcription to test transcriptions do not show after 90 days
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
-                                is_manual_transcription, hide_request_from_requestor)
+                                is_manual_transcription, hide_request_from_requestor, is_current)
                                 VALUES (601, NULL, 9, NULL, NULL, '2023-11-23 09:20:00+00', '2024-07-01 09:30:00+00', '2024-07-01 17:45:14.938855+00',
-                                '2024-07-01 17:45:51.1549+00', -10, -10, $URGENCY, 5, NULL, true, false);
+                                '2024-07-01 17:45:51.1549+00', -10, -10, $URGENCY, 5, NULL, true, false, true);
                                 INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (601,-1);
                                 INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (601,-1);
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
@@ -428,9 +428,9 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 -- This transcription would be hidden from Your work > Completed today (transcriber-view?assigned=true)
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
-                                is_manual_transcription, hide_request_from_requestor)
+                                is_manual_transcription, hide_request_from_requestor, is_current)
                                 VALUES (101, NULL, 9, NULL, NULL, '2023-11-24 09:00:00+00', '2023-11-24 09:30:00+00', '2023-11-24 12:37:00.782036+00',
-                                '2023-11-24 12:53:42.870475+00', -10, -10, $URGENCY, 6, NULL, true, false);
+                                '2023-11-24 12:53:42.870475+00', -10, -10, $URGENCY, 6, NULL, true, false, true);
                                 INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (101,-1);
                                 INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (101,-1);
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
@@ -447,9 +447,9 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 -- Your work > Completed today: Complete
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
-                                is_manual_transcription, hide_request_from_requestor)
+                                is_manual_transcription, hide_request_from_requestor, is_current)
                                 VALUES (121, NULL, 9, NULL, NULL, '$TODAYS_DATE', '$TODAYS_DATE', '$TODAYS_DATE', '$TODAYS_DATE', -10,
-                                -10, $URGENCY, 6, NULL, true, false);
+                                -10, $URGENCY, 6, NULL, true, false, true);
                                 INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (121,-1);
                                 INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (121,-1);
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
@@ -462,6 +462,42 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 VALUES (164, 121, 5, -10, '$TODAYS_DATE');
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
                                 VALUES (165, 121, 6, -10, '$TODAYS_DATE');
+                                
+                                -- test is_current false is not returned
+                                INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
+                                created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
+                                is_manual_transcription, hide_request_from_requestor, is_current)
+                                VALUES (150, NULL, 9, NULL, NULL, '2023-11-23 09:00:00+00', '2023-11-23 09:30:00+00', '2023-11-23 16:25:55.297666+00',
+                                '2023-11-23 16:26:20.451054+00', -10, -10, $URGENCY, 3, NULL, true, false, false);
+                                INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (150,-1);
+                                INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (150,-1);
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (241, 150, 1, -10, '2023-11-23 16:25:55.304517+00');
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (242, 150, 2, -10, '2023-11-23 16:25:55.338405+00');
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (243, 150, 3, -10, '2023-11-23 16:26:20.441633+00');
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (244, 150, 5, -10, '2023-11-23 16:30:00.0+00');
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (245, 150, 3, -10, '$MINUS_89_DAYS');
+                                
+                                INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
+                                created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
+                                is_manual_transcription, hide_request_from_requestor, is_current)
+                                VALUES (151, NULL, 9, NULL, NULL, '2023-11-23 09:20:00+00', '2023-11-23 09:30:00+00', '2023-11-23 17:45:14.938855+00',
+                                '2023-11-23 17:45:51.1549+00', -10, -10, $URGENCY, 5, NULL, true, false, false);
+                                INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (151,-1);
+                                INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (151,-1);
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (246, 151, 1, -10, '$MINUS_89_DAYS');
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (247, 151, 2, -10, '$MINUS_89_DAYS');
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (248, 151, 3, -10, '$MINUS_89_DAYS');
+                                INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
+                                VALUES (249, 151, 5, -10, '$MINUS_89_DAYS');
+                                
                                 """.replace(PLACEHOLDER_URGENCY_ID, generatedUrgency ? "1" : "NULL")
                                 .replace(TODAYS_DATE, todaysDate)
                                 .replace(MINUS_89_DAYS, dateMinus89Days)
@@ -471,11 +507,11 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
 
     private void deleteTranscription() {
         jdbcTemplate.update("""
-                                DELETE FROM darts.case_transcription_ae WHERE tra_id IN (41, 81, 101, 121, 601, 602);
-                                DELETE FROM darts.hearing_transcription_ae WHERE tra_id IN (41, 81, 101, 121, 601, 602);
+                                DELETE FROM darts.case_transcription_ae WHERE tra_id IN (41, 81, 101, 121, 150, 151, 601, 602);
+                                DELETE FROM darts.hearing_transcription_ae WHERE tra_id IN (41, 81, 101, 121, 150, 151, 601, 602);
 
-                                DELETE FROM darts.transcription_workflow WHERE tra_id IN (41, 81, 101, 121, 601, 602);
-                                DELETE FROM darts.transcription WHERE tra_id IN (41, 81, 101, 121, 601, 602);
+                                DELETE FROM darts.transcription_workflow WHERE tra_id IN (41, 81, 101, 121, 150, 151, 601, 602);
+                                DELETE FROM darts.transcription WHERE tra_id IN (41, 81, 101, 121, 150, 151, 601, 602);
 
                                 DELETE FROM darts.security_group_courthouse_ae WHERE grp_id=-4 AND cth_id=-1;
                                 DELETE FROM darts.security_group_user_account_ae WHERE usr_id=-10 AND grp_id=-4;
@@ -485,6 +521,7 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 DELETE FROM darts.court_case WHERE cas_id=-1;
                                 DELETE FROM darts.courtroom WHERE ctr_id=-1;
                                 DELETE FROM darts.courthouse WHERE cth_id=-1;
+                                
                                 """);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTest.java
@@ -80,27 +80,8 @@ class TranscriptionControllerGetTranscriptionTest extends IntegrationBase {
 
         UserAccountEntity userAccount = transcription.getCreatedBy();
 
-        {
-            TranscriptionWorkflowEntity workflowAEntity = new TranscriptionWorkflowEntity();
-            workflowAEntity.setTranscription(transcription);
-            workflowAEntity.setWorkflowActor(transcription.getCreatedBy());
-            workflowAEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
-            workflowAEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.REQUESTED));
-            dartsDatabase.save(workflowAEntity);
-
-            addCommentToWorkflow(workflowAEntity, "comment1", userAccount);
-        }
-
-        {
-            TranscriptionWorkflowEntity workflowBEntity = new TranscriptionWorkflowEntity();
-            workflowBEntity.setTranscription(transcription);
-            workflowBEntity.setWorkflowActor(transcription.getCreatedBy());
-            workflowBEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
-            workflowBEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.APPROVED));
-            dartsDatabase.save(workflowBEntity);
-
-            addCommentToWorkflow(workflowBEntity, "comment2", userAccount);
-        }
+        addTranscriptionWorkflow(transcription, userAccount, "comment1", TranscriptionStatusEnum.REQUESTED);
+        addTranscriptionWorkflow(transcription, userAccount, "comment2", TranscriptionStatusEnum.APPROVED);
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION, transcription.getId());
         String expected = TestUtils.removeTags(
@@ -130,27 +111,8 @@ class TranscriptionControllerGetTranscriptionTest extends IntegrationBase {
 
         UserAccountEntity userAccount = transcription.getCreatedBy();
 
-        {
-            TranscriptionWorkflowEntity workflowAEntity = new TranscriptionWorkflowEntity();
-            workflowAEntity.setTranscription(transcription);
-            workflowAEntity.setWorkflowActor(transcription.getCreatedBy());
-            workflowAEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
-            workflowAEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.REQUESTED));
-            dartsDatabase.save(workflowAEntity);
-
-            addCommentToWorkflow(workflowAEntity, "comment1", userAccount);
-        }
-
-        {
-            TranscriptionWorkflowEntity workflowBEntity = new TranscriptionWorkflowEntity();
-            workflowBEntity.setTranscription(transcription);
-            workflowBEntity.setWorkflowActor(transcription.getCreatedBy());
-            workflowBEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
-            workflowBEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.APPROVED));
-            dartsDatabase.save(workflowBEntity);
-
-            addCommentToWorkflow(workflowBEntity, "comment2", userAccount);
-        }
+        addTranscriptionWorkflow(transcription, userAccount, "comment1", TranscriptionStatusEnum.REQUESTED);
+        addTranscriptionWorkflow(transcription, userAccount, "comment2", TranscriptionStatusEnum.APPROVED);
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION, transcription.getId());
         String expected = TestUtils.removeTags(
@@ -180,27 +142,8 @@ class TranscriptionControllerGetTranscriptionTest extends IntegrationBase {
 
         UserAccountEntity userAccount = transcription.getCreatedBy();
 
-        {
-            TranscriptionWorkflowEntity workflowAEntity = new TranscriptionWorkflowEntity();
-            workflowAEntity.setTranscription(transcription);
-            workflowAEntity.setWorkflowActor(transcription.getCreatedBy());
-            workflowAEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
-            workflowAEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.REQUESTED));
-            dartsDatabase.save(workflowAEntity);
-
-            addCommentToWorkflow(workflowAEntity, "comment1", userAccount);
-        }
-
-        {
-            TranscriptionWorkflowEntity workflowBEntity = new TranscriptionWorkflowEntity();
-            workflowBEntity.setTranscription(transcription);
-            workflowBEntity.setWorkflowActor(transcription.getCreatedBy());
-            workflowBEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
-            workflowBEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.APPROVED));
-            dartsDatabase.save(workflowBEntity);
-
-            addCommentToWorkflow(workflowBEntity, "comment2", userAccount);
-        }
+        addTranscriptionWorkflow(transcription, userAccount, "comment1", TranscriptionStatusEnum.REQUESTED);
+        addTranscriptionWorkflow(transcription, userAccount, "comment2", TranscriptionStatusEnum.APPROVED);
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION, transcription.getId());
         String expected = TestUtils.removeTags(
@@ -226,27 +169,8 @@ class TranscriptionControllerGetTranscriptionTest extends IntegrationBase {
 
         UserAccountEntity userAccount = transcription.getCreatedBy();
 
-        {
-            TranscriptionWorkflowEntity workflowAEntity = new TranscriptionWorkflowEntity();
-            workflowAEntity.setTranscription(transcription);
-            workflowAEntity.setWorkflowActor(transcription.getCreatedBy());
-            workflowAEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
-            workflowAEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.REQUESTED));
-            dartsDatabase.save(workflowAEntity);
-
-            addCommentToWorkflow(workflowAEntity, "comment1", userAccount);
-        }
-
-        {
-            TranscriptionWorkflowEntity workflowBEntity = new TranscriptionWorkflowEntity();
-            workflowBEntity.setTranscription(transcription);
-            workflowBEntity.setWorkflowActor(transcription.getCreatedBy());
-            workflowBEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
-            workflowBEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(TranscriptionStatusEnum.APPROVED));
-            dartsDatabase.save(workflowBEntity);
-
-            addCommentToWorkflow(workflowBEntity, "comment2", userAccount);
-        }
+        addTranscriptionWorkflow(transcription, userAccount, "comment1", TranscriptionStatusEnum.REQUESTED);
+        addTranscriptionWorkflow(transcription, userAccount, "comment2", TranscriptionStatusEnum.APPROVED);
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION, transcription.getId());
         String expected = TestUtils.removeTags(
@@ -259,6 +183,28 @@ class TranscriptionControllerGetTranscriptionTest extends IntegrationBase {
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(status().isOk()).andReturn();
         String actualResponse = TestUtils.removeTags(TAGS_TO_IGNORE, mvcResult.getResponse().getContentAsString());
         JSONAssert.assertEquals(expected, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    void getTranscriptionNotFoundWhenIsCurrentFalse() throws Exception {
+        HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);
+        TranscriptionEntity transcription = dartsDatabase.getTranscriptionStub().createTranscription(hearingEntity);
+        transcription.setCreatedDateTime(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
+        transcription.setStartTime(SOME_DATE_TIME);
+        transcription.setEndTime(SOME_DATE_TIME);
+        transcription.setIsCurrent(false);
+        transcription = dartsDatabase.save(transcription);
+
+        UserAccountEntity userAccount = transcription.getCreatedBy();
+
+        addTranscriptionWorkflow(transcription, userAccount, "comment1", TranscriptionStatusEnum.REQUESTED);
+        addTranscriptionWorkflow(transcription, userAccount, "comment2", TranscriptionStatusEnum.APPROVED);
+
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION, transcription.getId());
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isNotFound()).andReturn();
+        String actualResponse = response.getResponse().getContentAsString();
+        String expectedResponse = getContentsFromFile("tests/transcriptions/transcription/expectedResponseNotFound.json");
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -278,5 +224,16 @@ class TranscriptionControllerGetTranscriptionTest extends IntegrationBase {
         commentEntity.setLastModifiedBy(userAccount);
         commentEntity.setCreatedBy(userAccount);
         dartsDatabase.save(commentEntity);
+    }
+
+    private void addTranscriptionWorkflow(TranscriptionEntity transcription, UserAccountEntity userAccount, String comment, TranscriptionStatusEnum status) {
+        TranscriptionWorkflowEntity workflowAEntity = new TranscriptionWorkflowEntity();
+        workflowAEntity.setTranscription(transcription);
+        workflowAEntity.setWorkflowActor(transcription.getCreatedBy());
+        workflowAEntity.setWorkflowTimestamp(OffsetDateTime.of(2023, 6, 20, 10, 0, 0, 0, ZoneOffset.UTC));
+        workflowAEntity.setTranscriptionStatus(dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(status));
+        dartsDatabase.save(workflowAEntity);
+
+        addCommentToWorkflow(workflowAEntity, comment, userAccount);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/mapper/TranscriptionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/mapper/TranscriptionMapper.java
@@ -15,7 +15,9 @@ public abstract class TranscriptionMapper<T extends TranscriptModel> {
     public List<T> mapResponse(List<TranscriptionEntity> transcriptionEntities) {
         List<T> response = new ArrayList<>();
         for (TranscriptionEntity transcriptionEntity : transcriptionEntities) {
-            response.add(map(transcriptionEntity));
+            if (Boolean.TRUE.equals(transcriptionEntity.getIsCurrent())) {
+                response.add(map(transcriptionEntity));
+            }
         }
         return response;
     }

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberTranscriptsQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberTranscriptsQueryImpl.java
@@ -83,6 +83,7 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                     GROUP BY tra_id
                 ) latest_trw ON tra.tra_id = latest_trw.tra_id AND approved_trw.workflow_ts = latest_trw.latest_ts
                 WHERE latest_trw.latest_ts >= :date_limit
+                AND tra.is_current = true
                 ORDER BY transcription_id desc
                 LIMIT :max_result_size
                 """,
@@ -161,6 +162,7 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                         WHERE trd.tra_id = tra.tra_id
                     )
                 )
+                AND tra.is_current = true
                                 
                 UNION
 
@@ -219,6 +221,7 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                         WHERE trd.tra_id = tra.tra_id
                     )
                 )
+                AND tra.is_current = true
                 ORDER BY transcription_id desc
                 LIMIT :max_result_size
                 """,

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/YourTranscriptsQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/YourTranscriptsQueryImpl.java
@@ -82,7 +82,7 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
                     )
                 )
                 AND trw.workflow_ts >= :date_limit
-
+                AND tra.is_current = true
                 UNION
 
                 -- Migrated "requester_transcriptions"
@@ -130,6 +130,7 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
                     )
                 )
                 AND trw.workflow_ts >= :date_limit
+                AND tra.is_current = true
                 ORDER BY transcription_id DESC
                 LIMIT :max_result_size
                 """,
@@ -196,6 +197,7 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
                     )
                 )
                 AND trw.workflow_ts >= :date_limit
+                AND tra.is_current = true
 
                 UNION
 
@@ -252,6 +254,7 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
                     )
                 )
                 AND trw.workflow_ts >= :date_limit
+                AND tra.is_current = true
                 ORDER BY transcription_id DESC
                 LIMIT :max_result_size
                 """,

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -548,7 +548,7 @@ public class TranscriptionServiceImpl implements TranscriptionService {
     @Override
     @Transactional
     public GetTranscriptionByIdResponse getTranscription(Integer transcriptionId) {
-        TranscriptionEntity transcription = transcriptionRepository.findById(transcriptionId)
+        TranscriptionEntity transcription = transcriptionRepository.findById(transcriptionId).filter(TranscriptionEntity::getIsCurrent)
             .orElseThrow(() -> new DartsApiException(TRANSCRIPTION_NOT_FOUND));
         return transcriptionResponseMapper.mapToTranscriptionResponse(transcription);
     }

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/TranscriptionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/TranscriptionMapperTest.java
@@ -58,6 +58,7 @@ class TranscriptionMapperTest {
         transcription.setId(1);
         transcription.setHearingDate(LocalDate.of(2023, 6, 20));
         transcription.setRequestedBy(CommonTestDataUtil.createUserAccount("someLegacyRequestor"));
+        transcription.setIsCurrent(true);
 
         TranscriptionStatusEntity transcriptionStatus = new TranscriptionStatusEntity();
         transcriptionStatus.setId(TranscriptionStatusEnum.APPROVED.getId());
@@ -72,5 +73,16 @@ class TranscriptionMapperTest {
         assertEquals(OffsetDateTime.of(2020, 6, 20, 10, 10, 0, 0, ZoneOffset.UTC), transcript.getRequestedOn());
         assertEquals("someLegacyRequestor", transcript.getRequestedByName());
         assertEquals("APPROVED", transcript.getStatus());
+    }
+
+    @Test
+    void happyPathDoNotIncludeTranscriptionsIsCurrentFalse() {
+        HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
+        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1);
+
+        transcriptionList.get(0).setIsCurrent(false);
+
+        List<Transcript> transcripts = caseTranscriptionMapper.getTranscriptList(caseTranscriptionMapper.mapResponse(transcriptionList));
+        assertEquals(0, transcripts.size());
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -319,6 +319,7 @@ public class CommonTestDataUtil {
         transcription.setTranscriptionUrgency(createTranscriptionUrgencyEntityFromEnum(TranscriptionUrgencyEnum.STANDARD));
         transcription.setTranscriptionCommentEntities(createTranscriptionComments());
         transcription.setIsManualTranscription(true);
+        transcription.setIsCurrent(true);
 
         if (!excludeWorkflow) {
             transcription.setTranscriptionWorkflowEntities(createTranscriptionWorkflow());

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/TranscriptionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/TranscriptionMapperTest.java
@@ -56,6 +56,7 @@ class TranscriptionMapperTest {
         transcription.setId(1);
         transcription.setHearingDate(LocalDate.of(2023, 6, 20));
         transcription.setRequestedBy(CommonTestDataUtil.createUserAccount("someLegacyRequestor"));
+        transcription.setIsCurrent(true);
 
         TranscriptionStatusEntity transcriptionStatus = new TranscriptionStatusEntity();
         transcriptionStatus.setId(TranscriptionStatusEnum.APPROVED.getId());
@@ -71,5 +72,16 @@ class TranscriptionMapperTest {
 
         assertEquals("someLegacyRequestor", transcript.getRequestedByName());
         assertEquals("APPROVED", transcript.getStatus());
+    }
+
+    @Test
+    void happyPathDoNotIncludeTranscriptionsIsCurrentFalse() {
+        HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
+        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1);
+
+        transcriptionList.get(0).setIsCurrent(false);
+
+        List<Transcript> transcripts = hearingTranscriptionMapper.getTranscriptList(hearingTranscriptionMapper.mapResponse(transcriptionList));
+        assertEquals(0, transcripts.size());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3623


### Change description ###
Transcriptions that are being migrated could have multiple records for the same transcription request. Only the latest should have an is_current = true value. Therefore, we only want to display this record on DARTS portal. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
