### PR TITLE
DMP-3303 Hide judges when hearing is actual false

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceGivenBuilder.java
@@ -60,21 +60,21 @@ public class AudioTransformationServiceGivenBuilder {
             LocalDateTime.of(2020, 6, 20, 10, 0, 0)
         );
         judge = dartsDatabase.save(createJudgeWithName("aJudge"));
-        hearingEntityWithMedia1.addJudge(judge);
+        hearingEntityWithMedia1.addJudge(judge, false);
         hearingEntityWithMedia2 = dartsDatabase.createHearing(
             "NEWCASTLE",
             "room_a",
             "c1",
             LocalDateTime.of(2020, 6, 21, 10, 0, 0)
         );
-        hearingEntityWithMedia2.addJudge(judge);
+        hearingEntityWithMedia2.addJudge(judge, false);
         hearingEntityWithoutMedia = dartsDatabase.createHearing(
             "NEWCASTLE",
             "room_a",
             "c1",
             LocalDateTime.of(2020, 6, 22, 10, 0, 0)
         );
-        hearingEntityWithoutMedia.addJudge(judge);
+        hearingEntityWithoutMedia.addJudge(judge, false);
 
         int channel = 1;
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
@@ -100,7 +100,7 @@ class CaseControllerAdminSearchTest extends IntegrationBase {
 
         HearingEntity hearing3a = createHearingWithDefaults(case3, courtroom1, LocalDate.of(2023, 7, 20), judge);
         JudgeEntity judge3a = createJudgeWithName("Judge3a");
-        hearing3a.addJudge(judge3a);
+        hearing3a.addJudge(judge3a, false);
 
         HearingEntity hearing3b = createHearingWithDefaults(case3, courtroom1, LocalDate.of(2023, 7, 21), judge);
 
@@ -124,7 +124,7 @@ class CaseControllerAdminSearchTest extends IntegrationBase {
         HearingEntity hearing6a = createHearingWithDefaults(case6, courtroom2, LocalDate.of(2023, 9, 20), judge);
 
         HearingEntity hearing6b = createHearingWithDefaults(case6, courtroom3, LocalDate.of(2023, 9, 21), judge);
-        hearing6b.addJudge(createJudgeWithName("Judge6b"));
+        hearing6b.addJudge(createJudgeWithName("Judge6b"), false);
 
         HearingEntity hearing6c = createHearingWithDefaults(case6, courtroom1, LocalDate.of(2023, 9, 22), judge);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
@@ -134,8 +134,8 @@ class CaseControllerGetCaseHearingsTest extends IntegrationBase {
         HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);
         HearingEntity hearingEntity2 = dartsDatabase.getHearingRepository().findAll().get(1);
 
-        hearingEntity.addJudge(dartsDatabase.createSimpleJudge("hearing1Judge"));
-        hearingEntity2.addJudge(dartsDatabase.createSimpleJudge("hearing2Judge"));
+        hearingEntity.addJudge(dartsDatabase.createSimpleJudge("hearing1Judge"), false);
+        hearingEntity2.addJudge(dartsDatabase.createSimpleJudge("hearing2Judge"), false);
 
         MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingEntity.getCourtCase().getId());
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -99,7 +99,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
 
         HearingEntity hearing3a = createHearingWithDefaults(case3, courtroom1, LocalDate.of(2023, 7, 20), judge);
         JudgeEntity judge3a = createJudgeWithName("Judge3a");
-        hearing3a.addJudge(judge3a);
+        hearing3a.addJudge(judge3a, false);
 
         HearingEntity hearing3b = createHearingWithDefaults(case3, courtroom1, LocalDate.of(2023, 7, 21), judge);
 
@@ -123,7 +123,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
         HearingEntity hearing6a = createHearingWithDefaults(case6, courtroom2, LocalDate.of(2023, 9, 20), judge);
 
         HearingEntity hearing6b = createHearingWithDefaults(case6, courtroom3, LocalDate.of(2023, 9, 21), judge);
-        hearing6b.addJudge(createJudgeWithName("Judge6b"));
+        hearing6b.addJudge(createJudgeWithName("Judge6b"), false);
 
         HearingEntity hearing6c = createHearingWithDefaults(case6, courtroom1, LocalDate.of(2023, 9, 22), judge);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
@@ -119,7 +119,7 @@ class CaseServiceAdminSearchTest extends IntegrationBase {
 
         HearingEntity hearing3a = createHearingWithDefaults(case3, courtroom1, LocalDate.of(2023, 7, 20), judge);
         JudgeEntity judge3a = createJudgeWithName("Judge3a");
-        hearing3a.addJudge(judge3a);
+        hearing3a.addJudge(judge3a, false);
 
         HearingEntity hearing3b = createHearingWithDefaults(case3, courtroom1, LocalDate.of(2023, 7, 21), judge);
 
@@ -142,7 +142,7 @@ class CaseServiceAdminSearchTest extends IntegrationBase {
         HearingEntity hearing6a = createHearingWithDefaults(case6, courtroom2, LocalDate.of(2023, 9, 20), judge);
 
         HearingEntity hearing6b = createHearingWithDefaults(case6, courtroom3, LocalDate.of(2023, 9, 21), judge);
-        hearing6b.addJudge(createJudgeWithName("Judge6b"));
+        hearing6b.addJudge(createJudgeWithName("Judge6b"), false);
 
         HearingEntity hearing6c = createHearingWithDefaults(case6, courtroom1, LocalDate.of(2023, 9, 22), judge);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -115,7 +115,7 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
 
         HearingEntity hearing3a = createHearingWithDefaults(case3, courtroom1, LocalDate.of(2023, 7, 20), judge);
         JudgeEntity judge3a = createJudgeWithName("Judge3a");
-        hearing3a.addJudge(judge3a);
+        hearing3a.addJudge(judge3a, false);
 
         HearingEntity hearing3b = createHearingWithDefaults(case3, courtroom1, LocalDate.of(2023, 7, 21), judge);
 
@@ -138,7 +138,7 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
         HearingEntity hearing6a = createHearingWithDefaults(case6, courtroom2, LocalDate.of(2023, 9, 20), judge);
 
         HearingEntity hearing6b = createHearingWithDefaults(case6, courtroom3, LocalDate.of(2023, 9, 21), judge);
-        hearing6b.addJudge(createJudgeWithName("Judge6b"));
+        hearing6b.addJudge(createJudgeWithName("Judge6b"), false);
 
         HearingEntity hearing6c = createHearingWithDefaults(case6, courtroom1, LocalDate.of(2023, 9, 22), judge);
 
@@ -151,7 +151,7 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
 
         CourtroomEntity courtroom4 = createCourtRoomWithNameAtCourthouse(swanseaCourthouse, "courtroom4");
         HearingEntity hearing10a = createHearingWithDefaults(case10, courtroom4, LocalDate.of(2023, 10, 23), judge);
-        HearingEntity hearing10b = createHearingWithDefaults(case10, courtroom4, LocalDate.of(2023, 10, 24), judge, false);
+        HearingEntity hearing10b = createHearingWithDefaults(case10, courtroom4, LocalDate.of(2023, 10, 24), judge3a, false);
 
         dartsDatabase.saveAll(hearing1a, hearing1b, hearing1c,
                               hearing2a, hearing2b, hearing2c,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
@@ -130,7 +130,7 @@ class HearingsGetControllerTest extends IntegrationBase {
         );
 
         JudgeEntity testJudge = dartsDatabase.createSimpleJudge("testJudge");
-        hearing.addJudge(testJudge);
+        hearing.addJudge(testJudge, false);
         dartsDatabase.save(hearing);
 
         when(mockUserIdentity.getUserAccount()).thenReturn(null);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseComposable.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseComposable.java
@@ -42,7 +42,7 @@ public class DartsDatabaseComposable {
             userAccountRepository.getReferenceById(0)
         );
         hearing.setHearingIsActual(true);
-        hearing.addJudge(createSimpleJudge(caseNumber + "judge1"));
+        hearing.addJudge(createSimpleJudge(caseNumber + "judge1"), false);
         return hearingRepository.saveAndFlush(hearing);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -337,7 +337,7 @@ public class DartsDatabaseStub {
             userAccountRepository.getReferenceById(0)
         );
         hearing.setHearingIsActual(true);
-        hearing.addJudge(createSimpleJudge(caseNumber + "judge1"));
+        hearing.addJudge(createSimpleJudge(caseNumber + "judge1"), false);
         return hearingRepository.saveAndFlush(hearing);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -99,8 +99,8 @@ public class HearingEntity extends CreatedModifiedBaseEntity {
         }
     }
 
-    public void addJudge(JudgeEntity judgeEntity) {
-        if (judgeEntity == null) {
+    public void addJudge(JudgeEntity judgeEntity, boolean isFromDailyList) {
+        if (judgeEntity == null || (!Boolean.TRUE.equals(hearingIsActual) && !isFromDailyList)) {
             return;
         }
         courtCase.addJudge(judgeEntity);
@@ -112,7 +112,7 @@ public class HearingEntity extends CreatedModifiedBaseEntity {
 
     public void addJudges(List<JudgeEntity> judges) {
         for (JudgeEntity judge : judges) {
-            addJudge(judge);
+            addJudge(judge, false);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListUpdater.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListUpdater.java
@@ -234,7 +234,7 @@ class DailyListUpdater {
         UserAccountEntity dailyListSystemUser = systemUserHelper.getDailyListProcessorUser();
         for (CitizenName judge : sitting.getJudiciary()) {
             JudgeEntity judgeEntity = retrieveCoreObjectService.retrieveOrCreateJudge(judge.getCitizenNameRequestedName(), dailyListSystemUser);
-            hearing.addJudge(judgeEntity);
+            hearing.addJudge(judgeEntity, true);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/AdvancedSearchResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/AdvancedSearchResponseMapperTest.java
@@ -57,6 +57,7 @@ class AdvancedSearchResponseMapperTest {
     @Test
     void twoSameCase() throws IOException {
         HearingEntity hearing1 = new HearingEntity();
+        hearing1.setHearingIsActual(true);
         hearing1.setCourtCase(CommonTestDataUtil.createCase(TEST_1));
         hearing1.setCourtroom(CommonTestDataUtil.createCourtroom("1"));
         hearing1.setHearingDate(LocalDate.of(2023, 6, 20));
@@ -65,13 +66,13 @@ class AdvancedSearchResponseMapperTest {
         hearing1.addJudges(CommonTestDataUtil.createJudges(2));
 
         HearingEntity hearing2 = new HearingEntity();
+        hearing2.setHearingIsActual(true);
         hearing2.setCourtCase(CommonTestDataUtil.createCase(TEST_1));
         hearing2.setCourtroom(CommonTestDataUtil.createCourtroom("2"));
         hearing2.setHearingDate(LocalDate.of(2023, 6, 21));
         hearing2.setScheduledStartTime(LocalTime.NOON);
         hearing2.setId(202);
         hearing2.addJudges(CommonTestDataUtil.createJudges(3));
-
 
         List<HearingEntity> hearings = new ArrayList<>();
         hearings.add(hearing1);
@@ -97,6 +98,7 @@ class AdvancedSearchResponseMapperTest {
     @Test
     void fourWithTwoSameCase() throws IOException {
         HearingEntity hearing1 = new HearingEntity();
+        hearing1.setHearingIsActual(true);
         hearing1.setCourtCase(CommonTestDataUtil.createCaseWithId(TEST_1, 101));
         hearing1.setCourtroom(CommonTestDataUtil.createCourtroom("1"));
         hearing1.setHearingDate(LocalDate.of(2023, 6, 20));
@@ -105,6 +107,7 @@ class AdvancedSearchResponseMapperTest {
         hearing1.addJudges(CommonTestDataUtil.createJudges(2));
 
         HearingEntity hearing2 = new HearingEntity();
+        hearing2.setHearingIsActual(true);
         hearing2.setCourtCase(CommonTestDataUtil.createCaseWithId(TEST_1, 101));
         hearing2.setCourtroom(CommonTestDataUtil.createCourtroom("2"));
         hearing2.setHearingDate(LocalDate.of(2023, 6, 21));
@@ -112,8 +115,8 @@ class AdvancedSearchResponseMapperTest {
         hearing2.setId(202);
         hearing2.addJudges(CommonTestDataUtil.createJudges(3));
 
-
         HearingEntity hearing3 = new HearingEntity();
+        hearing3.setHearingIsActual(true);
         hearing3.setCourtCase(CommonTestDataUtil.createCaseWithId("test2", 102));
         hearing3.setCourtroom(CommonTestDataUtil.createCourtroom("2"));
         hearing3.setHearingDate(LocalDate.of(2023, 6, 22));
@@ -121,15 +124,14 @@ class AdvancedSearchResponseMapperTest {
         hearing3.setId(203);
         hearing3.addJudges(CommonTestDataUtil.createJudges(4));
 
-
         HearingEntity hearing4 = new HearingEntity();
+        hearing4.setHearingIsActual(true);
         hearing4.setCourtCase(CommonTestDataUtil.createCaseWithId("test3", 103));
         hearing4.setCourtroom(CommonTestDataUtil.createCourtroom("2"));
         hearing4.setHearingDate(LocalDate.of(2023, 6, 23));
         hearing4.setScheduledStartTime(LocalTime.of(13, 0));
         hearing4.setId(204);
         hearing4.addJudges(CommonTestDataUtil.createJudges(5));
-
 
         List<HearingEntity> hearings = new ArrayList<>();
         hearings.add(hearing1);

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -240,6 +240,7 @@ public class CommonTestDataUtil {
 
     public HearingEntity createHearing(CourtCaseEntity courtCase, CourtroomEntity courtroom, LocalDate date, LocalTime time) {
         HearingEntity hearing1 = new HearingEntity();
+        hearing1.setHearingIsActual(true);
         hearing1.setCourtCase(courtCase);
         hearing1.setCourtroom(courtroom);
         hearing1.setHearingDate(date);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/HearingTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/HearingTestData.java
@@ -81,7 +81,7 @@ public class HearingTestData {
         hearing.setHearingDate(Objects.requireNonNullElseGet(hearingDate, LocalDate::now));
 
         hearing.setHearingIsActual(isHearingActual);
-        hearing.addJudge(judge);
+        hearing.addJudge(judge, false);
 
         return hearing;
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3303


### Change description ###
There was an issue with the 'is_hearing_actual' logic introduced whereby judges were being returned from hearings where the flag is set to false on the advanced search. 
To fix this, put an extra check in the HearingEntity, when not created from Daily List. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
