### PR TITLE
DMP-3494 Uploading Large Annotation Documents Fails with 'There is a Problem with the Service' Error

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -326,7 +326,7 @@ darts:
     allowed-extensions:
       - "docx"
       - "doc"
-    max-file-size: 10485760
+    max-file-size: 20971520
     allowed-content-types:
       - "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
       - "application/msword"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3494

### Change description ###

Modified the annotation document max file to 20MB in bytes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
