### PR TITLE
DMP-3513: Removing transactional from integration tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRetentionEventDateProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRetentionEventDateProcessorIntTest.java
@@ -81,6 +81,7 @@ class ArmRetentionEventDateProcessorIntTest extends IntegrationBase {
     private ArmDataManagementConfiguration armDataManagementConfiguration;
 
     private ArmDataManagementApi armDataManagementApi;
+
     @MockBean
     private UserIdentity userIdentity;
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestDownloadIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestDownloadIntTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.enums.MediaRequestStatus;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
@@ -40,7 +39,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @Slf4j
-@Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
 class AudioRequestsControllerAddAudioRequestDownloadIntTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestIntTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.enums.MediaRequestStatus;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
@@ -40,7 +39,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @Slf4j
-@Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
 class AudioRequestsControllerAddAudioRequestIntTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestPlaybackIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestPlaybackIntTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.enums.MediaRequestStatus;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestDetails;
@@ -39,7 +38,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @Slf4j
-@Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
 class AudioRequestsControllerAddAudioRequestPlaybackIntTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDownloadIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDownloadIntTest.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestType;
 import uk.gov.hmcts.darts.audit.api.AuditActivity;
 import uk.gov.hmcts.darts.audit.service.AuditService;
@@ -168,7 +167,6 @@ class AudioRequestsControllerDownloadIntTest extends IntegrationBase {
     }
 
     @Test
-    @Transactional
     void audioRequestDownloadGetShouldReturnBadRequestWhenMediaRequestEntityIsPlayback() throws Exception {
         authorisationStub.givenTestSchema();
 
@@ -196,7 +194,6 @@ class AudioRequestsControllerDownloadIntTest extends IntegrationBase {
     }
 
     @Test
-    @Transactional
     void audioRequestDownloadGetShouldReturnErrorWhenNoRelatedTransientObjectExistsInDatabase() throws Exception {
         authorisationStub.givenTestSchema();
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerPlaybackIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerPlaybackIntTest.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audit.api.AuditActivity;
 import uk.gov.hmcts.darts.audit.service.AuditService;
 import uk.gov.hmcts.darts.authorisation.component.Authorisation;
@@ -177,7 +176,6 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
     }
 
     @Test
-    @Transactional
     void audioRequestPlaybackGetShouldReturnBadRequestWhenMediaRequestEntityIsDownload() throws Exception {
         authorisationStub.givenTestSchema();
 
@@ -204,7 +202,6 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
     }
 
     @Test
-    @Transactional
     void audioRequestPlaybackGetShouldReturnErrorWhenNoRelatedTransientObjectExistsInDatabase() throws Exception {
         authorisationStub.givenTestSchema();
         var mediaRequestEntity = authorisationStub.getMediaRequestEntity();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImplTest.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.authorisation.component.impl;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.authorisation.component.Authorisation;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
@@ -31,7 +31,6 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.hearings.exception.HearingApiError.HEARING_NOT_FOUND;
 import static uk.gov.hmcts.darts.transcriptions.exception.TranscriptionApiError.TRANSCRIPTION_NOT_FOUND;
 
-@Transactional
 class AuthorisationImplTest extends IntegrationBase {
 
     @MockBean
@@ -43,6 +42,15 @@ class AuthorisationImplTest extends IntegrationBase {
     @Autowired
     private Authorisation authorisationToTest;
 
+    @BeforeEach
+    void startHibernateSession() {
+        openInViewUtil.openEntityManager();
+    }
+
+    @AfterEach
+    void closeHibernateSession() {
+        openInViewUtil.closeEntityManager();
+    }
 
     @BeforeEach
     void beforeEach() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImplTest.java
@@ -6,11 +6,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
-import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.AuthorisationStub;
 
@@ -30,9 +28,6 @@ class UserIdentityImplTest extends IntegrationBase {
 
     @Autowired
     private UserIdentity userIdentity;
-
-    @Autowired
-    private UserAccountRepository userAccountRepository;
 
     @Autowired
     private AuthorisationStub authorisationStub;
@@ -145,7 +140,6 @@ class UserIdentityImplTest extends IntegrationBase {
     }
 
     @Test
-    @Transactional
     void getGuid() {
         String guid = UUID.randomUUID().toString();
         Jwt jwt = Jwt.withTokenValue("test")
@@ -160,7 +154,6 @@ class UserIdentityImplTest extends IntegrationBase {
     }
 
     @Test
-    @Transactional
     void userHasGlobalAccess() {
         String guid = UUID.randomUUID().toString();
         Jwt jwt = Jwt.withTokenValue("test")
@@ -177,7 +170,6 @@ class UserIdentityImplTest extends IntegrationBase {
     }
 
     @Test
-    @Transactional
     void userHasGlobalAccessReturnsFalseWhenUserHasNoGlobalAccess() {
         String guid = UUID.randomUUID().toString();
         Jwt jwt = Jwt.withTokenValue("test")
@@ -194,7 +186,6 @@ class UserIdentityImplTest extends IntegrationBase {
     }
 
     @Test
-    @Transactional
     void whenEmailAddressIsWrongCaseInToken_thenUserHasGlobalAccessReturnsTrue() {
         String guid = UUID.randomUUID().toString();
         Jwt jwt = Jwt.withTokenValue("test")

--- a/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/GenerateCaseDocumentForRetentionDateBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/GenerateCaseDocumentForRetentionDateBatchProcessorIntTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.CaseRetentionEntity;
@@ -23,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 
-@Transactional
 class GenerateCaseDocumentForRetentionDateBatchProcessorIntTest extends IntegrationBase {
     protected static final String SOME_COURTHOUSE = "some-courthouse";
     protected static final String SOME_ROOM = "some-room";
@@ -124,12 +122,15 @@ class GenerateCaseDocumentForRetentionDateBatchProcessorIntTest extends Integrat
         generateCaseDocumentForRetentionDateBatchProcessor.processGenerateCaseDocumentForRetentionDate(2);
 
         // then
-        CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().getReferenceById(courtCaseEntityWithNoCaseDocuments.getId());
-        assertFalse(courtCaseEntity1.isRetentionUpdated());
+        assertFalse(
+            dartsDatabase.getCaseRepository()
+                .findById(courtCaseEntityWithNoCaseDocuments.getId()).orElseThrow()
+                .isRetentionUpdated());
 
-        CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().getReferenceById(courtCaseEntityWithCaseDocument.getId());
-        assertFalse(courtCaseEntity2.isRetentionUpdated());
-
+        assertFalse(
+            dartsDatabase.getCaseRepository()
+                .findById(courtCaseEntityWithCaseDocument.getId()).orElseThrow()
+                .isRetentionUpdated());
     }
 
     @Test
@@ -171,12 +172,15 @@ class GenerateCaseDocumentForRetentionDateBatchProcessorIntTest extends Integrat
         generateCaseDocumentForRetentionDateBatchProcessor.processGenerateCaseDocumentForRetentionDate(2);
 
         // then
-        CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().getReferenceById(courtCaseEntityWithCaseDocuments1.getId());
-        assertFalse(courtCaseEntity1.isRetentionUpdated());
+        assertFalse(
+            dartsDatabase.getCaseRepository()
+                .findById(courtCaseEntityWithCaseDocuments1.getId()).orElseThrow()
+                .isRetentionUpdated());
 
-        CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().getReferenceById(courtCaseEntityWithCaseDocument2.getId());
-        assertFalse(courtCaseEntity2.isRetentionUpdated());
-
+        assertFalse(
+            dartsDatabase.getCaseRepository()
+                .findById(courtCaseEntityWithCaseDocument2.getId()).orElseThrow()
+                .isRetentionUpdated());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
@@ -176,7 +176,7 @@ class CaseControllerAdminSearchTest extends IntegrationBase {
     }
 
     private void setupUserAccountAndSecurityGroup() {
-        var securityGroup = SecurityGroupTestData.buildGroupForRole(SUPER_ADMIN);
+        var securityGroup = SecurityGroupTestData.createGroupForRole(SUPER_ADMIN);
         securityGroup.setGlobalAccess(true);
         securityGroup.setUseInterpreter(false);
         assignSecurityGroupToUser(user, securityGroup);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
@@ -13,7 +13,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.exception.AuthorisationError;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
@@ -32,7 +31,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
-@Transactional
 class CaseControllerGetCaseHearingsTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -36,7 +36,7 @@ import static uk.gov.hmcts.darts.cases.CasesConstants.GetSearchCasesParams.ENDPO
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 import static uk.gov.hmcts.darts.test.common.data.CaseTestData.createCaseAt;
-import static uk.gov.hmcts.darts.test.common.data.CourthouseTestData.createCourthouse;
+import static uk.gov.hmcts.darts.test.common.data.CourthouseTestData.createCourthouseWithName;
 import static uk.gov.hmcts.darts.test.common.data.CourtroomTestData.createCourtRoomWithNameAtCourthouse;
 import static uk.gov.hmcts.darts.test.common.data.DefendantTestData.createDefendantForCaseWithName;
 import static uk.gov.hmcts.darts.test.common.data.EventTestData.createEventWith;
@@ -60,7 +60,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
 
     @BeforeEach
     void setupData() {
-        swanseaCourthouse = createCourthouse("SWANSEA");
+        swanseaCourthouse = createCourthouseWithName("SWANSEA");
 
         CourtCaseEntity case1 = createCaseAt(swanseaCourthouse);
         case1.setCaseNumber("Case1");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.cases.controller;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.cases.model.AddCaseRequest;
 import uk.gov.hmcts.darts.cases.model.PostCaseResponse;
@@ -54,12 +54,12 @@ import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createListOfJudg
 import static uk.gov.hmcts.darts.test.common.data.ProsecutorTestData.createListOfProsecutor;
 
 @AutoConfigureMockMvc
-@Transactional
 class CaseControllerTest extends IntegrationBase {
 
     public static final String EXPECTED_RESPONSE_FILE = "tests/cases/CaseControllerTest/casesGetEndpoint/expectedResponse.json";
     public static final String HEARING_DATE = "2023-06-20";
     public static final String BASE_PATH = "/cases";
+
     @Autowired
     private transient MockMvc mockMvc;
 
@@ -142,6 +142,16 @@ class CaseControllerTest extends IntegrationBase {
 
 
         dartsDatabase.saveAll(hearingForCase1, hearingForCase2, hearingForCase3, hearingForCase4);
+    }
+
+    @BeforeEach
+    void startHibernateSession() {
+        openInViewUtil.openEntityManager();
+    }
+
+    @AfterEach
+    void closeHibernateSession() {
+        openInViewUtil.closeEntityManager();
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CasesControllerGetTranscriptsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CasesControllerGetTranscriptsTest.java
@@ -11,7 +11,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
@@ -31,7 +30,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
 @AutoConfigureMockMvc
-@Transactional
 class CasesControllerGetTranscriptsTest extends IntegrationBase {
     private static final String ENDPOINT_URL_CASE = "/cases/{case_id}/transcripts";
     private static final OffsetDateTime SOME_DATE_TIME = OffsetDateTime.parse("2023-01-01T12:00Z");
@@ -71,6 +69,7 @@ class CasesControllerGetTranscriptsTest extends IntegrationBase {
         mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isNotFound());
 
     }
+
 
     @Test
     void casesGetTranscriptEndpointOneObjectReturned() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchUseInterpreterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchUseInterpreterTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.test.common.data.CourthouseTestData;
 import uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
@@ -22,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
 import static uk.gov.hmcts.darts.test.common.data.CaseTestData.createCaseAt;
-import static uk.gov.hmcts.darts.test.common.data.CourthouseTestData.createCourthouse;
 import static uk.gov.hmcts.darts.test.common.data.CourtroomTestData.createCourtRoomWithNameAtCourthouse;
 import static uk.gov.hmcts.darts.test.common.data.HearingTestData.createHearingWith;
 import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TEST_USER_EMAIL;
@@ -45,7 +45,7 @@ class CaseServiceAdvancedSearchUseInterpreterTest extends IntegrationBase {
     @BeforeEach
     void setupData() {
         // swansea cases
-        swanseaCourthouse = createCourthouse("SWANSEA");
+        swanseaCourthouse = CourthouseTestData.createCourthouseWithName("SWANSEA");
 
         CourtCaseEntity case1 = createCaseAt(swanseaCourthouse, "Case1");
         CourtCaseEntity case2 = createCaseAt(swanseaCourthouse, "Case2");
@@ -58,7 +58,7 @@ class CaseServiceAdvancedSearchUseInterpreterTest extends IntegrationBase {
         dartsDatabase.saveAll(hearing1, hearing2);
 
         // cardiff cases
-        cardiffCourthouse = createCourthouse("CARDIFF");
+        cardiffCourthouse = CourthouseTestData.createCourthouseWithName("CARDIFF");
 
         CourtCaseEntity case3 = createCaseAt(cardiffCourthouse, "Case3");
         CourtCaseEntity case4 = createCaseAt(cardiffCourthouse, "Case4");
@@ -71,7 +71,7 @@ class CaseServiceAdvancedSearchUseInterpreterTest extends IntegrationBase {
         dartsDatabase.saveAll(hearing3, hearing4);
 
         // liverpool cases
-        liverpoolCourthouse = createCourthouse("LIVERPOOL");
+        liverpoolCourthouse = CourthouseTestData.createCourthouseWithName("LIVERPOOL");
 
         CourtCaseEntity case5 = createCaseAt(liverpoolCourthouse, "Case5");
 
@@ -92,7 +92,7 @@ class CaseServiceAdvancedSearchUseInterpreterTest extends IntegrationBase {
     @Test
     void testSearchCasesWithUseInterpreterFalsePermissionIsIgnoredForTranslationQaAndCasesWithInterpreterAreReturned() {
         // given
-        var securityGroup = SecurityGroupTestData.buildGroupForRole(TRANSLATION_QA);
+        var securityGroup = SecurityGroupTestData.createGroupForRole(TRANSLATION_QA);
         securityGroup.setGlobalAccess(true);
         securityGroup.setUseInterpreter(false);
         assignSecurityGroupToUser(user, securityGroup);
@@ -111,7 +111,7 @@ class CaseServiceAdvancedSearchUseInterpreterTest extends IntegrationBase {
     @Test
     void testSearchCasesWithPermissionsGlobalTrue() {
         // given
-        var securityGroup = SecurityGroupTestData.buildGroupForRole(TRANSLATION_QA);
+        var securityGroup = SecurityGroupTestData.createGroupForRole(TRANSLATION_QA);
         securityGroup.setGlobalAccess(true);
         securityGroup.setUseInterpreter(true);
         assignSecurityGroupToUser(user, securityGroup);
@@ -130,7 +130,7 @@ class CaseServiceAdvancedSearchUseInterpreterTest extends IntegrationBase {
     @Test
     void testSearchCasesWithPermissionsGlobalFalse() {
         // given
-        var securityGroup = SecurityGroupTestData.buildGroupForRole(TRANSLATION_QA);
+        var securityGroup = SecurityGroupTestData.createGroupForRole(TRANSLATION_QA);
         securityGroup.setGlobalAccess(false);
         securityGroup.setUseInterpreter(true);
         assignSecurityGroupToUser(user, securityGroup);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/RetentionPolicyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/RetentionPolicyTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.cases.mapper.CasesMapper;
 import uk.gov.hmcts.darts.common.entity.CaseRetentionEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -126,7 +125,6 @@ class RetentionPolicyTest extends IntegrationBase {
 
     }
 
-    @Transactional
     private CaseRetentionEntity createCompleteCaseRetention(CourtCaseEntity courtCase) {
         return dartsDatabase.createCaseRetentionObject(courtCase, CaseRetentionStatus.COMPLETE, OffsetDateTime.parse("2029-01-31T15:42:10.361Z"), false);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/SecurityRoleRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/SecurityRoleRepositoryTest.java
@@ -1,8 +1,9 @@
 package uk.gov.hmcts.darts.common.repository;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.SecurityPermissionEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityRoleEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
@@ -24,11 +25,20 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.XHIBIT;
 
-@Transactional
 class SecurityRoleRepositoryTest extends IntegrationBase {
 
     @Autowired
     private SecurityRoleRepository securityRoleRepository;
+
+    @BeforeEach
+    void startHibernateSession() {
+        openInViewUtil.openEntityManager();
+    }
+
+    @AfterEach
+    void closeHibernateSession() {
+        openInViewUtil.closeEntityManager();
+    }
 
     @Test
     void shouldFindAllSecurityRoles() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsControllerGetTranscriptsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsControllerGetTranscriptsTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
@@ -34,7 +33,6 @@ import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
 @Slf4j
 @AutoConfigureMockMvc
-@Transactional
 class HearingsControllerGetTranscriptsTest extends IntegrationBase {
     private static final String ENDPOINT_URL_HEARINGS = "/hearings/{hearing_id}/transcripts";
     private static final OffsetDateTime SOME_DATE_TIME = OffsetDateTime.parse("2023-01-01T12:00Z");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
@@ -28,7 +27,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @AutoConfigureMockMvc
-@Transactional
 @Slf4j
 class HearingsGetControllerTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
@@ -27,7 +26,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 @AutoConfigureMockMvc
-@Transactional
 @Slf4j
 class HearingsGetEventsControllerTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.task.service;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -56,7 +55,6 @@ import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Transactional
 class ExternalDataStoreDeleterTest extends IntegrationBase {
     @Autowired
     protected TransientObjectDirectoryStub transientObjectDirectoryStub;
@@ -196,14 +194,13 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
             AudioRequestType.DOWNLOAD,
             COMPLETED
         );
-        dartsDatabase.save(
-            currentMediaRequest);
+        dartsDatabase.save(currentMediaRequest);
 
-        TransientObjectDirectoryEntity outboundEntity = createTransientDirectoryAndObjectStatus(
-            currentMediaRequest, STORED);
+        TransientObjectDirectoryEntity outboundEntity = createTransientDirectoryAndObjectStatus(currentMediaRequest, STORED);
         ExternalObjectDirectoryEntity unstructuredEntity = createExternalObjectDirectory(
             audioBuilder.getMediaEntity1(),
-            UNSTRUCTURED.getId(), STORED
+            UNSTRUCTURED.getId(),
+            STORED
         );
         ExternalObjectDirectoryEntity inboundEntity = createExternalObjectDirectory(
             audioBuilder.getMediaEntity2(),
@@ -237,25 +234,17 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
                 savedEntity.getLastModifiedBy().getId()
             );
 
-            assertEquals(entity.getLastModifiedDateTime(), savedEntity.getLastModifiedDateTime());
+            assertEquals(entity.getLastModifiedDateTime().toInstant(), savedEntity.getLastModifiedDateTime().toInstant());
         }
     }
 
-    private void assertExternalObjectDirectoryStateNotChanged(List<ExternalObjectDirectoryEntity> unstructuredEntity) {
-        for (ExternalObjectDirectoryEntity entity : unstructuredEntity) {
-            ExternalObjectDirectoryEntity savedEntity = dartsDatabase.getExternalObjectDirectoryRepository().findById(
-                entity.getId()).get();
-            assertEquals(
-                entity.getStatus().getId(),
-                savedEntity.getStatus().getId()
-            );
+    private void assertExternalObjectDirectoryStateNotChanged(List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities) {
+        for (ExternalObjectDirectoryEntity eod : externalObjectDirectoryEntities) {
+            ExternalObjectDirectoryEntity savedEod = dartsDatabase.getExternalObjectDirectoryRepository().findById(eod.getId()).get();
 
-            assertEquals(
-                entity.getLastModifiedBy().getId(),
-                savedEntity.getLastModifiedBy().getId()
-            );
-
-            assertEquals(entity.getLastModifiedDateTime(), savedEntity.getLastModifiedDateTime());
+            assertEquals(eod.getStatus().getId(), savedEod.getStatus().getId());
+            assertEquals(eod.getLastModifiedBy().getId(), savedEod.getLastModifiedBy().getId());
+            assertEquals(eod.getLastModifiedDateTime().toInstant(), savedEod.getLastModifiedDateTime().toInstant());
         }
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/GivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/GivenBuilder.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.UUID;
 
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
-import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.buildGroupForRole;
 import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.buildGroupForRoleAndCourthouse;
+import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.createGroupForRole;
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;
 
 @Component
@@ -28,7 +28,7 @@ public class GivenBuilder {
         var userEmail = role.name() + "@global.com";
         anAuthenticatedUserFor(userEmail);
 
-        var securityGroup = buildGroupForRole(role);
+        var securityGroup = createGroupForRole(role);
         securityGroup.setGlobalAccess(true);
 
         var user = minimalUserAccount();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -977,9 +977,7 @@ public class DartsDatabaseStub {
 
     @Transactional
     public SecurityRoleEntity findSecurityRole(SecurityRoleEnum role) {
-        var securityRoleEntity = securityRoleRepository.findById(role.getId()).orElseThrow();
-        var securityPermissionEntities = securityRoleEntity.getSecurityPermissionEntities();
-        return securityRoleEntity;
+        return securityRoleRepository.findById(role.getId()).orElseThrow();
 
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -34,6 +34,7 @@ import uk.gov.hmcts.darts.common.entity.NodeRegisterEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.RetentionPolicyTypeEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
+import uk.gov.hmcts.darts.common.entity.SecurityRoleEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionCommentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
@@ -42,6 +43,7 @@ import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.enums.SecurityGroupEnum;
+import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.AnnotationDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.AnnotationRepository;
@@ -208,6 +210,7 @@ public class DartsDatabaseStub {
     private final EntityManager entityManager;
     private final CurrentTimeHelper currentTimeHelper;
     private final TransactionalUtil transactionalUtil;
+    private final EntityGraphPersistence entityGraphPersistence;
 
     public void resetSequences() {
         try (EntityManager em = entityManagerFactory.createEntityManager()) {
@@ -391,7 +394,7 @@ public class DartsDatabaseStub {
     }
 
     public CourthouseEntity createCourthouseWithNameAndCode(String name, Integer code, String displayName) {
-        var courthouse = CourthouseTestData.createCourthouse(name);
+        var courthouse = CourthouseTestData.createCourthouseWithName(name);
         courthouse.setCode(code);
         courthouse.setDisplayName(displayName);
         UserAccountEntity defaultUser = userAccountRepository.getReferenceById(0);
@@ -550,6 +553,21 @@ public class DartsDatabaseStub {
     public CourtCaseEntity save(CourtCaseEntity courtCase) {
         save(courtCase.getCourthouse());
         return caseRepository.save(courtCase);
+    }
+
+    @Transactional
+    public TranscriptionEntity save(TranscriptionEntity transcriptionEntity) {
+        save(transcriptionEntity.getCourtCase());
+        userAccountRepository.save(transcriptionEntity.getCreatedBy());
+        userAccountRepository.save(transcriptionEntity.getLastModifiedBy());
+        var transcription = transcriptionRepository.save(transcriptionEntity);
+        userAccountRepository.save(transcription.getCreatedBy());
+        transcription.getTranscriptionDocumentEntities().forEach(td -> {
+            userAccountRepository.save(td.getUploadedBy());
+            userAccountRepository.save(td.getLastModifiedBy());
+            transcriptionDocumentRepository.save(td);
+        });
+        return transcription;
     }
 
     @Transactional
@@ -955,5 +973,13 @@ public class DartsDatabaseStub {
 
     public Revisions<Long, RetentionPolicyTypeEntity> findRetentionPolicyRevisionsFor(Integer id) {
         return retentionPolicyTypeRepository.findRevisions(id);
+    }
+
+    @Transactional
+    public SecurityRoleEntity findSecurityRole(SecurityRoleEnum role) {
+        var securityRoleEntity = securityRoleRepository.findById(role.getId()).orElseThrow();
+        var securityPermissionEntities = securityRoleEntity.getSecurityPermissionEntities();
+        return securityRoleEntity;
+
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStubComposable.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStubComposable.java
@@ -35,6 +35,7 @@ public class TranscriptionStubComposable {
 
     public TranscriptionEntity createTranscription(
         UserAccountStubComposable userAccountStubComposable, HearingEntity hearing, UserAccountEntity authorisedIntegrationTestUser) {
+
         TranscriptionTypeEntity transcriptionType = mapToTranscriptionTypeEntity(SENTENCING_REMARKS);
         TranscriptionStatusEntity transcriptionStatus = mapToTranscriptionStatusEntity(APPROVED);
         TranscriptionUrgencyEntity transcriptionUrgencyEntity = mapToTranscriptionUrgencyEntity(STANDARD);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetAllStatusTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetAllStatusTest.java
@@ -19,55 +19,54 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
 
-    @AutoConfigureMockMvc
-    class TranscriptionControllerGetAllStatusTest extends IntegrationBase {
+@AutoConfigureMockMvc
+class TranscriptionControllerGetAllStatusTest extends IntegrationBase {
 
-        private static final String ENDPOINT_URL_TRANSCRIPTION = "/admin/transcription-status";
+    private static final String ENDPOINT_URL_TRANSCRIPTION = "/admin/transcription-status";
 
-        @Autowired
-        private MockMvc mockMvc;
+    @Autowired
+    private MockMvc mockMvc;
 
-        @Autowired
-        private SuperAdminUserStub superAdminUserStub;
+    @Autowired
+    private SuperAdminUserStub superAdminUserStub;
 
-        @Autowired
-        private SuperUserStub superUserStub;
+    @Autowired
+    private SuperUserStub superUserStub;
 
-        @MockBean
-        private UserIdentity mockUserIdentity;
+    @MockBean
+    private UserIdentity mockUserIdentity;
 
-        @Test
-        void shouldSuccessfullyReturnTranscriptionStatusesForSuperAdmin() throws Exception {
+    @Test
+    void shouldSuccessfullyReturnTranscriptionStatusesForSuperAdmin() throws Exception {
 
-            superAdminUserStub.givenUserIsAuthorised(mockUserIdentity);
-            MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION);
-            MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk()).andReturn();
-            String actualResponse = response.getResponse().getContentAsString();
-            String expectedResponse = getContentsFromFile("tests/transcriptions/transcription_status/expectedResponse.json");
-            JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
-        }
-
-        @Test
-        void shouldSuccessfullyReturnTranscriptionStatusesForSuperUser() throws Exception {
-
-            superUserStub.givenUserIsAuthorised(mockUserIdentity);
-            MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION);
-            MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk()).andReturn();
-            String actualResponse = response.getResponse().getContentAsString();
-            String expectedResponse = getContentsFromFile("tests/transcriptions/transcription_status/expectedResponse.json");
-            JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
-        }
-
-
-        @Test
-        void shouldFailToReturnTranscriptionStatusesForNonSuperAdminOrSuperUser() throws Exception {
-
-            MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION);
-
-            mockMvc.perform(requestBuilder).andExpect(status().isForbidden()).andReturn();
-        }
-
-
-
+        superAdminUserStub.givenUserIsAuthorised(mockUserIdentity);
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION);
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk()).andReturn();
+        String actualResponse = response.getResponse().getContentAsString();
+        String expectedResponse = getContentsFromFile("tests/transcriptions/transcription_status/expectedResponse.json");
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
+
+    @Test
+    void shouldSuccessfullyReturnTranscriptionStatusesForSuperUser() throws Exception {
+
+        superUserStub.givenUserIsAuthorised(mockUserIdentity);
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION);
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk()).andReturn();
+        String actualResponse = response.getResponse().getContentAsString();
+        String expectedResponse = getContentsFromFile("tests/transcriptions/transcription_status/expectedResponse.json");
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+
+    @Test
+    void shouldFailToReturnTranscriptionStatusesForNonSuperAdminOrSuperUser() throws Exception {
+
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION);
+
+        mockMvc.perform(requestBuilder).andExpect(status().isForbidden()).andReturn();
+    }
+
+
+}
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchSecurityGroupIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchSecurityGroupIntTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.buildGroupForRole;
+import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.createGroupForRole;
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;
 
 @AutoConfigureMockMvc
@@ -375,7 +375,7 @@ class PatchSecurityGroupIntTest extends IntegrationBase {
     void removeAllUsersGivenEmptyUserPatchList() throws Exception {
         superAdminUserStub.givenUserIsAuthorised(userIdentity);
 
-        var securityGroupEntity = buildGroupForRole(APPROVER);
+        var securityGroupEntity = createGroupForRole(APPROVER);
         dartsDatabase.addUserToGroup(minimalUserAccount(), securityGroupEntity);
         dartsDatabase.addUserToGroup(minimalUserAccount(), securityGroupEntity);
 
@@ -393,7 +393,7 @@ class PatchSecurityGroupIntTest extends IntegrationBase {
     void removesOnlyAbsentUsersGivenPatchWithSubsetOfCurrentUsers() throws Exception {
         superAdminUserStub.givenUserIsAuthorised(userIdentity);
 
-        var securityGroupEntity = buildGroupForRole(APPROVER);
+        var securityGroupEntity = createGroupForRole(APPROVER);
         var userAccount1 = minimalUserAccount();
         var userAccount2 = minimalUserAccount();
         dartsDatabase.addUserToGroup(userAccount1, securityGroupEntity);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/SecurityGroupManagementAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/SecurityGroupManagementAuditTest.java
@@ -16,7 +16,7 @@ import static org.springframework.data.history.RevisionMetadata.RevisionType.INS
 import static org.springframework.data.history.RevisionMetadata.RevisionType.UPDATE;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
-import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.buildGroupForRole;
+import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.createGroupForRole;
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;
 
 class SecurityGroupManagementAuditTest extends IntegrationBase {
@@ -58,7 +58,7 @@ class SecurityGroupManagementAuditTest extends IntegrationBase {
     @Test
     void auditsWhenSecurityGroupsMembersAreUpdated() {
         var userAccountEntity = given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
-        var securityGroup = dartsDatabase.save(buildGroupForRole(TRANSCRIBER));
+        var securityGroup = dartsDatabase.save(createGroupForRole(TRANSCRIBER));
         var userAccount = dartsDatabase.save(minimalUserAccount());
 
         securityGroupService.modifySecurityGroup(

--- a/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/casesSearchGetEndpointOneObjectReturned.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/casesSearchGetEndpointOneObjectReturned.json
@@ -5,9 +5,9 @@
     "hea_id": 1,
     "hearing_id": 1,
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:00:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/casesSearchGetEndpointTwoObjectsReturned.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/casesSearchGetEndpointTwoObjectsReturned.json
@@ -5,10 +5,10 @@
     "hea_id": 1,
     "hearing_id": 1,
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:00:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   },
   {
     "tra_id": 2,
@@ -16,9 +16,9 @@
     "hea_id": 1,
     "hearing_id": 1,
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:00:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/ignoreAutomaticTranscripts.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerGetCaseTranscriptsTest/ignoreAutomaticTranscripts.json
@@ -1,23 +1,23 @@
 [
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:01:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   },
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:03:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   },
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:04:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   }
 ]

--- a/src/integrationTest/resources/tests/hearings/HearingsControllerGetTranscriptsTest/ignoreAutomaticTranscripts.json
+++ b/src/integrationTest/resources/tests/hearings/HearingsControllerGetTranscriptsTest/ignoreAutomaticTranscripts.json
@@ -1,23 +1,23 @@
 [
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:01:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   },
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:03:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   },
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:04:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   }
 ]

--- a/src/integrationTest/resources/tests/hearings/HearingsControllerGetTranscriptsTest/ignoreHiddenTranscripts.json
+++ b/src/integrationTest/resources/tests/hearings/HearingsControllerGetTranscriptsTest/ignoreHiddenTranscripts.json
@@ -1,23 +1,23 @@
 [
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:01:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   },
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:02:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   },
   {
     "hearing_date": "2023-01-01",
-    "type": "SENTENCING_REMARKS",
+    "type": "Sentencing remarks",
     "requested_on": "2023-06-20T10:03:00Z",
     "requested_by_name": "integrationtest.user@example.comFullName",
-    "status": "APPROVED"
+    "status": "Approved"
   }
 ]

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/CourthouseTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/CourthouseTestData.java
@@ -22,14 +22,14 @@ public class CourthouseTestData {
         return courtHouse;
     }
 
-    public static CourthouseEntity createCourthouse(String name) {
+    public static CourthouseEntity createCourthouseWithName(String name) {
         var courthouse = someMinimalCourthouse();
         courthouse.setCourthouseName(name);
         courthouse.setDisplayName(name);
         return courthouse;
     }
 
-    public static CourthouseEntity createCourthouse(String name, Integer code) {
+    public static CourthouseEntity createCourthouseWithNameAndCode(String name, Integer code) {
         var courthouse = someMinimalCourthouse();
         courthouse.setCourthouseName(name);
         courthouse.setDisplayName(name);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/CourtroomTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/CourtroomTestData.java
@@ -8,7 +8,6 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import java.util.ArrayList;
 
 import static org.apache.commons.lang3.RandomStringUtils.random;
-import static uk.gov.hmcts.darts.test.common.data.CourthouseTestData.createCourthouse;
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;
 
 @UtilityClass
@@ -18,7 +17,7 @@ public class CourtroomTestData {
     public static CourtroomEntity someMinimalCourtRoom() {
         var postfix = random(10, false, true);
         var courtroom = new CourtroomEntity();
-        var courthouse = createCourthouse("some-courthouse-" + postfix);
+        var courthouse = CourthouseTestData.createCourthouseWithName("some-courthouse-" + postfix);
         var courtrooms = new ArrayList<CourtroomEntity>();
         courtrooms.add(courtroom);
         courthouse.setCourtrooms(courtrooms);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/HearingTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/HearingTestData.java
@@ -12,7 +12,6 @@ import java.util.Objects;
 
 import static uk.gov.hmcts.darts.test.common.data.CaseTestData.createCaseWithCaseNumber;
 import static uk.gov.hmcts.darts.test.common.data.CaseTestData.createSomeMinimalCase;
-import static uk.gov.hmcts.darts.test.common.data.CourthouseTestData.createCourthouse;
 import static uk.gov.hmcts.darts.test.common.data.CourtroomTestData.createCourtRoomWithNameAtCourthouse;
 import static uk.gov.hmcts.darts.test.common.data.CourtroomTestData.someMinimalCourtRoom;
 
@@ -48,7 +47,7 @@ public class HearingTestData {
         HearingEntity hearing1 = createHearingWithDefaults(
             createCaseWithCaseNumber(caseNumber),
             createCourtRoomWithNameAtCourthouse(
-                createCourthouse("NEWCASTLE"),
+                CourthouseTestData.createCourthouseWithName("NEWCASTLE"),
                 "1"
             ),
             HEARING_DATE,

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/SecurityGroupTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/SecurityGroupTestData.java
@@ -7,13 +7,13 @@ import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import java.util.Set;
 
 import static org.apache.commons.lang3.RandomStringUtils.random;
-import static uk.gov.hmcts.darts.test.common.data.SecurityRoleTestData.securityRoleFor;
+import static uk.gov.hmcts.darts.test.common.data.SecurityRoleTestData.createSecurityRoleFor;
 
 @SuppressWarnings({"HideUtilityClassConstructor"})
 public class SecurityGroupTestData {
 
     public static SecurityGroupEntity minimalSecurityGroup() {
-        var postfix = random(10);
+        var postfix = random(10, false, true);
         var securityGroup = new SecurityGroupEntity();
         securityGroup.setGroupName("some-group-name-" + postfix);
         securityGroup.setGlobalAccess(false);
@@ -24,14 +24,18 @@ public class SecurityGroupTestData {
         return securityGroup;
     }
 
-    public static SecurityGroupEntity buildGroupForRole(SecurityRoleEnum role) {
+    // Use with caution, when persisted it will overwrite values for subsequent tests
+    @Deprecated
+    public static SecurityGroupEntity createGroupForRole(SecurityRoleEnum role) {
         var securityGroupEntity = minimalSecurityGroup();
-        securityGroupEntity.setSecurityRoleEntity(securityRoleFor(role));
+        securityGroupEntity.setSecurityRoleEntity(createSecurityRoleFor(role));
         return securityGroupEntity;
     }
 
+    // Use with caution, when persisted it will overwrite values for subsequent tests
+    @Deprecated
     public static SecurityGroupEntity buildGroupForRoleAndCourthouse(SecurityRoleEnum role, CourthouseEntity courthouse) {
-        var securityGroupEntity = buildGroupForRole(role);
+        var securityGroupEntity = createGroupForRole(role);
         securityGroupEntity.setCourthouseEntities(Set.of(courthouse));
         return securityGroupEntity;
     }

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/SecurityRoleTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/SecurityRoleTestData.java
@@ -3,12 +3,18 @@ package uk.gov.hmcts.darts.test.common.data;
 import uk.gov.hmcts.darts.common.entity.SecurityRoleEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 
+import static org.apache.commons.lang3.RandomStringUtils.random;
+
 @SuppressWarnings({"HideUtilityClassConstructor"})
 public class SecurityRoleTestData {
 
-    public static SecurityRoleEntity securityRoleFor(SecurityRoleEnum role) {
+    public static SecurityRoleEntity createSecurityRoleFor(SecurityRoleEnum role) {
+        var postfix = random(10, false, true);
         var securityRole = new SecurityRoleEntity();
         securityRole.setId(role.getId());
+        securityRole.setRoleName("some-role-name-" + postfix);
+        securityRole.setDisplayName("some-display-name-" + postfix);
+        securityRole.setDisplayState(true);
         return securityRole;
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-3513

Removing transactional from integration tests.  This ticket was mainly about the automated task integration tests.  I've gone further and done some of the other ones that were relatively easy.  The TranscriptionService integration tests are still mostly transactional as they are not quick wins and should be tackled in a separate ticket 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
