### PR TITLE
DMP-3398 changed audio requests download endpoint to return "Content-length" header

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDownloadIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerDownloadIntTest.java
@@ -106,7 +106,8 @@ class AudioRequestsControllerDownloadIntTest extends IntegrationBase {
             .queryParam("transformed_media_id", String.valueOf(transformedMediaId));
 
         mockMvc.perform(requestBuilder)
-            .andExpect(status().isOk());
+            .andExpect(status().isOk())
+            .andExpect(header().exists("Content-Length"));
 
         verify(dataManagementService).downloadData(eq(DatastoreContainerType.OUTBOUND), eq("darts-outbound"), any());
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerPlaybackIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerPlaybackIntTest.java
@@ -112,7 +112,8 @@ class AudioRequestsControllerPlaybackIntTest extends IntegrationBase {
             .queryParam("transformed_media_id", String.valueOf(transformedMediaId));
 
         mockMvc.perform(requestBuilder)
-            .andExpect(status().isOk());
+            .andExpect(status().isOk())
+            .andExpect(header().exists("Content-Length"));
 
         verify(dataManagementService).downloadData(eq(DatastoreContainerType.OUTBOUND), eq("darts-outbound"), any());
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -5,8 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,10 +28,11 @@ import uk.gov.hmcts.darts.audiorequests.model.MediaRequest;
 import uk.gov.hmcts.darts.audiorequests.model.SearchTransformedMediaRequest;
 import uk.gov.hmcts.darts.audiorequests.model.SearchTransformedMediaResponse;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
+import uk.gov.hmcts.darts.common.datamanagement.component.impl.DownloadResponseMetaData;
+import uk.gov.hmcts.darts.common.datamanagement.component.impl.FileBasedDownloadResponseMetaData;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.log.api.LogApi;
 
-import java.io.InputStream;
 import java.util.List;
 
 import static uk.gov.hmcts.darts.authorisation.constants.AuthorisationConstants.SECURITY_SCHEMES_BEARER_AUTH;
@@ -82,11 +84,10 @@ public class AudioRequestsController implements AudioRequestsApi {
         securityRoles = {TRANSCRIBER},
         globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER, DARTS})
     public ResponseEntity<Resource> download(Integer transformedMediaId) {
-        InputStream audioFileStream = mediaRequestService.download(transformedMediaId);
-
+        FileBasedDownloadResponseMetaData downloadResponseMetadata = (FileBasedDownloadResponseMetaData) mediaRequestService.download(transformedMediaId);
+        HttpHeaders respHeaders = new HttpHeaders();
         return new ResponseEntity<>(
-            new InputStreamResource(audioFileStream),
-            HttpStatus.OK
+            new FileSystemResource(downloadResponseMetadata.getFileToBeDownloadedTo()), respHeaders, HttpStatus.OK
         );
     }
 
@@ -137,9 +138,9 @@ public class AudioRequestsController implements AudioRequestsApi {
         securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
         globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA, DARTS})
     public ResponseEntity<byte[]> playback(Integer transformedMediaId, String httpRangeList) {
-        InputStream audioFileStream = mediaRequestService.playback(transformedMediaId);
+        DownloadResponseMetaData downloadResponseMetadata = mediaRequestService.playback(transformedMediaId);
 
-        return StreamingResponseEntityUtil.createResponseEntity(audioFileStream, httpRangeList);
+        return StreamingResponseEntityUtil.createResponseEntity(downloadResponseMetadata.getInputStream(), httpRangeList);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -85,10 +84,7 @@ public class AudioRequestsController implements AudioRequestsApi {
         globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER, DARTS})
     public ResponseEntity<Resource> download(Integer transformedMediaId) {
         FileBasedDownloadResponseMetaData downloadResponseMetadata = (FileBasedDownloadResponseMetaData) mediaRequestService.download(transformedMediaId);
-        HttpHeaders respHeaders = new HttpHeaders();
-        return new ResponseEntity<>(
-            new FileSystemResource(downloadResponseMetadata.getFileToBeDownloadedTo()), respHeaders, HttpStatus.OK
-        );
+        return ResponseEntity.ok().body(new FileSystemResource(downloadResponseMetadata.getFileToBeDownloadedTo()));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
@@ -12,9 +12,9 @@ import uk.gov.hmcts.darts.audiorequests.model.MediaPatchResponse;
 import uk.gov.hmcts.darts.audiorequests.model.MediaRequest;
 import uk.gov.hmcts.darts.audiorequests.model.SearchTransformedMediaRequest;
 import uk.gov.hmcts.darts.audiorequests.model.SearchTransformedMediaResponse;
+import uk.gov.hmcts.darts.common.datamanagement.component.impl.DownloadResponseMetaData;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 
-import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,9 +48,9 @@ public interface MediaRequestService {
 
     void updateTransformedMediaLastAccessedTimestampForMediaRequestId(Integer mediaRequestId);
 
-    InputStream download(Integer transformedMediaId);
+    DownloadResponseMetaData download(Integer transformedMediaId);
 
-    InputStream playback(Integer transformedMediaId);
+    DownloadResponseMetaData playback(Integer transformedMediaId);
 
     MediaRequestEntity updateAudioRequestCompleted(MediaRequestEntity mediaRequestEntity);
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -76,7 +76,6 @@ import uk.gov.hmcts.darts.notification.api.NotificationApi;
 import uk.gov.hmcts.darts.notification.dto.SaveNotificationToDbRequest;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -396,7 +395,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     }
 
     @Override
-    public InputStream download(Integer transformedMediaId) {
+    public DownloadResponseMetaData download(Integer transformedMediaId) {
         try {
             return downloadOrPlayback(transformedMediaId, EXPORT_AUDIO, AudioRequestType.DOWNLOAD);
         } catch (IOException | FileNotDownloadedException e) {
@@ -405,7 +404,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     }
 
     @Override
-    public InputStream playback(Integer transformedMediaId) {
+    public DownloadResponseMetaData playback(Integer transformedMediaId) {
         try {
             return downloadOrPlayback(transformedMediaId, AUDIO_PLAYBACK, AudioRequestType.PLAYBACK);
         } catch (IOException | FileNotDownloadedException e) {
@@ -434,7 +433,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
         return getTransformedMediaDetailsMapper.mapSearchResults(mediaEntities);
     }
 
-    private InputStream downloadOrPlayback(
+    private DownloadResponseMetaData downloadOrPlayback(
         Integer transformedMediaId, AuditActivity auditActivity, AudioRequestType expectedType
     ) throws FileNotDownloadedException, IOException {
         final TransformedMediaEntity transformedMediaEntity = getTransformedMediaById(transformedMediaId);
@@ -448,9 +447,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
             this.getUserAccount(),
             mediaRequestEntity.getHearing().getCourtCase()
         );
-
-        DownloadResponseMetaData downloadResponse = dataManagementApi.getBlobDataFromOutboundContainer(blobId);
-        return downloadResponse.getInputStream();
+        return dataManagementApi.getBlobDataFromOutboundContainer(blobId);
     }
 
     private UUID getBlobId(TransformedMediaEntity transformedMediaEntity) {

--- a/src/main/java/uk/gov/hmcts/darts/common/datamanagement/component/impl/FileBasedDownloadResponseMetaData.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/datamanagement/component/impl/FileBasedDownloadResponseMetaData.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.common.datamanagement.component.impl;
 
+import lombok.Getter;
 import uk.gov.hmcts.darts.common.datamanagement.StorageConfiguration;
 
 import java.io.File;
@@ -16,6 +17,8 @@ import java.util.UUID;
  *The response download data. Always use in combination with a try resources to ensure the file resources are cleaned up
  */
 public class FileBasedDownloadResponseMetaData extends DownloadResponseMetaData {
+
+    @Getter
     private File fileToBeDownloadedTo;
 
     @Override

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
@@ -48,7 +48,6 @@ import uk.gov.hmcts.darts.notification.api.NotificationApi;
 import uk.gov.hmcts.darts.notification.dto.SaveNotificationToDbRequest;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -426,7 +425,7 @@ class MediaRequestServiceImplTest {
 
     @SneakyThrows
     @Test
-    void downloadShouldReturnExpectedData() throws IOException {
+    void downloadShouldReturnExpectedData() {
         MediaEntity mediaEntity = new MediaEntity();
         mediaEntity.setId(1);
         mediaEntity.setStart(START_TIME);
@@ -461,8 +460,8 @@ class MediaRequestServiceImplTest {
         when(dataManagementApi.getBlobDataFromOutboundContainer(blobUuid)).thenReturn(responseMetaData);
         when(responseMetaData.getInputStream()).thenReturn(toInputStream(DUMMY_FILE_CONTENT, "UTF-8"));
 
-        try (InputStream inputStream = mediaRequestService.download(transformedMediaId)) {
-            byte[] bytes = inputStream.readAllBytes();
+        try (DownloadResponseMetaData downloadResponseMetaData = mediaRequestService.download(transformedMediaId)) {
+            byte[] bytes = downloadResponseMetaData.getInputStream().readAllBytes();
             assertEquals(DUMMY_FILE_CONTENT, new String(bytes));
         }
 
@@ -589,8 +588,8 @@ class MediaRequestServiceImplTest {
         when(dataManagementApi.getBlobDataFromOutboundContainer(blobUuid)).thenReturn(responseMetaData);
         when(responseMetaData.getInputStream()).thenReturn(toInputStream(DUMMY_FILE_CONTENT, "UTF-8"));
 
-        try (InputStream inputStream = mediaRequestService.playback(transformedMediaId)) {
-            byte[] bytes = inputStream.readAllBytes();
+        try (DownloadResponseMetaData downloadResponseMetaData = mediaRequestService.playback(transformedMediaId)) {
+            byte[] bytes = downloadResponseMetaData.getInputStream().readAllBytes();
             assertEquals(DUMMY_FILE_CONTENT, new String(bytes));
         }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3398


### Change description ###
This PR is a first attempt to fix DMP-3398. As of now the endpoint does not set a "Content-length" header resulting in the server using chunked transfer encoding to transmit the data to the user.
It seems that specifying "Content-Length" is always preferable when downloading binary files like in our case compared to chunked encoding. See [here](https://stackoverflow.com/questions/2419281/content-length-header-versus-chunked-encoding) for example.
I'm not sure whether this change would improve the download speed and fix the issue, since it's not possible to reproduce this issue locally. But this seems to me a good improvement anyway.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
