### PR TITLE
DMP-3674: Fix PATCH /admin/security-groups/<id> to correctly remove unassigned courthouses

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/SecurityGroupStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/SecurityGroupStub.java
@@ -1,13 +1,18 @@
 package uk.gov.hmcts.darts.testutils.stubs;
 
+import jakarta.annotation.PostConstruct;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
+import uk.gov.hmcts.darts.common.entity.SecurityRoleEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityGroupEnum;
+import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
+import uk.gov.hmcts.darts.common.repository.SecurityRoleRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.util.Optional;
@@ -18,7 +23,17 @@ import java.util.Set;
 public class SecurityGroupStub {
     private final SecurityGroupRepository securityGroupRepository;
     private final UserAccountRepository userAccountRepository;
+    private final SecurityRoleRepository securityRoleRepository;
 
+    private static SecurityRoleEntity defaultRole;
+
+    @PostConstruct
+    public void init() {
+        defaultRole = securityRoleRepository.findAll().stream()
+            .filter(securityRoleEntity -> securityRoleEntity.getId().equals(SecurityRoleEnum.REQUESTER.getId()))
+            .findFirst()
+            .orElseThrow();
+    }
 
     @Transactional
     public void addCourthouse(SecurityGroupEntity securityGroupEntity, CourthouseEntity courthouseEntity) {
@@ -48,5 +63,46 @@ public class SecurityGroupStub {
         entity.get().getUsers().clear();
 
         securityGroupRepository.saveAndFlush(entity.get());
+    }
+
+    public SecurityGroupEntity createAndSave(SecurityGroupEntitySpec spec) {
+        SecurityGroupEntity securityGroup = new SecurityGroupEntity();
+        securityGroup.setSecurityRoleEntity(spec.securityRoleEntity);
+        securityGroup.setLegacyObjectId(spec.legacyObjectId);
+        securityGroup.setGroupName(spec.groupName);
+        securityGroup.setIsPrivate(spec.isPrivate);
+        securityGroup.setDescription(spec.description);
+        securityGroup.setGroupGlobalUniqueId(securityGroup.getGroupGlobalUniqueId());
+        securityGroup.setGlobalAccess(spec.globalAccess);
+        securityGroup.setDisplayState(spec.displayState);
+        securityGroup.setUseInterpreter(spec.useInterpreter);
+        securityGroup.setCourthouseEntities(spec.courthouseEntities);
+        securityGroup.setUsers(spec.users);
+        securityGroup.setDisplayName(spec.displayName);
+
+        return securityGroupRepository.save(securityGroup);
+    }
+
+    @Builder
+    public static class SecurityGroupEntitySpec {
+        @Builder.Default
+        private SecurityRoleEntity securityRoleEntity = defaultRole;
+        private String legacyObjectId;
+        @Builder.Default
+        private String groupName = "Some security group name";
+        private Boolean isPrivate;
+        @Builder.Default
+        private String description = "Some description";
+        private String groupGlobalUniqueId;
+        @Builder.Default
+        private Boolean globalAccess = false;
+        @Builder.Default
+        private Boolean displayState = true;
+        @Builder.Default
+        private Boolean useInterpreter = false;
+        private Set<CourthouseEntity> courthouseEntities;
+        private Set<UserAccountEntity> users;
+        @Builder.Default
+        private String displayName = "Some security group display name";
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchSecurityGroupIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/PatchSecurityGroupIntTest.java
@@ -12,11 +12,15 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.testutils.stubs.SecurityGroupStub;
 import uk.gov.hmcts.darts.testutils.stubs.SuperAdminUserStub;
 import uk.gov.hmcts.darts.usermanagement.exception.UserManagementError;
 
+import java.util.Set;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -32,6 +36,7 @@ class PatchSecurityGroupIntTest extends IntegrationBase {
 
     private static final String TEST_COURTHOUSE_NAME_1 = "Courthouse name 1";
     private static final String TEST_COURTHOUSE_NAME_2 = "Courthouse name 2";
+    private static final String TEST_COURTHOUSE_NAME_3 = "Courthouse name 3";
     private static final String NEW_DESCRIPTION = "Security group description new";
 
 
@@ -40,6 +45,9 @@ class PatchSecurityGroupIntTest extends IntegrationBase {
 
     @Autowired
     private SuperAdminUserStub superAdminUserStub;
+
+    @Autowired
+    private SecurityGroupStub securityGroupStub;
 
     @MockBean
     private UserIdentity userIdentity;
@@ -119,31 +127,39 @@ class PatchSecurityGroupIntTest extends IntegrationBase {
     }
 
     @Test
-    void patchSecurityGroupShouldSucceedWhenProvidedWithCourthouseIds() throws Exception {
+    void patchSecurityGroupShouldSucceedAndReturnExpectedResultWhenCourthousesAreAddedAndRemoved() throws Exception {
+        // Given
         superAdminUserStub.givenUserIsAuthorised(userIdentity);
-
-        String name = "security group name" + UUID.randomUUID();
-        String displayName = "security group display name" + UUID.randomUUID();
-        Integer id = createSecurityGroup(name, displayName);
 
         var courthouseEntity1 = dartsDatabase.createCourthouseUnlessExists(TEST_COURTHOUSE_NAME_1);
         var courthouseEntity2 = dartsDatabase.createCourthouseUnlessExists(TEST_COURTHOUSE_NAME_2);
+        var courthouseEntity3 = dartsDatabase.createCourthouseUnlessExists(TEST_COURTHOUSE_NAME_3);
 
-        String patchContent = String.format("{\"courthouse_ids\": [%s, %s]}", courthouseEntity1.getId(), courthouseEntity2.getId());
+        // And a group with two assigned courthouses exists (1) (2).
+        var securityGroupEntity = securityGroupStub.createAndSave(SecurityGroupStub.SecurityGroupEntitySpec.builder()
+                                                                                      .courthouseEntities(Set.of(courthouseEntity1, courthouseEntity2))
+                                                                                      .build());
 
-        MockHttpServletRequestBuilder patchRequest = buildPatchRequest(id)
-            .content(patchContent);
+        // When we wish to keep one existing courthouse assigned (1), remove the other (2), and add a new one (3)
+        MockHttpServletRequestBuilder patchRequest = buildPatchRequest(securityGroupEntity.getId())
+            .content("""
+                         {
+                            "courthouse_ids": [%d, %d]
+                         }
+                         """.formatted(courthouseEntity1.getId(), courthouseEntity3.getId()));
 
+        // Then assert that only courthouse (1) and (3) are assigned
         mockMvc.perform(patchRequest)
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.id").value(id))
-            .andExpect(jsonPath("$.name").value(name))
-            .andExpect(jsonPath("$.display_name").value(displayName))
-            .andExpect(jsonPath("$.description").value(ORIGINAL_DESCRIPTION))
-            .andExpect(jsonPath("$.global_access").value(false))
-            .andExpect(jsonPath("$.security_role_id").isNumber())
-            .andExpect(jsonPath("$.courthouse_ids[0]").value(courthouseEntity1.getId()))
-            .andExpect(jsonPath("$.courthouse_ids[1]").value(courthouseEntity2.getId()))
+            .andExpect(jsonPath("$.id").value(securityGroupEntity.getId()))
+            .andExpect(jsonPath("$.name").value(securityGroupEntity.getGroupName()))
+            .andExpect(jsonPath("$.display_name").value(securityGroupEntity.getDisplayName()))
+            .andExpect(jsonPath("$.description").value(securityGroupEntity.getDescription()))
+            .andExpect(jsonPath("$.global_access").value(securityGroupEntity.getGlobalAccess()))
+            .andExpect(jsonPath("$.security_role_id").value(securityGroupEntity.getSecurityRoleEntity().getId()))
+            .andExpect(jsonPath("$.courthouse_ids", hasSize(2)))
+            .andExpect(jsonPath("$.courthouse_ids", hasItem(courthouseEntity1.getId())))
+            .andExpect(jsonPath("$.courthouse_ids", hasItem(courthouseEntity3.getId())))
             .andExpect(jsonPath("$.user_ids").isEmpty())
             .andReturn();
     }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/SecurityGroupServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/SecurityGroupServiceImpl.java
@@ -158,6 +158,10 @@ public class SecurityGroupServiceImpl implements SecurityGroupService {
             securityGroupEntity.setDescription(description);
         }
         if (securityGroupPatch.getCourthouseIds() != null) {
+            // The PATCH contains the totality of courthouses we wish to have assigned to our group. So first we must remove any existing courthouses, and then
+            // assign whatever courthouses are provided in the request.
+            securityGroupEntity.getCourthouseEntities()
+                .clear();
             securityGroupPatch.getCourthouseIds()
                 .forEach(courthouseId -> addToSecurityGroup(courthouseId, securityGroupEntity));
         }


### PR DESCRIPTION
# [DMP-3674](https://tools.hmcts.net/jira/browse/DMP-3674)

Bugfix per DMP-3674.

NOTE: This PR replaces https://github.com/hmcts/darts-api/pull/1819, which was failing to correctly report the Jenkins build status.

**Does this PR introduce a breaking change?** (check one with "x")