### PR TITLE
 NO_JIRA: log Darts feign clients requests/responses full details on Demo

### DIFF
--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.84
+version: 0.0.85
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.stg.template.yaml
+++ b/charts/darts-api/values.stg.template.yaml
@@ -6,3 +6,4 @@ java:
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
     DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net
     ARM_URL: http://darts-stub-services.staging.platform.hmcts.net
+    FEIGN_LOG_LEVEL: none

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -108,6 +108,7 @@ java:
     ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsstgextid.b2clogin.com
     ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
     ARM_URL: http://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
+    FEIGN_LOG_LEVEL: none
 
 function:
   scaleType: Job
@@ -214,6 +215,7 @@ function:
     ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsstgextid.b2clogin.com
     ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
     ARM_URL: http://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
+    FEIGN_LOG_LEVEL: none
 
   secrets:
     DARTS_API_DB_CONNECTION_STRING:

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/client/ArmTokenClientIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/client/ArmTokenClientIntTest.java
@@ -4,6 +4,7 @@ package uk.gov.hmcts.darts.arm.client;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import feign.FeignException;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @TestPropertySource(properties = {
     "darts.storage.arm-api.url=http://localhost:${wiremock.server.port}"
 })
+@Disabled("these test mysteriously fails when enabling feign full logging of request/responses")
 class ArmTokenClientIntTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/client/ArmTokenClientIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/client/ArmTokenClientIntTest.java
@@ -4,7 +4,6 @@ package uk.gov.hmcts.darts.arm.client;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import feign.FeignException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -32,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @TestPropertySource(properties = {
     "darts.storage.arm-api.url=http://localhost:${wiremock.server.port}"
 })
-@Disabled("these test mysteriously fails when enabling feign full logging of request/responses")
 class ArmTokenClientIntTest extends IntegrationBase {
 
     @Autowired

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -105,6 +105,12 @@ spring:
     locations: classpath:db/migration/common,db/migration/postgres
     default-schema: ${spring.datasource.schema}
     mixed: true
+  cloud:
+    openfeign:
+      client:
+        config:
+          default:
+            loggerLevel: ${FEIGN_LOG_LEVEL:full}
 
 darts:
   automated-tasks-pod: ${AUTOMATED_TASK_MODE:true}
@@ -362,8 +368,3 @@ logging:
   level:
     uk.gov.hmcts.darts: ${DARTS_LOG_LEVEL:INFO}
     net.javacrumbs.shedlock: ${DARTS_LOG_LEVEL:INFO}
-feign:
-  client:
-    config:
-      default:
-        loggerLevel: full

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -110,7 +110,7 @@ spring:
       client:
         config:
           default:
-            loggerLevel: ${FEIGN_LOG_LEVEL:full}
+            loggerLevel: ${FEIGN_LOG_LEVEL:none}
 
 darts:
   automated-tasks-pod: ${AUTOMATED_TASK_MODE:true}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -368,3 +368,8 @@ logging:
   level:
     uk.gov.hmcts.darts: ${DARTS_LOG_LEVEL:INFO}
     net.javacrumbs.shedlock: ${DARTS_LOG_LEVEL:INFO}
+feign:
+  client:
+    config:
+      default:
+        loggerLevel: full

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -368,8 +368,3 @@ logging:
   level:
     uk.gov.hmcts.darts: ${DARTS_LOG_LEVEL:INFO}
     net.javacrumbs.shedlock: ${DARTS_LOG_LEVEL:INFO}
-feign:
-  client:
-    config:
-      default:
-        loggerLevel: full


### PR DESCRIPTION
### Change description ###
During QA it it sometimes important to see the full details of http requests and responses Darts is making to external services, e.g. ARM. 
This PR configures Feign clients to log headers, body, and metadata for both requests and responses, and replaces an existing config that is not working.
For now we will enable full logging only on Demo:
https://github.com/hmcts/sds-flux-config/pull/5343

Note:
we have [this ticket](https://tools.hmcts.net/jira/browse/DMP-3854) to remove this setting before we go to Prod to avoid sensitive data leak in logs:

as part of that ticket we can consider having different configs depending on the environments, so that full logging is enabled on Staging (which would help QA) but disabled on Prod

Example:
[
<img width="1947" alt="Screenshot 2024-08-23 at 09 52 51" src="https://github.com/user-attachments/assets/71c634b0-0314-4244-a318-fab45d5e801a">
<img width="1054" alt="Screenshot 2024-08-23 at 10 25 41" src="https://github.com/user-attachments/assets/e4ee1fb8-0f3f-4880-9c21-ad0df5d7b3b3">
](url)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
