### PR TITLE
DMP-3323: Standardise to use springboot Transactional

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceGivenBuilder.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.audio.service;
 
-import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceHandleKedaInvocationForMediaRequestsGivenBuilder.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.darts.audio.service;
 
-import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestType;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/TransactionalUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/TransactionalUtil.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.darts.testutils;
 
-import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.Callable;
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseDocumentStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseDocumentStub.java
@@ -1,12 +1,12 @@
 package uk.gov.hmcts.darts.testutils.stubs;
 
-import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseRetrieval.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseRetrieval.java
@@ -2,12 +2,12 @@ package uk.gov.hmcts.darts.testutils.stubs;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
-import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.history.Revisions;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.AnnotationEntity;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Query;
-import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -12,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.platform.commons.JUnitException;
 import org.springframework.data.history.Revisions;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestType;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
@@ -854,7 +854,7 @@ public class DartsDatabaseStub {
         return automatedTaskRepository.findAll();
     }
 
-    @Transactional(dontRollbackOn = RuntimeException.class)
+    @Transactional(noRollbackFor = RuntimeException.class)
     public void lockTaskUntil(String taskName, OffsetDateTime taskReleaseDateTime) {
         var updateRowForTaskSql = """
             update darts.shedlock

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsPersistence.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsPersistence.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.darts.testutils.stubs;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
-import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.AnnotationEntity;
 import uk.gov.hmcts.darts.common.entity.CaseManagementRetentionEntity;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/EntityGraphPersistence.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/EntityGraphPersistence.java
@@ -2,10 +2,10 @@ package uk.gov.hmcts.darts.testutils.stubs;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.DefendantEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.repository.JudgeRepository;

--- a/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.admin.test;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Session;
@@ -8,6 +7,7 @@ import org.hibernate.SessionFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -207,7 +207,7 @@ public class TestSupportController {
     }
 
     @PostMapping(value = "/audit/{audit_activity}/courthouse/{courthouse_name}")
-    @Transactional(rollbackOn = DataIntegrityViolationException.class)
+    @Transactional(rollbackFor = DataIntegrityViolationException.class)
     public ResponseEntity<String> createAudit(@PathVariable(name = "audit_activity") String auditActivity,
                                               @PathVariable(name = "courthouse_name") String courthouseName) {
 

--- a/src/main/java/uk/gov/hmcts/darts/annotation/persistence/AnnotationPersistenceService.java
+++ b/src/main/java/uk/gov/hmcts/darts/annotation/persistence/AnnotationPersistenceService.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.darts.annotation.persistence;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;

--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/TransformedMediaHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/TransformedMediaHelper.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.audio.helper;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.enums.AudioRequestOutputFormat;
 import uk.gov.hmcts.darts.audio.model.AudioFileInfo;

--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.darts.audio.helper;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.audio.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.darts.audio.component.AddAudioRequestMapper;
 import uk.gov.hmcts.darts.audio.component.AudioMessageDigest;

--- a/src/main/java/uk/gov/hmcts/darts/audit/service/impl/AuditServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audit/service/impl/AuditServiceImpl.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.audit.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audit.api.AuditActivity;
 import uk.gov.hmcts.darts.audit.service.AuditService;
 import uk.gov.hmcts.darts.common.entity.AuditEntity;

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/CasesMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/CasesMapper.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.cases.mapper;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.cases.model.AddCaseRequest;
 import uk.gov.hmcts.darts.cases.model.PostCaseResponse;

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -1,11 +1,11 @@
 package uk.gov.hmcts.darts.cases.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.cases.exception.AdvancedSearchNoResultsException;
 import uk.gov.hmcts.darts.cases.exception.CaseApiError;

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CaseManagementRetentionRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CaseManagementRetentionRepository.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.common.repository;
 
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CaseManagementRetentionEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRetentionRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRetentionRepository.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.common.repository;
 
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CaseRetentionEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.event.model.stopandclosehandler.PendingRetention;

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/service/impl/CourthouseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/service/impl/CourthouseServiceImpl.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.courthouse.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.common.component.validation.BiValidator;

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/service/impl/CourthouseUpdateMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/service/impl/CourthouseUpdateMapperImpl.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.darts.courthouse.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.repository.RegionRepository;

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/validation/CourthousePatchValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/validation/CourthousePatchValidator.java
@@ -1,8 +1,9 @@
 package uk.gov.hmcts.darts.courthouse.validation;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.component.validation.BiValidator;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.CaseRepository;
@@ -30,7 +31,7 @@ public class CourthousePatchValidator implements BiValidator<CourthousePatch, In
     private final SecurityGroupRepository securityGroupRepository;
 
     @Override
-    @Transactional(value = Transactional.TxType.REQUIRED)
+    @Transactional(propagation = Propagation.REQUIRED)
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.UnnecessaryAnnotationValueElement"})
     public void validate(CourthousePatch patch, Integer id) {
         var courthouseEntity = repository.findById(id)

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListServiceImpl.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.dailylist.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.DailyListEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;

--- a/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListUpdater.java
+++ b/src/main/java/uk/gov/hmcts/darts/dailylist/service/impl/DailyListUpdater.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.darts.dailylist.service.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.DailyListEntity;

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorSingleElementImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorSingleElementImpl.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.darts.datamanagement.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;

--- a/src/main/java/uk/gov/hmcts/darts/event/service/EventPersistenceService.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/EventPersistenceService.java
@@ -1,9 +1,10 @@
 package uk.gov.hmcts.darts.event.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
@@ -27,7 +28,7 @@ public class EventPersistenceService {
     private final AuthorisationApi authorisationApi;
 
 
-    @Transactional(Transactional.TxType.REQUIRES_NEW)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public EventEntity recordEvent(DartsEvent dartsEvent, EventHandlerEntity eventHandler) {
         var currentUser = authorisationApi.getCurrentUser();
         var courtroomEntity = retrieveCoreObjectService.retrieveOrCreateCourtroom(

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.exception.DartsException;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;

--- a/src/main/java/uk/gov/hmcts/darts/hearings/mapper/GetHearingResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/mapper/GetHearingResponseMapper.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.darts.hearings.mapper;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.HearingReportingRestrictionsEntity;
 import uk.gov.hmcts.darts.common.repository.HearingReportingRestrictionsRepository;

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/SecurityGroupServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/SecurityGroupServiceImpl.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.darts.usermanagement.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.darts.usermanagement.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audit.api.AuditActivity;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;


### PR DESCRIPTION

### JIRA link (if applicable) ###
DMP-3323: 


### Change description ###
Standardise to use springboot Transactional. The project was using mix of Java EE Transactional annotation and Springboot Transactional annotation. This PR makes consistent use for Sprintboot Transactional.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
