### PR TITLE
DMP-3809 updated permissions for SuperUser user

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -121,7 +121,7 @@ public class AudioController implements AudioApi {
 
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
-    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = {SUPER_ADMIN})
+    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
     public ResponseEntity<GetTransformedMediaResponse> adminGetTransformedMedia(Integer transformedMediaId) {
         var transformedMedia = mediaRequestService.getTransformedMediaById(transformedMediaId);
         GetTransformedMediaResponse response = transformedMediaMapper.mapToGetTransformedMediaResponse(transformedMedia);

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -166,7 +166,7 @@ public class AudioRequestsController implements AudioRequestsApi {
     }
 
     @Override
-    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = SUPER_ADMIN)
+    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
     public ResponseEntity<List<SearchTransformedMediaResponse>> searchForTransformedMedia(SearchTransformedMediaRequest searchTransformedMediaRequest) {
         List<SearchTransformedMediaResponse> foundTransformedMediaResponse = mediaRequestService.searchRequest(searchTransformedMediaRequest);
 

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionController.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionController.java
@@ -112,7 +112,7 @@ public class TranscriptionController implements TranscriptionApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = TRANSCRIPTION_ID,
-        globalAccessSecurityRoles = {SUPER_ADMIN})
+        globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
     public ResponseEntity<UpdateTranscriptionAdminResponse> updateTranscriptionAdmin(Integer transcriptionId,
                                                                                      UpdateTranscriptionRequest updateTranscriptionRequest) {
         return ResponseEntity.ok(transcriptionService.updateTranscriptionAdmin(transcriptionId, updateTranscriptionRequest, false));


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3809

Changes:
- Transformed Media - Search for transformed media: allowed -> added SuperUser to global access roles for `AudioRequestsController.searchForTransformedMedia`
- Transformed Media - View transformed:  allowed -> added SuperUser to global access roles for `AudioController.adminGetTransformedMedia`
- Transcripts - Manually move a request through workflow stages -> added SuperUser to global access roles for `TranscriptionController.updateTranscriptionAdmin`

The above are all `/admin` endpoints.
All other permissions seem correct to me



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
