### PR TITLE
DMP-3809 updated permissions for SuperUser user

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetMediaRequestTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetMediaRequestTest.java
@@ -30,8 +30,8 @@ class AudioControllerGetMediaRequestTest extends IntegrationBase {
     private MockMvc mockMvc;
 
     @ParameterizedTest
-    @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_ADMIN"}, mode = EXCLUDE)
-    void disallowsAllUsersExceptSuperAdmin(SecurityRoleEnum role) throws Exception {
+    @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_ADMIN", "SUPER_USER"}, mode = EXCLUDE)
+    void disallowsAllUsersExceptSuperAdminAndSuperUser(SecurityRoleEnum role) throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(role);
 
         mockMvc.perform(

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -175,7 +175,7 @@ public class AudioRequestsController implements AudioRequestsApi {
 
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
-    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = {SUPER_ADMIN})
+    @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
     public ResponseEntity<MediaRequest> getMediaRequestById(Integer mediaRequestId) {
         var mediaRequest = mediaRequestService.getMediaRequestById(mediaRequestId);
         return new ResponseEntity<>(mediaRequest, HttpStatus.OK);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3809


### Change description ###
To allow the SuperUser to view the detail of a transformed media we also need to give him permissions to the below endpoint which is called the by Portals in the Transformed Media Details page:

`AudioRequestController.getMediaRequestById`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
