### PR TITLE
DMP=3851: Ensure we throw an exception when failing to download an arm audio file. …

### DIFF
--- a/src/integrationTest/resources/application-intTest.yaml
+++ b/src/integrationTest/resources/application-intTest.yaml
@@ -77,7 +77,7 @@ darts:
       arm-username: some-username
       arm-password: some-password
       arm-service-profile: some-profile-name
-      url: http://localhost:4551
+      url: http://localhost:${wiremock.server.port}
   transcription:
     max-file-size: 20
   automated:
@@ -91,3 +91,6 @@ logging:
         hmcts:
           darts: DEBUG
   config: classpath:logback-test.xml
+
+  darts:
+    storage:

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/exception/FileNotDownloadReadingBodyException.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/exception/FileNotDownloadReadingBodyException.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.darts.datamanagement.exception;
+
+public class FileNotDownloadReadingBodyException extends FileNotDownloadedException {
+    public FileNotDownloadReadingBodyException(String message) {
+        super(message);
+    }
+
+    public FileNotDownloadReadingBodyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
…Added wiremock testing to ensure this is now enforced

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3851

### Change description ###

Added logic to throw the associated arm exception when a feign arm download error occurs. Also added some integration tests to prove the exception is being correctly thrown in combination with wiremock

Explanation:

The problem stems from the fact that we are expecting a generic byte stream, so are using the generic feign http response  e.g. feign.Response. See interface ArmApiClient. The use of this generic feign response means we have to manage the exception ourselves.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
