### PR TITLE
DMP-3773 - remove jobs_list

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
@@ -23,10 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
@@ -41,12 +38,6 @@ public class UnstructuredDataHelper {
     private final UserAccountRepository userAccountRepository;
     private final DataManagementService dataManagementService;
     private final DataManagementConfiguration dataManagementConfiguration;
-
-    private static final List<CompletableFuture> JOBS_LIST = new ArrayList<>();
-
-    public  List<CompletableFuture> getJobsList() {
-        return JOBS_LIST;
-    }
 
     @Transactional
     public boolean createUnstructuredDataFromEod(
@@ -138,12 +129,4 @@ public class UnstructuredDataHelper {
         }
     }
 
-    public void addToJobsList(CompletableFuture<Void> saveToUnstructuredFuture) {
-        JOBS_LIST.add(saveToUnstructuredFuture);
-    }
-
-    public void waitForAllJobsToFinish() {
-        JOBS_LIST.forEach(CompletableFuture::join);
-        JOBS_LIST.clear();
-    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -93,8 +93,6 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
             this::processAudioRequest,
             () -> log.info("No open requests found for ATS to process.")
         );
-
-        unstructuredDataHelper.waitForAllJobsToFinish();
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImpl.java
@@ -35,7 +35,6 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType.ARM;
@@ -217,25 +216,28 @@ public class DataManagementFacadeImpl implements DataManagementFacade {
             downloadResponseMetaDataUnstructured.setEodEntity(eodEntity);
             downloadResponseMetaDataUnstructured.setContainerTypeUsedToDownload(downloadResponseMetaData.getContainerTypeUsedToDownload());
             downloadResponseMetaDataUnstructured.markInputStream(inputStreamUnstructured);
-            createUnstructuredData(downloadResponseMetaDataUnstructured, eodEntityToDelete, targetFile);
+            createCopyInUnstructuredDatastore(downloadResponseMetaDataUnstructured, eodEntityToDelete, targetFile);
         }
     }
 
-    private void createUnstructuredData(
+    /*
+    Creates a copy in the unstructured data store for quicker retrieval next time.
+     */
+    private void createCopyInUnstructuredDatastore(
         DownloadResponseMetaData downloadResponseMetaData,
         ExternalObjectDirectoryEntity eodEntityToDelete,
-        File targetFile) throws IOException {
-        InputStream inputStream =  new BufferedInputStream(downloadResponseMetaData.getInputStream());
-        CompletableFuture<Void> createUnstructuredJob = CompletableFuture.runAsync(() -> {
+        File targetFile) {
+        try {
+            InputStream inputStream = new BufferedInputStream(downloadResponseMetaData.getInputStream());
             unstructuredDataHelper.createUnstructuredDataFromEod(
                 eodEntityToDelete,
                 downloadResponseMetaData.getEodEntity(),
                 inputStream,
                 targetFile
             );
-        });
-        unstructuredDataHelper.addToJobsList(createUnstructuredJob);
-
+        } catch (Exception e) {
+            log.warn("unable to store a copy of EOD {} in the unstructured Datastore.", downloadResponseMetaData.getEodEntity().getId(), e);
+        }
     }
 
     private ExternalObjectDirectoryEntity findCorrespondingEodEntityForStorageLocation(List<ExternalObjectDirectoryEntity> storedEodEntities,

--- a/src/test/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImplTest.java
@@ -53,7 +53,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -148,7 +147,6 @@ class DataManagementFacadeImplTest {
     public void teardown() throws IOException {
         fileBasedDownloadResponseMetaData.close();
         downloadResponseMetaData.close();
-        unstructuredDataHelper.waitForAllJobsToFinish();
     }
 
     @Test
@@ -177,7 +175,6 @@ class DataManagementFacadeImplTest {
         try (DownloadResponseMetaData downloadResponseMetaData = dmFacade.retrieveFileFromStorage(entitiesToDownload)) {
             assertEquals(DatastoreContainerType.ARM, downloadResponseMetaData.getContainerTypeUsedToDownload());
         }
-        unstructuredDataHelper.waitForAllJobsToFinish();
 
     }
 
@@ -374,11 +371,11 @@ class DataManagementFacadeImplTest {
                                                                                dataManagementConfiguration, armApiService, objectRetrievalQueueRepository);
 
         when(objectRetrievalQueueRepository.findMatchingObjectRetrievalQueueItem(mediaEntity,
-                                                                                   null,
-                                                                                   mediaEntity.getId().toString(),
-                                                                                   mediaEntity.getContentObjectId(),
-                                                                                   mediaEntity.getClipId())
-                                                                                    ).thenReturn(Optional.of(objectRetrievalQueueEntity));
+                                                                                 null,
+                                                                                 mediaEntity.getId().toString(),
+                                                                                 mediaEntity.getContentObjectId(),
+                                                                                 mediaEntity.getClipId())
+        ).thenReturn(Optional.of(objectRetrievalQueueEntity));
         // make the assertion on the response
         var exception = assertThrows(
             FileNotDownloadedException.class,
@@ -626,7 +623,6 @@ class DataManagementFacadeImplTest {
 
     @Test
     void testDownloadOfFacadeCreatesUnstructuredWhenUnstructuredNotFound() throws Exception {
-        unstructuredDataHelper.waitForAllJobsToFinish();
         ExternalObjectDirectoryEntity inboundEntity = createEodEntity(inboundLocationEntity);
         ExternalObjectDirectoryEntity unstructuredEntity = createEodEntity(unstructuredLocationEntity);
         ExternalObjectDirectoryEntity armEntity = createEodEntity(armLocationEntity);
@@ -648,7 +644,6 @@ class DataManagementFacadeImplTest {
 
         downloadResponseMetaData = dmFacade.retrieveFileFromStorage(mediaEntity);
         assertEquals(DatastoreContainerType.ARM, downloadResponseMetaData.getContainerTypeUsedToDownload());
-        assertNotEquals(0, unstructuredDataHelperFacade.getJobsList().size());
     }
 
     @NotNull
@@ -674,12 +669,12 @@ class DataManagementFacadeImplTest {
         lenient().when(downloadable.getContainerName(containerType)).thenReturn(Optional.of("test"));
         if (processSuccess) {
             lenient().when(downloadable
-                     .downloadBlobFromContainer(eq(containerType),
-                                                Mockito.notNull())).thenReturn(fileBasedDownloadResponseMetaData);
+                               .downloadBlobFromContainer(eq(containerType),
+                                                          Mockito.notNull())).thenReturn(fileBasedDownloadResponseMetaData);
         } else {
             lenient().when(downloadable
-                                       .downloadBlobFromContainer(eq(containerType),
-                                                                  Mockito.notNull())).thenThrow(new FileNotDownloadedException());
+                               .downloadBlobFromContainer(eq(containerType),
+                                                          Mockito.notNull())).thenThrow(new FileNotDownloadedException());
         }
         return downloadable;
     }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-3773

Ticket was to change JOBS_LIST to be thread safe, but it looked like the logic was effectively meaning that the job to asynchronously copy a file to the unstructured datastore was holding up the response of the service anyway, so may as well be synchronous, so its been decided to remove the list.