### PR TITLE
DMP-3907 Allowing SUPER_USER access to view event details

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -166,7 +166,7 @@ public class EventsController implements EventApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID,
-        globalAccessSecurityRoles = {SUPER_ADMIN})
+        globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
     public ResponseEntity<AdminGetEventForIdResponseResult> adminGetEventById(Integer eventId) {
         return  new ResponseEntity<>(eventService.adminGetEventById(eventId), HttpStatus.OK);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3907

### Change description ###

Adding `SUPER_USER` to `/admin/events/:eventId` endpoint.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
