### PR TITLE
DMP-3899 Objects that fail to push to ARM should not have entries in the Manifest File when processed in BATCH Mode

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.darts.task.service;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -19,6 +22,7 @@ import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.DartsException;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
@@ -29,10 +33,14 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.AuthorisationStub;
 import uk.gov.hmcts.darts.testutils.stubs.ExternalObjectDirectoryStub;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.nio.file.Files.lines;
@@ -40,6 +48,8 @@ import static java.nio.file.Files.readString;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.matches;
@@ -62,6 +72,7 @@ import static uk.gov.hmcts.darts.common.util.EodHelper.failedArmRawDataStatus;
 import static uk.gov.hmcts.darts.common.util.EodHelper.storedStatus;
 import static uk.gov.hmcts.darts.common.util.EodHelper.unstructuredLocation;
 
+@Slf4j
 class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
     ArgumentCaptor<File> manifestFileNameCaptor = ArgumentCaptor.forClass(File.class);
@@ -106,6 +117,9 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
     @Autowired
     private ExternalObjectDirectoryService eodService;
+
+    @TempDir
+    private File tempDirectory;
 
     @Autowired
     private UnstructuredToArmBatchProcessor unstructuredToArmProcessor;
@@ -158,6 +172,102 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
             eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.get(0).getId()), storedStatus(), unstructuredLocation())
         )
             .hasSize(1);
+    }
+
+    @Test
+    void testBatchedQueryWhereSomeFailedToPush() throws IOException {
+
+        //given
+        //batch size is 5
+        List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
+
+        var eod1 = externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
+        var eod3 = externalObjectDirectoryStub.createAndSaveEod(medias.get(2), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.get(3), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.get(4), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.get(5), STORED, UNSTRUCTURED);
+
+        DartsException dartsException = new DartsException("Exception copying file");
+        String failedFilename1 = format("%s_%s_%s", 7, eod1.getMedia().getId(), eod1.getTransferAttempts());
+        doThrow(dartsException).when(armDataManagementApi).copyBlobDataToArm(any(), matches(failedFilename1));
+
+        String failedFilename3 = format("%s_%s_%s", 9, eod3.getMedia().getId(), eod3.getTransferAttempts());
+        doThrow(dartsException).when(armDataManagementApi).copyBlobDataToArm(any(), matches(failedFilename3));
+
+        String fileLocation = tempDirectory.getAbsolutePath();
+        armDataManagementConfiguration.setTempBlobWorkspace(fileLocation);
+
+        //when
+        unstructuredToArmProcessor.processUnstructuredToArm(5);
+
+        //then
+        List<Integer> foundMediaList = eodRepository.findMediaIdsByInMediaIdStatusAndType(
+            List.of(medias.get(0).getId(),
+                    medias.get(1).getId(),
+                    medias.get(2).getId(),
+                    medias.get(3).getId(),
+                    medias.get(4).getId(),
+                    medias.get(5).getId()),
+            armDropZoneStatus(),
+            armLocation()
+        );
+        assertThat(foundMediaList.size()).isEqualTo(3);
+        assertThat(
+            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.get(0).getId()), storedStatus(), unstructuredLocation())
+        ).hasSize(1);
+
+
+        List<Integer> failedMediaList = eodRepository.findMediaIdsByInMediaIdStatusAndType(
+            List.of(medias.get(0).getId(),
+                    medias.get(1).getId(),
+                    medias.get(2).getId(),
+                    medias.get(3).getId(),
+                    medias.get(4).getId(),
+                    medias.get(5).getId()),
+            failedArmRawDataStatus(),
+            armLocation()
+        );
+        assertThat(failedMediaList.size()).isEqualTo(2);
+
+        MediaEntity media = medias.stream()
+            .filter(mediaEntity -> mediaEntity.getId().equals(foundMediaList.get(0))).findFirst().orElseThrow();
+        var successEod = eodRepository.findByMediaAndExternalLocationType(media, armLocation()).getFirst();
+
+
+        Files.walk(Path.of(fileLocation)).filter(Files::isRegularFile).collect(Collectors.toList());
+        String[] types = {"a360"};
+        File manifestFile = FileUtils.listFiles(new File(fileLocation), types, true).stream()
+            .filter(file -> file.getName().contains(successEod.getManifestFile())).findFirst().orElseThrow();
+
+        log.info("manifestFile {}", manifestFile.getAbsolutePath());
+        int expectedNumberOfRows = 6;
+        String manifestFileContents = verifyManifestFileContents(manifestFile, expectedNumberOfRows);
+        log.info("actual response {}", manifestFileContents);
+
+        List<MediaEntity> successfulMedias = medias.stream()
+            .filter(mediaEntity -> foundMediaList.contains(mediaEntity.getId())).toList();
+        List<ExternalObjectDirectoryEntity> successEods = new ArrayList<>();
+
+        for (MediaEntity mediaEntity : successfulMedias) {
+            successEods.addAll(eodRepository.findByMediaAndExternalLocationType(mediaEntity, armLocation()));
+        }
+
+        List<MediaEntity> failedMedias = medias.stream()
+            .filter(mediaEntity -> failedMediaList.contains(mediaEntity.getId())).toList();
+        List<ExternalObjectDirectoryEntity> failedEods = new ArrayList<>();
+
+        for (MediaEntity mediaEntity : failedMedias) {
+            failedEods.addAll(eodRepository.findByMediaAndExternalLocationType(mediaEntity, armLocation()));
+        }
+
+        assertTrue(successEods.stream().allMatch(eodEntity -> manifestFileContents.contains(
+            format("\"relation_id\":\"%d\"", eodEntity.getId())
+        )));
+        assertTrue(failedEods.stream().allMatch(eodEntity -> !manifestFileContents.contains(
+            format("\"relation_id\":\"%d\"", eodEntity.getId())
+        )));
+
     }
 
     @Test
@@ -388,4 +498,19 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertThat(failedEod.getManifestFile()).isEqualTo("existingManifestFile");
     }
 
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    private static String verifyManifestFileContents(File manifestFile, int expectedNumberOfRows) throws IOException {
+        StringBuilder fileContents = new StringBuilder();
+        int rows = 0;
+        try (BufferedReader reader = Files.newBufferedReader(manifestFile.toPath())) {
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                ++rows;
+                fileContents.append(line);
+            }
+        }
+        assertEquals(expectedNumberOfRows, rows);
+        return fileContents.toString();
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3899

### Change description ###

Added test to read the manifest file and check the contents does not contain the failed eod records

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
