### PR TITLE
DMP-3908 - Judges and Defendants showing 'multiple' when case has hearing_is_actual flag set to false

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdvancedSearchResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdvancedSearchResponseMapper.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @UtilityClass
@@ -20,6 +21,16 @@ public class AdvancedSearchResponseMapper {
         for (HearingEntity hearing : hearings) {
             addHearingToResultList(advancedSearchResults, hearing);
         }
+        //Set the top level judges to be all the distinct judges in each valid hearing for the case
+        advancedSearchResults
+            .forEach(advancedSearchResult ->
+                         advancedSearchResult.setJudges(
+                             Optional.ofNullable(advancedSearchResult.getHearings()).orElseGet(ArrayList::new)
+                                 .stream()
+                                 .map(AdvancedSearchResultHearing::getJudges)
+                                 .flatMap(List::stream)
+                                 .distinct()
+                                 .toList()));
         return advancedSearchResults;
     }
 
@@ -43,7 +54,6 @@ public class AdvancedSearchResponseMapper {
         advancedSearchResult.setCaseNumber(courtCase.getCaseNumber());
         advancedSearchResult.setCourthouse(courtCase.getCourthouse().getDisplayName());
         advancedSearchResult.setDefendants(courtCase.getDefendantStringList());
-        advancedSearchResult.setJudges(courtCase.getJudgeStringList());
         advancedSearchResult.setIsDataAnonymised(courtCase.isDataAnonymised());
         advancedSearchResult.setDataAnonymisedAt(courtCase.getDataAnonymisedTs());
 

--- a/src/test/resources/Tests/cases/AdvancedSearchResponseMapperTest/fourWithTwoSameCase/expectedResponse.json
+++ b/src/test/resources/Tests/cases/AdvancedSearchResponseMapperTest/fourWithTwoSameCase/expectedResponse.json
@@ -9,7 +9,8 @@
     ],
     "judges": [
       "Judge_1",
-      "Judge_2"
+      "Judge_2",
+      "Judge_3"
     ],
     "hearings": [
       {

--- a/src/test/resources/Tests/cases/AdvancedSearchResponseMapperTest/twoSameCase/expectedResponse.json
+++ b/src/test/resources/Tests/cases/AdvancedSearchResponseMapperTest/twoSameCase/expectedResponse.json
@@ -9,7 +9,8 @@
     ],
     "judges": [
       "Judge_1",
-      "Judge_2"
+      "Judge_2",
+      "Judge_3"
     ],
     "hearings": [
       {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-3908)


### Change description ###
When a case contains multiple hearings, and only one of the hearing_is_actual flags is set to true and all of the others are set to false, these results are stripped out of the advanced search results, displaying just one hearing. However, the judges  fields are displaying the label 'Multiple'. It should only display the judge(s) for the hearing that is actual. 

 

!image (35).png|width=361,height=202,thumbnail!

Example case on demo with this issue is 'S20240187'.

 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
