### PR TITLE
dmp-3922: revert remove access tier flag from azcopy

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/util/AzureCopyUtil.java
+++ b/src/main/java/uk/gov/hmcts/darts/util/AzureCopyUtil.java
@@ -19,7 +19,7 @@ public class AzureCopyUtil {
     public void copy(String source, String destination) {
         try {
             ProcessBuilder builder = new ProcessBuilder();
-            builder.command(config.getAzCopyExecutable(), "copy", source, destination);
+            builder.command(config.getAzCopyExecutable(), "copy", source, destination, config.getAzCopyPreserveAccessTier());
 
             var startTime = Instant.now();
             log.info("copy of blob started at {}", startTime);


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
DMP-3922


### Change description ###
Reverting the changes for removal of access tier in azcopy


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
