### PR TITLE
DMP-3909 - extend shedlock timeout and add logging if breached.

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
@@ -193,9 +193,14 @@ public abstract class AbstractLockableAutomatedTask implements AutomatedTask {
 
     private void stopStopwatchAndLogFinished() {
         Instant finish = Instant.now();
-        long timeElapsed = Duration.between(start, finish).toMillis();
+        Duration timeElapsedDuration = Duration.between(start, finish);
+        long timeElapsed = timeElapsedDuration.toMillis();
         log.info("Task: {} finished running at: {}", getTaskName(), LocalDateTime.now());
-        log.debug("Task: {} time elapsed: {} ms", getTaskName(), timeElapsed);
+        log.info("Task: {} time elapsed: {} ms", getTaskName(), timeElapsed);
+        if (lockService.getLockAtMostFor().compareTo(timeElapsedDuration) < 0) {
+            log.warn("Task: {} started at {} and finished at {}, taking {}ms, which is longer than the max locking time of {}",
+                     getTaskName(), start, finish, timeElapsed, lockService.getLockAtMostFor());
+        }
     }
 
     class LockedTask implements Runnable {

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImpl.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LockServiceImpl implements LockService {
 
-    private static final Duration DEFAULT_LOCK_AT_MOST = Duration.ofSeconds(600);
+    private static final Duration DEFAULT_LOCK_AT_MOST = Duration.ofMinutes(300);
     private static final Duration DEFAULT_LOCK_AT_LEAST = Duration.ofSeconds(20);
 
     private final AutomatedTaskRepository automatedTaskRepository;

--- a/src/test/java/uk/gov/hmcts/darts/task/service/impl/AutomatedTaskServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/service/impl/AutomatedTaskServiceImplTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.config.ScheduledTask;
@@ -24,6 +23,8 @@ import uk.gov.hmcts.darts.task.runner.impl.ProcessDailyListAutomatedTask;
 import uk.gov.hmcts.darts.task.service.LockService;
 import uk.gov.hmcts.darts.task.status.AutomatedTaskStatus;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -61,7 +62,7 @@ class AutomatedTaskServiceImplTest {
     @Mock
     private LogApi logApi;
 
-    @Autowired
+    @Mock
     private LockService lockService;
 
     @Test
@@ -213,6 +214,7 @@ class AutomatedTaskServiceImplTest {
     @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
     void taskFailedToBeStartedMovesToFailedStatus() {
         when(mockAutomatedTaskConfigurationProperties.getSystemUserEmail()).thenReturn("system@darts.test");
+        when(lockService.getLockAtMostFor()).thenReturn(Duration.of(1, ChronoUnit.HOURS));
 
         var failingAutomatedTask = new AbstractLockableAutomatedTask(
             mockAutomatedTaskRepository,

--- a/src/test/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/service/impl/LockServiceImplTest.java
@@ -38,7 +38,7 @@ class LockServiceImplTest {
 
     @Test
     void getLockAtMostFor() {
-        assertEquals(Duration.ofSeconds(600), lockService.getLockAtMostFor());
+        assertEquals(Duration.ofMinutes(300), lockService.getLockAtMostFor());
     }
 
     @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-3909