### PR TITLE
Updated getCurrentEventIdsToBeProcessed() to exclude duplicate event_ids with unique hearing ids

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.common.repository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.util.DateConverterUtil;
 import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
@@ -31,14 +30,14 @@ class EventRepositoryTest extends PostgresIntegrationBase {
 
         Map<Integer, List<EventEntity>> eventIdMap = eventStub.generateEventIdEventsIncludingZeroEventId(3);
 
-        List<Integer> eventIdsToBeProcessed1 = eventRepository.getCurrentEventIdsToBeProcessed(Pageable.ofSize(1));
+        List<Integer> eventIdsToBeProcessed1 = eventRepository.getCurrentEventIdsToBeProcessed(1);
         Assertions.assertEquals(1, eventIdsToBeProcessed1.size());
         EventRepository.EventIdAndHearingIds eventPkid = eventRepository.getTheLatestCreatedEventPrimaryKeyForTheEventId(eventIdsToBeProcessed1.getFirst());
         eventRepository.updateAllEventIdEventsToNotCurrentWithTheExclusionOfTheCurrentEventPrimaryKey(
             eventPkid.getEveId(), eventPkid.getEventId(), eventPkid.getHearingIds());
         Assertions.assertTrue(eventStub.isOnlyOneOfTheEventIdSetToCurrent(eventIdMap.get(eventIdsToBeProcessed1.getFirst())));
 
-        List<Integer> eventIdsToBeProcessed2 = eventRepository.getCurrentEventIdsToBeProcessed(Pageable.ofSize(1));
+        List<Integer> eventIdsToBeProcessed2 = eventRepository.getCurrentEventIdsToBeProcessed(1);
         EventRepository.EventIdAndHearingIds eventPkidSecond =
             eventRepository.getTheLatestCreatedEventPrimaryKeyForTheEventId(eventIdsToBeProcessed2.getFirst());
         eventRepository.updateAllEventIdEventsToNotCurrentWithTheExclusionOfTheCurrentEventPrimaryKey(
@@ -49,7 +48,7 @@ class EventRepositoryTest extends PostgresIntegrationBase {
         Assertions.assertNotEquals(eventIdsToBeProcessed1, eventIdsToBeProcessed2);
 
         // ENSURE WE DONT PROCESS THE THIRD BATCH I.E. THE ZERO EVENT ID
-        List<Integer> eventIdsToBeProcessed3 = eventRepository.getCurrentEventIdsToBeProcessed(Pageable.ofSize(1));
+        List<Integer> eventIdsToBeProcessed3 = eventRepository.getCurrentEventIdsToBeProcessed(1);
         Assertions.assertTrue(eventIdsToBeProcessed3.isEmpty());
     }
 
@@ -61,7 +60,7 @@ class EventRepositoryTest extends PostgresIntegrationBase {
 
         Map<Integer, List<EventEntity>> eventIdMap = eventStub.generateEventIdEventsIncludingZeroEventId(3);
 
-        List<Integer> eventIdsToBeProcessed1 = eventRepository.getCurrentEventIdsToBeProcessed(Pageable.ofSize(1));
+        List<Integer> eventIdsToBeProcessed1 = eventRepository.getCurrentEventIdsToBeProcessed(1);
         Assertions.assertEquals(1, eventIdsToBeProcessed1.size());
         List<EventEntity> eventEntities = eventIdMap.get(eventIdsToBeProcessed1.getFirst());
         EventEntity eventEntity = eventEntities.getFirst();

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -84,13 +84,13 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
     @Query(value = """
         SELECT distinct e2.event_id
         from (
-        	SELECT e.event_id, he.eve_id, string_agg(he.hea_id::varchar, ',' order by he.hea_id) as hearing_ids FROM darts.event e
-            LEFT JOIN darts.hearing_event_ae he
-            ON he.eve_id = e.eve_id
-            where e.is_current = true
-        	AND e.event_id <> 0
-        	AND e.event_id IS NOT null
-            GROUP by he.eve_id, e.event_id
+          SELECT e.event_id, he.eve_id, string_agg(he.hea_id::varchar, ',' order by he.hea_id) as hearing_ids FROM darts.event e
+          LEFT JOIN darts.hearing_event_ae he
+          ON he.eve_id = e.eve_id
+          where e.is_current = true
+          AND e.event_id <> 0
+          AND e.event_id IS NOT null
+          GROUP by he.eve_id, e.event_id
         ) e2
         GROUP BY e2.event_id, e2.hearing_ids
         having count(e2.event_id) > 1

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -82,15 +82,21 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
         Pageable pageable);
 
     @Query(value = """
-        SELECT event_id
-        FROM  darts.event
-        WHERE is_current=true
-        AND event_id <> 0
-        AND event_id IS NOT NULL
-        GROUP BY event_id
-        HAVING count(event_id) > 1
+        SELECT distinct e2.event_id
+        from (
+        	SELECT e.event_id, he.eve_id, string_agg(he.hea_id::varchar, ',' order by he.hea_id) as hearing_ids FROM darts.event e
+            LEFT JOIN darts.hearing_event_ae he
+            ON he.eve_id = e.eve_id
+            where e.is_current = true
+        	AND e.event_id <> 0
+        	AND e.event_id IS NOT null
+            GROUP by he.eve_id, e.event_id
+        ) e2
+        GROUP BY e2.event_id, e2.hearing_ids
+        having count(e2.event_id) > 1
+        limit = :limit
         """, nativeQuery = true)
-    List<Integer> getCurrentEventIdsToBeProcessed(Pageable pageable);
+    List<Integer> getCurrentEventIdsToBeProcessed(long limit);
 
     @Query(value = """
          SELECT e.eve_id, event_id, string_agg(he.hea_id::varchar, ',' order by he.hea_id) as hearing_ids FROM darts.event e

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -94,7 +94,7 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
         ) e2
         GROUP BY e2.event_id, e2.hearing_ids
         having count(e2.event_id) > 1
-        limit = :limit
+        limit :limit
         """, nativeQuery = true)
     List<Integer> getCurrentEventIdsToBeProcessed(long limit);
 

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/CleanupCurrentFlagEventProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/CleanupCurrentFlagEventProcessorImpl.java
@@ -22,7 +22,7 @@ public class CleanupCurrentFlagEventProcessorImpl implements CleanupCurrentFlagE
     public List<Integer> processCurrentEvent() {
         List<Integer> processedEventIdLst = new ArrayList<>();
         log.debug("Batch size to process event ids for {}", batchSize);
-        List<Integer> eventEntityReturned = eventRepository.getCurrentEventIdsToBeProcessed(Pageable.ofSize(batchSize));
+        List<Integer> eventEntityReturned = eventRepository.getCurrentEventIdsToBeProcessed(batchSize);
         if (log.isDebugEnabled()) {
             log.debug("Event ids being processed {}", eventEntityReturned
                 .stream()

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/CleanupCurrentFlagEventProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/CleanupCurrentFlagEventProcessorImpl.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.event.service.impl;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.event.service.CleanupCurrentFlagEventProcessor;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3892

### Change description ###
Updated getCurrentEventIdsToBeProcessed() to exclude processed event_ids that have multiple current eve_ids but are associated to different hearings


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
