### PR TITLE
DMP-2559 - Write to log when a case is deleted due to expiry for Dynatrace purposes

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
@@ -18,6 +18,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceReasonEnum;
@@ -34,6 +35,7 @@ import java.util.UUID;
 @SuppressWarnings({"PMD.ShortClassName"})
 @Getter
 @Setter
+@Slf4j
 public class CourtCaseEntity extends CreatedModifiedBaseEntity implements CanAnonymized {
 
     public static final String COURT_CASE = "courtCase";
@@ -207,5 +209,6 @@ public class CourtCaseEntity extends CreatedModifiedBaseEntity implements CanAno
         this.getDefenceList().forEach(defenceEntity -> defenceEntity.anonymize(userAccount, uuid));
         this.getProsecutorList().forEach(prosecutorEntity -> prosecutorEntity.anonymize(userAccount, uuid));
         this.getHearings().forEach(hearingEntity -> hearingEntity.anonymize(userAccount, uuid));
+        log.info("Case expired: cas_id={}, case_number={}", this.getId(), this.getCaseNumber());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
@@ -209,6 +209,7 @@ public class CourtCaseEntity extends CreatedModifiedBaseEntity implements CanAno
         this.getDefenceList().forEach(defenceEntity -> defenceEntity.anonymize(userAccount, uuid));
         this.getProsecutorList().forEach(prosecutorEntity -> prosecutorEntity.anonymize(userAccount, uuid));
         this.getHearings().forEach(hearingEntity -> hearingEntity.anonymize(userAccount, uuid));
+        //Required for Dynatrace dashboards
         log.info("Case expired: cas_id={}, case_number={}", this.getId(), this.getCaseNumber());
     }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-2559)


### Change description ###
h3. Background:

The client has requested that we have a Dynatrace dashboard tile that proves that the Deletion Service is working. Outputs should show the number of cases expired in the selected timeframe.
h3. Technical:

When a case has been expired successfully, write the following log statement at INFO level:
{noformat}
"Case expired: cas_id={cas_id}, case_number={case_number}"{noformat}
Dynamic data:
||field||value||
|cas_id|Case id for the case that has been deleted |
|case_number|Case number for the case that has been deleted|

Please add the log entry in a service under the [log package|https://github.com/hmcts/darts-api/tree/master/src/main/java/uk/gov/hmcts/darts/log], exposing the service method via the "api" sub-package. Add unit tests to cover the log entry scenarios.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
