### PR TITLE
DMP-3923 - Hide CaseExpiryDeletion task if disabled by feature flag

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskITest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.common.util.DateConverterUtil;
 import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
 import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.test.common.data.DefenceTestData;
 import uk.gov.hmcts.darts.test.common.data.DefendantTestData;
 import uk.gov.hmcts.darts.test.common.data.ProsecutorTestData;
@@ -38,8 +39,7 @@ import static org.assertj.core.api.BDDAssertions.within;
 class CaseExpiryDeletionAutomatedTaskITest extends PostgresIntegrationBase {
 
     private final CaseExpiryDeletionAutomatedTask caseExpiryDeletionAutomatedTask;
-    private static final Pattern UUID_REGEX =
-        Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+    private static final Pattern UUID_REGEX = Pattern.compile(TestUtils.UUID_REGEX);
     private static final int AUTOMATION_USER_ID = 0;
     private int caseIndex;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
@@ -27,7 +27,6 @@ import uk.gov.hmcts.darts.task.runner.CanAnonymized;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Entity
 @Table(name = CourtCaseEntity.TABLE_NAME)
@@ -199,13 +198,13 @@ public class CourtCaseEntity extends CreatedModifiedBaseEntity implements CanAno
     }
 
     @Override
-    public void anonymize(UserAccountEntity userAccount, UUID uuid) {
+    public void anonymize(UserAccountEntity userAccount) {
         this.setDataAnonymised(true);
         this.setDataAnonymisedBy(userAccount.getId());
         this.setDataAnonymisedTs(OffsetDateTime.now());
-        this.getDefendantList().forEach(defendantEntity -> defendantEntity.anonymize(userAccount, uuid));
-        this.getDefenceList().forEach(defenceEntity -> defenceEntity.anonymize(userAccount, uuid));
-        this.getProsecutorList().forEach(prosecutorEntity -> prosecutorEntity.anonymize(userAccount, uuid));
-        this.getHearings().forEach(hearingEntity -> hearingEntity.anonymize(userAccount, uuid));
+        this.getDefendantList().forEach(defendantEntity -> defendantEntity.anonymize(userAccount));
+        this.getDefenceList().forEach(defenceEntity -> defenceEntity.anonymize(userAccount));
+        this.getProsecutorList().forEach(prosecutorEntity -> prosecutorEntity.anonymize(userAccount));
+        this.getHearings().forEach(hearingEntity -> hearingEntity.anonymize(userAccount));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DefenceEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DefenceEntity.java
@@ -43,8 +43,8 @@ public class DefenceEntity extends CreatedModifiedBaseEntity implements CanAnony
     private String name;
 
     @Override
-    public void anonymize(UserAccountEntity userAccount, UUID uuid) {
-        this.setName(uuid.toString());
+    public void anonymize(UserAccountEntity userAccount) {
+        this.setName(UUID.randomUUID().toString());
         this.setLastModifiedBy(userAccount);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DefendantEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DefendantEntity.java
@@ -43,8 +43,8 @@ public class DefendantEntity extends CreatedModifiedBaseEntity implements CanAno
     private String name;
 
     @Override
-    public void anonymize(UserAccountEntity userAccount, UUID uuid) {
-        this.setName(uuid.toString());
+    public void anonymize(UserAccountEntity userAccount) {
+        this.setName(UUID.randomUUID().toString());
         this.setLastModifiedBy(userAccount);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
@@ -91,7 +91,7 @@ public class EventEntity extends CreatedModifiedBaseEntity implements CanAnonymi
     }
 
     @Override
-    public void anonymize(UserAccountEntity userAccount, UUID uuid) {
-        this.setEventText(uuid.toString());
+    public void anonymize(UserAccountEntity userAccount) {
+        this.setEventText(UUID.randomUUID().toString());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -27,7 +27,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Entity
 @Table(name = "hearing")
@@ -125,8 +124,8 @@ public class HearingEntity extends CreatedModifiedBaseEntity implements CanAnony
     }
 
     @Override
-    public void anonymize(UserAccountEntity userAccount, UUID uuid) {
-        this.getTranscriptions().forEach(transcriptionEntity -> transcriptionEntity.anonymize(userAccount, uuid));
-        this.getEventList().forEach(eventEntity -> eventEntity.anonymize(userAccount, uuid));
+    public void anonymize(UserAccountEntity userAccount) {
+        this.getTranscriptions().forEach(transcriptionEntity -> transcriptionEntity.anonymize(userAccount));
+        this.getEventList().forEach(eventEntity -> eventEntity.anonymize(userAccount));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ProsecutorEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ProsecutorEntity.java
@@ -43,8 +43,8 @@ public class ProsecutorEntity extends CreatedModifiedBaseEntity implements CanAn
     private String name;
 
     @Override
-    public void anonymize(UserAccountEntity userAccount, UUID uuid) {
-        this.setName(uuid.toString());
+    public void anonymize(UserAccountEntity userAccount) {
+        this.setName(UUID.randomUUID().toString());
         this.setLastModifiedBy(userAccount);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionCommentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionCommentEntity.java
@@ -67,8 +67,8 @@ public class TranscriptionCommentEntity extends CreatedModifiedBaseEntity implem
     private boolean isDataAnonymised;
 
     @Override
-    public void anonymize(UserAccountEntity userAccount, UUID uuid) {
-        this.setComment(uuid.toString());
+    public void anonymize(UserAccountEntity userAccount) {
+        this.setComment(UUID.randomUUID().toString());
         this.setLastModifiedBy(userAccount);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntity.java
@@ -27,7 +27,6 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static jakarta.persistence.CascadeType.MERGE;
 import static jakarta.persistence.CascadeType.PERSIST;
@@ -247,7 +246,7 @@ public class TranscriptionEntity extends CreatedModifiedBaseEntity implements Ca
     }
 
     @Override
-    public void anonymize(UserAccountEntity userAccount, UUID uuid) {
-        this.getTranscriptionCommentEntities().forEach(transcriptionCommentEntity -> transcriptionCommentEntity.anonymize(userAccount, uuid));
+    public void anonymize(UserAccountEntity userAccount) {
+        this.getTranscriptionCommentEntities().forEach(transcriptionCommentEntity -> transcriptionCommentEntity.anonymize(userAccount));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.common.repository;
 
+import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -83,13 +84,11 @@ public interface CaseRepository extends JpaRepository<CourtCaseEntity, Integer> 
                                                                                  Pageable pageable);
 
     @Query(value = """
-        select cc.* from darts.darts.court_case cc
-        join darts.darts.case_retention cr
-        on cr.cas_id = cc.cas_id and cr.current_state = 'COMPLETE'
-        where cc.is_data_anonymised = false
-        and cr.retain_until_ts < :maxRetentionDate
-        limit :limit
-        """,
-        nativeQuery = true)
-    List<CourtCaseEntity> findCasesToBeAnonymized(OffsetDateTime maxRetentionDate, long limit);
+        select cc from CourtCaseEntity cc
+        join CaseRetentionEntity cr
+        on cr.courtCase.id = cc.id and cr.currentState = 'COMPLETE'
+        where cc.isDataAnonymised = false
+        and cr.retainUntil < :maxRetentionDate
+        """)
+    List<CourtCaseEntity> findCasesToBeAnonymized(OffsetDateTime maxRetentionDate, Limit limit);
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
@@ -1,11 +1,14 @@
 package uk.gov.hmcts.darts.task.api;
 
+import lombok.Getter;
+
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * The task names map directly to the task names in the table automated_tasks, so there should only be one task per name.
  */
+@Getter
 public enum AutomatedTaskName {
     PROCESS_DAILY_LIST_TASK_NAME("ProcessDailyList"),
     CLOSE_OLD_UNFINISHED_TRANSCRIPTIONS_TASK_NAME("CloseOldUnfinishedTranscriptions"),
@@ -45,9 +48,6 @@ public enum AutomatedTaskName {
         this.taskName = taskName;
     }
 
-    public String getTaskName() {
-        return taskName;
-    }
 
     public static AutomatedTaskName valueOfTaskName(String taskName) {
         return BY_TASK_NAME.get(taskName);

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/CanAnonymized.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/CanAnonymized.java
@@ -2,9 +2,7 @@ package uk.gov.hmcts.darts.task.runner;
 
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
-import java.util.UUID;
-
 public interface CanAnonymized {
 
-    void anonymize(UserAccountEntity userAccount, UUID uuid);
+    void anonymize(UserAccountEntity userAccount);
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
@@ -6,6 +6,7 @@ import net.javacrumbs.shedlock.core.LockConfiguration;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
@@ -79,6 +80,7 @@ public abstract class AbstractLockableAutomatedTask implements AutomatedTask, Au
     }
 
     @Override
+    @Transactional
     public void run() {
         executionId = ThreadLocal.withInitial(UUID::randomUUID);
         preRunTask();

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTask.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.darts.task.service.LockService;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Component
 @ConditionalOnProperty(
@@ -56,16 +55,14 @@ public class CaseExpiryDeletionAutomatedTask
     @Override
     @Transactional
     public void runTask() {
-        final UUID uuid = UUID.randomUUID();
         final UserAccountEntity userAccount = userIdentity.getUserAccount();
         final List<CourtCaseEntity> courtCaseEntities = new ArrayList<>();
 
         caseRepository.findCasesToBeAnonymized(currentTimeHelper.currentOffsetDateTime(),
                                                Limit.of(getAutomatedTaskBatchSize()))
             .forEach(courtCase -> {
-                log.info("Anonymising case with id: {} using uuid: {} because the criteria for retention has been met.",
-                         courtCase.getId(), uuid);
-                courtCase.anonymize(userAccount, uuid);
+                log.info("Anonymising case with id: {} because the criteria for retention has been met.", courtCase.getId());
+                courtCase.anonymize(userAccount);
                 courtCaseEntities.add(courtCase);
             });
         //This also saves defendant, defence and prosecutor entities

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTask.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.task.runner.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
@@ -59,8 +60,8 @@ public class CaseExpiryDeletionAutomatedTask
         final UserAccountEntity userAccount = userIdentity.getUserAccount();
         final List<CourtCaseEntity> courtCaseEntities = new ArrayList<>();
 
-
-        caseRepository.findCasesToBeAnonymized(currentTimeHelper.currentOffsetDateTime(), getAutomatedTaskBatchSize())
+        caseRepository.findCasesToBeAnonymized(currentTimeHelper.currentOffsetDateTime(),
+                                               Limit.of(getAutomatedTaskBatchSize()))
             .forEach(courtCase -> {
                 log.info("Anonymising case with id: {} using uuid: {} because the criteria for retention has been met.",
                          courtCase.getId(), uuid);

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.task.service.impl;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,7 +38,7 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
     private final AuditApi auditApi;
     private final LockService lockService;
 
-    @Value("${automated.task.expiry-deletion}")
+    @Value("${automated.task.expiry-deletion:false}")
     private final boolean caseExpiryDeletionEnabled;
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.service.impl;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
@@ -38,7 +38,7 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
     private final AuditApi auditApi;
     private final LockService lockService;
 
-    @Value("${automated.task.expiry-deletion:false}")
+    @Value("${darts.automated.task.expiry-deletion.enabled:false}")
     private final boolean caseExpiryDeletionEnabled;
 
     @Override

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntityTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.common.entity;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.UUID;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,21 +35,19 @@ class CourtCaseEntityTest {
 
         UserAccountEntity userAccount = new UserAccountEntity();
         userAccount.setId(123);
-        UUID uuid = UUID.randomUUID();
-
-        courtCase.anonymize(userAccount, uuid);
+        courtCase.anonymize(userAccount);
         assertThat(courtCase.isDataAnonymised()).isTrue();
         assertThat(courtCase.getDataAnonymisedBy()).isEqualTo(123);
         assertThat(courtCase.getDataAnonymisedTs()).isCloseToUtcNow(within(5, SECONDS));
 
-        verify(defendantEntity1, times(1)).anonymize(userAccount, uuid);
-        verify(defendantEntity2, times(1)).anonymize(userAccount, uuid);
+        verify(defendantEntity1, times(1)).anonymize(userAccount);
+        verify(defendantEntity2, times(1)).anonymize(userAccount);
 
-        verify(defenceEntity1, times(1)).anonymize(userAccount, uuid);
-        verify(defenceEntity2, times(1)).anonymize(userAccount, uuid);
-        verify(prosecutorEntity1, times(1)).anonymize(userAccount, uuid);
-        verify(prosecutorEntity2, times(1)).anonymize(userAccount, uuid);
-        verify(hearingEntity1, times(1)).anonymize(userAccount, uuid);
-        verify(hearingEntity2, times(1)).anonymize(userAccount, uuid);
+        verify(defenceEntity1, times(1)).anonymize(userAccount);
+        verify(defenceEntity2, times(1)).anonymize(userAccount);
+        verify(prosecutorEntity1, times(1)).anonymize(userAccount);
+        verify(prosecutorEntity2, times(1)).anonymize(userAccount);
+        verify(hearingEntity1, times(1)).anonymize(userAccount);
+        verify(hearingEntity2, times(1)).anonymize(userAccount);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/DefenceEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/DefenceEntityTest.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.darts.common.entity;
 
 import org.junit.jupiter.api.Test;
-
-import java.util.UUID;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,9 +13,8 @@ class DefenceEntityTest {
         defenceEntity.setName("name");
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        UUID uuid = UUID.randomUUID();
 
-        defenceEntity.anonymize(userAccount, uuid);
-        assertThat(defenceEntity.getName()).isEqualTo(uuid.toString());
+        defenceEntity.anonymize(userAccount);
+        assertThat(defenceEntity.getName()).matches(TestUtils.UUID_REGEX);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/DefendantEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/DefendantEntityTest.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.darts.common.entity;
 
 import org.junit.jupiter.api.Test;
-
-import java.util.UUID;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,9 +13,7 @@ class DefendantEntityTest {
         defendantEntity.setName("name");
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        UUID uuid = UUID.randomUUID();
-
-        defendantEntity.anonymize(userAccount, uuid);
-        assertThat(defendantEntity.getName()).isEqualTo(uuid.toString());
+        defendantEntity.anonymize(userAccount);
+        assertThat(defendantEntity.getName()).matches(TestUtils.UUID_REGEX);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/EventEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/EventEntityTest.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.darts.common.entity;
 
 import org.junit.jupiter.api.Test;
-
-import java.util.UUID;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +13,8 @@ class EventEntityTest {
         eventEntity.setEventText("event text");
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        UUID uuid = UUID.randomUUID();
-
-        eventEntity.anonymize(userAccount, uuid);
-        assertThat(eventEntity.getEventText()).isEqualTo(uuid.toString());
+        eventEntity.anonymize(userAccount);
+        assertThat(eventEntity.getEventText()).matches(TestUtils.UUID_REGEX);
         assertThat(eventEntity.isDataAnonymised()).isFalse();//This is only set for manual anonymization
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/HearingEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/HearingEntityTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.common.entity;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.UUID;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -24,12 +23,11 @@ class HearingEntityTest {
         hearingEntity.setEventList(List.of(entityEntity1, entityEntity2));
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        UUID uuid = UUID.randomUUID();
 
-        hearingEntity.anonymize(userAccount, uuid);
-        verify(transcriptionEntity1, times(1)).anonymize(userAccount, uuid);
-        verify(transcriptionEntity2, times(1)).anonymize(userAccount, uuid);
-        verify(entityEntity1, times(1)).anonymize(userAccount, uuid);
-        verify(entityEntity2, times(1)).anonymize(userAccount, uuid);
+        hearingEntity.anonymize(userAccount);
+        verify(transcriptionEntity1, times(1)).anonymize(userAccount);
+        verify(transcriptionEntity2, times(1)).anonymize(userAccount);
+        verify(entityEntity1, times(1)).anonymize(userAccount);
+        verify(entityEntity2, times(1)).anonymize(userAccount);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/ProsecutorEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/ProsecutorEntityTest.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.darts.common.entity;
 
 import org.junit.jupiter.api.Test;
-
-import java.util.UUID;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,9 +13,8 @@ class ProsecutorEntityTest {
         prosecutorEntity.setName("name");
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        UUID uuid = UUID.randomUUID();
 
-        prosecutorEntity.anonymize(userAccount, uuid);
-        assertThat(prosecutorEntity.getName()).isEqualTo(uuid.toString());
+        prosecutorEntity.anonymize(userAccount);
+        assertThat(prosecutorEntity.getName()).matches(TestUtils.UUID_REGEX);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/TranscriptionCommentEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/TranscriptionCommentEntityTest.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.darts.common.entity;
 
 import org.junit.jupiter.api.Test;
-
-import java.util.UUID;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +13,8 @@ class TranscriptionCommentEntityTest {
         transcriptionCommentEntity.setComment("comment");
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        UUID uuid = UUID.randomUUID();
-
-        transcriptionCommentEntity.anonymize(userAccount, uuid);
-        assertThat(transcriptionCommentEntity.getComment()).isEqualTo(uuid.toString());
+        transcriptionCommentEntity.anonymize(userAccount);
+        assertThat(transcriptionCommentEntity.getComment()).matches(TestUtils.UUID_REGEX);
         assertThat(transcriptionCommentEntity.getLastModifiedBy()).isEqualTo(userAccount);
         assertThat(transcriptionCommentEntity.isDataAnonymised()).isFalse();//This is only set for manual anonymization
 

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntityTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.common.entity;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -23,13 +22,12 @@ class TranscriptionEntityTest {
         transcriptionEntity.setTranscriptionCommentEntities(List.of(transcriptionCommentEntity, transcriptionCommentEntity2));
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        UUID uuid = UUID.randomUUID();
-        transcriptionEntity.anonymize(userAccount, uuid);
+        transcriptionEntity.anonymize(userAccount);
 
         verify(transcriptionCommentEntity, times(1))
-            .anonymize(userAccount, uuid);
+            .anonymize(userAccount);
         verify(transcriptionCommentEntity2, times(1))
-            .anonymize(userAccount, uuid);
+            .anonymize(userAccount);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Limit;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -21,7 +22,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -64,7 +64,7 @@ class CaseExpiryDeletionAutomatedTaskTest {
         CourtCaseEntity courtCase2 = mock(CourtCaseEntity.class);
         CourtCaseEntity courtCase3 = mock(CourtCaseEntity.class);
 
-        when(caseRepository.findCasesToBeAnonymized(any(), anyLong()))
+        when(caseRepository.findCasesToBeAnonymized(any(), any()))
             .thenReturn(List.of(courtCase1, courtCase2, courtCase3));
 
         doReturn(5).when(caseExpiryDeletionAutomatedTask)
@@ -85,7 +85,7 @@ class CaseExpiryDeletionAutomatedTaskTest {
             .anonymize(eq(userAccount), any(UUID.class));
 
         verify(caseRepository, times(1))
-            .findCasesToBeAnonymized(offsetDateTime, 5);
+            .findCasesToBeAnonymized(offsetDateTime, Limit.of(5));
 
         verify(caseExpiryDeletionAutomatedTask, times(1))
             .getAutomatedTaskBatchSize();

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.darts.task.service.LockService;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -78,11 +77,11 @@ class CaseExpiryDeletionAutomatedTaskTest {
             .currentOffsetDateTime();
 
         verify(courtCase1, times(1))
-            .anonymize(eq(userAccount), any(UUID.class));
+            .anonymize(eq(userAccount));
         verify(courtCase2, times(1))
-            .anonymize(eq(userAccount), any(UUID.class));
+            .anonymize(eq(userAccount));
         verify(courtCase3, times(1))
-            .anonymize(eq(userAccount), any(UUID.class));
+            .anonymize(eq(userAccount));
 
         verify(caseRepository, times(1))
             .findCasesToBeAnonymized(offsetDateTime, Limit.of(5));

--- a/src/test/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImplTest.java
@@ -9,14 +9,12 @@ import uk.gov.hmcts.darts.audit.api.AuditActivity;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
 import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.exception.DartsApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.task.exception.AutomatedTaskApiError;
 import uk.gov.hmcts.darts.task.runner.impl.AbstractLockableAutomatedTask;
 import uk.gov.hmcts.darts.task.service.LockService;
 import uk.gov.hmcts.darts.tasks.model.AutomatedTaskPatch;
-import uk.gov.hmcts.darts.tasks.model.AutomatedTaskSummary;
 import uk.gov.hmcts.darts.tasks.model.DetailedAutomatedTask;
 
 import java.time.OffsetDateTime;

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/TestUtils.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/TestUtils.java
@@ -35,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.CognitiveComplexity"})
 public final class TestUtils {
 
+    public static final String UUID_REGEX = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$";
+
     private TestUtils() {
         throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-3923)


### Change description ###
The expiry deletion automated task, named "CaseExpiryDeletion" and added by DMP-2543, is configured within the database automated_tasks table. In addition, there is a feature flag within application.yaml driven by an env var set in flux, named CASE_EXPIRY_DELETION_ENABLED

If the task is not enabled then we need to prevent it from being the subject of the following automated tasks endpoints, as follows:

- GET /admin/automated-tasks - do not include the "CaseExpiryDeletion" task in the response
- GET /admin/automated-tasks/\{task_id} - return 404 (AUTOMATED_TASK_NOT_FOUND)
- PATCH /admin/automated-tasks/\{task_id} - return 404 (AUTOMATED_TASK_NOT_FOUND)
- POST /admin/automated-tasks/\{task_id}/run - return 404 (AUTOMATED_TASK_NOT_FOUND)

This will prevent it from showing on the admin portal and prevent consuming the API endpoints directly to amend or run the task.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
