### PR TITLE
DMP-3947 - Add 2 new Archive Retention Policies

### DIFF
--- a/src/integrationTest/resources/tests/retention/expectedResponse.json
+++ b/src/integrationTest/resources/tests/retention/expectedResponse.json
@@ -79,5 +79,23 @@
     "fixed_policy_key": "MANUAL",
     "duration": "0Y0M0D",
     "policy_start_at": "2024-01-01T00:00:00Z"
+  },
+  {
+    "id": 10,
+    "name": "DARTS Archive Permanent Retention",
+    "display_name": "Archive Permanent",
+    "description": "DARTS Archive Permanent Retention",
+    "fixed_policy_key": "-3",
+    "duration": "30Y0M0D",
+    "policy_start_at": "2024-01-01T00:00:00Z"
+  },
+  {
+    "id": 11,
+    "name": "DARTS Archive Standard Retention",
+    "display_name": "Archive Standard",
+    "description": "DARTS Archive Standard Retention",
+    "fixed_policy_key": "-4",
+    "duration": "7Y0M0D",
+    "policy_start_at": "2024-01-01T00:00:00Z"
   }
 ]

--- a/src/main/resources/db/migration/common/V1_379__added_additional_retention_policy_type.sql
+++ b/src/main/resources/db/migration/common/V1_379__added_additional_retention_policy_type.sql
@@ -1,0 +1,3 @@
+INSERT INTO darts.retention_policy_type (rpt_id,policy_name,display_name,fixed_policy_key,duration,policy_start_ts,policy_end_ts,retention_policy_object_id,created_ts,created_by,last_modified_ts,last_modified_by,description) VALUES
+(nextval('rpt_seq'),'DARTS Archive Permanent Retention','Archive Permanent',-3,'30Y0M0D',current_timestamp,null,null,current_timestamp,0,current_timestamp,0,'DARTS Archive Permanent Retention'),
+(nextval('rpt_seq'),'DARTS Archive Standard Retention','Archive Standard',-4,'7Y0M0D',current_timestamp,null,null,current_timestamp,0,current_timestamp,0,'DARTS Archive Standard Retention');

--- a/src/main/resources/db/migration/common/V1_379__added_additional_retention_policy_type.sql
+++ b/src/main/resources/db/migration/common/V1_379__added_additional_retention_policy_type.sql
@@ -1,3 +1,3 @@
 INSERT INTO darts.retention_policy_type (rpt_id,policy_name,display_name,fixed_policy_key,duration,policy_start_ts,policy_end_ts,retention_policy_object_id,created_ts,created_by,last_modified_ts,last_modified_by,description) VALUES
-(nextval('rpt_seq'),'DARTS Archive Permanent Retention','Archive Permanent',-3,'30Y0M0D',current_timestamp,null,null,current_timestamp,0,current_timestamp,0,'DARTS Archive Permanent Retention'),
-(nextval('rpt_seq'),'DARTS Archive Standard Retention','Archive Standard',-4,'7Y0M0D',current_timestamp,null,null,current_timestamp,0,current_timestamp,0,'DARTS Archive Standard Retention');
+(nextval('rpt_seq'),'DARTS Archive Permanent Retention','Archive Permanent',-3,'30Y0M0D','2024-01-01T00:00:00Z',null,null,current_timestamp,0,current_timestamp,0,'DARTS Archive Permanent Retention'),
+(nextval('rpt_seq'),'DARTS Archive Standard Retention','Archive Standard',-4,'7Y0M0D','2024-01-01T00:00:00Z',null,null,current_timestamp,0,current_timestamp,0,'DARTS Archive Standard Retention');


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-3947)


### Change description ###
As agreed with HMCTS on 16/09/2024 in the review of Retention Migration Transformation spec, the following records need to be created in the *darts.retention_policy_type* table to allow migration to work.

This will be a flyway change and required to be deployed to both Application and Data Migration DBs.

 
|*policy_name*|*display_name*|*fixed_policy_key*|*duration*|
|DARTS Archive Permanent Retention|Archive Permanent|-3|30Y0M0D|
|DARTS Archive Standard Retention|Archive Standard|-4|7Y0M0D|

 

 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
