### PR TITLE
DMP-3955 Fixing transcriber transcripts count endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
@@ -366,6 +366,24 @@ public class TranscriptionStub {
     }
 
     @Transactional
+    public TranscriptionEntity createAndSaveApprovedTranscription(UserAccountEntity userAccountEntity,
+                                                                  CourtCaseEntity courtCaseEntity,
+                                                                  HearingEntity hearingEntity,
+                                                                  OffsetDateTime workflowTimestamp,
+                                                                  Boolean hideRequestFromRequester) {
+        var transcriptionEntity = this.createTranscriptionWithStatus(
+            userAccountEntity,
+            courtCaseEntity,
+            hearingEntity,
+            workflowTimestamp,
+            getTranscriptionStatusByEnum(APPROVED),
+            null
+        );
+        transcriptionEntity.setHideRequestFromRequestor(hideRequestFromRequester);
+        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+    }
+
+    @Transactional
     public TranscriptionEntity createAndSaveWithTranscriberTranscription(UserAccountEntity userAccountEntity,
                                                                          CourtCaseEntity courtCaseEntity,
                                                                          HearingEntity hearingEntity,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3955

### Change description ###

- if multiple APPROVED or WITH_TRANSCRIBER workflow records exist for a transcription it was being counted more than once
- amending the SQL query to take this into account
- using the same approach as the query which drives the data in the tabs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
