### PR TITLE
DMP-3821 - Re-enable disabled integration tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/retention/RetentionFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/retention/RetentionFunctionalTest.java
@@ -20,7 +20,7 @@ class RetentionFunctionalTest extends FunctionalTest {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - needs to be fixed")
     void testGetCaseRetention() {
         String caseId = createCaseRetentions();
 

--- a/src/functionalTest/java/uk/gov/hmcts/darts/retention/RetentionFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/retention/RetentionFunctionalTest.java
@@ -20,7 +20,6 @@ class RetentionFunctionalTest extends FunctionalTest {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - needs to be fixed")
     void testGetCaseRetention() {
         String caseId = createCaseRetentions();
 

--- a/src/functionalTest/java/uk/gov/hmcts/darts/retention/RetentionFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/retention/RetentionFunctionalTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.retention;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.darts.FunctionalTest;
 

--- a/src/functionalTest/resources/application-functionalTest.yaml
+++ b/src/functionalTest/resources/application-functionalTest.yaml
@@ -33,6 +33,8 @@ azure-ad-b2c-darpc-midtier-global-auth:
 deployed-application-uri: ${TEST_URL:http://localhost:4550}
 
 darts:
+  testing-support-endpoints:
+    enabled: ${TESTING_SUPPORT_ENDPOINTS_ENABLED:true}
   storage:
     arm-api:
       arm-username: ${ARM_USERNAME:func-username}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/admin/test/TestSupportControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/admin/test/TestSupportControllerTest.java
@@ -95,7 +95,6 @@ class TestSupportControllerTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void createsAudit() throws Exception {
         mockMvc.perform(post(ENDPOINT_URL + "/courthouse/func-swansea/courtroom/cr1"))
             .andExpect(status().isCreated());
@@ -139,7 +138,6 @@ class TestSupportControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void createRetention() throws Exception {
         MvcResult response = mockMvc.perform(post(ENDPOINT_URL + "/case-retentions/caseNumber/func-case-a"))
             .andExpect(status().isOk())

--- a/src/integrationTest/java/uk/gov/hmcts/darts/admin/test/TestSupportControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/admin/test/TestSupportControllerTest.java
@@ -95,7 +95,7 @@ class TestSupportControllerTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void createsAudit() throws Exception {
         mockMvc.perform(post(ENDPOINT_URL + "/courthouse/func-swansea/courtroom/cr1"))
             .andExpect(status().isCreated());
@@ -108,7 +108,6 @@ class TestSupportControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void createsNoAuditAndNoCourtCaseOnBadRequest() throws Exception {
         when(auditActivityRepository.getReferenceById(anyInt())).thenThrow(DataIntegrityViolationException.class);
 
@@ -140,7 +139,7 @@ class TestSupportControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void createRetention() throws Exception {
         MvcResult response = mockMvc.perform(post(ENDPOINT_URL + "/case-retentions/caseNumber/func-case-a"))
             .andExpect(status().isOk())

--- a/src/integrationTest/java/uk/gov/hmcts/darts/admin/test/TestSupportControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/admin/test/TestSupportControllerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.admin.test;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -859,7 +859,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         expectedResponse = expectedResponse.replaceAll("<CASE_NUMBERS>", String.format("T%s", YESTERDAY.format(BASIC_ISO_DATE)) + "|Case1");
         expectedResponse = expectedResponse.replaceAll("<UPLOADED_BY>", String.valueOf(uploadedBy.getId()));
         expectedResponse = expectedResponse.replaceAll("<UPLOADED_DATE_TIME>", caseDocument.getCreatedDateTime().format(formatter));
-        expectedResponse = expectedResponse.replaceAll("<bf_011>", caseDocument.getCreatedDateTime().format(formatter));
 
         log.info("expect response {}", expectedResponse);
         assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -225,7 +225,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed (Validation)")
+    @Disabled("Failed Validation")
     void generateArchiveRecord_WithAllMediaProperties_ReturnFileSuccess() throws IOException {
 
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 14, 0, 0, 0, UTC);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -697,7 +697,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void generateArchiveRecord_WithLiveCaseProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -756,7 +756,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void generateArchiveRecord_WithLiveCasePropertiesRetentionDate_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         OffsetDateTime retainUntil = OffsetDateTime.of(2024, 9, 23, 13, 0, 0, 0, UTC);
@@ -817,7 +817,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void generateArchiveRecord_WithAllCaseProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -94,10 +94,10 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             "Int Test Courtroom 2",
             HEARING_DATE
         );
-
     }
 
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void generateArchiveRecord_WithLiveMediaProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -161,6 +161,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void generateArchiveRecord_WithLiveMediaPropertiesAndRetentionDate_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         OffsetDateTime retainUntil = OffsetDateTime.of(2024, 9, 23, 13, 45, 0, 0, UTC);
@@ -226,6 +227,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void generateArchiveRecord_WithAllMediaProperties_ReturnFileSuccess() throws IOException {
 
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 14, 0, 0, 0, UTC);
@@ -286,7 +288,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void generateArchiveRecord_WithLiveTranscriptionProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -357,7 +358,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void generateArchiveRecord_WithLiveTranscriptionPropertiesRetentionDate_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -430,7 +430,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void generateArchiveRecord_WithAllPropertiesTranscription_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -503,7 +502,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void generateArchiveRecord_WithLiveAnnotationProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -567,7 +565,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void generateArchiveRecord_WithLiveAnnotationPropertiesRetentionDate_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         OffsetDateTime retainUntil = OffsetDateTime.of(2024, 9, 23, 13, 0, 0, 0, UTC);
@@ -633,7 +630,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void generateArchiveRecord_WithAllAnnotationProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -44,7 +44,6 @@ import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_DROP_ZONE;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 @Slf4j
 @SuppressWarnings({"PMD.ExcessiveImports", "VariableDeclarationUsageDistance", "PMD.AssignmentInOperand"})
 class ArchiveRecordServiceIntTest extends IntegrationBase {
@@ -110,7 +109,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             endedAt,
             1
         );
-        MediaEntity savedMedia = dartsDatabase.getMediaRepository().saveAndFlush(media);
+        MediaEntity savedMedia = dartsDatabase.save(media);
         savedMedia.setMediaFile("a-media-file.mp2");
         savedMedia.setCreatedDateTime(startedAt);
         savedMedia.setRetConfReason(RETENTION_CONFIDENCE_REASON);
@@ -124,10 +123,10 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             UUID.randomUUID()
         );
         hearing.addMedia(savedMedia);
-        dartsDatabase.getHearingRepository().saveAndFlush(hearing);
+        dartsDatabase.save(hearing);
 
         armEod.setTransferAttempts(1);
-        dartsDatabase.getExternalObjectDirectoryRepository().saveAndFlush(armEod);
+        dartsDatabase.save(armEod);
 
         when(armDataManagementConfiguration.getMediaRecordClass()).thenReturn(DARTS);
         when(armDataManagementConfiguration.getMediaRecordPropertiesFile()).thenReturn("tests/arm/properties/media-record.properties");
@@ -175,7 +174,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             1
         );
         media.setRetainUntilTs(retainUntil);
-        MediaEntity savedMedia = dartsDatabase.getMediaRepository().saveAndFlush(media);
+        MediaEntity savedMedia = dartsDatabase.save(media);
         savedMedia.setMediaFile("a-media-file.mp2");
         savedMedia.setCreatedDateTime(startedAt);
         savedMedia.setRetConfReason(RETENTION_CONFIDENCE_REASON);
@@ -189,10 +188,10 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             UUID.randomUUID()
         );
         hearing.addMedia(savedMedia);
-        dartsDatabase.getHearingRepository().saveAndFlush(hearing);
+        dartsDatabase.save(hearing);
 
         armEod.setTransferAttempts(1);
-        dartsDatabase.getExternalObjectDirectoryRepository().saveAndFlush(armEod);
+        dartsDatabase.save(armEod);
 
         when(armDataManagementConfiguration.getMediaRecordClass()).thenReturn(DARTS);
         when(armDataManagementConfiguration.getMediaRecordPropertiesFile()).thenReturn("tests/arm/properties/media-record.properties");
@@ -239,7 +238,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             endedAt,
             1
         );
-        MediaEntity savedMedia = dartsDatabase.getMediaRepository().saveAndFlush(media);
+        MediaEntity savedMedia = dartsDatabase.save(media);
         savedMedia.setMediaFile("a-media-file.mp2");
         savedMedia.setCreatedDateTime(startedAt);
         savedMedia.setRetConfReason(RETENTION_CONFIDENCE_REASON);
@@ -253,10 +252,10 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
             UUID.randomUUID()
         );
         hearing.addMedia(savedMedia);
-        dartsDatabase.getHearingRepository().saveAndFlush(hearing);
+        dartsDatabase.save(hearing);
 
         armEod.setTransferAttempts(1);
-        dartsDatabase.getExternalObjectDirectoryRepository().saveAndFlush(armEod);
+        dartsDatabase.save(armEod);
 
         when(armDataManagementConfiguration.getMediaRecordClass()).thenReturn(DARTS);
         when(armDataManagementConfiguration.getMediaRecordPropertiesFile()).thenReturn("tests/arm/properties/all_properties/media-record.properties");
@@ -698,6 +697,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     void generateArchiveRecord_WithLiveCaseProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -756,6 +756,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     void generateArchiveRecord_WithLiveCasePropertiesRetentionDate_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         OffsetDateTime retainUntil = OffsetDateTime.of(2024, 9, 23, 13, 0, 0, 0, UTC);
@@ -816,6 +817,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     void generateArchiveRecord_WithAllCaseProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceIntTest.java
@@ -97,7 +97,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void generateArchiveRecord_WithLiveMediaProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -161,7 +160,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void generateArchiveRecord_WithLiveMediaPropertiesAndRetentionDate_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         OffsetDateTime retainUntil = OffsetDateTime.of(2024, 9, 23, 13, 45, 0, 0, UTC);
@@ -227,7 +225,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
+    @Disabled("Impacted by V1_364_*.sql - fix needed (Validation)")
     void generateArchiveRecord_WithAllMediaProperties_ReturnFileSuccess() throws IOException {
 
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 14, 0, 0, 0, UTC);
@@ -693,7 +691,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void generateArchiveRecord_WithLiveCaseProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -752,7 +749,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void generateArchiveRecord_WithLiveCasePropertiesRetentionDate_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         OffsetDateTime retainUntil = OffsetDateTime.of(2024, 9, 23, 13, 0, 0, 0, UTC);
@@ -813,7 +809,6 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void generateArchiveRecord_WithAllCaseProperties_ReturnFileSuccess() throws IOException {
         OffsetDateTime startedAt = OffsetDateTime.of(2023, 9, 23, 13, 0, 0, 0, UTC);
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(startedAt);
@@ -864,6 +859,7 @@ class ArchiveRecordServiceIntTest extends IntegrationBase {
         expectedResponse = expectedResponse.replaceAll("<CASE_NUMBERS>", String.format("T%s", YESTERDAY.format(BASIC_ISO_DATE)) + "|Case1");
         expectedResponse = expectedResponse.replaceAll("<UPLOADED_BY>", String.valueOf(uploadedBy.getId()));
         expectedResponse = expectedResponse.replaceAll("<UPLOADED_DATE_TIME>", caseDocument.getCreatedDateTime().format(formatter));
+        expectedResponse = expectedResponse.replaceAll("<bf_011>", caseDocument.getCreatedDateTime().format(formatter));
 
         log.info("expect response {}", expectedResponse);
         assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmBatchProcessResponseFilesIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmBatchProcessResponseFilesIntTest.java
@@ -119,7 +119,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
 
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void batchProcessResponseFiles_WithMediaReturnsSuccess() throws IOException {
 
@@ -310,7 +309,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
         verify(armDataManagementApi).getBlobData(createRecordFilename5);
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void batchProcessResponseFiles_GetBlobsThrowsException() throws IOException {
 
@@ -471,7 +469,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
         assertFalse(foundMedia5.isResponseCleaned());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void batchProcessResponseFiles_WithInvalidJson() throws IOException {
 
@@ -647,7 +644,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
         assertFalse(foundMedia5.isResponseCleaned());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void batchProcessResponseFiles_WithInvalidFilenameStatus() throws IOException {
 
@@ -748,7 +744,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void batchProcessResponseFiles_WithTranscriptionReturnsSuccess() throws IOException {
 
         // given
@@ -852,7 +847,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void batchProcessResponseFiles_WithInvalidTranscriptionChecksum() throws IOException {
 
         // given
@@ -1346,7 +1340,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
         assertNotNull(foundCaseDocEod.getErrorCode());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void batchProcessResponseFiles_ReturnsNoRecordsToProcess() {
 
@@ -1394,7 +1387,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
         verifyNoMoreInteractions(armDataManagementApi);
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void batchProcessResponseFiles_ThrowsExceptionWhenListingPrefix() {
 
@@ -1438,7 +1430,6 @@ class ArmBatchProcessResponseFilesIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void batchProcessResponseFiles_WithNullTranscriptionChecksum() throws IOException {
 
         // given

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmBatchProcessResponseFilesIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmBatchProcessResponseFilesIntTest.java
@@ -5,7 +5,6 @@ import com.azure.core.util.BinaryData;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmResponseFilesProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmResponseFilesProcessorIntTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.arm.service;
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.models.BlobStorageException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -799,7 +798,6 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void givenProcessResponseFilesFailsTranscriptionChecksum() throws IOException {
         authorisationStub.givenTestSchema();
         TranscriptionEntity transcriptionEntity = authorisationStub.getTranscriptionEntity();
@@ -1022,7 +1020,6 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void givenProcessResponseFilesSuccessfullyCompletesForTranscription() throws IOException {
         authorisationStub.givenTestSchema();
         TranscriptionEntity transcriptionEntity = authorisationStub.getTranscriptionEntity();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmResponseFilesProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmResponseFilesProcessorIntTest.java
@@ -51,7 +51,6 @@ import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONS
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 class ArmResponseFilesProcessorIntTest extends IntegrationBase {
 
     private static final LocalDateTime HEARING_DATE = LocalDateTime.of(2023, 6, 10, 10, 0, 0);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRetentionEventDateProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRetentionEventDateProcessorIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.arm.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -124,7 +123,6 @@ class ArmRetentionEventDateProcessorIntTest extends IntegrationBase {
 
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void calculateEventDates_WithMediaSuccessfulUpdate() {
         final String confidenceReason = "reason";
@@ -195,7 +193,6 @@ class ArmRetentionEventDateProcessorIntTest extends IntegrationBase {
 
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void calculateEventDates_NoEodsToProcess() {
 
@@ -252,7 +249,6 @@ class ArmRetentionEventDateProcessorIntTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void calculateEventDates_WithTranscriptionSuccessfulUpdate() {
         // given
         when(armDataManagementConfiguration.getEventDateAdjustmentYears()).thenReturn(EVENT_DATE_ADJUSTMENT_YEARS);
@@ -529,7 +525,6 @@ class ArmRetentionEventDateProcessorIntTest extends IntegrationBase {
         verify(armApiClient, times(0)).updateMetadata(notNull(), notNull());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void calculateEventDates_NoArmRecord_NoRetentionDateSet() {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/BatchCleanupArmResponseFilesServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/BatchCleanupArmResponseFilesServiceIntTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.arm.service;
 
 import com.azure.core.util.BinaryData;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/BatchCleanupArmResponseFilesServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/BatchCleanupArmResponseFilesServiceIntTest.java
@@ -39,7 +39,6 @@ import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 @SuppressWarnings({"PMD.NcssCount"})
 class BatchCleanupArmResponseFilesServiceIntTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/CleanupArmResponseFilesServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/CleanupArmResponseFilesServiceIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.arm.service;
 
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -35,7 +34,6 @@ import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONS
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_PROCESSING_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 class CleanupArmResponseFilesServiceIntTest extends IntegrationBase {
 
     private static final LocalDateTime HEARING_DATE = LocalDateTime.of(2023, 9, 26, 10, 0, 0);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 @SuppressWarnings({"PMD.ExcessiveImports"})
 class AudioTransformationServiceTest extends IntegrationBase {
 
@@ -41,6 +40,7 @@ class AudioTransformationServiceTest extends IntegrationBase {
     FileOperationService mockFileOperationService;
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void getMediaByHearingIdShouldReturnExpectedMediaEntitiesWhenHearingIdHasRelatedMedia() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity1());
@@ -58,6 +58,7 @@ class AudioTransformationServiceTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void getMediaByHearingIdShouldNotReturnMediaEntitiesWhenMediaIsHidden() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity4());
@@ -73,6 +74,7 @@ class AudioTransformationServiceTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void getMediaByHearingIdShouldReturnEmptyListWhenHearingIdHasNoRelatedMedia() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity1());
@@ -84,6 +86,7 @@ class AudioTransformationServiceTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void getMediaByHearingIdShouldReturnEmptyListWhenHearingIdDoesNotExist() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity1());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioTransformationServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.audio.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -40,7 +39,6 @@ class AudioTransformationServiceTest extends IntegrationBase {
     FileOperationService mockFileOperationService;
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void getMediaByHearingIdShouldReturnExpectedMediaEntitiesWhenHearingIdHasRelatedMedia() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity1());
@@ -58,7 +56,6 @@ class AudioTransformationServiceTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void getMediaByHearingIdShouldNotReturnMediaEntitiesWhenMediaIsHidden() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity4());
@@ -74,7 +71,6 @@ class AudioTransformationServiceTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void getMediaByHearingIdShouldReturnEmptyListWhenHearingIdHasNoRelatedMedia() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity1());
@@ -86,7 +82,6 @@ class AudioTransformationServiceTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void getMediaByHearingIdShouldReturnEmptyListWhenHearingIdDoesNotExist() {
         given.setupTest();
         given.externalObjectDirForMedia(given.getMediaEntity1());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImplTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.authorisation.component.impl;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -32,7 +31,6 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.hearings.exception.HearingApiError.HEARING_NOT_FOUND;
 import static uk.gov.hmcts.darts.transcriptions.exception.TranscriptionApiError.TRANSCRIPTION_NOT_FOUND;
 
-@Disabled("Impacted by V1_364_*.sql")
 class AuthorisationImplTest extends IntegrationBase {
 
     @MockBean

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImplTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.authorisation.component.impl;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,7 +24,6 @@ import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.USER
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.CPP;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.XHIBIT;
 
-@Disabled("Impacted by V1_364_*.sql")
 class UserIdentityImplTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.authorisation.service;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -40,7 +39,6 @@ import static uk.gov.hmcts.darts.test.common.data.CourthouseTestData.createCourt
 import static uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData.minimalSecurityGroup;
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;
 
-@Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
 class AuthorisationServiceTest extends IntegrationBase {
 
     private static final String TEST_JUDGE_EMAIL = "test.judge@example.com";
@@ -220,7 +218,6 @@ class AuthorisationServiceTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void shouldGetOptionalUserStateForMissingUserAccount() {
         Optional<UserState> userStateOptional = authorisationService.getAuthorisation("test.missing@example.com");
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.cases.controller;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +26,6 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
@@ -45,7 +45,7 @@ import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TES
 
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
 class CaseControllerAdminSearchTest extends IntegrationBase {
 
     private static final String ENDPOINT_URL = "/admin/cases/search";
@@ -150,7 +150,6 @@ class CaseControllerAdminSearchTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testOk() throws Exception {
 
         String requestBody = """

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
@@ -45,7 +45,7 @@ import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TES
 
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (UnsupportedOperationException)")
 class CaseControllerAdminSearchTest extends IntegrationBase {
 
     private static final String ENDPOINT_URL = "/admin/cases/search";

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
@@ -26,7 +26,9 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -45,7 +47,6 @@ import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TES
 
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (UnsupportedOperationException)")
 class CaseControllerAdminSearchTest extends IntegrationBase {
 
     private static final String ENDPOINT_URL = "/admin/cases/search";
@@ -70,7 +71,7 @@ class CaseControllerAdminSearchTest extends IntegrationBase {
 
         CourtCaseEntity case2 = createCaseAt(swanseaCourthouse);
         case2.setCaseNumber("Case2");
-        case2.setDefendantList(Arrays.asList(createDefendantForCaseWithName(case2, "Defendant2")));
+        case2.setDefendantList(new ArrayList<>(List.of(createDefendantForCaseWithName(case2, "Defendant2"))));
 
         CourtCaseEntity case3 = createCaseAt(swanseaCourthouse);
         case3.setCaseNumber("Case3");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.cases.controller;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -25,11 +24,10 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.test.common.data.DefendantTestData.someMinimalDefendant;
+import static uk.gov.hmcts.darts.test.common.data.DefendantTestData.createDefendantForCase;
 import static uk.gov.hmcts.darts.test.common.data.ProsecutorTestData.createProsecutorForCase;
 
 @AutoConfigureMockMvc
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
 class CaseControllerGetCaseByIdTest extends IntegrationBase {
 
     @Autowired
@@ -57,7 +55,7 @@ class CaseControllerGetCaseByIdTest extends IntegrationBase {
         );
         CourtCaseEntity courtCase = hearingEntity.getCourtCase();
         courtCase.addProsecutor(createProsecutorForCase(courtCase));
-        courtCase.addDefendant(someMinimalDefendant());
+        courtCase.addDefendant(createDefendantForCase(courtCase));
         courtCase.addDefence("aDefence");
         dartsDatabase.save(courtCase);
 
@@ -86,13 +84,14 @@ class CaseControllerGetCaseByIdTest extends IntegrationBase {
         String expectedJson = """
             {"case_id":<case-id>,
             "courthouse_id":<courthouse-id>,
-            "courthouse":"some-courthouse",
+            "courthouse":"SOME-COURTHOUSE",
             "case_number":"1",
-            "defendants":["aDefendant"],
+            "defendants":["some-defendant"],
             "judges":["1JUDGE1"],
-            "prosecutors":["aProsecutor"],
+            "prosecutors":["some-prosecutor"],
             "defenders":["aDefence"],
-            "reporting_restrictions":[]
+            "reporting_restrictions":[],
+            "is_data_anonymised":false
             }
             """;
 
@@ -114,9 +113,9 @@ class CaseControllerGetCaseByIdTest extends IntegrationBase {
             .andExpect(jsonPath("$.judges", Matchers.hasSize(1)))
             .andExpect(jsonPath("$.judges[0]", Matchers.is("1JUDGE1")))
             .andExpect(jsonPath("$.prosecutors", Matchers.hasSize(1)))
-            .andExpect(jsonPath("$.prosecutors[0]", Matchers.is("aProsecutor")))
+            .andExpect(jsonPath("$.prosecutors[0]", Matchers.is("some-prosecutor")))
             .andExpect(jsonPath("$.defendants", Matchers.hasSize(1)))
-            .andExpect(jsonPath("$.defendants[0]", Matchers.is("aDefendant")))
+            .andExpect(jsonPath("$.defendants[0]", Matchers.is("some-defendant")))
             .andExpect(jsonPath("$.defenders", Matchers.hasSize(1)))
             .andExpect(jsonPath("$.defenders[0]", Matchers.is("aDefence")));
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
@@ -29,7 +29,7 @@ import static uk.gov.hmcts.darts.test.common.data.DefendantTestData.someMinimalD
 import static uk.gov.hmcts.darts.test.common.data.ProsecutorTestData.createProsecutorForCase;
 
 @AutoConfigureMockMvc
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
 class CaseControllerGetCaseByIdTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -47,7 +47,7 @@ import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TES
 
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
 class CaseControllerSearchPostTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.cases.controller;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +27,6 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -27,7 +27,9 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -47,7 +49,6 @@ import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TES
 
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (UnsupportedOperationException)")
 class CaseControllerSearchPostTest extends IntegrationBase {
 
     @Autowired
@@ -68,7 +69,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
 
         CourtCaseEntity case2 = createCaseAt(swanseaCourthouse);
         case2.setCaseNumber("Case2");
-        case2.setDefendantList(Arrays.asList(createDefendantForCaseWithName(case2, "Defendant2")));
+        case2.setDefendantList(new ArrayList<>(List.of(createDefendantForCaseWithName(case2, "Defendant2"))));
 
         CourtCaseEntity case3 = createCaseAt(swanseaCourthouse);
         case3.setCaseNumber("Case3");
@@ -241,7 +242,8 @@ class CaseControllerSearchPostTest extends IntegrationBase {
                       "AJUDGE"
                     ]
                   }
-                ]
+                ],
+                "is_data_anonymised": false
               }
             ]
             """;
@@ -299,7 +301,8 @@ class CaseControllerSearchPostTest extends IntegrationBase {
                       "AJUDGE"
                     ]
                   }
-                ]
+                ],
+                "is_data_anonymised": false
               }
             ]
             """;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -47,7 +47,7 @@ import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TES
 
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (UnsupportedOperationException)")
 class CaseControllerSearchPostTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/repository/CaseRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/repository/CaseRepositoryIntTest.java
@@ -280,7 +280,7 @@ class CaseRepositoryIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
+    @Disabled("Impacted by V1_364_*.sql - fix needed (Validation)")
     void testFindOpenCasesToClosePaged() {
         // given
         caseStub.createAndSaveCourtCase(courtCase -> {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/repository/CaseRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/repository/CaseRepositoryIntTest.java
@@ -280,7 +280,7 @@ class CaseRepositoryIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed (Validation)")
+    @Disabled("Failed Validation")
     void testFindOpenCasesToClosePaged() {
         // given
         caseStub.createAndSaveCourtCase(courtCase -> {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/repository/CaseRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/repository/CaseRepositoryIntTest.java
@@ -35,7 +35,6 @@ class CaseRepositoryIntTest extends IntegrationBase {
     CaseRepository caseRepository;
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testFindByIsRetentionUpdatedTrueAndRetentionRetriesLessThan() {
         // given
         caseStub.createAndSaveCourtCase(courtCase -> {
@@ -64,7 +63,6 @@ class CaseRepositoryIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testFindCasesNeedingCaseDocumentGeneratedPaged() {
         // given
         caseStub.createAndSaveCourtCase(courtCase -> {
@@ -108,7 +106,6 @@ class CaseRepositoryIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testFindCasesNeedingCaseDocumentGeneratedUnpaged() {
         // given
         caseStub.createAndSaveCourtCase(courtCase -> {
@@ -156,7 +153,6 @@ class CaseRepositoryIntTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testFindCasesNeedingCaseDocumentForRetentionDateGenerationPagedSuccess() {
         // given
         CourtCaseEntity courtCaseEntityWithNoCaseDocuments = dartsDatabase.createCase(SOME_COURTHOUSE, SOME_CASE_NUMBER_1);
@@ -284,7 +280,7 @@ class CaseRepositoryIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testFindOpenCasesToClosePaged() {
         // given
         caseStub.createAndSaveCourtCase(courtCase -> {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseMapperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseMapperTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.cases.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.cases.mapper.CasesMapper;
@@ -27,7 +26,6 @@ import static uk.gov.hmcts.darts.test.common.data.EventTestData.someReportingRes
 import static uk.gov.hmcts.darts.test.common.data.HearingTestData.someMinimalHearing;
 
 @SuppressWarnings("VariableDeclarationUsageDistance")
-@Disabled("Impacted by V1_364_*.sql - fix needed")
 class CaseMapperTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseMapperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseMapperTest.java
@@ -27,7 +27,7 @@ import static uk.gov.hmcts.darts.test.common.data.EventTestData.someReportingRes
 import static uk.gov.hmcts.darts.test.common.data.HearingTestData.someMinimalHearing;
 
 @SuppressWarnings("VariableDeclarationUsageDistance")
-@Disabled("Impacted by V1_364_*.sql")
+@Disabled("Impacted by V1_364_*.sql - fix needed")
 class CaseMapperTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
@@ -47,7 +47,7 @@ import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createJudgeWithN
     "darts.cases.admin-search.max-results=20"
 })
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
 class CaseServiceAdminSearchTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
@@ -47,7 +47,7 @@ import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createJudgeWithN
     "darts.cases.admin-search.max-results=20"
 })
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (UnsupportedOperationException)")
 class CaseServiceAdminSearchTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.darts.testutils.stubs.CourtCaseStub;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -47,7 +48,6 @@ import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createJudgeWithN
     "darts.cases.admin-search.max-results=20"
 })
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (UnsupportedOperationException)")
 class CaseServiceAdminSearchTest extends IntegrationBase {
 
     @Autowired
@@ -79,7 +79,7 @@ class CaseServiceAdminSearchTest extends IntegrationBase {
 
         CourtCaseEntity case2 = createCaseAt(swanseaCourthouse);
         case2.setCaseNumber("Case2");
-        case2.setDefendantList(Arrays.asList(createDefendantForCaseWithName(case2, "Defendant2")));
+        case2.setDefendantList(new ArrayList<>(List.of(createDefendantForCaseWithName(case2, "Defendant2"))));
 
         CourtCaseEntity case3 = createCaseAt(swanseaCourthouse);
         case3.setCaseNumber("Case3");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdminSearchTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.cases.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -29,7 +28,6 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.cases.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -28,7 +27,6 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -45,7 +45,7 @@ import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createJudgeWithN
 import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TEST_USER_EMAIL;
 
 @Slf4j
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
 class CaseServiceAdvancedSearchTest extends IntegrationBase {
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -45,7 +46,6 @@ import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createJudgeWithN
 import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TEST_USER_EMAIL;
 
 @Slf4j
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (UnsupportedOperationException)")
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
 class CaseServiceAdvancedSearchTest extends IntegrationBase {
     @Autowired
@@ -75,7 +75,7 @@ class CaseServiceAdvancedSearchTest extends IntegrationBase {
 
         CourtCaseEntity case2 = createCaseAt(swanseaCourthouse);
         case2.setCaseNumber("Case2");
-        case2.setDefendantList(Arrays.asList(createDefendantForCaseWithName(case2, "Defendant2")));
+        case2.setDefendantList(new ArrayList<>(List.of(createDefendantForCaseWithName(case2, "Defendant2"))));
 
         CourtCaseEntity case3 = createCaseAt(swanseaCourthouse);
         case3.setCaseNumber("Case3");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchTest.java
@@ -45,7 +45,7 @@ import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createJudgeWithN
 import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TEST_USER_EMAIL;
 
 @Slf4j
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (UnsupportedOperationException)")
 @SuppressWarnings({"PMD.VariableDeclarationUsageDistance", "PMD.NcssCount", "PMD.ExcessiveImports"})
 class CaseServiceAdvancedSearchTest extends IntegrationBase {
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchUseInterpreterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceAdvancedSearchUseInterpreterTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.cases.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.cases.model.AdvancedSearchResult;
@@ -29,7 +28,6 @@ import static uk.gov.hmcts.darts.test.common.data.HearingTestData.createHearingW
 import static uk.gov.hmcts.darts.testutils.stubs.UserAccountStub.INTEGRATION_TEST_USER_EMAIL;
 
 @Slf4j
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
 class CaseServiceAdvancedSearchUseInterpreterTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceGetEventsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CaseServiceGetEventsTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.cases.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -17,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.darts.test.common.data.EventTestData.createEventWith;
 
 @Slf4j
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
 class CaseServiceGetEventsTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CloseOldCasesProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CloseOldCasesProcessorTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.cases.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -31,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 @Slf4j
 class CloseOldCasesProcessorTest extends IntegrationBase {
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/RetentionPolicyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/RetentionPolicyTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.cases.service;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -108,7 +107,6 @@ class RetentionPolicyTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void onePolicyWithCurrentStatePending() {
         CourtCaseEntity courtCase = dartsDatabase.createCase("Swansea", "aCaseNumber");
         courtCase.setCaseClosedTimestamp(OffsetDateTime.now());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/RetentionPolicyTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/RetentionPolicyTest.java
@@ -17,7 +17,6 @@ import java.time.OffsetDateTime;
 
 import static org.mockito.Mockito.when;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 @SuppressWarnings("VariableDeclarationUsageDistance")
 class RetentionPolicyTest extends IntegrationBase {
 
@@ -109,6 +108,7 @@ class RetentionPolicyTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void onePolicyWithCurrentStatePending() {
         CourtCaseEntity courtCase = dartsDatabase.createCase("Swansea", "aCaseNumber");
         courtCase.setCaseClosedTimestamp(OffsetDateTime.now());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/DailyListEntityTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/DailyListEntityTest.java
@@ -41,7 +41,7 @@ class DailyListEntityTest extends IntegrationBase {
     UserIdentity mockUserIdentity;
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListAddDailyListEndpoint() throws Exception {
         when(mockUserIdentity.userHasGlobalAccess(Set.of(XHIBIT, CPP))).thenReturn(true);
 
@@ -120,7 +120,7 @@ class DailyListEntityTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListPatchDailyListEndpoint() throws Exception {
         when(mockUserIdentity.userHasGlobalAccess(Set.of(XHIBIT, CPP))).thenReturn(true);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/DailyListEntityTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/DailyListEntityTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.common.controller;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -41,9 +40,9 @@ class DailyListEntityTest extends IntegrationBase {
     UserIdentity mockUserIdentity;
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListAddDailyListEndpoint() throws Exception {
         when(mockUserIdentity.userHasGlobalAccess(Set.of(XHIBIT, CPP))).thenReturn(true);
+        when(mockUserIdentity.getUserAccount()).thenReturn(dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity());
 
         dartsDatabase.createCourthouseWithNameAndCode("SWANSEA", 457, "Swansea");
 
@@ -120,9 +119,9 @@ class DailyListEntityTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListPatchDailyListEndpoint() throws Exception {
         when(mockUserIdentity.userHasGlobalAccess(Set.of(XHIBIT, CPP))).thenReturn(true);
+        when(mockUserIdentity.getUserAccount()).thenReturn(dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity());
 
         dartsDatabase.createCourthouseWithNameAndCode("SWANSEA", 457, "Swansea");
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/CaseManagementRetentionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/CaseManagementRetentionRepositoryTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.common.repository;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.CaseManagementRetentionEntity;
@@ -15,7 +14,6 @@ import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.darts.test.common.data.CaseManagementRetentionTestData.someMinimalCaseManagementRetention;
 
-@Disabled("Impacted by V1_362__constraint_transcription_part6.sql - fix needed")
 class CaseManagementRetentionRepositoryTest extends PostgresIntegrationBase {
 
     @Autowired
@@ -26,7 +24,7 @@ class CaseManagementRetentionRepositoryTest extends PostgresIntegrationBase {
 
     @Test
     void getCaseManagementRetentionIdsForEvents() {
-        var caseManagementRetention = entityGraphPersistence.persist(someMinimalCaseManagementRetention());
+        var caseManagementRetention = dartsDatabase.save(someMinimalCaseManagementRetention());
 
         var cmrIds = caseManagementRetentionRepository.getIdsForEvents(List.of(caseManagementRetention.getEventEntity()));
 
@@ -37,7 +35,6 @@ class CaseManagementRetentionRepositoryTest extends PostgresIntegrationBase {
     @Test
     void deletesCaseManagementRetentionsForAssociatedWithEvents() {
         var caseManagementRetentionsWithEvents = createSomeCmrWithEvents(3);
-        entityGraphPersistence.persistAll(caseManagementRetentionsWithEvents);
 
         caseManagementRetentionRepository.deleteAllByEventEntityIn(
             asList(
@@ -52,6 +49,7 @@ class CaseManagementRetentionRepositoryTest extends PostgresIntegrationBase {
     private List<CaseManagementRetentionEntity> createSomeCmrWithEvents(int quantity) {
         return range(0, quantity)
             .mapToObj(i -> someMinimalCaseManagementRetention())
+            .map(caseManagementRetentionEntity -> dartsDatabase.save(caseManagementRetentionEntity))
             .collect(toList());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/CaseManagementRetentionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/CaseManagementRetentionRepositoryTest.java
@@ -15,7 +15,7 @@ import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.darts.test.common.data.CaseManagementRetentionTestData.someMinimalCaseManagementRetention;
 
-@Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
+@Disabled("Impacted by V1_362__constraint_transcription_part6.sql - fix needed")
 class CaseManagementRetentionRepositoryTest extends PostgresIntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EodRepositoryHasMediaNotBeenCopiedFromInboundStorageIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EodRepositoryHasMediaNotBeenCopiedFromInboundStorageIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.common.repository;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
@@ -27,7 +26,6 @@ import static uk.gov.hmcts.darts.common.util.EodHelper.inboundLocation;
 import static uk.gov.hmcts.darts.common.util.EodHelper.storedStatus;
 import static uk.gov.hmcts.darts.common.util.EodHelper.unstructuredLocation;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 class EodRepositoryHasMediaNotBeenCopiedFromInboundStorageIntTest extends IntegrationBase {
 
     MediaEntity media;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepositoryTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.common.repository;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -46,7 +45,6 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
 
     private List<ExternalObjectDirectoryEntity> entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours;
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void testGetDirectoryIfMediaDate24Hours() throws Exception {
 
@@ -69,7 +67,6 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
                               entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void testGetDirectoryIfMediaDateBeyond24Hours() throws Exception {
 
@@ -157,7 +154,6 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
         Assertions.assertTrue(results.isEmpty());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void testGetDirectoryIfMediaDateNotBeyondThreshold() throws Exception {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/HearingRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/HearingRepositoryIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.common.repository;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
@@ -12,7 +11,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("Impacted by V1_364_*.sql")
 class HearingRepositoryIntTest extends PostgresIntegrationBase {
 
     // generation count. Should always be an even number

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/ObjectAdminActionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/ObjectAdminActionRepositoryTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.common.repository;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
@@ -51,7 +50,6 @@ class ObjectAdminActionRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void findAllWithAnyDeletionReasonShouldReturnExpectedResultsWhenMediaExistsMediaActionsWithDeletionReasonButNotYetApprovedForDeletion() {
         // Given
         var courtroomEntity = courtroomStub.createCourtroomUnlessExists("Test Courthouse", "Test Courtroom",

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.common.repository;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -16,7 +15,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
-@Disabled("Impacted by V1_364_*.sql")
 class TranscriptionDocumentTest extends PostgresIntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.common.repository;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -85,7 +84,6 @@ class TranscriptionRepositoryTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void excludesHidden() {
         var courtCase = createSomeMinimalCase();
         persistTwoHiddenTwoNotHiddenTranscriptionsFor(courtCase);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/courthouse/AudioAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/courthouse/AudioAuditTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.courthouse;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
@@ -35,7 +34,6 @@ class AudioAuditTest extends IntegrationBase {
     private GivenBuilder given;
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void performsStandardAndAdvancedAuditsWhenAudioOwnershipIsChanged() {
         var activeUser = given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
         MediaRequestEntity mediaRequest = entityGraphPersistence.persist(someMinimalRequestData());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/courthouse/AudioAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/courthouse/AudioAuditTest.java
@@ -52,7 +52,6 @@ class AudioAuditTest extends IntegrationBase {
         assertThat(mediaRequestRevisions.getLatestRevision().getMetadata().getRevisionType()).isEqualTo(UPDATE);
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void performsStandardAuditWhenAudioIsChangedToHidden() {
         var activeUser = given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorTest.java
@@ -10,7 +10,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -92,7 +91,6 @@ class DailyListProcessorTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListProcessorMultipleDailyList() throws IOException {
         log.info("start dailyListProcessorMultipleDailyList");
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
@@ -111,7 +109,8 @@ class DailyListProcessorTest extends IntegrationBase {
             "tests/dailyListProcessorTest/dailyListCPP.json"
         );
 
-        dailyListRepository.saveAllAndFlush(List.of(dailyListEntity, oldDailyListEntity));
+        dartsDatabase.save(dailyListEntity);
+        dartsDatabase.save(oldDailyListEntity);
 
         dailyListProcessor.processAllDailyLists();
 
@@ -245,7 +244,6 @@ class DailyListProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListForListingCourthouseWithIgnore() throws IOException {
         log.info("start dailyListProcessorMultipleDailyList");
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
@@ -264,7 +262,8 @@ class DailyListProcessorTest extends IntegrationBase {
             "tests/dailyListProcessorTest/dailyListCPP.json"
         );
 
-        dailyListRepository.saveAllAndFlush(List.of(dailyListEntity, oldDailyListEntity));
+        dartsDatabase.save(dailyListEntity);
+        dartsDatabase.save(oldDailyListEntity);
 
         dailyListProcessor.processAllDailyListForListingCourthouse(swanseaCourtEntity.getCourthouseName());
 
@@ -308,7 +307,6 @@ class DailyListProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListProcessorCppAndXhbDailyLists() throws IOException {
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
 
@@ -380,18 +378,17 @@ class DailyListProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void setsDailyListStatusToFailedIfUpdateFails() {
         var dailyListEntity = DailyListTestData.minimalDailyList();
         dailyListEntity.setListingCourthouse("SOME-COURTHOUSE");
         dailyListEntity.setStartDate(LocalDate.now());
         dailyListEntity.setSource("CPP");
 
-        var dailyListEntities = dartsDatabase.saveAll(dailyListEntity);
+        var dailyListEntities = dartsDatabase.save(dailyListEntity);
 
         dailyListProcessor.processAllDailyLists();
 
-        int id = dailyListEntities.get(0).getId();
+        int id = dailyListEntities.getId();
 
         DailyListLogJobReport report = new DailyListLogJobReport(1, SourceType.CPP);
         report.registerResult(FAILED);
@@ -405,7 +402,6 @@ class DailyListProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void setsDailyListStatusToIgnoredIfNotLatest() throws IOException {
         var latestDailyList = DailyListTestData.minimalDailyList();
         latestDailyList.setListingCourthouse("SOME-COURTHOUSE");
@@ -419,7 +415,8 @@ class DailyListProcessorTest extends IntegrationBase {
         oldDailyList.setPublishedTimestamp(OffsetDateTime.now().minusHours(1));
         oldDailyList.setStartDate(LocalDate.now());
         oldDailyList.setSource("CPP");
-        dartsDatabase.saveAll(latestDailyList, oldDailyList);
+        dartsDatabase.save(latestDailyList);
+        dartsDatabase.save(oldDailyList);
 
         dailyListProcessor.processAllDailyLists();
 
@@ -437,7 +434,6 @@ class DailyListProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListProcessorWithLock() throws IOException {
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
         dartsDatabase.createDailyLists(swanseaCourtEntity.getCourthouseName());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorTest.java
@@ -91,8 +91,8 @@ class DailyListProcessorTest extends IntegrationBase {
     }
 
 
-    @Disabled("Impacted by V1_364_*.sql")
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListProcessorMultipleDailyList() throws IOException {
         log.info("start dailyListProcessorMultipleDailyList");
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
@@ -244,8 +244,8 @@ class DailyListProcessorTest extends IntegrationBase {
         assertEquals(IGNORED, savedDailyList2.getStatus());
     }
 
-    @Disabled("Impacted by V1_364_*.sql")
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListForListingCourthouseWithIgnore() throws IOException {
         log.info("start dailyListProcessorMultipleDailyList");
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
@@ -307,8 +307,8 @@ class DailyListProcessorTest extends IntegrationBase {
 
     }
 
-    @Disabled("Impacted by V1_364_*.sql")
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListProcessorCppAndXhbDailyLists() throws IOException {
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
 
@@ -379,8 +379,8 @@ class DailyListProcessorTest extends IntegrationBase {
 
     }
 
-    @Disabled("Impacted by V1_364_*.sql")
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void setsDailyListStatusToFailedIfUpdateFails() {
         var dailyListEntity = DailyListTestData.minimalDailyList();
         dailyListEntity.setListingCourthouse("SOME-COURTHOUSE");
@@ -404,8 +404,8 @@ class DailyListProcessorTest extends IntegrationBase {
         Assertions.assertThat(dailyListStatus).isEqualTo(FAILED);
     }
 
-    @Disabled("Impacted by V1_364_*.sql")
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void setsDailyListStatusToIgnoredIfNotLatest() throws IOException {
         var latestDailyList = DailyListTestData.minimalDailyList();
         latestDailyList.setListingCourthouse("SOME-COURTHOUSE");
@@ -436,8 +436,8 @@ class DailyListProcessorTest extends IntegrationBase {
         Assertions.assertThat(dailyListStatus).isEqualTo(IGNORED);
     }
 
-    @Disabled("Impacted by V1_364_*.sql")
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void dailyListProcessorWithLock() throws IOException {
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
         dartsDatabase.createDailyLists(swanseaCourtEntity.getCourthouseName());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListProcessorTest.java
@@ -10,6 +10,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -434,6 +435,7 @@ class DailyListProcessorTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Failed Validation (Only on Jenkins)")
     void dailyListProcessorWithLock() throws IOException {
         CourthouseEntity swanseaCourtEntity = dartsDatabase.createCourthouseWithTwoCourtrooms();
         dartsDatabase.createDailyLists(swanseaCourtEntity.getCourthouseName());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListServiceHousekeepingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListServiceHousekeepingTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.DailyListEntity;
@@ -18,7 +17,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("Impacted by V1_364_*.sql - fix needed")
 class DailyListServiceHousekeepingTest extends IntegrationBase {
 
     static final ObjectMapper MAPPER = new ObjectMapper();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListServiceHousekeepingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListServiceHousekeepingTest.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Disabled("Impacted by V1_364_*.sql")
+@Disabled("Impacted by V1_364_*.sql - fix needed")
 class DailyListServiceHousekeepingTest extends IntegrationBase {
 
     static final ObjectMapper MAPPER = new ObjectMapper();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/dailylist/service/DailyListServiceTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
-@Disabled("Impacted by V1_364_*.sql")
+@Disabled("Impacted by V1_364_*.sql - fix needed")
 class DailyListServiceTest extends IntegrationBase {
 
     static final ObjectMapper MAPPER = new ObjectMapper();
@@ -57,7 +57,7 @@ class DailyListServiceTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
+    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql - fix needed")
     void insert1OkJson() throws IOException {
         dartsDatabase.createCourthouseWithNameAndCode("SWANSEA", 457, "Swansea");
         String dailyListJsonStr = getContentsFromFile(
@@ -77,7 +77,7 @@ class DailyListServiceTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
+    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql - fix needed")
     void insert1OkJsonAndXml() throws IOException {
         dartsDatabase.createCourthouseWithNameAndCode("SWANSEA", 457, "Swansea");
         String dailyListJsonStr = getContentsFromFile(
@@ -97,7 +97,7 @@ class DailyListServiceTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
+    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql - fix needed")
     void updateOkJsonWithXml() throws IOException {
         dartsDatabase.createCourthouseWithNameAndCode("SWANSEA", 457, "Swansea");
         String dailyListJsonStr = getContentsFromFile(
@@ -123,7 +123,7 @@ class DailyListServiceTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
+    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql - fix needed")
     void insert1DuplicateOk() throws IOException {
         dartsDatabase.createCourthouseWithNameAndCode("SWANSEA", 457, "Swansea");
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
@@ -49,7 +49,6 @@ class EventSearchControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void returnsErrorIfTooManyResults() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
         eventsGivensBuilder.persistedEvents(6);
@@ -90,7 +89,7 @@ class EventSearchControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
+    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
     void returnsAllFieldsCorrectly() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
         eventsGivensBuilder.persistedEvents(1);
@@ -108,8 +107,8 @@ class EventSearchControllerTest extends IntegrationBase {
         assertThat(response).hasJsonPathStringValue("[0].courthouse.display_name");
         assertThat(response).hasJsonPathNumberValue("[0].courtroom.id");
         assertThat(response).hasJsonPathStringValue("[0].courtroom.name");
-        assertThat(response).hasJsonPathStringValue("[0].isManuallyAnonymised");
-        assertThat(response).hasJsonPathStringValue("[0].isCaseExpired");
+        assertThat(response).hasJsonPathBooleanValue("[0].is_manually_anonymised");
+        assertThat(response).hasJsonPathBooleanValue("[0].is_case_expired");
         assertThat(response).hasJsonPathStringValue("[0].caseExpiredAt");
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
@@ -89,7 +89,7 @@ class EventSearchControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (Validation)")
+    @Disabled("Failed Validation")
     void returnsAllFieldsCorrectly() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
         eventsGivensBuilder.persistedEvents(1);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
@@ -89,7 +89,7 @@ class EventSearchControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
+    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed (Validation)")
     void returnsAllFieldsCorrectly() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
         eventsGivensBuilder.persistedEvents(1);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerCourtLogsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerCourtLogsTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.event.controller;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -170,13 +169,12 @@ class EventsControllerCourtLogsTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void courtLogsGetResultMatch() throws Exception {
 
         HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);
 
         var event = createEventWith(LOG, "test", hearingEntity, createOffsetDateTime("2023-07-01T10:00:00"));
-        eventRepository.saveAndFlush(event);
+        dartsDatabase.save(event);
 
         String courthouseName = hearingEntity.getCourtCase().getCourthouse().getDisplayName();
         String caseNumber = hearingEntity.getCourtCase().getCaseNumber();
@@ -198,7 +196,6 @@ class EventsControllerCourtLogsTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void courtlogsGetOnlyExpectedResults() throws Exception {
 
         HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);
@@ -209,10 +206,10 @@ class EventsControllerCourtLogsTest extends IntegrationBase {
         var event3 = createEventWith("Event", "ShouldNotShow", hearingEntity, eventTime);
         var event4 = createEventWith("Event", "ShouldAlsoNotShow", hearingEntity, eventTime);
 
-        eventRepository.saveAndFlush(event);
-        eventRepository.saveAndFlush(event2);
-        eventRepository.saveAndFlush(event3);
-        eventRepository.saveAndFlush(event4);
+        dartsDatabase.save(event);
+        dartsDatabase.save(event2);
+        dartsDatabase.save(event3);
+        dartsDatabase.save(event4);
 
         String courthouseName = hearingEntity.getCourtCase().getCourthouse().getCourthouseName();
         String caseNumber = hearingEntity.getCourtCase().getCaseNumber();
@@ -231,7 +228,6 @@ class EventsControllerCourtLogsTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void courtLogsWrongCaseNumber() throws Exception {
 
         HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);
@@ -250,10 +246,10 @@ class EventsControllerCourtLogsTest extends IntegrationBase {
         var eventHearing = createEventWith(LOG, "eventText", hearingEntity1, eventTime);
         var eventHearing2 = createEventWith(LOG, "eventText2", hearingEntity1, eventTime);
 
-        eventRepository.saveAndFlush(event);
-        eventRepository.saveAndFlush(event2);
-        eventRepository.saveAndFlush(eventHearing);
-        eventRepository.saveAndFlush(eventHearing2);
+        dartsDatabase.save(event);
+        dartsDatabase.save(event2);
+        dartsDatabase.save(eventHearing);
+        dartsDatabase.save(eventHearing2);
 
         String displayName = hearingEntity.getCourtCase().getCourthouse().getDisplayName();
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/AdminEventSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/AdminEventSearchTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.event.service.impl;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -19,7 +18,6 @@ import static uk.gov.hmcts.darts.test.common.data.CourtroomTestData.someMinimalC
 import static uk.gov.hmcts.darts.test.common.data.HearingTestData.someMinimalHearing;
 
 @TestPropertySource(properties = {"darts.events.admin-search.max-results=5"})
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
 class AdminEventSearchTest extends IntegrationBaseWithWiremock {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStartHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStartHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -54,7 +53,6 @@ class DarStartHandlerTest extends HandlerTestData {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void throwsOnUnknownCourthouse() {
         dartsDatabase.save(someMinimalCase());
         DartsEvent event = someMinimalDartsEvent().courthouse(SOME_ROOM);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStopHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DarStopHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -46,7 +45,6 @@ class DarStopHandlerTest extends HandlerTestData {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void throwsOnUnknownCourthouse() {
         dartsDatabase.save(someMinimalCase());
         DartsEvent event = someMinimalDartsEvent().courthouse(SOME_ROOM);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DartsEventNullHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/DartsEventNullHandlerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -39,7 +38,6 @@ class DartsEventNullHandlerTest extends HandlerTestData {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void shouldDoNothingForNullMappedEvent() {
         dartsDatabase.save(someMinimalCase());
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/EventProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/EventProcessorTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.event.service.impl;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.arm.component.AutomatedTaskProcessorFactory;
@@ -16,7 +15,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
 class EventProcessorTest extends PostgresIntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StandardEventHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StandardEventHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -55,7 +54,6 @@ class StandardEventHandlerTest extends HandlerTestData {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void throwsOnUnknownCourthouse() {
         dartsDatabase.save(someMinimalCase());
         DartsEvent dartsEvent = someMinimalDartsEvent().courthouse(UNKNOWN_COURTHOUSE);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StopAndCloseHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StopAndCloseHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +47,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum.CASE_CLOSED;
 import static uk.gov.hmcts.darts.test.common.data.CaseTestData.someMinimalCase;
 
-@Disabled("Impacted by V1_366__add_missing_constraints_part5b.sql")
 class StopAndCloseHandlerTest extends HandlerTestData {
 
     private static final String ARCHIVE_CASE_EVENT_TYPE = "3000";
@@ -85,7 +83,6 @@ class StopAndCloseHandlerTest extends HandlerTestData {
     }
 
     @Test
-    @Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
     void throwsOnUnknownCourthouse() {
         dartsDatabase.save(someMinimalCase());
         DartsEvent event = someMinimalDartsEvent().courthouse(SOME_ROOM);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsControllerAdminPostTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsControllerAdminPostTranscriptionIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.hearings.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -30,7 +29,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
-@Disabled("Impacted by V1_364_*.sql")
 class HearingsControllerAdminPostTranscriptionIntTest extends IntegrationBase {
 
     private static final String ENDPOINT_URL = "/admin/hearings/search";

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.hearings.controller;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -17,10 +16,12 @@ import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.JudgeEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.test.common.data.JudgeTestData;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Locale;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,7 +34,6 @@ import static uk.gov.hmcts.darts.test.common.data.ProsecutorTestData.createProse
 
 @AutoConfigureMockMvc
 @Slf4j
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
 class HearingsGetControllerTest extends IntegrationBase {
 
     @Autowired
@@ -58,8 +58,8 @@ class HearingsGetControllerTest extends IntegrationBase {
         courtCase.addDefendant(createDefendantForCase(courtCase));
         courtCase.addDefence(createDefenceForCase(courtCase));
         var hearing = createHearingWith(courtCase, someMinimalCourtRoom(), LocalDate.parse(SOME_DATE_TIME));
-
-        dartsPersistence.save(hearing);
+        hearing.addJudge(JudgeTestData.createJudgeWithName("1JUDGE1"), false);
+        hearingEntity = dartsPersistence.save(hearing);
 
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub()
             .createAuthorisedIntegrationTestUser(hearingEntity.getCourtroom().getCourthouse());
@@ -73,15 +73,16 @@ class HearingsGetControllerTest extends IntegrationBase {
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
         String actualJson = mvcResult.getResponse().getContentAsString();
+
         String expectedJson = """
             {
                "hearing_id": <hearing-id>,
                "courthouse_id": <courthouse-id>,
-               "courthouse": "some-courthouse",
-               "courtroom": "SOME-COURTROOM",
+               "courthouse": "<courthouse>",
+               "courtroom": "<courtroom>",
                "hearing_date": "<hearing-date>",
                "case_id": <case-id>,
-               "case_number": "1",
+               "case_number": "<case-number>",
                "judges": [
                  "1JUDGE1"
                ],
@@ -91,9 +92,12 @@ class HearingsGetControllerTest extends IntegrationBase {
             """;
         log.info(actualJson);
         expectedJson = expectedJson.replace("<hearing-id>", hearingEntity.getId().toString());
-        expectedJson = expectedJson.replace("<courthouse-id>", hearingEntity.getCourtCase().getCourthouse().getId().toString());
+        expectedJson = expectedJson.replace("<courthouse-id>", hearingEntity.getCourtroom().getCourthouse().getId().toString());
         expectedJson = expectedJson.replace("<case-id>", hearingEntity.getCourtCase().getId().toString());
         expectedJson = expectedJson.replace("<hearing-date>", hearingEntity.getHearingDate().toString());
+        expectedJson = expectedJson.replace("<case-number>", hearingEntity.getCourtCase().getCaseNumber());
+        expectedJson = expectedJson.replace("<courtroom>", hearingEntity.getCourtroom().getName());
+        expectedJson = expectedJson.replace("<courthouse>", hearingEntity.getCourtroom().getCourthouse().getCourthouseName().toLowerCase(Locale.ROOT));
         JSONAssert.assertEquals(expectedJson, actualJson, JSONCompareMode.NON_EXTENSIBLE);
 
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
@@ -33,7 +33,7 @@ import static uk.gov.hmcts.darts.test.common.data.ProsecutorTestData.createProse
 
 @AutoConfigureMockMvc
 @Slf4j
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
+@Disabled("Impacted by V1_363__not_null_constraints_part3.sql - fix needed")
 class HearingsGetControllerTest extends IntegrationBase {
 
     @Autowired
@@ -46,7 +46,7 @@ class HearingsGetControllerTest extends IntegrationBase {
 
     private HearingEntity hearingEntity;
 
-    private static final String SOME_DATE_TIME = "2023-01-01T12:00Z";
+    private static final String SOME_DATE_TIME = "2023-01-01";
     private static final String SOME_COURTHOUSE = "SOME-COURTHOUSE";
     private static final String SOME_COURTROOM = "some-courtroom";
     private static final String SOME_CASE_NUMBER = "1";

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.hearings.controller;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -32,7 +31,6 @@ import static uk.gov.hmcts.darts.test.common.data.ProsecutorTestData.createProse
 
 @AutoConfigureMockMvc
 @Slf4j
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
 class HearingsGetEventsControllerTest extends IntegrationBase {
 
     @Autowired
@@ -46,7 +44,7 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
     private HearingEntity hearingEntity;
     private EventEntity event;
 
-    private static final String SOME_DATE = "2023-01-01T12:00Z";
+    private static final String SOME_DATE = "2023-01-01";
     private static final String SOME_COURTHOUSE = "SOME-COURTHOUSE";
     private static final String SOME_COURTROOM = "some-courtroom";
     private static final String SOME_CASE_NUMBER = "1";

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/service/GetHearingResponseMapperIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/service/GetHearingResponseMapperIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.hearings.service;
 
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.cases.mapper.CasesMapper;
@@ -28,7 +27,6 @@ import static uk.gov.hmcts.darts.test.common.data.EventTestData.SECTION_4_1981_D
 import static uk.gov.hmcts.darts.test.common.data.EventTestData.someReportingRestrictionId;
 import static uk.gov.hmcts.darts.test.common.data.HearingTestData.someMinimalHearing;
 
-@Disabled("Impacted by V1_364_*.sql")
 class GetHearingResponseMapperIntTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/noderegistration/controller/NodeRegistrationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/noderegistration/controller/NodeRegistrationControllerTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.noderegistration.controller;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -46,7 +45,6 @@ class NodeRegistrationControllerTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testPostRegisterDevices() throws Exception {
         dartsDatabase.createCourthouseWithTwoCourtrooms();
         UserAccountEntity userCreated = setupExternalUserForCourthouse(null);
@@ -99,7 +97,6 @@ class NodeRegistrationControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testAcceptNonDarDevices() throws Exception {
         dartsDatabase.createCourthouseWithTwoCourtrooms();
 
@@ -115,7 +112,6 @@ class NodeRegistrationControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testAcceptsDuplicates() throws Exception {
         dartsDatabase.createCourthouseWithTwoCourtrooms();
 
@@ -136,7 +132,6 @@ class NodeRegistrationControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testEmptyStrings() throws Exception {
         dartsDatabase.createCourthouseWithTwoCourtrooms();
         setupExternalUserForCourthouse(null);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/noderegistration/controller/NodeRegistrationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/noderegistration/controller/NodeRegistrationControllerTest.java
@@ -46,7 +46,7 @@ class NodeRegistrationControllerTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testPostRegisterDevices() throws Exception {
         dartsDatabase.createCourthouseWithTwoCourtrooms();
         UserAccountEntity userCreated = setupExternalUserForCourthouse(null);
@@ -99,7 +99,7 @@ class NodeRegistrationControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testAcceptNonDarDevices() throws Exception {
         dartsDatabase.createCourthouseWithTwoCourtrooms();
 
@@ -115,7 +115,7 @@ class NodeRegistrationControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testAcceptsDuplicates() throws Exception {
         dartsDatabase.createCourthouseWithTwoCourtrooms();
 
@@ -136,7 +136,7 @@ class NodeRegistrationControllerTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void testEmptyStrings() throws Exception {
         dartsDatabase.createCourthouseWithTwoCourtrooms();
         setupExternalUserForCourthouse(null);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/notification/service/NotificationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/notification/service/NotificationServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.notification.service;
 
 import org.apache.commons.collections4.map.LinkedMap;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -32,7 +31,6 @@ import static uk.gov.hmcts.darts.notification.api.NotificationApi.NotificationTe
 import static uk.gov.hmcts.darts.test.common.data.CaseTestData.someMinimalCase;
 
 @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
-@Disabled("Impacted by V1_363__not_null_constraints_part3.sql")
 class NotificationServiceTest extends IntegrationBase {
 
     private static final int SYSTEM_USER_ID = 0;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/retention/repository/CaseRetentionRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/retention/repository/CaseRetentionRepositoryIntTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.darts.test.common.data.CaseManagementRetentionTestData.someMinimalCaseManagementRetention;
 import static uk.gov.hmcts.darts.test.common.data.CaseRetentionTestData.createCaseRetentionFor;
 
-@Disabled("Impacted by V1_364_*.sql")
 class CaseRetentionRepositoryIntTest extends IntegrationBase {
 
     private static final OffsetDateTime DT_2025 = OffsetDateTime.of(2025, 1, 1, 1, 0, 0, 0, UTC);
@@ -58,7 +57,7 @@ class CaseRetentionRepositoryIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
+    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql - to fix")
     void deleteCaseRetentionsByCaseManagementId() {
         var caseRetentionsWithCmr = entityGraphPersistence.persistAll(someCaseRetentionsWithCmr(3));
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/retention/repository/CaseRetentionRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/retention/repository/CaseRetentionRepositoryIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.retention.repository;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.CaseRetentionEntity;
@@ -57,9 +56,8 @@ class CaseRetentionRepositoryIntTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql - to fix")
     void deleteCaseRetentionsByCaseManagementId() {
-        var caseRetentionsWithCmr = entityGraphPersistence.persistAll(someCaseRetentionsWithCmr(3));
+        var caseRetentionsWithCmr = someCaseRetentionsWithCmr(3);
 
         caseRetentionRepository.deleteAllByCaseManagementIdsIn(
             firstTwoCmrIdsFrom(caseRetentionsWithCmr));
@@ -78,6 +76,7 @@ class CaseRetentionRepositoryIntTest extends IntegrationBase {
     private List<CaseRetentionEntity> someCaseRetentionsWithCmr(int quantity) {
         return range(0, quantity)
             .mapToObj(i -> createCaseRetentionFor(someMinimalCaseManagementRetention()))
+            .peek(caseRetentionEntity -> dartsDatabase.save(caseRetentionEntity))
             .collect(toList());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/retention/service/ApplyRetentionCaseAssociatedObjectsProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/retention/service/ApplyRetentionCaseAssociatedObjectsProcessorIntTest.java
@@ -346,7 +346,7 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed (Validation)")
+    @Disabled("Failed Validation")
     void testExceptionOnOneObjectCausesRollbackOfAllChangesToAllObjectsAndProcessingOfOtherCasesContinues() {
 
         // given

--- a/src/integrationTest/java/uk/gov/hmcts/darts/retention/service/ApplyRetentionCaseAssociatedObjectsProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/retention/service/ApplyRetentionCaseAssociatedObjectsProcessorIntTest.java
@@ -42,7 +42,7 @@ import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_DROP_ZONE;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
-@Disabled("Impacted by V1_364_*.sql")
+@Disabled("Impacted by V1_364_*.sql - fix needed")
 class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBase {
 
     private static final OffsetDateTime DT_2025 = OffsetDateTime.of(2025, 1, 1, 1, 0, 0, 0, UTC);
@@ -341,7 +341,6 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void testExceptionOnOneObjectCausesRollbackOfAllChangesToAllObjectsAndProcessingOfOtherCasesContinues() {
 
         // given

--- a/src/integrationTest/java/uk/gov/hmcts/darts/retention/service/ApplyRetentionCaseAssociatedObjectsProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/retention/service/ApplyRetentionCaseAssociatedObjectsProcessorIntTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -37,12 +39,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_DROP_ZONE;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
-@Disabled("Impacted by V1_364_*.sql - fix needed")
 class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBase {
 
     private static final OffsetDateTime DT_2025 = OffsetDateTime.of(2025, 1, 1, 1, 0, 0, 0, UTC);
@@ -86,6 +88,8 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     CaseDocumentRepository caseDocumentRepository;
     @SpyBean
     ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl singleCaseProcessor;
+    @MockBean
+    UserIdentity userIdentity;
 
     @Autowired
     ApplyRetentionCaseAssociatedObjectsProcessor processor;
@@ -145,6 +149,7 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
         eodStub.createAndSaveEod(medias.get(2), ARM_DROP_ZONE, ARM, eod -> eod.setUpdateRetention(false));
 
         testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+        when(userIdentity.getUserAccount()).thenReturn(testUser);
     }
 
     @Test
@@ -341,6 +346,7 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed (Validation)")
     void testExceptionOnOneObjectCausesRollbackOfAllChangesToAllObjectsAndProcessingOfOtherCasesContinues() {
 
         // given

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskITest.java
@@ -104,7 +104,7 @@ class CaseExpiryDeletionAutomatedTaskITest extends PostgresIntegrationBase {
 
 
     private void assertCase(int caseId, boolean isAnonymized) {
-        executeInTransaction(() -> {
+        transactionalUtil.executeInTransaction(() -> {
             CourtCaseEntity courtCase = dartsDatabase.getCourtCaseStub().getCourtCase(caseId);
             assertThat(courtCase.isDataAnonymised())
                 .isEqualTo(isAnonymized);
@@ -226,7 +226,7 @@ class CaseExpiryDeletionAutomatedTaskITest extends PostgresIntegrationBase {
 
 
     private CourtCaseEntity createCase(final long daysUntilRetention, final CaseRetentionStatus caseRetentionStatus) {
-        return executeInTransaction(() -> {
+        return transactionalUtil.executeInTransaction(() -> {
             caseIndex++;
             CourtCaseEntity caseEntity = dartsDatabase.createCase("Bristol", "case" + caseIndex);
             caseEntity.addDefendant(createDefendantEntity(caseEntity));

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AdminGetAutomatedTasksByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AdminGetAutomatedTasksByIdTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -31,7 +30,6 @@ class AdminGetAutomatedTasksByIdTest extends IntegrationBase {
 
     @ParameterizedTest
     @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_ADMIN"}, mode = Mode.INCLUDE)
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void allowsSuperAdminToRetrieveAllAutomatedTasks(SecurityRoleEnum role) throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(role);
 
@@ -54,8 +52,7 @@ class AdminGetAutomatedTasksByIdTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
-    void returns404WhenTheTaskDoesntExist()  throws Exception {
+    void returns404WhenTheTaskDoesntExist() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
 
         mockMvc.perform(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AdminGetAutomatedTasksTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AdminGetAutomatedTasksTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +16,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
-@Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
 class AdminGetAutomatedTasksTest extends IntegrationBase {
 
     private static final URI ENDPOINT = URI.create("/admin/automated-tasks");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
@@ -55,7 +55,6 @@ import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTU
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 @SuppressWarnings({"PMD.ExcessiveImports"})
 class ExternalDataStoreDeleterTest extends IntegrationBase {
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/ExternalDataStoreDeleterTest.java
@@ -4,7 +4,6 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -141,7 +140,6 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
 
     @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void deleteMarkedForDeletionDataFromDataStores() {
         audioBuilder.setupTest();
         Mockito.when(dataManagementFactory.getBlobServiceClient(anyString())).thenReturn(blobServiceClient);
@@ -182,7 +180,6 @@ class ExternalDataStoreDeleterTest extends IntegrationBase {
 
     @SuppressWarnings("checkstyle:VariableDeclarationUsageDistance")
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void dontDeleteWhenStatusIsNotMarkedForDeletionDataFromDataStores() {
         audioBuilder.setupTest();
         Mockito.when(dataManagementFactory.getBlobServiceClient(anyString())).thenReturn(blobServiceClient);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/GenerateCaseDocumentProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/GenerateCaseDocumentProcessorIntTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -25,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_DROP_ZONE;
 
-@Disabled("Impacted by V1_364_*.sql")
 class GenerateCaseDocumentProcessorIntTest extends IntegrationBase {
 
     private static final OffsetDateTime DT_2025 = OffsetDateTime.of(2025, 1, 1, 1, 0, 0, 0, UTC);
@@ -60,14 +58,14 @@ class GenerateCaseDocumentProcessorIntTest extends IntegrationBase {
         var hearing = courtCase.getHearings().get(0);
         hearing.addMedia(medias.get(0));
 
-        hearingRepository.save(hearing);
+        dartsDatabase.save(hearing);
         dartsDatabase.getCaseRetentionStub().createCaseRetentionObject(courtCase, DT_2025);
 
         dartsDatabase.getExternalObjectDirectoryStub().createAndSaveEod(medias.get(0), ARM_DROP_ZONE, ARM, eod -> { });
 
         var testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         var annotation = dartsDatabase.getAnnotationStub().createAndSaveAnnotationEntityWith(testUser, "TestAnnotation", hearing);
-        annotationRepository.save(annotation);
+        dartsDatabase.save(annotation);
 
         // when
         processor.processGenerateCaseDocument(courtCase.getId());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundAudioDeleterProcessorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.task.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -24,7 +23,6 @@ import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTU
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.MARKED_FOR_DELETION;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 @SuppressWarnings("PMD.ExcessiveImports")
 class InboundAudioDeleterProcessorTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundToUnstructuredProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundToUnstructuredProcessorIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.task.service;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +47,6 @@ class InboundToUnstructuredProcessorIntTest extends IntegrationBase {
         externalObjectDirectoryStub = dartsDatabase.getExternalObjectDirectoryStub();
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     @Test
     void processInboundMediasToUnstructured() {
         // given

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.task.service;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -69,7 +68,6 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void whereLastAccessed2DaysAgoAndStatusIsCompleted() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",
@@ -86,8 +84,8 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             AudioRequestType.PLAYBACK,
             COMPLETED
         );
-        dartsDatabase.save(
-            unchangedMediaRequest);
+
+        dartsDatabase.save(unchangedMediaRequest);
 
         //This media request should be deleted as its 3 days old
         MediaRequestEntity currentMediaRequest = MediaRequestTestData.createCurrentMediaRequest(
@@ -98,8 +96,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             AudioRequestType.DOWNLOAD,
             COMPLETED
         );
-        dartsDatabase.save(
-            currentMediaRequest);
+        dartsDatabase.save(currentMediaRequest);
 
         TransientObjectDirectoryEntity notMarkedForDeletion = createStoredTransientDirectory(
             unchangedMediaRequest,
@@ -127,7 +124,6 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void whereLastAccessed2DaysAgoAndStatusIsCompletedAndMarkedForDeletion() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",
@@ -186,7 +182,6 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
      * The deleter task should not be using hours to calculate last accessed time but days.
      */
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void shouldNotTakeIntoAccountTimeWhenCalculatingLastAccessed() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",
@@ -221,7 +216,6 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void whereLastAccessedDoesNotIncludesNonBusinessDays() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",
@@ -255,7 +249,6 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void shouldNotDeleteIfLastAccessWas10DaysAgoWith3BankHoliday() {
         outboundAudioDeleterProcessor.setDeletionDays(10);
         HearingEntity hearing = dartsDatabase.createHearing(
@@ -299,7 +292,6 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void deleteWithTwoTransformedMediaDefaultLastAccessedDays() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",
@@ -345,7 +337,6 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void ifMediaRequestLastAccessedIsOnAWeekendThenTreatItAsItWasAccessedOnAFriday() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",
@@ -404,7 +395,6 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
 
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void whereLastAccessedIsNullUseCreatedAtAndInProgressStatus() {
         TransientObjectDirectoryEntity markedForDeletion = createMediaRequestsAndTransientObjectDirectoryWithHearingWithLastAccessedTimeIsNull();
 
@@ -416,13 +406,13 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
 
 
     private TransientObjectDirectoryEntity createMediaRequestsAndTransientObjectDirectoryWithHearingWithLastAccessedTimeIsNull() {
+
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",
             "Int Test Courtroom 2",
             "2",
             HEARING_DATE
         );
-
 
         // Non Matching request
         MediaRequestEntity currentMediaRequest2 = MediaRequestTestData.createCurrentMediaRequest(
@@ -432,10 +422,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             OffsetDateTime.parse("2023-06-26T13:45:00Z"),
             AudioRequestType.DOWNLOAD, PROCESSING
         );
-
-        MediaRequestEntity savedValue = dartsDatabase.save(
-            currentMediaRequest2);
-
+        MediaRequestEntity savedValue = dartsDatabase.save(currentMediaRequest2);
 
         createTransientDirectoryWithTransformedMediaNullLastAccessedDate(savedValue, OffsetDateTime.parse("2023-06-26T13:45:00Z"));
 
@@ -445,9 +432,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             OffsetDateTime.parse("2023-06-26T13:00:00Z"),
             OffsetDateTime.parse("2023-06-26T13:45:00Z"), AudioRequestType.DOWNLOAD, OPEN
         );
-        savedValue = dartsDatabase.save(
-            currentMediaRequest3);
-
+        savedValue = dartsDatabase.save(currentMediaRequest3);
         createTransientDirectoryWithTransformedMediaNullLastAccessedDate(savedValue, currentTimeHelper.currentOffsetDateTime());
 
 
@@ -460,9 +445,7 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
             AudioRequestType.DOWNLOAD, OPEN
         );
 
-        savedValue = dartsDatabase.save(
-            mediaRequestThatShouldMatch);
-
+        savedValue = dartsDatabase.save(mediaRequestThatShouldMatch);
         return createTransientDirectoryWithTransformedMediaNullLastAccessedDate(
             savedValue,
             OffsetDateTime.parse(
@@ -538,12 +521,10 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         transformedMediaEntity.setCreatedDateTime(createdAt);
         TransformedMediaEntity savedTM = dartsDatabase.save(transformedMediaEntity);
 
-        return dartsDatabase.getTransientObjectDirectoryRepository().saveAndFlush(transientObjectDirectoryStub.createTransientObjectDirectoryEntity(
+        return dartsDatabase.save(transientObjectDirectoryStub.createTransientObjectDirectoryEntity(
             savedTM,
             objectDirectoryStatusEntity,
             UUID.randomUUID()
         ));
-
-
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
@@ -310,8 +310,8 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertThat(armDropZoneEodsMedia1.get(0).getManifestFile()).isEqualTo(manifestFile.getName());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed (Validation)")
     @Test
+    @Disabled("Failed Validation")
     void movePreviousArmFailedFromUnstructuredToArmStorage() throws IOException {
 
         //given

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
@@ -310,7 +310,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertThat(armDropZoneEodsMedia1.get(0).getManifestFile()).isEqualTo(manifestFile.getName());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     @Test
     void movePreviousArmFailedFromUnstructuredToArmStorage() throws IOException {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
@@ -310,7 +310,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertThat(armDropZoneEodsMedia1.get(0).getManifestFile()).isEqualTo(manifestFile.getName());
     }
 
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed (Validation)")
     @Test
     void movePreviousArmFailedFromUnstructuredToArmStorage() throws IOException {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
@@ -324,7 +324,7 @@ class UnstructuredToArmProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed (Validation)")
     void updateTransferAttemptIfUnableToFindUnstructuredRecordFromFailedArmEod() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
@@ -325,7 +325,7 @@ class UnstructuredToArmProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed")
     void updateTransferAttemptIfUnableToFindUnstructuredRecordFromFailedArmEod() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
@@ -138,7 +138,6 @@ class UnstructuredToArmProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void movePendingTranscriptionDataFromUnstructuredToArmStorage() {
 
         authorisationStub.givenTestSchema();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
@@ -324,7 +324,7 @@ class UnstructuredToArmProcessorTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql - Fix needed (Validation)")
+    @Disabled("Failed Validation")
     void updateTransferAttemptIfUnableToFindUnstructuredRecordFromFailedArmEod() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmProcessorTest.java
@@ -36,7 +36,6 @@ import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_MANIFES
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RAW_DATA_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 class UnstructuredToArmProcessorTest extends IntegrationBase {
 
     private static final LocalDateTime HEARING_DATE = LocalDateTime.of(2023, 6, 10, 10, 0, 0);
@@ -326,6 +325,7 @@ class UnstructuredToArmProcessorTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
     void updateTransferAttemptIfUnableToFindUnstructuredRecordFromFailedArmEod() {
         HearingEntity hearing = dartsDatabase.createHearing(
             "NEWCASTLE",

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/PostgresIntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/PostgresIntegrationBase.java
@@ -7,15 +7,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import uk.gov.hmcts.darts.test.common.LogUtil;
 import uk.gov.hmcts.darts.test.common.MemoryLogAppender;
 import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
 import uk.gov.hmcts.darts.testutils.stubs.DartsPersistence;
-
-import java.util.function.Supplier;
 
 /**
  * Base class for integration tests running against a containerized Postgres with Testcontainers.
@@ -34,8 +30,7 @@ public class PostgresIntegrationBase {
     protected OpenInViewUtil openInViewUtil;
 
     @Autowired
-    private PlatformTransactionManager transactionManager;
-    private TransactionTemplate transactionTemplate;
+    protected TransactionalUtil transactionalUtil;
 
     protected MemoryLogAppender logAppender = LogUtil.getMemoryLogger();
 
@@ -75,19 +70,5 @@ public class PostgresIntegrationBase {
     @AfterEach
     void clearTestData() {
         logAppender.reset();
-    }
-
-    protected void executeInTransaction(Runnable supplier) {
-        executeInTransaction(() -> {
-            supplier.run();
-            return null;
-        });
-    }
-
-    protected <R> R executeInTransaction(Supplier<R> supplier) {
-        if (transactionTemplate == null) {
-            transactionTemplate = new TransactionTemplate(transactionManager);
-        }
-        return transactionTemplate.execute(status -> supplier.get());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/TransactionalUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/TransactionalUtil.java
@@ -1,12 +1,22 @@
 package uk.gov.hmcts.darts.testutils;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 @Component
 public class TransactionalUtil {
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate transactionTemplate;
+
 
     @Transactional()
     public void inTransaction(Runnable runnable) {
@@ -21,5 +31,19 @@ public class TransactionalUtil {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void executeInTransaction(Runnable supplier) {
+        executeInTransaction(() -> {
+            supplier.run();
+            return null;
+        });
+    }
+
+    public <R> R executeInTransaction(Supplier<R> supplier) {
+        if (transactionTemplate == null) {
+            transactionTemplate = new TransactionTemplate(transactionManager);
+        }
+        return transactionTemplate.execute(status -> supplier.get());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AnnotationStubComposable.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AnnotationStubComposable.java
@@ -18,6 +18,7 @@ public class AnnotationStubComposable {
 
     private final AnnotationRepository annotationRepository;
     private final AnnotationDocumentRepository annotationDocumentRepository;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     public AnnotationEntity createAndSaveAnnotationEntityWith(UserAccountEntity currentOwner,
                                                               String annotationText) {
@@ -26,7 +27,7 @@ public class AnnotationStubComposable {
         annotationEntity.setText(annotationText);
         annotationEntity.setCreatedBy(currentOwner);
         annotationEntity.setLastModifiedBy(currentOwner);
-        return annotationRepository.save(annotationEntity);
+        return dartsDatabaseSaveStub.save(annotationEntity);
     }
 
     @Transactional
@@ -35,7 +36,7 @@ public class AnnotationStubComposable {
                                                               HearingEntity hearingEntity) {
         AnnotationEntity annotationEntity = createAnnotationEntity(currentOwner, annotationText);
         annotationEntity.addHearing(hearingEntity);
-        return annotationRepository.save(annotationEntity);
+        return dartsDatabaseSaveStub.save(annotationEntity);
     }
 
     @Transactional
@@ -74,7 +75,7 @@ public class AnnotationStubComposable {
                                                                                      uploadedBy, uploadedDateTime, checksum, confScore, confReason);
         annotationDocument.setAnnotation(annotationRepository.getReferenceById(annotationEntity.getId()));
         annotationDocument.setLastModifiedBy(uploadedBy);
-        annotationDocument = annotationDocumentRepository.saveAndFlush(annotationDocument);
+        annotationDocument = dartsDatabaseSaveStub.save(annotationDocument);
         return annotationDocument;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseDocumentStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseDocumentStub.java
@@ -23,11 +23,12 @@ public class CaseDocumentStub {
 
     private final CaseDocumentRepository caseDocumentRepository;
     private final UserAccountStub userAccountStub;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     @Transactional
     public CaseDocumentEntity createAndSaveCaseDocumentEntity(CourtCaseEntity courtCaseEntity, UserAccountEntity uploadedBy) {
         CaseDocumentEntity caseDocumentEntity = createCaseDocumentEntity(courtCaseEntity, uploadedBy);
-        caseDocumentEntity = caseDocumentRepository.saveAndFlush(caseDocumentEntity);
+        caseDocumentEntity = dartsDatabaseSaveStub.save(caseDocumentEntity);
         return caseDocumentEntity;
     }
 
@@ -35,7 +36,7 @@ public class CaseDocumentStub {
     public CaseDocumentEntity createAndSaveCaseDocumentEntity(CourtCaseEntity courtCaseEntity) {
         UserAccountEntity testUser = userAccountStub.getIntegrationTestUserAccountEntity();
         CaseDocumentEntity caseDocumentEntity = createCaseDocumentEntity(courtCaseEntity, testUser);
-        caseDocumentEntity = caseDocumentRepository.save(caseDocumentEntity);
+        caseDocumentEntity = dartsDatabaseSaveStub.save(caseDocumentEntity);
         return caseDocumentEntity;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseRetentionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseRetentionStub.java
@@ -7,7 +7,6 @@ import uk.gov.hmcts.darts.common.entity.CaseRetentionEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.RetentionPolicyTypeEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
-import uk.gov.hmcts.darts.common.repository.CaseRetentionRepository;
 import uk.gov.hmcts.darts.common.repository.RetentionPolicyTypeRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseRetentionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseRetentionStub.java
@@ -20,8 +20,8 @@ import java.time.OffsetDateTime;
 public class CaseRetentionStub {
     private final UserAccountRepository userAccountRepository;
     private final RetentionPolicyTypeRepository retentionPolicyTypeRepository;
-    private final CaseRetentionRepository caseRetentionRepository;
     private final CurrentTimeHelper currentTimeHelper;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     @Transactional
     public CaseRetentionEntity createCaseRetentionObject(CourtCaseEntity courtCase,
@@ -51,7 +51,7 @@ public class CaseRetentionStub {
         caseRetentionEntity.setLastModifiedDateTime(currentTimeHelper.currentOffsetDateTime());
         caseRetentionEntity.setLastModifiedBy(userAccountRepository.getReferenceById(0));
         caseRetentionEntity.setSubmittedBy(userAccountRepository.getReferenceById(0));
-        caseRetentionRepository.saveAndFlush(caseRetentionEntity);
+        dartsDatabaseSaveStub.save(caseRetentionEntity);
         return caseRetentionEntity;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CourtCaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CourtCaseStub.java
@@ -38,24 +38,26 @@ public class CourtCaseStub {
 
     @Autowired
     CourthouseStub courthouseStub;
+    @Autowired
+    DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     @Transactional
     public CourtCaseEntity createAndSaveMinimalCourtCase() {
 
         var courtCase = CaseTestData.createSomeMinimalCase();
         courtCase.getCourthouse().getCreatedBy().setId(0);
-        return caseRepository.save(courtCase);
+        return dartsDatabaseSaveStub.save(courtCase);
     }
 
     @Transactional
     public CourtCaseEntity createAndSaveMinimalCourtCase(String caseNumber, Integer courthouseId) {
         var courtCase = CaseTestData.createCaseWith(caseNumber, courthouseRepository.findById(courthouseId).get());
-        return caseRepository.save(courtCase);
+        return dartsDatabaseSaveStub.save(courtCase);
     }
 
     public CourtCaseEntity createAndSaveMinimalCourtCase(String caseNumber, CourthouseEntity courthouse) {
         var courtCase = CaseTestData.createCaseWith(caseNumber, courthouse);
-        return caseRepository.save(courtCase);
+        return dartsDatabaseSaveStub.save(courtCase);
     }
 
     /**
@@ -66,7 +68,7 @@ public class CourtCaseStub {
 
         var courtCase = createAndSaveMinimalCourtCase();
         caseConsumer.accept(courtCase);
-        return caseRepository.save(courtCase);
+        return dartsDatabaseSaveStub.save(courtCase);
     }
 
     /**
@@ -83,7 +85,7 @@ public class CourtCaseStub {
         var hear3 = hearingStub.createHearing(courthouseName, "testCourtroom", courtCase.getCaseNumber(), D_2020_10_2, courthouseStub, userAccountStub);
         courtCase.getHearings().addAll(List.of(hear1, hear2, hear3));
 
-        return caseRepository.save(courtCase);
+        return dartsDatabaseSaveStub.save(courtCase);
     }
 
     @Transactional

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DailyListStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DailyListStub.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.testutils.stubs;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.entity.DailyListEntity;
-import uk.gov.hmcts.darts.common.repository.DailyListRepository;
 import uk.gov.hmcts.darts.dailylist.enums.JobStatusType;
 
 import java.time.LocalDate;
@@ -11,14 +10,14 @@ import java.time.LocalDate;
 @Component
 @RequiredArgsConstructor
 public class DailyListStub {
-    private final DailyListRepository dailyListRepository;
+    private final DartsDatabaseStub dartsDatabaseStub;
 
     public void createEmptyDailyList(LocalDate date, String courthouse) {
         DailyListEntity dailyListEntity = new DailyListEntity();
         dailyListEntity.setStartDate(date);
         dailyListEntity.setListingCourthouse(courthouse);
         dailyListEntity.setStatus(JobStatusType.NEW);
-        dailyListRepository.saveAndFlush(dailyListEntity);
+        dartsDatabaseStub.save(dailyListEntity);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.darts.testutils.stubs;
+
+import jakarta.persistence.EntityManager;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+import org.junit.platform.commons.JUnitException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+@Service
+@AllArgsConstructor
+public class DartsDatabaseSaveStub {
+
+    private final UserAccountRepository userAccountRepository;
+    private final EntityManager entityManager;
+
+
+    @Transactional
+    public <T> T save(T entity) {
+        if (entity instanceof CreatedModifiedBaseEntity createdModifiedBaseEntity) {
+            updateCreatedByLastModifiedBy(createdModifiedBaseEntity);
+        }
+        Method getIdInstanceMethod;
+        try {
+            getIdInstanceMethod = entity.getClass().getMethod("getId");
+            Integer id = (Integer) getIdInstanceMethod.invoke(entity);
+            if (id == null) {
+                this.entityManager.persist(entity);
+                return entity;
+            } else {
+                return this.entityManager.merge(entity);
+            }
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new JUnitException("Failed to save entity", e);
+        }
+    }
+
+    private void updateCreatedByLastModifiedBy(CreatedModifiedBaseEntity createdModifiedBaseEntity) {
+        if (createdModifiedBaseEntity.getCreatedBy() == null) {
+            createdModifiedBaseEntity.setCreatedBy(userAccountRepository.getReferenceById(0));
+        } else if (createdModifiedBaseEntity.getCreatedBy().getId() == null) {
+            UserAccountEntity userAccount = createdModifiedBaseEntity.getCreatedBy();
+            updateCreatedByLastModifiedBy(userAccount);
+            createdModifiedBaseEntity.setCreatedBy(userAccountRepository.save(userAccount));
+        }
+
+        if (createdModifiedBaseEntity.getLastModifiedBy() == null) {
+            createdModifiedBaseEntity.setLastModifiedBy(userAccountRepository.getReferenceById(0));
+        } else if (createdModifiedBaseEntity.getLastModifiedBy().getId() == null) {
+            UserAccountEntity userAccount = createdModifiedBaseEntity.getLastModifiedBy();
+            updateCreatedByLastModifiedBy(userAccount);
+            createdModifiedBaseEntity.setLastModifiedBy(userAccountRepository.save(userAccount));
+        }
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.testutils.stubs;
 
 import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
+import org.hibernate.proxy.HibernateProxy;
 import org.junit.platform.commons.JUnitException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,7 +58,13 @@ public class DartsDatabaseSaveStub {
     }
 
 
+    @Transactional
     public void updateCreatedByLastModifiedBy(CreatedModifiedBaseEntity createdModifiedBaseEntity) {
+        //No need to update values if the entity is a proxy and is not initialized
+        if (createdModifiedBaseEntity instanceof HibernateProxy proxy
+            && proxy.getHibernateLazyInitializer().isUninitialized()) {
+            return;
+        }
         if (createdModifiedBaseEntity.getCreatedBy() == null) {
             createdModifiedBaseEntity.setCreatedBy(userAccountRepository.getReferenceById(0));
             createdModifiedBaseEntity.setCreatedDateTime(OffsetDateTime.now());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
@@ -29,6 +29,9 @@ public class DartsDatabaseSaveStub {
 
     @Transactional
     public <T> T save(T entity) {
+        if (entity == null) {
+            return null;
+        }
         return transactionalUtil.executeInTransaction(() -> {
             if (entity instanceof CreatedModifiedBaseEntity createdModifiedBaseEntity) {
                 updateCreatedByLastModifiedBy(createdModifiedBaseEntity);
@@ -72,6 +75,8 @@ public class DartsDatabaseSaveStub {
             UserAccountEntity userAccount = createdModifiedBaseEntity.getCreatedBy();
             updateCreatedByLastModifiedBy(userAccount);
             createdModifiedBaseEntity.setCreatedBy(userAccountRepository.save(userAccount));
+        } else {
+            userAccountRepository.save(createdModifiedBaseEntity.getCreatedBy());
         }
         if (createdModifiedBaseEntity.getCreatedDateTime() == null) {
             createdModifiedBaseEntity.setCreatedDateTime(OffsetDateTime.now());
@@ -84,6 +89,8 @@ public class DartsDatabaseSaveStub {
             UserAccountEntity userAccount = createdModifiedBaseEntity.getLastModifiedBy();
             updateCreatedByLastModifiedBy(userAccount);
             createdModifiedBaseEntity.setLastModifiedBy(userAccountRepository.save(userAccount));
+        } else {
+            userAccountRepository.save(createdModifiedBaseEntity.getLastModifiedBy());
         }
         if (createdModifiedBaseEntity.getLastModifiedDateTime() == null) {
             createdModifiedBaseEntity.setLastModifiedDateTime(OffsetDateTime.now());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.testutils.stubs;
 
 import jakarta.persistence.EntityManager;
 import lombok.AllArgsConstructor;
-import lombok.Setter;
 import org.junit.platform.commons.JUnitException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseSaveStub.java
@@ -5,12 +5,15 @@ import lombok.AllArgsConstructor;
 import org.junit.platform.commons.JUnitException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.darts.common.entity.CaseManagementRetentionEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.OffsetDateTime;
+import java.util.List;
 
 @Service
 @AllArgsConstructor
@@ -43,18 +46,31 @@ public class DartsDatabaseSaveStub {
     private void updateCreatedByLastModifiedBy(CreatedModifiedBaseEntity createdModifiedBaseEntity) {
         if (createdModifiedBaseEntity.getCreatedBy() == null) {
             createdModifiedBaseEntity.setCreatedBy(userAccountRepository.getReferenceById(0));
+            createdModifiedBaseEntity.setCreatedDateTime(OffsetDateTime.now());
         } else if (createdModifiedBaseEntity.getCreatedBy().getId() == null) {
             UserAccountEntity userAccount = createdModifiedBaseEntity.getCreatedBy();
             updateCreatedByLastModifiedBy(userAccount);
             createdModifiedBaseEntity.setCreatedBy(userAccountRepository.save(userAccount));
+            if (createdModifiedBaseEntity.getCreatedDateTime() == null) {
+                createdModifiedBaseEntity.setCreatedDateTime(OffsetDateTime.now());
+            }
         }
 
         if (createdModifiedBaseEntity.getLastModifiedBy() == null) {
             createdModifiedBaseEntity.setLastModifiedBy(userAccountRepository.getReferenceById(0));
+            createdModifiedBaseEntity.setLastModifiedDateTime(OffsetDateTime.now());
         } else if (createdModifiedBaseEntity.getLastModifiedBy().getId() == null) {
             UserAccountEntity userAccount = createdModifiedBaseEntity.getLastModifiedBy();
             updateCreatedByLastModifiedBy(userAccount);
             createdModifiedBaseEntity.setLastModifiedBy(userAccountRepository.save(userAccount));
+            if (createdModifiedBaseEntity.getLastModifiedDateTime() == null) {
+                createdModifiedBaseEntity.setLastModifiedDateTime(OffsetDateTime.now());
+            }
         }
+    }
+
+    @Transactional
+    public void saveAll(List<CaseManagementRetentionEntity> caseManagementRetentionsWithEvents) {
+        caseManagementRetentionsWithEvents.forEach(this::save);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -537,6 +537,7 @@ public class DartsDatabaseStub {
         save(hearingEntity.getCourtroom().getCourthouse());
         save(hearingEntity.getCourtroom());
         save(hearingEntity.getCourtCase());
+        saveAllList(hearingEntity.getJudges());
         return dartsDatabaseSaveStub.save(hearingEntity);
     }
 
@@ -562,6 +563,7 @@ public class DartsDatabaseStub {
             return null;
         }
         save(courtCase.getCourthouse());
+        saveAllList(courtCase.getJudges());
         courtCase.getDefenceList().forEach(dartsDatabaseSaveStub::updateCreatedByLastModifiedBy);
         courtCase.getDefendantList().forEach(dartsDatabaseSaveStub::updateCreatedByLastModifiedBy);
         courtCase.getProsecutorList().forEach(dartsDatabaseSaveStub::updateCreatedByLastModifiedBy);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -569,6 +569,9 @@ public class DartsDatabaseStub {
         return transcription;
     }
 
+    public <T> T save(T entity) {
+        return dartsDatabaseSaveStub.save(entity);
+    }
 
     @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.AvoidAccessibilityAlteration"})
     @Transactional
@@ -934,9 +937,5 @@ public class DartsDatabaseStub {
     @Transactional
     public SecurityRoleEntity findSecurityRole(SecurityRoleEnum role) {
         return securityRoleRepository.findById(role.getId()).orElseThrow();
-    }
-
-    public <T> T save(T entity) {
-        return dartsDatabaseSaveStub.save(entity);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/EventStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/EventStub.java
@@ -32,6 +32,7 @@ public class EventStub {
     private final UserAccountStub userAccountStub;
     private final CourtroomStub courtroomStub;
     private final UserAccountRepository userAccountRepository;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     public static final OffsetDateTime STARTED_AT = OffsetDateTime.of(2024, 10, 10, 10, 0, 0, 0, ZoneOffset.UTC);
 
@@ -73,8 +74,7 @@ public class EventStub {
         eventEntity.setIsCurrent(true);
         eventEntity.setEventStatus(AUDIO_LINK_NOT_DONE_MODERNISED.getStatusNumber());
         eventEntity.setEventId(eventId);
-        eventRepository.saveAndFlush(eventEntity);
-        return eventEntity;
+        return dartsDatabaseSaveStub.save(eventEntity);
     }
 
     public EventEntity createEvent(CourtroomEntity courtroom, int eventHandlerId, OffsetDateTime eventTimestamp, String eventName) {
@@ -97,8 +97,7 @@ public class EventStub {
         eventEntity.setIsCurrent(true);
         eventEntity.setEventStatus(AUDIO_LINK_NOT_DONE_MODERNISED.getStatusNumber());
         eventEntity.setEventId(eventId);
-        eventRepository.saveAndFlush(eventEntity);
-        return eventEntity;
+       return dartsDatabaseSaveStub.save(eventEntity);
     }
 
     public EventEntity createDefaultEvent() {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ExternalObjectDirectoryStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ExternalObjectDirectoryStub.java
@@ -58,6 +58,7 @@ public class ExternalObjectDirectoryStub {
     private final TranscriptionDocumentStubComposable transcriptionDocumentStub;
     private final DartsDatabaseComposable dartsDatabaseComposable;
     private final TranscriptionStubComposable transcriptionStubComposable;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     public ExternalObjectDirectoryEntity createAndSaveEod(MediaEntity media,
                                                           ObjectRecordStatusEnum objectRecordStatusEnum,
@@ -65,7 +66,7 @@ public class ExternalObjectDirectoryStub {
     ) {
         UUID uuid = UUID.randomUUID();
         var eod = createExternalObjectDirectory(media, objectRecordStatusEnum, externalLocationTypeEnum, uuid);
-        return eodRepository.save(eod);
+        return dartsDatabaseSaveStub.save(eod);
     }
 
     public ExternalObjectDirectoryEntity createAndSaveEod(MediaEntity media,
@@ -76,7 +77,7 @@ public class ExternalObjectDirectoryStub {
         UUID uuid = UUID.randomUUID();
         var eod = createExternalObjectDirectory(media, objectRecordStatusEnum, externalLocationTypeEnum, uuid);
         eod.setLastModifiedDateTime(lastModified);
-        return eodRepository.save(eod);
+        return dartsDatabaseSaveStub.save(eod);
     }
 
     /**
@@ -89,7 +90,7 @@ public class ExternalObjectDirectoryStub {
         UUID uuid = UUID.randomUUID();
         var eod = createExternalObjectDirectory(media, objectRecordStatusEnum, externalLocationTypeEnum, uuid);
         createdEodConsumer.accept(eod);
-        return eodRepository.save(eod);
+        return dartsDatabaseSaveStub.save(eod);
     }
 
     public ExternalObjectDirectoryEntity createAndSaveEod(AnnotationDocumentEntity annotationDocument,
@@ -99,7 +100,7 @@ public class ExternalObjectDirectoryStub {
         UUID uuid = UUID.randomUUID();
         var eod = createExternalObjectDirectory(annotationDocument, getStatus(objectRecordStatus), getLocation(externalLocationType), uuid);
         createdEodConsumer.accept(eod);
-        return eodRepository.save(eod);
+        return dartsDatabaseSaveStub.save(eod);
     }
 
     public ExternalObjectDirectoryEntity createAndSaveEod(AnnotationDocumentEntity annotationDocument,
@@ -114,8 +115,7 @@ public class ExternalObjectDirectoryStub {
             eod.setTranscriptionDocumentEntity(transcriptionDocumentEntity);
         }
         createdEodConsumer.accept(eod);
-        eodRepository.save(eod);
-        eodRepository.flush();
+        dartsDatabaseSaveStub.save(eod);
         return eod;
     }
 
@@ -137,8 +137,7 @@ public class ExternalObjectDirectoryStub {
         );
 
         externalObjectDirectory.setMedia(mediaEntity);
-        eodRepository.save(externalObjectDirectory);
-        eodRepository.flush();
+        dartsDatabaseSaveStub.save(externalObjectDirectory);
 
         return externalObjectDirectory;
     }
@@ -154,9 +153,7 @@ public class ExternalObjectDirectoryStub {
         );
 
         externalObjectDirectory.setCaseDocument(caseDocumentEntity);
-        eodRepository.save(externalObjectDirectory);
-        eodRepository.flush();
-
+        dartsDatabaseSaveStub.save(externalObjectDirectory);
         return externalObjectDirectory;
     }
 
@@ -225,7 +222,7 @@ public class ExternalObjectDirectoryStub {
 
         externalObjectDirectory.setTranscriptionDocumentEntity(transcriptionDocument);
 
-        return eodRepository.saveAndFlush(externalObjectDirectory);
+        return dartsDatabaseSaveStub.save(externalObjectDirectory);
     }
 
     public List<ExternalObjectDirectoryEntity> findByMediaStatusAndType(MediaEntity media,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ExternalObjectDirectoryStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ExternalObjectDirectoryStub.java
@@ -115,7 +115,8 @@ public class ExternalObjectDirectoryStub {
             eod.setTranscriptionDocumentEntity(transcriptionDocumentEntity);
         }
         createdEodConsumer.accept(eod);
-        dartsDatabaseSaveStub.save(eod);
+        eodRepository.save(eod);
+        eodRepository.flush();
         return eod;
     }
 
@@ -137,7 +138,8 @@ public class ExternalObjectDirectoryStub {
         );
 
         externalObjectDirectory.setMedia(mediaEntity);
-        dartsDatabaseSaveStub.save(externalObjectDirectory);
+        eodRepository.save(externalObjectDirectory);
+        eodRepository.flush();
 
         return externalObjectDirectory;
     }
@@ -153,7 +155,9 @@ public class ExternalObjectDirectoryStub {
         );
 
         externalObjectDirectory.setCaseDocument(caseDocumentEntity);
-        dartsDatabaseSaveStub.save(externalObjectDirectory);
+        eodRepository.save(externalObjectDirectory);
+        eodRepository.flush();
+
         return externalObjectDirectory;
     }
 
@@ -222,7 +226,7 @@ public class ExternalObjectDirectoryStub {
 
         externalObjectDirectory.setTranscriptionDocumentEntity(transcriptionDocument);
 
-        return dartsDatabaseSaveStub.save(externalObjectDirectory);
+        return eodRepository.saveAndFlush(externalObjectDirectory);
     }
 
     public List<ExternalObjectDirectoryEntity> findByMediaStatusAndType(MediaEntity media,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ExternalObjectDirectoryStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ExternalObjectDirectoryStub.java
@@ -138,7 +138,7 @@ public class ExternalObjectDirectoryStub {
         );
 
         externalObjectDirectory.setMedia(mediaEntity);
-        eodRepository.save(externalObjectDirectory);
+        externalObjectDirectory = eodRepository.save(externalObjectDirectory);
         eodRepository.flush();
 
         return externalObjectDirectory;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/MediaRequestStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/MediaRequestStub.java
@@ -22,6 +22,7 @@ public class MediaRequestStub {
     private final HearingStub hearingStub;
     private final MediaRequestRepository mediaRequestRepository;
     private final UserAccountStub userAccountStub;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     @Transactional
     public MediaRequestEntity createAndLoadMediaRequestEntity(UserAccountEntity requestor,
@@ -51,8 +52,7 @@ public class MediaRequestStub {
             audioRequestType, status, requestedDate
         );
         currentMediaRequest.setCreatedDateTime(requestedDate);
-        return  mediaRequestRepository.save(
-            currentMediaRequest);
+        return dartsDatabaseSaveStub.save(currentMediaRequest);
     }
 
     @Transactional

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/NodeRegisterStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/NodeRegisterStub.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.NodeRegisterEntity;
-import uk.gov.hmcts.darts.common.repository.NodeRegisterRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.time.OffsetDateTime;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/NodeRegisterStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/NodeRegisterStub.java
@@ -13,7 +13,7 @@ import java.time.OffsetDateTime;
 @RequiredArgsConstructor
 @SuppressWarnings({"PMD.AvoidUsingHardCodedIP"})
 public class NodeRegisterStub {
-    private final NodeRegisterRepository nodeRegisterRepository;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
     private final UserAccountRepository userAccountRepository;
 
     public void setupNodeRegistry(CourtroomEntity courtroom) {
@@ -25,7 +25,7 @@ public class NodeRegisterStub {
         nodeRegisterEntity.setMacAddress("theMacAddress");
         nodeRegisterEntity.setCreatedBy(userAccountRepository.getReferenceById(0));
         nodeRegisterEntity.setCreatedDateTime(OffsetDateTime.now());
-        nodeRegisterRepository.save(nodeRegisterEntity);
+        dartsDatabaseSaveStub.save(nodeRegisterEntity);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ObjectAdminActionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ObjectAdminActionStub.java
@@ -26,6 +26,8 @@ public class ObjectAdminActionStub {
 
     @Autowired
     private ObjectAdminActionRepository objectAdminActionRepository;
+    @Autowired
+    private DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     private static UserAccountEntity defaultUser;
     private static ObjectHiddenReasonEntity defaultReason;
@@ -57,7 +59,7 @@ public class ObjectAdminActionStub {
     }
 
     public ObjectAdminActionEntity createAndSave(ObjectAdminActionEntity objectAdminActionEntity) {
-        return objectAdminActionRepository.save(objectAdminActionEntity);
+        return dartsDatabaseSaveStub.save(objectAdminActionEntity);
     }
 
     @Builder

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/SecurityGroupStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/SecurityGroupStub.java
@@ -25,6 +25,7 @@ public class SecurityGroupStub {
     private final SecurityGroupRepository securityGroupRepository;
     private final UserAccountRepository userAccountRepository;
     private final SecurityRoleRepository securityRoleRepository;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     private static SecurityRoleEntity defaultRole;
 
@@ -58,12 +59,12 @@ public class SecurityGroupStub {
         Optional<SecurityGroupEntity> entity = securityGroupRepository.findByGroupNameIgnoreCase(groupEnum.getName());
         for (UserAccountEntity accountEntity : entity.get().getUsers()) {
             accountEntity.getSecurityGroupEntities().remove(entity.get());
-            userAccountRepository.save(accountEntity);
+            dartsDatabaseSaveStub.save(accountEntity);
         }
 
         entity.get().getUsers().clear();
 
-        securityGroupRepository.saveAndFlush(entity.get());
+        dartsDatabaseSaveStub.save(entity.get());
     }
 
     public SecurityGroupEntity createAndSave(SecurityGroupEntitySpec spec, UserAccountEntity user) {
@@ -85,7 +86,7 @@ public class SecurityGroupStub {
         securityGroup.setCreatedDateTime(OffsetDateTime.now());
         securityGroup.setLastModifiedDateTime(OffsetDateTime.now());
 
-        return securityGroupRepository.save(securityGroup);
+        return dartsDatabaseSaveStub.save(securityGroup);
     }
 
     @Builder

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
@@ -72,6 +72,7 @@ public class TranscriptionStub {
     private final UserAccountStubComposable userAccountStub;
     private final HearingStub hearingStub;
     private final TranscriptionStubComposable transcriptionStubComposable;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     public TranscriptionEntity createMinimalTranscription() {
         return createTranscription(hearingStub.createMinimalHearing());
@@ -237,7 +238,7 @@ public class TranscriptionStub {
             hearing.getTranscriptions().add(transcription);
         }
 
-        return transcriptionRepository.saveAndFlush(transcription);
+        return dartsDatabaseSaveStub.save(transcription);
     }
 
 
@@ -282,7 +283,7 @@ public class TranscriptionStub {
         transcription.setIsManualTranscription(isManualTranscription);
         transcription.setHideRequestFromRequestor(false);
         transcription.setIsCurrent(true);
-        return transcriptionRepository.saveAndFlush(transcription);
+        return dartsDatabaseSaveStub.save(transcription);
     }
 
     public TranscriptionEntity createAndSaveTranscriptionEntity(CourtCaseEntity courtCase,
@@ -301,7 +302,7 @@ public class TranscriptionStub {
         transcription.setIsManualTranscription(true);
         transcription.setHideRequestFromRequestor(false);
         transcription.setIsCurrent(true);
-        return transcriptionRepository.saveAndFlush(transcription);
+        return dartsDatabaseSaveStub.save(transcription);
     }
 
     @Transactional
@@ -317,7 +318,7 @@ public class TranscriptionStub {
             getTranscriptionStatusByEnum(AWAITING_AUTHORISATION),
             null
         );
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     @Transactional
@@ -334,7 +335,7 @@ public class TranscriptionStub {
             getTranscriptionStatusByEnum(AWAITING_AUTHORISATION),
             comment
         );
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     @Transactional
@@ -380,7 +381,7 @@ public class TranscriptionStub {
             null
         );
         transcriptionEntity.setHideRequestFromRequestor(hideRequestFromRequester);
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     @Transactional
@@ -398,7 +399,7 @@ public class TranscriptionStub {
             null
         );
         transcriptionEntity.setHideRequestFromRequestor(hideRequestFromRequester);
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     @Transactional
@@ -416,7 +417,7 @@ public class TranscriptionStub {
             null
         );
         transcriptionEntity.setHideRequestFromRequestor(hideRequestFromRequester);
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     @Transactional
@@ -438,7 +439,7 @@ public class TranscriptionStub {
         transcriptionEntity.setHideRequestFromRequestor(hideRequestFromRequester);
         transcriptionEntity.setStartTime(startDate);
         transcriptionEntity.setEndTime(endDate);
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     @Transactional
@@ -463,7 +464,7 @@ public class TranscriptionStub {
         transcriptionEntity.setEndTime(endDate);
         transcriptionEntity.setTranscriptionType(transcriptionType);
         transcriptionEntity.setIsCurrent(true);
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     @Transactional
@@ -504,7 +505,7 @@ public class TranscriptionStub {
 
         var transcriptionWorkflow = createTranscriptionWorkflowEntity(transcription, transcription.getCreatedBy(), workflowTimestamp, transcriptionStatus);
 
-        return transcriptionWorkflowRepository.save(transcriptionWorkflow);
+        return dartsDatabaseSaveStub.save(transcriptionWorkflow);
     }
 
     public TranscriptionEntity updateTranscriptionWithDocument(TranscriptionEntity transcriptionEntity,
@@ -519,10 +520,10 @@ public class TranscriptionStub {
         transcriptionDocumentEntity.setHidden(hideDocument);
         transcriptionDocumentEntity.setUploadedBy(userAccountEntity);
         transcriptionDocumentEntity.setLastModifiedBy(userAccountEntity);
-        transcriptionDocumentRepository.saveAndFlush(transcriptionDocumentEntity);
+        dartsDatabaseSaveStub.save(transcriptionDocumentEntity);
 
         transcriptionEntity.getTranscriptionDocumentEntities().add(transcriptionDocumentEntity);
-        transcriptionRepository.saveAndFlush(transcriptionEntity);
+        dartsDatabaseSaveStub.save(transcriptionEntity);
 
         return transcriptionEntity;
     }
@@ -569,9 +570,9 @@ public class TranscriptionStub {
         TranscriptionDocumentEntity transcriptionDocumentEntity = createTranscriptionDocumentEntity(transcriptionEntity, fileName,
                                                                                                     fileType, fileSize, testUser,
                                                                                                     checksum, confScore, confReason);
-        transcriptionDocumentRepository.save(transcriptionDocumentEntity);
+        dartsDatabaseSaveStub.save(transcriptionDocumentEntity);
         transcriptionEntity.getTranscriptionDocumentEntities().add(transcriptionDocumentEntity);
-        transcriptionRepository.save(transcriptionEntity);
+        dartsDatabaseSaveStub.save(transcriptionEntity);
 
         ExternalObjectDirectoryEntity externalObjectDirectoryEntity = new ExternalObjectDirectoryEntity();
         externalObjectDirectoryEntity.setStatus(objectRecordStatusEntity);
@@ -583,10 +584,10 @@ public class TranscriptionStub {
         externalObjectDirectoryEntity.setCreatedBy(testUser);
         externalObjectDirectoryEntity.setLastModifiedBy(testUser);
         externalObjectDirectoryEntity.setTranscriptionDocumentEntity(transcriptionDocumentEntity);
-        externalObjectDirectoryEntity = externalObjectDirectoryRepository.save(externalObjectDirectoryEntity);
+        externalObjectDirectoryEntity = dartsDatabaseSaveStub.save(externalObjectDirectoryEntity);
 
         transcriptionDocumentEntity.getExternalObjectDirectoryEntities().add(externalObjectDirectoryEntity);
-        return transcriptionRepository.save(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     private String getChecksum() {
@@ -688,7 +689,7 @@ public class TranscriptionStub {
         transcriptionEntity.setIsManualTranscription(true);
         transcriptionEntity.setHideRequestFromRequestor(false);
         transcriptionEntity.setIsCurrent(isCurrent);
-        transcriptionRepository.save(transcriptionEntity);
+        dartsDatabaseSaveStub.save(transcriptionEntity);
 
         final var requestedTranscriptionWorkflowEntity = createTranscriptionWorkflowEntity(
             transcriptionEntity,
@@ -696,11 +697,11 @@ public class TranscriptionStub {
             workflowTimestamp,
             getTranscriptionStatusByEnum(REQUESTED)
         );
-        transcriptionWorkflowRepository.saveAndFlush(requestedTranscriptionWorkflowEntity);
+        dartsDatabaseSaveStub.save(requestedTranscriptionWorkflowEntity);
 
         if (nonNull(comment)) {
             final var transcriptionComment = createTranscriptionWorkflowComment(requestedTranscriptionWorkflowEntity, comment, userAccountEntity);
-            transcriptionCommentRepository.save(transcriptionComment);
+            dartsDatabaseSaveStub.save(transcriptionComment);
 
             requestedTranscriptionWorkflowEntity.getTranscriptionComments().add(transcriptionComment);
         }
@@ -711,11 +712,11 @@ public class TranscriptionStub {
             workflowTimestamp,
             status
         );
-        transcriptionWorkflowRepository.saveAndFlush(transcriptionWorkflowEntity);
+        dartsDatabaseSaveStub.save(transcriptionWorkflowEntity);
 
         transcriptionEntity.getTranscriptionWorkflowEntities()
             .addAll(List.of(requestedTranscriptionWorkflowEntity, transcriptionWorkflowEntity));
-        return transcriptionRepository.saveAndFlush(transcriptionEntity);
+        return dartsDatabaseSaveStub.save(transcriptionEntity);
     }
 
     public TranscriptionCommentEntity createTranscriptionWorkflowComment(TranscriptionWorkflowEntity workflowEntity, String comment,
@@ -734,7 +735,7 @@ public class TranscriptionStub {
     public TranscriptionCommentEntity createAndSaveTranscriptionWorkflowComment(TranscriptionWorkflowEntity workflowEntity,
                                                                                 String comment, UserAccountEntity userAccount) {
         var transcriptionComment = createTranscriptionWorkflowComment(workflowEntity, comment, userAccount);
-        return transcriptionCommentRepository.save(transcriptionComment);
+        return dartsDatabaseSaveStub.save(transcriptionComment);
     }
 
     public TranscriptionCommentEntity createAndSaveTranscriptionCommentNotAssociatedToWorkflow(TranscriptionEntity transcription,
@@ -747,7 +748,7 @@ public class TranscriptionStub {
         transcriptionComment.setAuthorUserId(transcription.getCreatedBy().getId());
         transcriptionComment.setLastModifiedBy(transcription.getCreatedBy());
         transcriptionComment.setCreatedBy(transcription.getCreatedBy());
-        return transcriptionCommentRepository.save(transcriptionComment);
+        return dartsDatabaseSaveStub.save(transcriptionComment);
     }
 
     private ExternalLocationTypeEntity getLocationEntity(ExternalLocationTypeEnum externalLocationTypeEnum) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStub.java
@@ -248,7 +248,7 @@ public class TranscriptionStub {
                                                                 TranscriptionStatusEntity transcriptionStatus,
                                                                 TranscriptionUrgencyEntity transcriptionUrgency,
                                                                 UserAccountEntity testUser,
-                                                                List<TranscriptionWorkflowEntity>  workflowEntity,
+                                                                List<TranscriptionWorkflowEntity> workflowEntity,
                                                                 boolean isManualTranscription) {
         TranscriptionEntity transcription = new TranscriptionEntity();
         for (CourtCaseEntity caseEntity : courtCase) {
@@ -345,7 +345,7 @@ public class TranscriptionStub {
                                                                                OffsetDateTime workflowTimestamp,
                                                                                boolean associatedUrgency) {
         return createAndSaveAwaitingAuthorisationTranscription(userAccountEntity, courtCaseEntity,
-                                                               hearingEntity, workflowTimestamp, associatedUrgency,true);
+                                                               hearingEntity, workflowTimestamp, associatedUrgency, true);
     }
 
     @Transactional
@@ -565,7 +565,7 @@ public class TranscriptionStub {
                                                                String checksum,
                                                                Integer confScore,
                                                                String confReason
-                                                               ) {
+    ) {
 
         TranscriptionDocumentEntity transcriptionDocumentEntity = createTranscriptionDocumentEntity(transcriptionEntity, fileName,
                                                                                                     fileType, fileSize, testUser,
@@ -660,7 +660,7 @@ public class TranscriptionStub {
                                                               String comment, boolean associateUrgency) {
 
         return createTranscriptionWithStatus(userAccountEntity, courtCaseEntity, hearingEntity, workflowTimestamp,
-                                      status, comment, associateUrgency, true);
+                                             status, comment, associateUrgency, true);
     }
 
     private TranscriptionEntity createTranscriptionWithStatus(UserAccountEntity userAccountEntity,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStubComposable.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/TranscriptionStubComposable.java
@@ -28,9 +28,10 @@ public class TranscriptionStubComposable {
 
     private final TranscriptionRepository transcriptionRepository;
     private final TranscriptionUrgencyRepository transcriptionUrgencyRepository;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     public TranscriptionEntity createTranscription(UserAccountStubComposable userAccountStubComposable, HearingEntity hearing) {
-        return createTranscription(userAccountStubComposable, hearing,null);
+        return createTranscription(userAccountStubComposable, hearing, null);
     }
 
     public TranscriptionEntity createTranscription(
@@ -99,7 +100,7 @@ public class TranscriptionStubComposable {
             hearing.getTranscriptions().add(transcription);
         }
 
-        return transcriptionRepository.saveAndFlush(transcription);
+        return dartsDatabaseSaveStub.save(transcription);
     }
 
     private TranscriptionUrgencyEntity mapToTranscriptionUrgencyEntity(TranscriptionUrgencyEnum urgencyEnum) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
@@ -261,9 +261,6 @@ public class UserAccountStub {
 
     public UserAccountEntity createExternalUser(String guid, SecurityGroupEntity securityGroupEntity,
                                                 CourthouseEntity courthouseEntity) {
-        if (nonNull(courthouseEntity)) {
-            securityGroupStub.addCourthouse(securityGroupEntity, courthouseEntity);
-        }
 
         var testUser = getIntegrationTestUserAccountEntity();
         Set<SecurityGroupEntity> securityGroupEntities = new LinkedHashSet<>();
@@ -271,7 +268,11 @@ public class UserAccountStub {
         testUser.setSecurityGroupEntities(securityGroupEntities);
         testUser.setIsSystemUser(true);
         testUser.setAccountGuid(guid);
+
         testUser = dartsDatabaseSaveStub.save(testUser);
+        if (nonNull(courthouseEntity)) {
+            securityGroupStub.addCourthouse(securityGroupEntity, courthouseEntity);
+        }
         return testUser;
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
@@ -43,6 +43,7 @@ public class UserAccountStub {
     private final CourthouseRepository courthouseRepository;
     private final SecurityGroupStub securityGroupStub;
     private final UserAccountStubComposable userAccountStubComposable;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     public UserAccountEntity getSystemUserAccountEntity() {
         return userAccountStubComposable.getSystemUserAccountEntity();
@@ -96,7 +97,7 @@ public class UserAccountStub {
         newUser.setCreatedDateTime(CREATED_DATE_TIME);
         newUser.setLastModifiedDateTime(LAST_MODIFIED_DATE_TIME);
         newUser.setLastLoginTime(LAST_LOGIN_TIME);
-        return userAccountRepository.saveAndFlush(newUser);
+        return dartsDatabaseSaveStub.save(newUser);
     }
 
     @Transactional
@@ -142,7 +143,7 @@ public class UserAccountStub {
                 addCourthouseToSecurityGroup(securityGroupEntity, courthouseEntity);
             }
             testUser.getSecurityGroupEntities().add(securityGroupEntity);
-            testUser = userAccountRepository.saveAndFlush(testUser);
+            testUser = dartsDatabaseSaveStub.save(testUser);
         }
 
         return testUser;
@@ -152,7 +153,7 @@ public class UserAccountStub {
                                               CourthouseEntity courthouseEntity) {
         if (!securityGroupEntity.getCourthouseEntities().contains(courthouseEntity)) {
             securityGroupEntity.getCourthouseEntities().add(courthouseEntity);
-            securityGroupRepository.saveAndFlush(securityGroupEntity);
+            dartsDatabaseSaveStub.save(securityGroupEntity);
         }
     }
 
@@ -160,11 +161,11 @@ public class UserAccountStub {
     public UserAccountEntity createUnauthorisedIntegrationTestUser() {
         SecurityGroupEntity securityGroupEntity = securityGroupRepository.getReferenceById(-4);
         securityGroupEntity.getCourthouseEntities().clear();
-        securityGroupRepository.saveAndFlush(securityGroupEntity);
+        dartsDatabaseSaveStub.save(securityGroupEntity);
 
         var testUser = getIntegrationTestUserAccountEntity();
         testUser.getSecurityGroupEntities().clear();
-        testUser = userAccountRepository.saveAndFlush(testUser);
+        testUser = dartsDatabaseSaveStub.save(testUser);
         return testUser;
     }
 
@@ -172,12 +173,12 @@ public class UserAccountStub {
     public UserAccountEntity createTranscriptionCompanyUser(CourthouseEntity courthouseEntity) {
         SecurityGroupEntity securityGroupEntity = securityGroupRepository.findById(-4).get();
         securityGroupEntity.getCourthouseEntities().add(courthouseEntity);
-        securityGroupEntity = securityGroupRepository.saveAndFlush(securityGroupEntity);
+        securityGroupEntity = dartsDatabaseSaveStub.save(securityGroupEntity);
 
         var testUser = getIntegrationTestUserAccountEntity();
         testUser.getSecurityGroupEntities().clear();
         testUser.getSecurityGroupEntities().add(securityGroupEntity);
-        testUser = userAccountRepository.saveAndFlush(testUser);
+        testUser = dartsDatabaseSaveStub.save(testUser);
         return testUser;
     }
 
@@ -185,12 +186,12 @@ public class UserAccountStub {
     public UserAccountEntity createJudgeUser(CourthouseEntity courthouseEntity) {
         SecurityGroupEntity securityGroupEntity = securityGroupRepository.getReferenceById(-3);
         securityGroupEntity.getCourthouseEntities().add(courthouseEntity);
-        securityGroupEntity = securityGroupRepository.saveAndFlush(securityGroupEntity);
+        securityGroupEntity = dartsDatabaseSaveStub.save(securityGroupEntity);
 
         var testUser = getIntegrationTestUserAccountEntity();
         testUser.getSecurityGroupEntities().clear();
         testUser.getSecurityGroupEntities().add(securityGroupEntity);
-        testUser = userAccountRepository.saveAndFlush(testUser);
+        testUser = dartsDatabaseSaveStub.save(testUser);
         return testUser;
     }
 
@@ -203,12 +204,12 @@ public class UserAccountStub {
     public UserAccountEntity createJudgeUser(String identifier) {
         SecurityGroupEntity securityGroupEntity = securityGroupRepository.findById(TEST_JUDGE_GLOBAL_SECURITY_GROUP_ID).get();
         securityGroupEntity.getCourthouseEntities().addAll(courthouseRepository.findAll());
-        securityGroupEntity = securityGroupRepository.saveAndFlush(securityGroupEntity);
+        securityGroupEntity = dartsDatabaseSaveStub.save(securityGroupEntity);
 
         var testUser = getIntegrationTestUserAccountEntity("Judge" + identifier);
         testUser.getSecurityGroupEntities().clear();
         testUser.getSecurityGroupEntities().add(securityGroupEntity);
-        testUser = userAccountRepository.saveAndFlush(testUser);
+        testUser = dartsDatabaseSaveStub.save(testUser);
         return testUser;
     }
 
@@ -216,19 +217,19 @@ public class UserAccountStub {
     public UserAccountEntity createRcjAppealUser(CourthouseEntity courthouseEntity) {
         SecurityGroupEntity securityGroupEntity = SecurityGroupTestData
             .buildGroupForRoleAndCourthouse(SecurityRoleEnum.RCJ_APPEALS, courthouseEntity);
-        securityGroupEntity = securityGroupRepository.saveAndFlush(securityGroupEntity);
+        securityGroupEntity = dartsDatabaseSaveStub.save(securityGroupEntity);
 
         var testUser = getIntegrationTestUserAccountEntity();
         testUser.getSecurityGroupEntities().clear();
         testUser.getSecurityGroupEntities().add(securityGroupEntity);
-        testUser = userAccountRepository.saveAndFlush(testUser);
+        testUser = dartsDatabaseSaveStub.save(testUser);
         return testUser;
     }
 
     public UserAccountEntity createXhibitExternalUser(String guid, CourthouseEntity courthouseEntity) {
         SecurityGroupEntity securityGroupEntity = securityGroupRepository.findById(-14).get();
         securityGroupEntity.setGlobalAccess(true);
-        securityGroupEntity = securityGroupRepository.saveAndFlush(securityGroupEntity);
+        securityGroupEntity = dartsDatabaseSaveStub.save(securityGroupEntity);
 
         return createExternalUser(guid, securityGroupEntity, courthouseEntity);
     }
@@ -236,7 +237,7 @@ public class UserAccountStub {
     public UserAccountEntity createCppExternalUser(String guid, CourthouseEntity courthouseEntity) {
         SecurityGroupEntity securityGroupEntity = securityGroupRepository.getReferenceById(-15);
         securityGroupEntity.setGlobalAccess(true);
-        securityGroupEntity = securityGroupRepository.saveAndFlush(securityGroupEntity);
+        securityGroupEntity = dartsDatabaseSaveStub.save(securityGroupEntity);
 
         return createExternalUser(guid, securityGroupEntity, courthouseEntity);
     }
@@ -245,7 +246,7 @@ public class UserAccountStub {
     public UserAccountEntity createDarPcExternalUser(String guid, CourthouseEntity courthouseEntity) {
         SecurityGroupEntity securityGroupEntity = securityGroupRepository.getReferenceById(-16);
         securityGroupEntity.setGlobalAccess(true);
-        securityGroupEntity = securityGroupRepository.saveAndFlush(securityGroupEntity);
+        securityGroupEntity = dartsDatabaseSaveStub.save(securityGroupEntity);
 
         return createExternalUser(guid, securityGroupEntity, courthouseEntity);
     }
@@ -253,7 +254,7 @@ public class UserAccountStub {
     public UserAccountEntity createMidTierExternalUser(String guid, CourthouseEntity courthouseEntity) {
         SecurityGroupEntity securityGroupEntity = securityGroupRepository.findById(-17).get();
         securityGroupEntity.setGlobalAccess(true);
-        securityGroupEntity = securityGroupRepository.saveAndFlush(securityGroupEntity);
+        securityGroupEntity = dartsDatabaseSaveStub.save(securityGroupEntity);
 
         return createExternalUser(guid, securityGroupEntity, courthouseEntity);
     }
@@ -270,7 +271,7 @@ public class UserAccountStub {
         testUser.setSecurityGroupEntities(securityGroupEntities);
         testUser.setIsSystemUser(true);
         testUser.setAccountGuid(guid);
-        testUser = userAccountRepository.saveAndFlush(testUser);
+        testUser = dartsDatabaseSaveStub.save(testUser);
         return testUser;
     }
 
@@ -279,13 +280,13 @@ public class UserAccountStub {
         var adminGroup = securityGroupRepository.findByGroupNameIgnoreCase("SUPER_ADMIN")
             .orElseThrow();
         adminGroup.setGlobalAccess(true);
-        adminGroup = securityGroupRepository.saveAndFlush(adminGroup);
+        adminGroup = dartsDatabaseSaveStub.save(adminGroup);
 
         var user = getIntegrationTestUserAccountEntity("adminUserAccount");
         user.getSecurityGroupEntities().clear();
         user.getSecurityGroupEntities().add(adminGroup);
 
-        return userAccountRepository.saveAndFlush(user);
+        return dartsDatabaseSaveStub.save(user);
     }
 
     @Transactional
@@ -293,13 +294,13 @@ public class UserAccountStub {
         var adminGroup = securityGroupRepository.findByGroupNameIgnoreCase("SUPER_ADMIN")
             .orElseThrow();
         adminGroup.setGlobalAccess(true);
-        adminGroup = securityGroupRepository.saveAndFlush(adminGroup);
+        adminGroup = dartsDatabaseSaveStub.save(adminGroup);
 
         var user = getIntegrationTestUserAccountEntityInactive("adminUserAccount");
         user.getSecurityGroupEntities().clear();
         user.getSecurityGroupEntities().add(adminGroup);
 
-        return userAccountRepository.saveAndFlush(user);
+        return dartsDatabaseSaveStub.save(user);
     }
 
     @Transactional
@@ -307,13 +308,13 @@ public class UserAccountStub {
         var superUserGroup = securityGroupRepository.findByGroupNameIgnoreCase("SUPER_USER")
             .orElseThrow();
         superUserGroup.setGlobalAccess(true);
-        superUserGroup = securityGroupRepository.saveAndFlush(superUserGroup);
+        superUserGroup = dartsDatabaseSaveStub.save(superUserGroup);
 
         var user = getIntegrationTestUserAccountEntity("superUserAccount");
         user.getSecurityGroupEntities().clear();
         user.getSecurityGroupEntities().add(superUserGroup);
 
-        return userAccountRepository.saveAndFlush(user);
+        return dartsDatabaseSaveStub.save(user);
     }
 
     @Transactional
@@ -323,12 +324,12 @@ public class UserAccountStub {
 
         var testUserNonSystem = getIntegrationTestUserAccountEntity();
         testUserNonSystem.getSecurityGroupEntities().add(securityGroupEntity);
-        testUserNonSystem = userAccountRepository.saveAndFlush(testUserNonSystem);
+        testUserNonSystem = dartsDatabaseSaveStub.save(testUserNonSystem);
 
         var testUserSystem = getSeparateIntegrationTestUserAccountEntity();
         testUserSystem.getSecurityGroupEntities().add(securityGroupEntity);
         testUserSystem.setIsSystemUser(true);
-        testUserSystem = userAccountRepository.saveAndFlush(testUserSystem);
+        testUserSystem = dartsDatabaseSaveStub.save(testUserSystem);
 
         return Arrays.asList(testUserNonSystem, testUserSystem);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStubComposable.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStubComposable.java
@@ -30,6 +30,7 @@ public class UserAccountStubComposable {
     private final SecurityGroupRepository securityGroupRepository;
 
     private final DartsPersistence dartsPersistence;
+    private final DartsDatabaseSaveStub dartsDatabaseSaveStub;
 
     @Transactional
     public UserAccountEntity createAuthorisedIntegrationTestUser(CourthouseStubComposable courthouseStubComposable, String courthouse) {
@@ -172,7 +173,7 @@ public class UserAccountStubComposable {
                 addCourthouseToSecurityGroup(securityGroupEntity, courthouseEntity);
             }
             testUser.getSecurityGroupEntities().add(securityGroupEntity);
-            testUser = userAccountRepository.saveAndFlush(testUser);
+            testUser = dartsDatabaseSaveStub.save(testUser);
         }
 
         return testUser;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminGetTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminGetTranscriptionIntTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.transcriptions.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -302,7 +301,6 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testSearchForTranscriptionDocumentWithCaseNumberAndReturnApplicableResults() throws Exception {
         List<TranscriptionDocumentEntity> transcriptionDocumentResults = transcriptionDocumentStub.generateTranscriptionEntities(4, 1, 1, false, true, false);
 
@@ -328,7 +326,6 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testSearchForTranscriptionDocumentWithDateFromAndReturnApplicableResults() throws Exception {
         List<TranscriptionDocumentEntity> transcriptionDocumentResults = transcriptionDocumentStub
             .generateTranscriptionEntities(4, 1, 1, true, false, false);
@@ -356,7 +353,6 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testSearchForTranscriptionDocumentWithDateFromAndDateToAndReturnApplicableResults() throws Exception {
         List<TranscriptionDocumentEntity> transcriptionDocumentResults = transcriptionDocumentStub.generateTranscriptionEntities(4, 1, 1, true, false, false);
 
@@ -384,7 +380,6 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testSearchForTranscriptionDocumentWithDateFromAndDateToAndReturnNoResults() throws Exception {
         List<TranscriptionDocumentEntity> transcriptionDocumentResults = transcriptionDocumentStub.generateTranscriptionEntities(4, 1, 1, true, false, false);
 
@@ -408,7 +403,6 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testSearchForTranscriptionDocumentUsingAllSearchCriteria() throws Exception {
         List<TranscriptionDocumentEntity> transcriptionDocumentResults = transcriptionDocumentStub.generateTranscriptionEntities(4, 1, 1, true, false, true);
 
@@ -444,7 +438,6 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testSearchForTranscriptionDocumentWithoutCriteriaAndReturnAll() throws Exception {
         List<TranscriptionDocumentEntity> transcriptionDocumentResults = transcriptionDocumentStub.generateTranscriptionEntities(4, 1, 1, true, false, true);
 
@@ -546,7 +539,6 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void testGetTranscriptionDocumentMarkedForDeletionWithResults() throws Exception {
         // TODO: Resume when all test disablements are re-enabled. See https://tools.hmcts.net/jira/browse/DMP-3821
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminGetTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminGetTranscriptionIntTest.java
@@ -124,7 +124,6 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
     }
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void getTransactionsForUserWithoutDateAndWithoutHearing() throws Exception {
         superAdminUserStub.givenUserIsAuthorised(userIdentity);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAttachTranscriptIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAttachTranscriptIntTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -55,7 +54,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WI
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql")
 class TranscriptionControllerAttachTranscriptIntTest extends IntegrationBase {
 
     private static final String URL_TEMPLATE = "/transcriptions/{transcription_id}/document";

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerDownloadTranscriptIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerDownloadTranscriptIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -54,7 +53,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WI
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql")
 class TranscriptionControllerDownloadTranscriptIntTest extends IntegrationBase {
 
     private static final String URL_TEMPLATE = "/transcriptions/{transcription_id}/document";

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriberTranscriptsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriberTranscriptsIntTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -27,7 +26,6 @@ import static uk.gov.hmcts.darts.testutils.DateHelper.convertSqlDateTimeToLocalD
 import static uk.gov.hmcts.darts.testutils.DateHelper.todaysDateMinusDaysFormattedForSql;
 
 @AutoConfigureMockMvc
-@Disabled("Impacted by V1_364_*.sql - fix needed")
 class TranscriptionControllerGetTranscriberTranscriptsIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT_URI = URI.create("/transcriptions/transcriber-view");
@@ -346,18 +344,19 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 last_modified_by, display_name)
                                 VALUES (-1, NULL, 'BRISTOL', '2023-11-17 15:06:15.859244+00', '2023-11-17 15:06:15.859244+00', 0, 0, 'Bristol');
                                 INSERT INTO darts.courtroom (ctr_id, cth_id, courtroom_name, created_ts, created_by)
-                                VALUES (-1, -1, 'COURT 1', NULL, 0);
+                                VALUES (-1, -1, 'COURT 1', current_timestamp, 0);
                                 INSERT INTO darts.court_case (cas_id, cth_id, evh_id, case_object_id, case_number, case_closed, interpreter_used,
                                 case_closed_ts, created_ts, created_by, last_modified_ts, last_modified_by)
-                                VALUES (-1, -1, NULL, NULL, 'T20231009-1', false, false, NULL, NULL, NULL, NULL, NULL);
+                                VALUES (-1, -1, NULL, NULL, 'T20231009-1', false, false, NULL, current_timestamp, 0, current_timestamp, 0);
                                 INSERT INTO darts.hearing (hea_id, cas_id, ctr_id, hearing_date, scheduled_start_time, hearing_is_actual,
                                 created_ts, created_by, last_modified_ts, last_modified_by)
-                                VALUES (-1, -1, -1, '2023-11-17', NULL, true, NULL, NULL, NULL, NULL);
-                                                                
+                                VALUES (-1, -1, -1, '2023-11-17', NULL, true, current_timestamp, 0, current_timestamp, 0);
+                                
                                 INSERT INTO darts.user_account (usr_id, dm_user_s_object_id, user_name, user_full_name, user_email_address, description,
                                 is_active, created_ts,
                                 last_modified_ts, last_login_ts, last_modified_by, created_by, account_guid, is_system_user)
-                                VALUES (-10, NULL, 'Richard B', 'Richard B', 'Richard.B@example.com', NULL, true, NULL, NULL, NULL, NULL, NULL, NULL, false);
+                                VALUES (-10, NULL, 'Richard B', 'Richard B', 'Richard.B@example.com', NULL, true, current_timestamp,
+                                current_timestamp, NULL, 0, 0, NULL, false);
                                 INSERT INTO darts.security_group_user_account_ae (usr_id, grp_id)
                                 VALUES (-10, -4);
                                 INSERT INTO darts.security_group_courthouse_ae (grp_id, cth_id)
@@ -381,7 +380,7 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 VALUES (44, 41, 5, -10, '2023-11-23 16:30:00.0+00');
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
                                 VALUES (45, 41, 3, -10, '$MINUS_89_DAYS');
-                                                                
+                                
                                 -- Add transcript request to test transcriptions do not show after 90 days
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
@@ -523,7 +522,6 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                                 DELETE FROM darts.court_case WHERE cas_id=-1;
                                 DELETE FROM darts.courtroom WHERE ctr_id=-1;
                                 DELETE FROM darts.courthouse WHERE cth_id=-1;
-                                                                
                                 """);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriberTranscriptsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriberTranscriptsIntTest.java
@@ -27,7 +27,7 @@ import static uk.gov.hmcts.darts.testutils.DateHelper.convertSqlDateTimeToLocalD
 import static uk.gov.hmcts.darts.testutils.DateHelper.todaysDateMinusDaysFormattedForSql;
 
 @AutoConfigureMockMvc
-@Disabled("Impacted by V1_364_*.sql")
+@Disabled("Impacted by V1_364_*.sql - fix needed")
 class TranscriptionControllerGetTranscriberTranscriptsIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT_URI = URI.create("/transcriptions/transcriber-view");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.transcriptions.controller;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.transcriptions.controller;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTranscriberCountsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTranscriberCountsIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -46,28 +45,30 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
                                 last_modified_by, display_name)
                                 VALUES (-1, NULL, 'BRISTOL', '2023-11-17 15:06:15.859244+00', '2023-11-17 15:06:15.859244+00', 0, 0, 'Bristol');
                                 INSERT INTO darts.courtroom (ctr_id, cth_id, courtroom_name, created_ts, created_by)
-                                VALUES (-1, -1, 'COURT 1', NULL, 0);
+                                VALUES (-1, -1, 'COURT 1', current_timestamp, 0);
                                 INSERT INTO darts.court_case (cas_id, cth_id, evh_id, case_object_id, case_number, case_closed, interpreter_used,
                                 case_closed_ts, created_ts, created_by, last_modified_ts, last_modified_by)
-                                VALUES (-1, -1, NULL, NULL, 'T20231009-1', false, false, NULL, NULL, NULL, NULL, NULL);
+                                VALUES (-1, -1, NULL, NULL, 'T20231009-1', false, false, NULL, current_timestamp, 0, current_timestamp, 0);
                                 INSERT INTO darts.hearing (hea_id, cas_id, ctr_id, hearing_date, scheduled_start_time, hearing_is_actual,
                                 created_ts, created_by, last_modified_ts, last_modified_by)
-                                VALUES (-1, -1, -1, '2023-11-17', NULL, true, NULL, NULL, NULL, NULL);
-
+                                VALUES (-1, -1, -1, '2023-11-17', NULL, true, current_timestamp, 0, current_timestamp, 0);
+                                
                                 INSERT INTO darts.user_account (usr_id, dm_user_s_object_id, user_name, user_full_name, user_email_address, description,
                                 is_active, created_ts,
                                 last_modified_ts, last_login_ts, last_modified_by, created_by, account_guid, is_system_user)
-                                VALUES (-10, NULL, 'John R', 'John R', 'John.R@example.com', NULL, true, NULL, NULL, NULL, NULL, NULL, NULL, false);
+                                VALUES (-10, NULL, 'John R', 'John R', 'John.R@example.com', NULL, true, current_timestamp,
+                                current_timestamp, NULL, 0, 0, NULL, false);
                                 INSERT INTO darts.security_group_user_account_ae (usr_id, grp_id)
                                 VALUES (-10, -4);
                                 INSERT INTO darts.security_group_courthouse_ae (grp_id, cth_id)
                                 VALUES (-4, -1);
-
+                                
                                 INSERT INTO darts.user_account (usr_id, dm_user_s_object_id, user_name, user_full_name, user_email_address, description,
                                 is_active, created_ts,
                                 last_modified_ts, last_login_ts, last_modified_by, created_by, account_guid, is_system_user)
-                                VALUES (-20, NULL, 'John R', 'John R', 'John.R@example.com', NULL, true, NULL, NULL, NULL, NULL, NULL, NULL, false);
-
+                                VALUES (-20, NULL, 'John R', 'John R', 'John.R@example.com', NULL, true, current_timestamp,
+                                current_timestamp, NULL, 0, 0, NULL, false);
+                                
                                 -- Transcript Requests: Approved
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
@@ -82,7 +83,7 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
                                 VALUES (42, 41, 2, -10, '2023-11-23 16:25:55.338405+00');
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
                                 VALUES (43, 41, 3, -10, '2023-11-23 16:26:20.441633+00');
-
+                                
                                 -- Transcript Requests: With Transcriber
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
@@ -99,7 +100,7 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
                                 VALUES (101, 81, 3, -10, '2023-11-23 17:45:27.069655+00');
                                 INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
                                 VALUES (102, 81, 5, -10, '2023-11-23 17:45:51.151621+00');
-
+                                
                                 -- Transcript Requests: Approved
                                 INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                                 created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
@@ -122,15 +123,15 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
         jdbcTemplate.update("""
                                 DELETE FROM darts.case_transcription_ae WHERE tra_id IN (41, 81, 101);
                                 DELETE FROM darts.hearing_transcription_ae WHERE tra_id IN (41, 81, 101);
-
+                                
                                 DELETE FROM darts.transcription_workflow WHERE tra_id IN (41, 81, 101);
                                 DELETE FROM darts.transcription WHERE tra_id IN (41, 81, 101);
-
+                                
                                 DELETE FROM darts.security_group_courthouse_ae WHERE grp_id=-4 AND cth_id=-1;
                                 DELETE FROM darts.security_group_user_account_ae WHERE usr_id=-10 AND grp_id=-4;
                                 DELETE FROM darts.user_account WHERE usr_id=-10;
                                 DELETE FROM darts.user_account WHERE usr_id=-20;
-
+                                
                                 DELETE FROM darts.hearing WHERE hea_id=-1;
                                 DELETE FROM darts.court_case WHERE cas_id=-1;
                                 DELETE FROM darts.courtroom WHERE ctr_id=-1;
@@ -140,7 +141,6 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - Needs fix")
     void getTranscriberCountsShouldReturnOk() throws Exception {
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URI)
             .header(
@@ -163,7 +163,6 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - Needs fix")
     void getTranscriberCountsShouldReturnOkWithInactive() throws Exception {
 
         UserAccountEntity userAccountEntity = userAccountRepository.findById(-10).get();
@@ -183,7 +182,6 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - Needs fix")
     void getTranscriberCountsShouldReturnForbiddenWhenUserNotTranscriber() throws Exception {
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URI)
             .header(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTranscriberCountsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTranscriberCountsIntTest.java
@@ -23,7 +23,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Disabled("Impacted by V1_367__adding_not_null_constraints_part_4.sql")
 @AutoConfigureMockMvc
 class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends IntegrationBase {
 
@@ -141,7 +140,7 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
 
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - Needs fix")
     void getTranscriberCountsShouldReturnOk() throws Exception {
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URI)
             .header(
@@ -164,7 +163,7 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - Needs fix")
     void getTranscriberCountsShouldReturnOkWithInactive() throws Exception {
 
         UserAccountEntity userAccountEntity = userAccountRepository.findById(-10).get();
@@ -184,7 +183,7 @@ class TranscriptionControllerGetTranscriptionTranscriberCountsIntTest extends In
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
+    @Disabled("Impacted by V1_364_*.sql - Needs fix")
     void getTranscriberCountsShouldReturnForbiddenWhenUserNotTranscriber() throws Exception {
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URI)
             .header(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionWorkflowsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionWorkflowsIntTest.java
@@ -65,7 +65,7 @@ class TranscriptionControllerGetTranscriptionWorkflowsIntTest extends Integratio
         transcription.setCreatedDateTime(OffsetDateTime.of(2024, 4, 24, 10, 0, 0, 0, ZoneOffset.UTC));
         transcription.setStartTime(SOME_DATE_TIME);
         transcription.setEndTime(SOME_DATE_TIME);
-        transcription = dartsDatabase.save(transcription);
+        transcription = dartsDatabase.getTranscriptionRepository().save(transcription);
 
         var transcriptionWorkflow1 = transcriptionStub.createAndSaveTranscriptionWorkflow(transcription,
                                                                                           OffsetDateTime.of(2024, 4, 23, 10, 0, 0, 0, ZoneOffset.UTC),
@@ -127,7 +127,7 @@ class TranscriptionControllerGetTranscriptionWorkflowsIntTest extends Integratio
         transcription2.setCreatedDateTime(OffsetDateTime.of(2024, 4, 24, 10, 0, 0, 0, ZoneOffset.UTC));
         transcription2.setStartTime(SOME_DATE_TIME);
         transcription2.setEndTime(SOME_DATE_TIME);
-        transcription2 = dartsDatabase.save(transcription2);
+        transcription2 = dartsDatabase.getTranscriptionRepository().save(transcription2);
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URI)
             .queryParam("transcription_id", transcription2.getId().toString())

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetYourTranscriptsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetYourTranscriptsIntTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @Transactional
-@Disabled("Impacted by V1_364_*.sql - fix needed")
+@Disabled("Impacted by V1_364_*.sql - fix needed (Validation)")
 class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT_URI = URI.create("/transcriptions");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetYourTranscriptsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetYourTranscriptsIntTest.java
@@ -29,7 +29,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @Transactional
-@Disabled("Impacted by V1_364_*.sql - fix needed (Validation)")
 class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT_URI = URI.create("/transcriptions");
@@ -63,6 +62,7 @@ class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Failed Validation")
     void getYourTranscriptsShouldReturnRequesterOnlyOk() throws Exception {
         var courtCase = authorisationStub.getCourtCaseEntity();
         var hearing = authorisationStub.getHearingEntity();
@@ -100,6 +100,7 @@ class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Failed Validation")
     void getYourTranscriptsShouldReturnRequesterOnlyOkWithNoUrgency() throws Exception {
         var courtCase = authorisationStub.getCourtCaseEntity();
         var hearing = authorisationStub.getHearingEntity();
@@ -150,6 +151,7 @@ class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Failed Validation")
     void getYourTranscriptsShouldReturnRequesterAndApproverCombinedOk() throws Exception {
         var courtCase = authorisationStub.getCourtCaseEntity();
         var systemUserTranscription = dartsDatabase.getTranscriptionStub()
@@ -231,6 +233,7 @@ class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Failed Validation")
     void getYourTranscriptsRequesterShouldNotReturnHidden() throws Exception {
         var courtCase = authorisationStub.getCourtCaseEntity();
         var hearing = authorisationStub.getHearingEntity();
@@ -251,6 +254,7 @@ class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Failed Validation")
     void getYourTranscriptsApproverShouldNotReturnHidden() throws Exception {
         var courtCase = authorisationStub.getCourtCaseEntity();
         TranscriptionEntity systemUserTranscription = dartsDatabase.getTranscriptionStub()
@@ -277,6 +281,7 @@ class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Failed Validation")
     void getYourTranscriptsShouldNotReturnTranscriptWhenIsCurrentFalse() throws Exception {
         var courtCase = authorisationStub.getCourtCaseEntity();
         transcriptionStub.createAndSaveAwaitingAuthorisationTranscription(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetYourTranscriptsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetYourTranscriptsIntTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @Transactional
-@Disabled("Impacted by V1_364_*.sql")
+@Disabled("Impacted by V1_364_*.sql - fix needed")
 class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT_URI = URI.create("/transcriptions");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -59,6 +60,7 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.RE
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.ExcessiveImports"})
 @Transactional
+@Disabled("Pass locally but not in Jenkins need to investigate")
 class TranscriptionControllerRequestTranscriptionIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT_URI = URI.create("/transcriptions");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -60,7 +59,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.RE
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.ExcessiveImports"})
 @Transactional
-@Disabled("Impacted by V1_364_*.sql")
 class TranscriptionControllerRequestTranscriptionIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT_URI = URI.create("/transcriptions");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -60,7 +59,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.RE
 @AutoConfigureMockMvc
 @SuppressWarnings({"PMD.ExcessiveImports"})
 @Transactional
-@Disabled("Pass locally but not in Jenkins need to investigate")
 class TranscriptionControllerRequestTranscriptionIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT_URI = URI.create("/transcriptions");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionAdminApprovedIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionAdminApprovedIntTest.java
@@ -43,7 +43,7 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WI
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql")
+@Disabled("Impacted by V1_364_*.sql - fix needed")
 class TranscriptionControllerUpdateTranscriptionAdminApprovedIntTest extends IntegrationBase {
 
     public static final String ENDPOINT_URL = "/admin/transcriptions/%d";

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionAdminApprovedIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionAdminApprovedIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -29,6 +28,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -43,7 +43,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WI
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql - fix needed")
 class TranscriptionControllerUpdateTranscriptionAdminApprovedIntTest extends IntegrationBase {
 
     public static final String ENDPOINT_URL = "/admin/transcriptions/%d";
@@ -81,7 +80,7 @@ class TranscriptionControllerUpdateTranscriptionAdminApprovedIntTest extends Int
 
         testUser = dartsDatabase.getUserAccountStub().createSuperAdminUser();
         when(mockUserIdentity.getUserAccount()).thenReturn(testUser);
-        when(mockUserIdentity.userHasGlobalAccess(Set.of(SUPER_ADMIN))).thenReturn(true);
+        when(mockUserIdentity.userHasGlobalAccess(any())).thenReturn(true);
         transcriptCreatorId = authorisationStub.getTestUser().getId();
 
         doNothing().when(mockAuditApi)

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionApprovedIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionApprovedIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -49,7 +48,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WI
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql")
 class TranscriptionControllerUpdateTranscriptionApprovedIntTest extends IntegrationBase {
 
     @MockBean

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionRejectedIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionRejectedIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -45,7 +44,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WI
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql")
 class TranscriptionControllerUpdateTranscriptionRejectedIntTest extends IntegrationBase {
 
     @MockBean

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionWithTranscriberIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionWithTranscriberIntTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.transcriptions.controller;
 
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -44,7 +43,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.WI
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql")
 class TranscriptionControllerUpdateTranscriptionWithTranscriberIntTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionsTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -47,7 +46,6 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.AW
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql - fix needed")
 class TranscriptionControllerUpdateTranscriptionsTest extends IntegrationBase {
 
     @MockBean

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerUpdateTranscriptionsTest.java
@@ -47,7 +47,7 @@ import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.AW
 @AutoConfigureMockMvc
 @Transactional
 @SuppressWarnings({"PMD.ExcessiveImports"})
-@Disabled("Impacted by V1_364_*.sql")
+@Disabled("Impacted by V1_364_*.sql - fix needed")
 class TranscriptionControllerUpdateTranscriptionsTest extends IntegrationBase {
 
     @MockBean

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/MigratedTranscriptionSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/MigratedTranscriptionSearchTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.transcriptions.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -13,7 +12,6 @@ import static java.time.LocalDate.now;
 import static java.time.LocalDate.parse;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled("Impacted by V1_364_*.sql")
 class MigratedTranscriptionSearchTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/ModernisedTranscriptionSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/ModernisedTranscriptionSearchTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.transcriptions.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -13,7 +12,6 @@ import static java.time.LocalDate.now;
 import static java.time.LocalDate.parse;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled("Impacted by V1_364_*.sql")
 class ModernisedTranscriptionSearchTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/TranscriptionReportingRestrictionsMapperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/TranscriptionReportingRestrictionsMapperTest.java
@@ -39,6 +39,7 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void mapsOneReportingRestrictionsCorrectly() {
         var reportingRestrictions = createEventsWithDefaults(1).stream()
             .map(eve -> dartsDatabase.addHandlerToEvent(eve, someReportingRestrictionId()))
@@ -57,6 +58,7 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void mapsMultipleReportingRestrictionsValuesCorrectly() {
         var reportingRestrictions = createEventsWithDifferentTimestamps(3).stream()
             .map(eve -> dartsDatabase.addHandlerToEvent(eve, someReportingRestrictionId()))
@@ -75,6 +77,7 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void ordersMultipleReportingRestrictionsElementCorrectly() {
         var reportingRestrictions = createEventsWithDifferentTimestamps(10).stream()
             .map(eve -> dartsDatabase.addHandlerToEvent(eve, someReportingRestrictionId()))
@@ -92,6 +95,7 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
+    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void includesReportingRestrictionsLifted() {
         var event1 = dartsDatabase.getEventStub().createDefaultEvent();
         event1.setTimestamp(now().minusDays(1));
@@ -115,7 +119,6 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void includesReportingRestrictionsLiftedWhenReapplied() {
         var event1 = dartsDatabase.getEventStub().createDefaultEvent();
         event1.setTimestamp(now().minusDays(2));
@@ -146,7 +149,6 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql")
     void includesMigratedCaseWithRestrictionPersistedOnCaseTable() {
         var caseWithReportingRestrictions = dartsDatabase.addHandlerToCase(createSomeMinimalCase(), someReportingRestrictionId());
         var transcriptionEntity = dartsDatabase.getTranscriptionStub().createTranscription(caseWithReportingRestrictions);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/TranscriptionReportingRestrictionsMapperTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/TranscriptionReportingRestrictionsMapperTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.transcriptions.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
@@ -39,7 +38,6 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void mapsOneReportingRestrictionsCorrectly() {
         var reportingRestrictions = createEventsWithDefaults(1).stream()
             .map(eve -> dartsDatabase.addHandlerToEvent(eve, someReportingRestrictionId()))
@@ -58,7 +56,6 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void mapsMultipleReportingRestrictionsValuesCorrectly() {
         var reportingRestrictions = createEventsWithDifferentTimestamps(3).stream()
             .map(eve -> dartsDatabase.addHandlerToEvent(eve, someReportingRestrictionId()))
@@ -77,7 +74,6 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void ordersMultipleReportingRestrictionsElementCorrectly() {
         var reportingRestrictions = createEventsWithDifferentTimestamps(10).stream()
             .map(eve -> dartsDatabase.addHandlerToEvent(eve, someReportingRestrictionId()))
@@ -95,7 +91,6 @@ class TranscriptionReportingRestrictionsMapperTest extends IntegrationBase {
     }
 
     @Test
-    @Disabled("Impacted by V1_364_*.sql - fix needed")
     void includesReportingRestrictionsLifted() {
         var event1 = dartsDatabase.getEventStub().createDefaultEvent();
         event1.setTimestamp(now().minusDays(1));

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/TranscriptionWorkflowAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/service/TranscriptionWorkflowAuditTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.transcriptions.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.AuditEntity;
@@ -19,7 +18,6 @@ import static org.springframework.data.history.RevisionMetadata.RevisionType.INS
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionUrgencyEnum.STANDARD;
 
-@Disabled("Impacted by V1_364_*.sql")
 class TranscriptionWorkflowAuditTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/GetSecurityGroupsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/GetSecurityGroupsIntTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.usermanagement.controller;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -41,7 +40,6 @@ class GetSecurityGroupsIntTest extends IntegrationBase {
     private MockMvc mockMvc;
 
     @Test
-    @Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
     void givenAUserNotAuthorisedThenReturnA403() throws Exception {
         superAdminUserStub.givenUserIsNotAuthorised(userIdentity);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerTest.java
@@ -90,7 +90,15 @@ class UserControllerTest extends IntegrationBase {
         UserAccountEntity userAccountEntity = UserAccountTestData.minimalUserAccount();
         userAccountEntity = userAccountRepository.save(userAccountEntity);
 
-        dartsDatabase.addUserToGroup(userAccountEntity, SecurityGroupEnum.SUPER_ADMIN);
+
+        Optional<SecurityGroupEntity> groupEntity
+            = securityGroupRepository.findByGroupNameIgnoreCase(SecurityGroupEnum.SUPER_ADMIN.getName());
+
+
+        userAccountEntity.getSecurityGroupEntities().add(groupEntity.get());
+        userAccountEntity = dartsDatabaseStub.save(userAccountEntity);
+
+
 
         HearingEntity hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
             SOME_CASE_ID,
@@ -148,11 +156,10 @@ class UserControllerTest extends IntegrationBase {
         // add user to the super user group
         Optional<SecurityGroupEntity> groupEntity
             = securityGroupRepository.findByGroupNameIgnoreCase(SecurityGroupEnum.SUPER_USER.getName());
-        Set<UserAccountEntity> entitiesSet = new HashSet<>();
-        entitiesSet.add(userAccountEntity);
 
-        groupEntity.get().setUsers(entitiesSet);
-        dartsDatabase.addUserToGroup(userAccountEntity, groupEntity.get());
+
+        userAccountEntity.getSecurityGroupEntities().add(groupEntity.get());
+        userAccountEntity = dartsDatabaseStub.save(userAccountEntity);
 
         HearingEntity hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
             SOME_CASE_ID,
@@ -213,11 +220,10 @@ class UserControllerTest extends IntegrationBase {
         // add user to the super admin group
         Optional<SecurityGroupEntity> groupEntity
             = securityGroupRepository.findByGroupNameIgnoreCase(SecurityGroupEnum.SUPER_ADMIN.getName());
-        Set<UserAccountEntity> entitiesSet = new HashSet<>();
-        entitiesSet.add(userAccountEntity);
 
-        groupEntity.get().setUsers(entitiesSet);
-        dartsDatabase.addUserToGroup(userAccountEntity, groupEntity.get());
+
+        userAccountEntity.getSecurityGroupEntities().add(groupEntity.get());
+        userAccountEntity = dartsDatabaseStub.save(userAccountEntity);
 
         HearingEntity hearingEntity
             = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
@@ -275,11 +281,10 @@ class UserControllerTest extends IntegrationBase {
         // add user to the super admin group
         Optional<SecurityGroupEntity> groupEntity
             = securityGroupRepository.findByGroupNameIgnoreCase(SecurityGroupEnum.SUPER_ADMIN.getName());
-        Set<UserAccountEntity> entitiesSet = new HashSet<>();
-        entitiesSet.add(userAccountEntity);
 
-        groupEntity.get().setUsers(entitiesSet);
-        dartsDatabase.addUserToGroup(userAccountEntity, groupEntity.get());
+
+        userAccountEntity.getSecurityGroupEntities().add(groupEntity.get());
+        userAccountEntity = dartsDatabaseStub.save(userAccountEntity);
 
         HearingEntity hearingEntity
             = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
@@ -325,11 +330,10 @@ class UserControllerTest extends IntegrationBase {
         // add user to the super admin group
         Optional<SecurityGroupEntity> groupEntity
             = securityGroupRepository.findByGroupNameIgnoreCase(SecurityGroupEnum.SUPER_ADMIN.getName());
-        Set<UserAccountEntity> entitiesSet = new HashSet<>();
-        entitiesSet.add(userAccountEntity);
 
-        groupEntity.get().setUsers(entitiesSet);
-        dartsDatabase.addUserToGroup(userAccountEntity, groupEntity.get());
+
+        userAccountEntity.getSecurityGroupEntities().add(groupEntity.get());
+        userAccountEntity = dartsDatabaseStub.save(userAccountEntity);
 
         HearingEntity hearingEntity
             = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
@@ -373,11 +377,10 @@ class UserControllerTest extends IntegrationBase {
         // add user to the super admin group
         Optional<SecurityGroupEntity> groupEntity
             = securityGroupRepository.findByGroupNameIgnoreCase(SecurityGroupEnum.SUPER_ADMIN.getName());
-        Set<UserAccountEntity> entitiesSet = new HashSet<>();
-        entitiesSet.add(userAccountEntity);
 
-        groupEntity.get().setUsers(entitiesSet);
-        dartsDatabase.addUserToGroup(userAccountEntity, groupEntity.get());
+
+        userAccountEntity.getSecurityGroupEntities().add(groupEntity.get());
+        userAccountEntity = dartsDatabaseStub.save(userAccountEntity);
 
         HearingEntity hearingEntity
             = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
@@ -420,7 +423,13 @@ class UserControllerTest extends IntegrationBase {
         // clear all users that are associated with the super admin group
         securityGroupStub.clearUsers(SecurityGroupEnum.SUPER_ADMIN);
 
-        dartsDatabaseStub.addUserToGroup(userAccountEntity, SecurityGroupEnum.SUPER_ADMIN);
+        Optional<SecurityGroupEntity> groupEntity
+            = securityGroupRepository.findByGroupNameIgnoreCase(SecurityGroupEnum.SUPER_ADMIN.getName());
+        Set<UserAccountEntity> entitiesSet = new HashSet<>();
+        entitiesSet.add(userAccountEntity);
+
+        userAccountEntity.getSecurityGroupEntities().add(groupEntity.get());
+        userAccountEntity = dartsDatabaseStub.save(userAccountEntity);
 
         HearingEntity hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
             SOME_CASE_ID,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/RetentionPolicyAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/RetentionPolicyAuditTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.usermanagement.service;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.common.entity.AuditEntity;
@@ -19,7 +18,6 @@ import static org.springframework.data.history.RevisionMetadata.RevisionType.UPD
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 import static uk.gov.hmcts.darts.test.common.data.RetentionPolicyTestData.minimalRetentionPolicy;
 
-@Disabled("Impacted by V1_362__constraint_transcription_part6.sql - needs fix")
 class RetentionPolicyAuditTest extends IntegrationBase {
 
     @Autowired
@@ -50,7 +48,7 @@ class RetentionPolicyAuditTest extends IntegrationBase {
         var userAccountEntity = given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
         var priorPolicyEntity = minimalRetentionPolicy();
         priorPolicyEntity.setPolicyStart(OffsetDateTime.now().minusWeeks(1));
-        dartsDatabase.saveWithTransientEntities(priorPolicyEntity);
+        dartsDatabase.save(priorPolicyEntity);
 
         // When
         var adminPostRetentionRevision = adminPostRetentionRequestWithDefaults();
@@ -77,7 +75,7 @@ class RetentionPolicyAuditTest extends IntegrationBase {
         var userAccountEntity = given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
         var retentionPolicyType = minimalRetentionPolicy();
         retentionPolicyType.setPolicyStart(OffsetDateTime.now().plusWeeks(1));
-        dartsDatabase.saveWithTransientEntities(retentionPolicyType);
+        dartsDatabase.save(retentionPolicyType);
 
         // When
         var adminPatchRetentionPolicy = new AdminPatchRetentionRequest().name("some-new-patched-name");
@@ -98,6 +96,7 @@ class RetentionPolicyAuditTest extends IntegrationBase {
             .name("some-retention-policy-name")
             .fixedPolicyKey("some-fixed-policy-key")
             .description("some-description")
+            .displayName("some-display-name")
             .policyStartAt(OffsetDateTime.now().plusWeeks(1))
             .duration("1Y2M3D");
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/RetentionPolicyAuditTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/RetentionPolicyAuditTest.java
@@ -19,7 +19,7 @@ import static org.springframework.data.history.RevisionMetadata.RevisionType.UPD
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 import static uk.gov.hmcts.darts.test.common.data.RetentionPolicyTestData.minimalRetentionPolicy;
 
-@Disabled("Impacted by V1_362__constraint_transcription_part6.sql")
+@Disabled("Impacted by V1_362__constraint_transcription_part6.sql - needs fix")
 class RetentionPolicyAuditTest extends IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/resources/tests/arm/service/testGenerateCaseArchiveRecord/all_properties/expectedResponse.a360
+++ b/src/integrationTest/resources/tests/arm/service/testGenerateCaseArchiveRecord/all_properties/expectedResponse.a360
@@ -9,7 +9,7 @@
     "event_date": "<UPLOADED_DATE_TIME>",
     "title": "test_filename",
     "client_identifier": "<EODID>",
-    "contributor": "Bristol",
+    "contributor": "BRISTOL",
     "rtn_score":2,
     "rtn_reason":"RetentionConfidenceReason",
     "bf_001": "Case",
@@ -17,9 +17,10 @@
     "bf_003": "docx",
     "bf_005": "xC3CCA7021CF79B42F245AF350601C284",
     "bf_010": "<UPLOADED_DATE_TIME>",
+    "bf_011": "<bf_011>",
     "bf_012": <OBJECT_ID>,
     "bf_013": <PARENT_ID>,
-    "bf_019": "Bristol"
+    "bf_019": "BRISTOL"
   }
 }
 {

--- a/src/integrationTest/resources/tests/arm/service/testGenerateCaseArchiveRecord/all_properties/expectedResponse.a360
+++ b/src/integrationTest/resources/tests/arm/service/testGenerateCaseArchiveRecord/all_properties/expectedResponse.a360
@@ -17,7 +17,6 @@
     "bf_003": "docx",
     "bf_005": "xC3CCA7021CF79B42F245AF350601C284",
     "bf_010": "<UPLOADED_DATE_TIME>",
-    "bf_011": "<bf_011>",
     "bf_012": <OBJECT_ID>,
     "bf_013": <PARENT_ID>,
     "bf_019": "BRISTOL"

--- a/src/integrationTest/resources/tests/arm/service/testGenerateCaseArchiveRecord/expectedResponse.a360
+++ b/src/integrationTest/resources/tests/arm/service/testGenerateCaseArchiveRecord/expectedResponse.a360
@@ -9,7 +9,7 @@
     "event_date": "<EVENT_DATE_TIME>",
     "title": "test_case_document.docx",
     "client_identifier": "<EODID>",
-    "contributor": "Bristol",
+    "contributor": "BRISTOL",
     "rtn_score":2,
     "rtn_reason":"RetentionConfidenceReason",
     "bf_001": "Case",
@@ -19,7 +19,7 @@
     "bf_010": "<UPLOADED_DATE_TIME>",
     "bf_012": <OBJECT_ID>,
     "bf_013": <PARENT_ID>,
-    "bf_019": "Bristol"
+    "bf_019": "BRISTOL"
   }
 }
 {

--- a/src/integrationTest/resources/tests/cases/CaseControllerAdminSearchTest/testOk/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerAdminSearchTest/testOk/expectedResponse.json
@@ -14,6 +14,7 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponse.json
@@ -30,6 +30,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponseDateRange.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponseDateRange.json
@@ -30,7 +30,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case2",
@@ -63,7 +64,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case3",
@@ -98,7 +100,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case4",
@@ -131,7 +134,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case5",
@@ -164,7 +168,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case6",
@@ -199,6 +204,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponseEventText.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponseEventText.json
@@ -30,6 +30,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponseJudgeName.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponseJudgeName.json
@@ -32,6 +32,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/allResults/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/allResults/expectedResponse.json
@@ -14,7 +14,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case2",
@@ -31,7 +32,8 @@
     ],
     "defendants": [
       "Defendant2"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case3",
@@ -49,7 +51,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case4",
@@ -69,7 +72,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case5",
@@ -92,7 +96,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case6",
@@ -116,7 +121,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case7",
@@ -133,7 +139,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case8",
@@ -150,7 +157,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case9",
@@ -167,7 +175,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case10",
@@ -184,6 +193,7 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/hearingDateEndOnly/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/hearingDateEndOnly/expectedResponse.json
@@ -14,7 +14,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case9",
@@ -31,6 +32,7 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/hearingDateStartAndEndOnly/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/hearingDateStartAndEndOnly/expectedResponse.json
@@ -14,7 +14,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case9",
@@ -31,6 +32,7 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/hearingDateStartOnly/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/hearingDateStartOnly/expectedResponse.json
@@ -14,7 +14,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case8",
@@ -31,7 +32,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case10",
@@ -48,6 +50,7 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/multipleFieldsExcludingHearingDate/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/multipleFieldsExcludingHearingDate/expectedResponse.json
@@ -15,6 +15,7 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/usingCourthouseIds/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/usingCourthouseIds/expectedResponse.json
@@ -14,7 +14,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case2",
@@ -31,7 +32,8 @@
     ],
     "defendants": [
       "Defendant2"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case3",
@@ -49,7 +51,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case4",
@@ -69,7 +72,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case5",
@@ -92,7 +96,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case6",
@@ -116,7 +121,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case7",
@@ -133,7 +139,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case8",
@@ -150,7 +157,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case9",
@@ -167,7 +175,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case10",
@@ -184,6 +193,7 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/usingEmptyCourthouseIds/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdminSearchTest/usingEmptyCourthouseIds/expectedResponse.json
@@ -14,7 +14,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case2",
@@ -31,7 +32,8 @@
     ],
     "defendants": [
       "Defendant2"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case3",
@@ -49,7 +51,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case4",
@@ -69,7 +72,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case5",
@@ -92,7 +96,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case6",
@@ -116,7 +121,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case7",
@@ -133,7 +139,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case8",
@@ -150,7 +157,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case9",
@@ -167,7 +175,8 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case10",
@@ -184,6 +193,7 @@
     ],
     "defendants": [
       "aDefendant"
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithCaseNumber/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithCaseNumber/expectedResponse.json
@@ -30,7 +30,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case10",
@@ -49,6 +50,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithCourtroom/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithCourtroom/expectedResponse.json
@@ -30,7 +30,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case5",
@@ -63,7 +64,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case6",
@@ -98,6 +100,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithCourtroomJudge/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithCourtroomJudge/expectedResponse.json
@@ -32,6 +32,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithDateRangeFrom/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithDateRangeFrom/expectedResponse.json
@@ -32,7 +32,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case4",
@@ -65,7 +66,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case5",
@@ -98,7 +100,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case6",
@@ -133,7 +136,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case7",
@@ -159,7 +163,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case8",
@@ -178,7 +183,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "case10",
@@ -197,6 +203,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithDateRangeFromTo/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithDateRangeFromTo/expectedResponse.json
@@ -30,7 +30,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case3",
@@ -65,6 +66,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithDateRangeFromToSameDate/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithDateRangeFromToSameDate/expectedResponse.json
@@ -16,6 +16,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithDateRangeTo/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithDateRangeTo/expectedResponse.json
@@ -30,7 +30,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case2",
@@ -63,6 +64,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithEventText/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithEventText/expectedResponse.json
@@ -30,6 +30,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithJudge/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithJudge/expectedResponse.json
@@ -32,6 +32,7 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithJudgeMultipleCourtHouses/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseServiceAdvancedSearchTest/getWithJudgeMultipleCourtHouses/expectedResponse.json
@@ -32,7 +32,8 @@
           "AJUDGE"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   },
   {
     "case_number": "Case9",
@@ -51,6 +52,7 @@
           "JUDGE3A"
         ]
       }
-    ]
+    ],
+    "is_data_anonymised": false
   }
 ]

--- a/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
+++ b/src/main/java/uk/gov/hmcts/darts/admin/test/TestSupportController.java
@@ -218,12 +218,16 @@ public class TestSupportController {
         courtCase.setClosed(false);
         courtCase.setInterpreterUsed(false);
 
-        Optional<CourthouseEntity> foundCourthouse = courthouseRepository.findByCourthouseName(
-            courthouseName);
+        courtCase.setCreatedBy(userAccountRepository.getReferenceById(0));
+        courtCase.setCreatedDateTime(OffsetDateTime.now());
+        courtCase.setLastModifiedBy(userAccountRepository.getReferenceById(0));
+        courtCase.setLastModifiedDateTime(OffsetDateTime.now());
+
+        Optional<CourthouseEntity> foundCourthouse = courthouseRepository.findByCourthouseName(StringUtils.toRootUpperCase(courthouseName));
         if (foundCourthouse.isPresent()) {
             courtCase.setCourthouse(foundCourthouse.get());
         } else {
-            return new ResponseEntity<>(BAD_REQUEST);
+            return new ResponseEntity<>("Court house not found", BAD_REQUEST);
         }
 
         CourtCaseEntity savedCase = caseRepository.saveAndFlush(courtCase);
@@ -437,6 +441,11 @@ public class TestSupportController {
         courtCase.setCaseNumber(caseNumber);
         courtCase.setClosed(false);
         courtCase.setInterpreterUsed(false);
+
+        courtCase.setCreatedBy(userAccountRepository.getReferenceById(0));
+        courtCase.setCreatedDateTime(OffsetDateTime.now());
+        courtCase.setLastModifiedBy(userAccountRepository.getReferenceById(0));
+        courtCase.setLastModifiedDateTime(OffsetDateTime.now());
 
         String courtroomName = "func-" + randomAlphanumeric(7);
         String courthouseName = "func-" + randomAlphanumeric(7);

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedBaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedBaseEntity.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.envers.NotAudited;
+import org.springframework.data.annotation.CreatedBy;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
 import java.time.OffsetDateTime;
@@ -24,6 +25,7 @@ public class CreatedBaseEntity {
     @NotAudited
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by")
+    @CreatedBy
     private UserAccountEntity createdBy;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedBaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedBaseEntity.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.envers.NotAudited;
-import org.springframework.data.annotation.CreatedBy;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
 import java.time.OffsetDateTime;
@@ -25,7 +24,6 @@ public class CreatedBaseEntity {
     @NotAudited
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "created_by")
-    @CreatedBy
     private UserAccountEntity createdBy;
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedModifiedBaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedModifiedBaseEntity.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.envers.NotAudited;
-import org.springframework.data.annotation.LastModifiedBy;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
 import java.time.OffsetDateTime;
@@ -26,6 +25,5 @@ public class CreatedModifiedBaseEntity extends CreatedBaseEntity {
     @NotAudited
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "last_modified_by")
-    @LastModifiedBy
     private UserAccountEntity lastModifiedBy;
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedModifiedBaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/base/CreatedModifiedBaseEntity.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.envers.NotAudited;
+import org.springframework.data.annotation.LastModifiedBy;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
 import java.time.OffsetDateTime;
@@ -25,5 +26,6 @@ public class CreatedModifiedBaseEntity extends CreatedBaseEntity {
     @NotAudited
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "last_modified_by")
+    @LastModifiedBy
     private UserAccountEntity lastModifiedBy;
 }

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/RetentionPolicyTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/RetentionPolicyTestData.java
@@ -16,6 +16,7 @@ public class RetentionPolicyTestData {
         minimalRetentionPolicy.setFixedPolicyKey("some-fixed-policy-key");
         minimalRetentionPolicy.setPolicyName("some-policy-name");
         minimalRetentionPolicy.setDuration("some-duration");
+        minimalRetentionPolicy.setDisplayName("some-display-name");
         minimalRetentionPolicy.setPolicyStart(OffsetDateTime.now());
         minimalRetentionPolicy.setCreatedBy(minimalUserAccount());
         minimalRetentionPolicy.setLastModifiedBy(minimalUserAccount());

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/RetentionPolicyTypeTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/RetentionPolicyTypeTestData.java
@@ -18,6 +18,7 @@ public class RetentionPolicyTypeTestData {
         var retentionPolicyType = new RetentionPolicyTypeEntity();
         retentionPolicyType.setFixedPolicyKey("some-fixed-policy-key-" + postfix);
         retentionPolicyType.setPolicyName("some-policy-name-" + postfix);
+        retentionPolicyType.setDisplayName("some-display-name-" + postfix);
         retentionPolicyType.setDuration("some-duration");
         retentionPolicyType.setPolicyStart(OffsetDateTime.now());
         retentionPolicyType.setCreatedBy(minimalUserAccount());


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-3821)


### Change description ###
Renable integration tests that were disabled when adding various non-null constraints to the datamodel. These tests can be identified by searching for `@Disabled("Impacted by ...")`.

The approach is to work through each feature/package under `src/integrationTest/java/uk/gov/hmcts/darts`, raising a PR per package.

The following list items will be struckthrough as they're resolved. See ticket comments for further details.
 * admin
 * -annotation-
 * -arm-
 * -audio-
 * authorisation
 * -casedocument-
 * cases - ME
 * common
 * courthouse
 * dailylist
 * event
 * hearings
 * noderegistration
 * notification
 * retention
 * task
 * transcriptions
 * usermanagement

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
