### PR TITLE
DMP-3959 - Set is_anonymised on events and transcription comments when case expiry job runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
   id 'jacoco'
   id 'idea'
   id 'io.spring.dependency-management' version '1.1.6'
-  id 'org.springframework.boot' version '3.3.3'
+  id 'org.springframework.boot' version '3.3.4'
   id 'org.owasp.dependencycheck' version '10.0.4'
   id 'com.github.ben-manes.versions' version '0.51.0'
   id 'org.sonarqube' version '5.1.0.4882'

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskITest.java
@@ -177,19 +177,21 @@ class CaseExpiryDeletionAutomatedTaskITest extends PostgresIntegrationBase {
     }
 
     private void assertEvent(EventEntity eventEntity, boolean isAnonymized) {
-        assertThat(eventEntity.isDataAnonymised()).isFalse();
         if (isAnonymized) {
+            assertThat(eventEntity.isDataAnonymised()).isTrue();
             assertThat(eventEntity.getEventText()).matches(UUID_REGEX);
         } else {
+            assertThat(eventEntity.isDataAnonymised()).isFalse();
             assertThat(eventEntity.getEventText()).doesNotMatch(UUID_REGEX);
         }
     }
 
     private void assertTranscriptionComment(TranscriptionCommentEntity transcriptionCommentEntity, boolean isAnonymized) {
-        assertThat(transcriptionCommentEntity.isDataAnonymised()).isFalse();
         if (isAnonymized) {
+            assertThat(transcriptionCommentEntity.isDataAnonymised()).isTrue();
             assertThat(transcriptionCommentEntity.getComment()).matches(UUID_REGEX);
         } else {
+            assertThat(transcriptionCommentEntity.isDataAnonymised()).isFalse();
             assertThat(transcriptionCommentEntity.getComment()).doesNotMatch(UUID_REGEX);
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/service/DataAnonymisationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/DataAnonymisationService.java
@@ -12,11 +12,11 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
 public interface DataAnonymisationService {
-    default void anonymizeCourtCaseEntity(CourtCaseEntity courtCase, boolean isManual) {
-        anonymizeCourtCaseEntity(getUserAccount(), courtCase, isManual);
+    default void anonymizeCourtCaseEntity(CourtCaseEntity courtCase) {
+        anonymizeCourtCaseEntity(getUserAccount(), courtCase);
     }
 
-    void anonymizeCourtCaseEntity(UserAccountEntity userAccount, CourtCaseEntity courtCase, boolean isManual);
+    void anonymizeCourtCaseEntity(UserAccountEntity userAccount, CourtCaseEntity courtCase);
 
     void anonymizeDefenceEntity(UserAccountEntity userAccount, DefenceEntity entity);
 
@@ -24,15 +24,13 @@ public interface DataAnonymisationService {
 
     void anonymizeProsecutorEntity(UserAccountEntity userAccount, ProsecutorEntity entity);
 
-    void anonymizeHearingEntity(UserAccountEntity userAccount, HearingEntity hearingEntity, boolean isManual);
+    void anonymizeHearingEntity(UserAccountEntity userAccount, HearingEntity hearingEntity);
 
-    void anonymizeEventEntity(UserAccountEntity userAccount, EventEntity eventEntity, boolean isManual);
+    void anonymizeEventEntity(UserAccountEntity userAccount, EventEntity eventEntity);
 
-    void anonymizeTranscriptionEntity(UserAccountEntity userAccount, TranscriptionEntity transcriptionEntity,
-                                      boolean isManual);
+    void anonymizeTranscriptionEntity(UserAccountEntity userAccount, TranscriptionEntity transcriptionEntity);
 
-    void anonymizeTranscriptionCommentEntity(UserAccountEntity userAccount, TranscriptionCommentEntity transcriptionCommentEntity,
-                                             boolean isManual);
+    void anonymizeTranscriptionCommentEntity(UserAccountEntity userAccount, TranscriptionCommentEntity transcriptionCommentEntity);
 
     void anonymizeTranscriptionWorkflowEntity(TranscriptionWorkflowEntity transcriptionWorkflowEntity);
 

--- a/src/main/java/uk/gov/hmcts/darts/common/service/DataAnonymisationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/DataAnonymisationServiceImpl.java
@@ -31,11 +31,11 @@ public class DataAnonymisationServiceImpl implements DataAnonymisationService {
     private final UserIdentity userIdentity;
 
     @Override
-    public void anonymizeCourtCaseEntity(UserAccountEntity userAccount, CourtCaseEntity courtCase, boolean isManual) {
+    public void anonymizeCourtCaseEntity(UserAccountEntity userAccount, CourtCaseEntity courtCase) {
         courtCase.getDefendantList().forEach(defendantEntity -> anonymizeDefendantEntity(userAccount, defendantEntity));
         courtCase.getDefenceList().forEach(defenceEntity -> anonymizeDefenceEntity(userAccount, defenceEntity));
         courtCase.getProsecutorList().forEach(prosecutorEntity -> anonymizeProsecutorEntity(userAccount, prosecutorEntity));
-        courtCase.getHearings().forEach(hearingEntity -> anonymizeHearingEntity(userAccount, hearingEntity, isManual));
+        courtCase.getHearings().forEach(hearingEntity -> anonymizeHearingEntity(userAccount, hearingEntity));
 
         courtCase.markAsExpired(userAccount);
         auditApi.record(AuditActivity.CASE_EXPIRED, userAccount, courtCase);
@@ -60,36 +60,30 @@ public class DataAnonymisationServiceImpl implements DataAnonymisationService {
     }
 
     @Override
-    public void anonymizeHearingEntity(UserAccountEntity userAccount, HearingEntity hearingEntity, boolean isManual) {
-        hearingEntity.getTranscriptions().forEach(transcriptionEntity -> anonymizeTranscriptionEntity(userAccount, transcriptionEntity, isManual));
-        hearingEntity.getEventList().forEach(eventEntity -> anonymizeEventEntity(userAccount, eventEntity, isManual));
+    public void anonymizeHearingEntity(UserAccountEntity userAccount, HearingEntity hearingEntity) {
+        hearingEntity.getTranscriptions().forEach(transcriptionEntity -> anonymizeTranscriptionEntity(userAccount, transcriptionEntity));
+        hearingEntity.getEventList().forEach(eventEntity -> anonymizeEventEntity(userAccount, eventEntity));
     }
 
     @Override
-    public void anonymizeEventEntity(UserAccountEntity userAccount, EventEntity eventEntity, boolean isManual) {
+    public void anonymizeEventEntity(UserAccountEntity userAccount, EventEntity eventEntity) {
         eventEntity.setEventText(UUID.randomUUID().toString());
         eventEntity.setLastModifiedBy(userAccount);
-        if (isManual) {
-            eventEntity.setDataAnonymised(true);
-        }
+        eventEntity.setDataAnonymised(true);
     }
 
     @Override
-    public void anonymizeTranscriptionEntity(UserAccountEntity userAccount, TranscriptionEntity transcriptionEntity,
-                                             boolean isManual) {
+    public void anonymizeTranscriptionEntity(UserAccountEntity userAccount, TranscriptionEntity transcriptionEntity) {
         transcriptionEntity.getTranscriptionCommentEntities().forEach(
-            transcriptionCommentEntity -> anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity, isManual));
+            transcriptionCommentEntity -> anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity));
         transcriptionEntity.getTranscriptionWorkflowEntities().forEach(this::anonymizeTranscriptionWorkflowEntity);
     }
 
     @Override
-    public void anonymizeTranscriptionCommentEntity(UserAccountEntity userAccount, TranscriptionCommentEntity transcriptionCommentEntity,
-                                                    boolean isManual) {
+    public void anonymizeTranscriptionCommentEntity(UserAccountEntity userAccount, TranscriptionCommentEntity transcriptionCommentEntity) {
         transcriptionCommentEntity.setComment(UUID.randomUUID().toString());
         transcriptionCommentEntity.setLastModifiedBy(userAccount);
-        if (isManual) {
-            transcriptionCommentEntity.setDataAnonymised(true);
-        }
+        transcriptionCommentEntity.setDataAnonymised(true);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTask.java
@@ -59,7 +59,7 @@ public class CaseExpiryDeletionAutomatedTask
         caseRepository.findCasesToBeAnonymized(currentTimeHelper.currentOffsetDateTime(), Limit.of(getAutomatedTaskBatchSize()))
             .forEach(courtCase -> {
                 log.info("Anonymising case with id: {} because the criteria for retention has been met.", courtCase.getId());
-                dataAnonymisationService.anonymizeCourtCaseEntity(courtCase, false);
+                dataAnonymisationService.anonymizeCourtCaseEntity(courtCase);
                 courtCaseEntities.add(courtCase);
             });
         //This also saves defendant, defence and prosecutor entities

--- a/src/test/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImplTest.java
@@ -27,7 +27,6 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -46,24 +45,12 @@ class DataAnonymisationServiceImplTest {
 
 
     @Test
-    void positiveEventEntityAnonymizeIsAutomatic() {
+    void positiveEventEntityAnonymize() {
         EventEntity eventEntity = new EventEntity();
         eventEntity.setEventText("event text");
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        dataAnonymisationService.anonymizeEventEntity(userAccount, eventEntity, false);
-        assertThat(eventEntity.getEventText()).matches(TestUtils.UUID_REGEX);
-        assertThat(eventEntity.isDataAnonymised()).isFalse();//This is only set for manual anonymization
-        assertThat(eventEntity.getLastModifiedBy()).isEqualTo(userAccount);
-    }
-
-    @Test
-    void positiveEventEntityAnonymizeIsManual() {
-        EventEntity eventEntity = new EventEntity();
-        eventEntity.setEventText("event text");
-
-        UserAccountEntity userAccount = new UserAccountEntity();
-        dataAnonymisationService.anonymizeEventEntity(userAccount, eventEntity, true);
+        dataAnonymisationService.anonymizeEventEntity(userAccount, eventEntity);
         assertThat(eventEntity.getEventText()).matches(TestUtils.UUID_REGEX);
         assertThat(eventEntity.isDataAnonymised()).isTrue();
         assertThat(eventEntity.getLastModifiedBy()).isEqualTo(userAccount);
@@ -105,42 +92,21 @@ class DataAnonymisationServiceImplTest {
     }
 
     @Test
-    void positiveAnonymizeTranscriptionCommentEntityIsAutomatic() {
+    void positiveAnonymizeTranscriptionCommentEntity() {
         TranscriptionCommentEntity transcriptionCommentEntity = new TranscriptionCommentEntity();
         transcriptionCommentEntity.setComment("comment");
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        dataAnonymisationService.anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity, false);
-        assertThat(transcriptionCommentEntity.getComment()).matches(TestUtils.UUID_REGEX);
-        assertThat(transcriptionCommentEntity.getLastModifiedBy()).isEqualTo(userAccount);
-        assertThat(transcriptionCommentEntity.isDataAnonymised()).isFalse();//This is only set for manual anonymization
-        assertThat(transcriptionCommentEntity.getLastModifiedBy()).isEqualTo(userAccount);
-    }
-
-    @Test
-    void positiveAnonymizeTranscriptionCommentEntityIsManual() {
-        TranscriptionCommentEntity transcriptionCommentEntity = new TranscriptionCommentEntity();
-        transcriptionCommentEntity.setComment("comment");
-
-        UserAccountEntity userAccount = new UserAccountEntity();
-        dataAnonymisationService.anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity, true);
+        dataAnonymisationService.anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity);
         assertThat(transcriptionCommentEntity.getComment()).matches(TestUtils.UUID_REGEX);
         assertThat(transcriptionCommentEntity.getLastModifiedBy()).isEqualTo(userAccount);
         assertThat(transcriptionCommentEntity.isDataAnonymised()).isTrue();//This is only set for manual anonymization
         assertThat(transcriptionCommentEntity.getLastModifiedBy()).isEqualTo(userAccount);
     }
 
-    @Test
-    void positiveAnonymizeCourtCaseEntityIsAutomatic() {
-        assertPositiveAnonymizeCourtCaseEntity(false);
-    }
 
     @Test
-    void positiveAnonymizeCourtCaseEntityIsManual() {
-        assertPositiveAnonymizeCourtCaseEntity(true);
-    }
-
-    void assertPositiveAnonymizeCourtCaseEntity(boolean isManual) {
+    void assertPositiveAnonymizeCourtCaseEntity() {
         CourtCaseEntity courtCase = new CourtCaseEntity();
 
         DefendantEntity defendantEntity1 = mock(DefendantEntity.class);
@@ -165,9 +131,9 @@ class DataAnonymisationServiceImplTest {
         doNothing().when(dataAnonymisationService).anonymizeDefendantEntity(any(), any());
         doNothing().when(dataAnonymisationService).anonymizeDefenceEntity(any(), any());
         doNothing().when(dataAnonymisationService).anonymizeProsecutorEntity(any(), any());
-        doNothing().when(dataAnonymisationService).anonymizeHearingEntity(any(), any(), anyBoolean());
+        doNothing().when(dataAnonymisationService).anonymizeHearingEntity(any(), any());
 
-        dataAnonymisationService.anonymizeCourtCaseEntity(userAccount, courtCase, isManual);
+        dataAnonymisationService.anonymizeCourtCaseEntity(userAccount, courtCase);
 
         assertThat(courtCase.isDataAnonymised()).isTrue();
         assertThat(courtCase.getDataAnonymisedBy()).isEqualTo(123);
@@ -183,24 +149,13 @@ class DataAnonymisationServiceImplTest {
         verify(dataAnonymisationService, times(1)).anonymizeProsecutorEntity(userAccount, prosecutorEntity1);
         verify(dataAnonymisationService, times(1)).anonymizeProsecutorEntity(userAccount, prosecutorEntity2);
 
-        verify(dataAnonymisationService, times(1)).anonymizeHearingEntity(userAccount, hearingEntity1, isManual);
-        verify(dataAnonymisationService, times(1)).anonymizeHearingEntity(userAccount, hearingEntity2, isManual);
+        verify(dataAnonymisationService, times(1)).anonymizeHearingEntity(userAccount, hearingEntity1);
+        verify(dataAnonymisationService, times(1)).anonymizeHearingEntity(userAccount, hearingEntity2);
     }
 
 
     @Test
-    void positiveAnonymizeTranscriptionEntityIsManual() {
-        positiveAnonymizeTranscriptionEntity(true);
-    }
-
-
-    @Test
-    void positiveAnonymizeTranscriptionEntityIsAutomatic() {
-        positiveAnonymizeTranscriptionEntity(false);
-
-    }
-
-    void positiveAnonymizeTranscriptionEntity(boolean isManual) {
+    void positiveAnonymizeTranscriptionEntity() {
         TranscriptionEntity transcriptionEntity = new TranscriptionEntity();
 
         TranscriptionCommentEntity transcriptionCommentEntity1 = mock(TranscriptionCommentEntity.class);
@@ -211,31 +166,22 @@ class DataAnonymisationServiceImplTest {
         TranscriptionWorkflowEntity transcriptionWorkflowEntity2 = mock(TranscriptionWorkflowEntity.class);
         transcriptionEntity.setTranscriptionWorkflowEntities(List.of(transcriptionWorkflowEntity1, transcriptionWorkflowEntity2));
 
-        doNothing().when(dataAnonymisationService).anonymizeTranscriptionCommentEntity(any(), any(), anyBoolean());
+        doNothing().when(dataAnonymisationService).anonymizeTranscriptionCommentEntity(any(), any());
         doNothing().when(dataAnonymisationService).anonymizeTranscriptionWorkflowEntity(any());
 
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        dataAnonymisationService.anonymizeTranscriptionEntity(userAccount, transcriptionEntity, isManual);
+        dataAnonymisationService.anonymizeTranscriptionEntity(userAccount, transcriptionEntity);
 
-        verify(dataAnonymisationService, times(1)).anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity1, isManual);
-        verify(dataAnonymisationService, times(1)).anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity2, isManual);
+        verify(dataAnonymisationService, times(1)).anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity1);
+        verify(dataAnonymisationService, times(1)).anonymizeTranscriptionCommentEntity(userAccount, transcriptionCommentEntity2);
 
         verify(dataAnonymisationService, times(1)).anonymizeTranscriptionWorkflowEntity(transcriptionWorkflowEntity1);
         verify(dataAnonymisationService, times(1)).anonymizeTranscriptionWorkflowEntity(transcriptionWorkflowEntity2);
     }
 
     @Test
-    void positiveAnonymizeHearingEntityIsAutomatic() {
-        positiveAnonymizeHearingEntity(false);
-    }
-
-    @Test
-    void positiveAnonymizeHearingEntityIsManual() {
-        positiveAnonymizeHearingEntity(true);
-    }
-
-    void positiveAnonymizeHearingEntity(boolean isManual) {
+    void positiveAnonymizeHearingEntity() {
         HearingEntity hearingEntity = new HearingEntity();
 
         TranscriptionEntity transcriptionEntity1 = mock(TranscriptionEntity.class);
@@ -246,17 +192,17 @@ class DataAnonymisationServiceImplTest {
         EventEntity entityEntity2 = mock(EventEntity.class);
         hearingEntity.setEventList(List.of(entityEntity1, entityEntity2));
 
-        doNothing().when(dataAnonymisationService).anonymizeTranscriptionEntity(any(), any(), anyBoolean());
-        doNothing().when(dataAnonymisationService).anonymizeEventEntity(any(), any(), anyBoolean());
+        doNothing().when(dataAnonymisationService).anonymizeTranscriptionEntity(any(), any());
+        doNothing().when(dataAnonymisationService).anonymizeEventEntity(any(), any());
 
         UserAccountEntity userAccount = new UserAccountEntity();
-        dataAnonymisationService.anonymizeHearingEntity(userAccount, hearingEntity, isManual);
+        dataAnonymisationService.anonymizeHearingEntity(userAccount, hearingEntity);
 
-        verify(dataAnonymisationService, times(1)).anonymizeTranscriptionEntity(userAccount, transcriptionEntity1, isManual);
-        verify(dataAnonymisationService, times(1)).anonymizeTranscriptionEntity(userAccount, transcriptionEntity2, isManual);
+        verify(dataAnonymisationService, times(1)).anonymizeTranscriptionEntity(userAccount, transcriptionEntity1);
+        verify(dataAnonymisationService, times(1)).anonymizeTranscriptionEntity(userAccount, transcriptionEntity2);
 
-        verify(dataAnonymisationService, times(1)).anonymizeEventEntity(userAccount, entityEntity1, isManual);
-        verify(dataAnonymisationService, times(1)).anonymizeEventEntity(userAccount, entityEntity2, isManual);
+        verify(dataAnonymisationService, times(1)).anonymizeEventEntity(userAccount, entityEntity1);
+        verify(dataAnonymisationService, times(1)).anonymizeEventEntity(userAccount, entityEntity2);
 
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskTest.java
@@ -71,11 +71,11 @@ class CaseExpiryDeletionAutomatedTaskTest {
             .currentOffsetDateTime();
 
         verify(dataAnonymisationService, times(1))
-            .anonymizeCourtCaseEntity(courtCase1, false);
+            .anonymizeCourtCaseEntity(courtCase1);
         verify(dataAnonymisationService, times(1))
-            .anonymizeCourtCaseEntity(courtCase2, false);
+            .anonymizeCourtCaseEntity(courtCase2);
         verify(dataAnonymisationService, times(1))
-            .anonymizeCourtCaseEntity(courtCase3, false);
+            .anonymizeCourtCaseEntity(courtCase3);
 
 
         verify(caseRepository, times(1))


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-3959)


### Change description ###
When the case expiry job kicks in, the is_anonymised flags should be set on the events and transcription comments linked to a case. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
