### PR TITLE
DMP-3201 - Expire transformed media when original audio is hidden

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
@@ -8,12 +8,14 @@ import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.service.OutboundAudioDeleterProcessor;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestType;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.service.bankholidays.BankHolidaysService;
 import uk.gov.hmcts.darts.test.common.data.MediaRequestTestData;
+import uk.gov.hmcts.darts.test.common.data.MediaTestData;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.TransientObjectDirectoryStub;
 
@@ -402,6 +404,70 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         assertTransientObjectDirectoryStateChanged(markedForDeletion.getId());
         TransientObjectDirectoryEntity tod = dartsDatabase.getTransientObjectDirectoryRepository().findById(markedForDeletion.getId()).get();
         assertEquals(EXPIRED, tod.getTransformedMedia().getMediaRequest().getStatus());
+    }
+
+    @Test
+    void whereLastAccessedWasOneDayAgo() {
+        whereLastAccessedWasOneDayAgoSupport(false, false);
+    }
+
+    @Test
+    void whereLastAccessedWasOneDayAgoButMediaIsHidden() {
+        whereLastAccessedWasOneDayAgoSupport(true, false);
+    }
+
+    @Test
+    void whereLastAccessedWasOneDayAgoButMediaIsDeleted() {
+        whereLastAccessedWasOneDayAgoSupport(false, true);
+    }
+
+    @Test
+    void whereLastAccessedWasOneDayAgoButMediaIsHiddenAndDeleted() {
+        whereLastAccessedWasOneDayAgoSupport(true, true);
+    }
+
+    void whereLastAccessedWasOneDayAgoSupport(boolean isHidden, boolean isDeleted) {
+        HearingEntity hearing = dartsDatabase.createHearing(
+            "NEWCASTLE",
+            "Int Test Courtroom 2",
+            "2",
+            HEARING_DATE
+        );
+
+
+        // Last accessed on a 2023-10-20 friday
+        MediaRequestEntity currentMediaRequest = MediaRequestTestData.createCurrentMediaRequest(
+            hearing,
+            requestor,
+            OffsetDateTime.parse("2023-06-26T13:00:00Z"),
+            OffsetDateTime.parse("2023-06-26T13:45:00Z"),
+            AudioRequestType.DOWNLOAD, COMPLETED
+        );
+        currentMediaRequest = dartsDatabase.save(currentMediaRequest);
+
+
+        MediaEntity mediaEntity =
+            MediaTestData.createMediaWith(hearing.getCourtroom(), currentMediaRequest.getStartTime(), currentMediaRequest.getEndTime(), 1);
+        mediaEntity.setHidden(isHidden);
+        mediaEntity.setDeleted(isDeleted);
+        dartsDatabase.save(mediaEntity);
+        hearing.getMediaList().add(mediaEntity);
+        dartsDatabase.save(hearing);
+        TransientObjectDirectoryEntity notMarkedForDeletion = createStoredTransientDirectory(
+            currentMediaRequest,
+            OffsetDateTime.parse("2023-10-22T13:45:00Z")
+        );
+
+        //setting clock to 2023-10-23 on a monday
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.of(2023, 10, 23, 22, 0, 0, 0, ZoneOffset.UTC));
+
+        if (isHidden || isDeleted) {
+            assertEquals(1, outboundAudioDeleterProcessor.markForDeletion().size());
+            assertTransientObjectDirectoryStateChanged(notMarkedForDeletion.getId());
+        } else {
+            assertEquals(0, outboundAudioDeleterProcessor.markForDeletion().size());
+            assertTransientObjectDirectoryStateNotChanged(notMarkedForDeletion.getId());
+        }
     }
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/OutboundAudioDeleterProcessorTest.java
@@ -227,15 +227,17 @@ class OutboundAudioDeleterProcessorTest extends IntegrationBase {
         );
 
         // Last accessed on a 2023-10-20 friday
-        MediaRequestEntity currentMediaRequest = MediaRequestTestData.createCurrentMediaRequest(
-            hearing,
-            requestor,
-            OffsetDateTime.parse("2023-06-26T13:00:00Z"),
-            OffsetDateTime.parse("2023-06-26T13:45:00Z"),
-            AudioRequestType.DOWNLOAD, COMPLETED
-        );
-        dartsDatabase.save(
-            currentMediaRequest);
+        MediaRequestEntity currentMediaRequest = new MediaRequestTestData()
+            .fromSpec(MediaRequestTestData.TestSpec.builder()
+                          .hearing(hearing)
+                          .requestor(requestor)
+                          .currentOwner(requestor)
+                          .startTime(OffsetDateTime.parse("2023-06-26T13:00:00Z"))
+                          .endTime(OffsetDateTime.parse("2023-06-26T13:45:00Z"))
+                          .requestType(AudioRequestType.DOWNLOAD)
+                          .status(COMPLETED)
+                          .build());
+        dartsDatabase.save(currentMediaRequest);
 
         TransientObjectDirectoryEntity notMarkedForDeletion = createStoredTransientDirectory(
             currentMediaRequest,

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TransformedMediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TransformedMediaRepository.java
@@ -36,7 +36,7 @@ public interface TransformedMediaRepository extends JpaRepository<TransformedMed
         tm.outputFilename,
         tm.outputFormat,
         tm.lastAccessed)
-
+        
         FROM TransformedMediaEntity tm, MediaRequestEntity mr, HearingEntity he, CourtCaseEntity case, CourthouseEntity ch
         WHERE tm.mediaRequest = mr
         and mr.hearing = he
@@ -54,11 +54,19 @@ public interface TransformedMediaRepository extends JpaRepository<TransformedMed
 
     @EntityGraph(attributePaths = {"mediaRequest.currentOwner.securityGroupEntities"})
     @Query("""
-        SELECT tm FROM MediaRequestEntity mr, TransformedMediaEntity tm
+        SELECT tm FROM TransformedMediaEntity tm
         JOIN tm.transientObjectDirectoryEntities tod
-        WHERE tm.mediaRequest = mr
-        AND ((tm.lastAccessed < :createdAtOrLastAccessedDateTime AND mr.status = 'COMPLETED')
-             OR (tm.createdDateTime < :createdAtOrLastAccessedDateTime AND  mr.status <> 'PROCESSING' AND tm.lastAccessed IS NULL))
+        JOIN tm.mediaRequest mr
+        JOIN mr.hearing he
+        LEFT JOIN he.mediaList me on me.start >= mr.startTime and me.end <= mr.endTime
+        WHERE (
+            (tm.lastAccessed < :createdAtOrLastAccessedDateTime AND mr.status = 'COMPLETED')
+            OR (tm.createdDateTime < :createdAtOrLastAccessedDateTime AND  mr.status <> 'PROCESSING' AND tm.lastAccessed IS NULL)
+            OR (
+                me is NOT NULL
+                AND (me.isDeleted = true OR me.isHidden = true)
+           )
+        )
         AND upper(tod.status.description) <> 'MARKED FOR DELETION'
         """)
     List<TransformedMediaEntity> findAllDeletableTransformedMedia(OffsetDateTime createdAtOrLastAccessedDateTime);
@@ -81,7 +89,7 @@ public interface TransformedMediaRepository extends JpaRepository<TransformedMed
            (:requestedBy IS NULL OR (tm.createdBy.userFullName ILIKE CONCAT('%', cast (:requestedBy as text), '%'))) AND
            ((cast(:requestedAtFrom as TIMESTAMP)) IS NULL OR media.createdDateTime >= :requestedAtFrom) AND
            ((cast(:requestedAtTo as TIMESTAMP)) IS NULL OR (media.createdDateTime <= :requestedAtTo))
-           """)
+        """)
     List<TransformedMediaEntity> findTransformedMedia(Integer mediaId,
                                                       String caseNumber,
                                                       String courtHouseDisplayName,


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3201)


### Change description ###
See the [Task automation LLD|https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1689786831#TaskautomationLLD-Markaudiotobedeletedinoutbounddatastore(andmoverequesttoexpired)] for more information.

Enhance the "OutboundAudioDeleter" automated task to expire transformed media which has it's related media set to is_hidden or is_deleted.

As well as expiring transformed media which has not been accessed within the configured number of days (default 2), the task should also check for media which has is_hidden or is_deleted set to true. This can be determined using the route via media_request and hearing to media, filtering by the media request start and end times. If any of the matching media has either flag set the the the transformed media should be expired and associated entries in the transient_object_directory marked for deletion.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
