### PR TITLE
DMP-3915: renamed event search result property `is_manually_anonymise…

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventSearchMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventSearchMapper.java
@@ -19,7 +19,7 @@ public class EventSearchMapper {
             .antecedentId(evr.antecedentId())
             .courthouse(buildCourthouse(evr))
             .courtroom(buildCourtroom(evr))
-            .isManuallyAnonymised(evr.isDataAnonymised())
+            .isEventAnonymised(evr.isDataAnonymised())
             .isCaseExpired(evr.isDataAnonymisedForCase())
             .caseExpiredAt(evr.dataAnonymisedTs());
     }

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -721,7 +721,7 @@ components:
           type: string
         antecedent_id:
           type: string
-        is_manually_anonymised:
+        is_event_anonymised:
           type: boolean
         is_case_expired:
           type: boolean

--- a/src/test/java/uk/gov/hmcts/darts/event/mapper/EventSearchMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/mapper/EventSearchMapperTest.java
@@ -27,7 +27,7 @@ class EventSearchMapperTest {
         assertThat(result.getCourthouse().getDisplayName()).isEqualTo(eventSearchResult.courtHouseDisplayName());
         assertThat(result.getCourtroom().getId()).isEqualTo(eventSearchResult.courtroomId());
         assertThat(result.getCourtroom().getName()).isEqualTo(eventSearchResult.courtroomName());
-        assertThat(result.getIsManuallyAnonymised()).isEqualTo(eventSearchResult.isDataAnonymised());
+        assertThat(result.getIsEventAnonymised()).isEqualTo(eventSearchResult.isDataAnonymised());
         assertThat(result.getIsCaseExpired()).isEqualTo(eventSearchResult.isDataAnonymisedForCase());
         assertThat(result.getCaseExpiredAt()).isEqualTo(eventSearchResult.dataAnonymisedTs());
     }


### PR DESCRIPTION
…d` to `is_event_anonymised`

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3915


### Change description ###
In the original version of the ticket the property was called `is_manually_anonymised`. Now it has been changed to `
is_event_anonymised` so making the change

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
