### PR TITLE
DMP-3908 - Revert "DMP-3908 - Judges showing 'multiple' when case has hearing_is_actual flag set to false"

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdvancedSearchResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdvancedSearchResponseMapper.java
@@ -10,7 +10,6 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @UtilityClass
@@ -21,16 +20,6 @@ public class AdvancedSearchResponseMapper {
         for (HearingEntity hearing : hearings) {
             addHearingToResultList(advancedSearchResults, hearing);
         }
-        //Set the top level judges to be all the distinct judges in each valid hearing for the case
-        advancedSearchResults
-            .forEach(advancedSearchResult ->
-                         advancedSearchResult.setJudges(
-                             Optional.ofNullable(advancedSearchResult.getHearings()).orElseGet(ArrayList::new)
-                                 .stream()
-                                 .map(AdvancedSearchResultHearing::getJudges)
-                                 .flatMap(List::stream)
-                                 .distinct()
-                                 .toList()));
         return advancedSearchResults;
     }
 
@@ -54,6 +43,7 @@ public class AdvancedSearchResponseMapper {
         advancedSearchResult.setCaseNumber(courtCase.getCaseNumber());
         advancedSearchResult.setCourthouse(courtCase.getCourthouse().getDisplayName());
         advancedSearchResult.setDefendants(courtCase.getDefendantStringList());
+        advancedSearchResult.setJudges(courtCase.getJudgeStringList());
         advancedSearchResult.setIsDataAnonymised(courtCase.isDataAnonymised());
         advancedSearchResult.setDataAnonymisedAt(courtCase.getDataAnonymisedTs());
 

--- a/src/test/resources/Tests/cases/AdvancedSearchResponseMapperTest/fourWithTwoSameCase/expectedResponse.json
+++ b/src/test/resources/Tests/cases/AdvancedSearchResponseMapperTest/fourWithTwoSameCase/expectedResponse.json
@@ -9,8 +9,7 @@
     ],
     "judges": [
       "Judge_1",
-      "Judge_2",
-      "Judge_3"
+      "Judge_2"
     ],
     "hearings": [
       {

--- a/src/test/resources/Tests/cases/AdvancedSearchResponseMapperTest/twoSameCase/expectedResponse.json
+++ b/src/test/resources/Tests/cases/AdvancedSearchResponseMapperTest/twoSameCase/expectedResponse.json
@@ -9,8 +9,7 @@
     ],
     "judges": [
       "Judge_1",
-      "Judge_2",
-      "Judge_3"
+      "Judge_2"
     ],
     "hearings": [
       {


### PR DESCRIPTION
Reverts hmcts/darts-api#1963 following design changes.

See https://tools.hmcts.net/jira/browse/DMP-3908 for more details