### PR TITLE
DMP-3966 - allow ATS to go into a loop if multiple requests to process.

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/repository/MediaRequestRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/repository/MediaRequestRepositoryIntTest.java
@@ -7,6 +7,8 @@ import uk.gov.hmcts.darts.common.repository.MediaRequestRepository;
 import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.MediaRequestStub;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.COMPLETED;
 import static uk.gov.hmcts.darts.audio.enums.MediaRequestStatus.OPEN;
@@ -27,7 +29,8 @@ class MediaRequestRepositoryIntTest extends PostgresIntegrationBase {
         mediaRequestStub.createAndSaveMediaRequestEntity(OPEN);
         mediaRequestStub.createAndSaveMediaRequestEntity(OPEN);
 
-        var updatedMediaRequest = mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(mediaRequestEntity.getLastModifiedBy().getId());
+        var updatedMediaRequest = mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(mediaRequestEntity.getLastModifiedBy().getId(),
+                                                                                                   List.of(0));
 
         assertThat(updatedMediaRequest.getId()).isEqualTo(mediaRequest1.getId());
         assertThat(updatedMediaRequest.getStatus()).isEqualTo(PROCESSING);
@@ -40,7 +43,8 @@ class MediaRequestRepositoryIntTest extends PostgresIntegrationBase {
         mediaRequestStub.createAndSaveMediaRequestEntity(COMPLETED);
         mediaRequestStub.createAndSaveMediaRequestEntity(COMPLETED);
 
-        var updatedMediaRequest = mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(mediaRequestEntity.getLastModifiedBy().getId());
+        var updatedMediaRequest = mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(mediaRequestEntity.getLastModifiedBy().getId(),
+                                                                                                   List.of(0));
 
         assertThat(updatedMediaRequest).isNull();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/MediaRequestRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/MediaRequestRepositoryTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 import static uk.gov.hmcts.darts.audiorequests.model.AudioRequestType.DOWNLOAD;
 
@@ -48,7 +49,8 @@ class MediaRequestRepositoryTest extends PostgresIntegrationBase {
         OffsetDateTime createdTime = request.getLastModifiedDateTime();
 
         mediaRequestService.getMediaRequestEntityById(request.getId());
-        MediaRequestEntity mediaRequestEntity = mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(request.getLastModifiedBy().getId());
+        MediaRequestEntity mediaRequestEntity = mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(request.getLastModifiedBy().getId(),
+                                                                                                                 List.of(0));
 
         // prove an update happened on the date and time
         Assertions.assertNotEquals(createdTime.atZoneSameInstant(ZoneOffset.UTC),

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StopAndCloseHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/StopAndCloseHandlerTest.java
@@ -379,6 +379,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertEquals(RetentionConfidenceScoreEnum.CASE_PERFECTLY_CLOSED, persistedCase.getRetConfScore());
 
         // apply retention and check it was applied correctly
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.now().plusMonths(1));
         applyRetentionProcessor.processApplyRetention();
         CaseRetentionEntity processedCaseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findById(caseRetentionEntity.getId()).get();
         assertEquals(String.valueOf(COMPLETE), processedCaseRetentionEntity.getCurrentState());
@@ -473,6 +474,7 @@ class StopAndCloseHandlerTest extends HandlerTestData {
         assertEquals(RetentionConfidenceScoreEnum.CASE_PERFECTLY_CLOSED, persistedCase.getRetConfScore());
 
         // apply retention and check it was applied correctly
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.now().plusMonths(1));
         applyRetentionProcessor.processApplyRetention();
         CaseRetentionEntity processedInitialCaseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findById(initialCaseRetentionEntity.getId()).get();
         CaseRetentionEntity processedLatestCaseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findById(latestCaseRetentionEntity.getId()).get();

--- a/src/main/java/uk/gov/hmcts/darts/audio/config/AudioTransformationServiceProperties.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/config/AudioTransformationServiceProperties.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.darts.audio.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("darts.audio.audio-transformation-service")
+@Getter
+@Setter
+public class AudioTransformationServiceProperties {
+
+    private Integer loopCutoffMinutes;
+}

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/MediaRequestService.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 
 public interface MediaRequestService {
 
+    Optional<MediaRequestEntity> retrieveMediaRequestForProcessing(List<Integer> mediaRequestIdsToIgnore);
+
     AudioNonAccessedResponse countNonAccessedAudioForUser(Integer userId);
 
     MediaRequestEntity getMediaRequestEntityById(Integer id);
@@ -39,8 +41,6 @@ public interface MediaRequestService {
     void deleteTransformedMedia(Integer transformedMediaId);
 
     Optional<MediaRequestEntity> getOldestMediaRequestByStatus(MediaRequestStatus status);
-
-    Optional<MediaRequestEntity> retrieveMediaRequestForProcessing();
 
     GetAudioRequestResponse getAudioRequests(Integer userId, Boolean expired);
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -133,8 +133,12 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     }
 
     @Override
-    public Optional<MediaRequestEntity> retrieveMediaRequestForProcessing() {
-        return Optional.ofNullable(mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(systemUserHelper.getSystemUser().getId()));
+    public Optional<MediaRequestEntity> retrieveMediaRequestForProcessing(List<Integer> mediaRequestIdsToIgnore) {
+        if (mediaRequestIdsToIgnore.isEmpty()) {
+            mediaRequestIdsToIgnore.add(0);//JPA doesn't work well with empty lists in JQL, so adding this dummy value
+        }
+        return Optional.ofNullable(
+            mediaRequestRepository.updateAndRetrieveMediaRequestToProcessing(systemUserHelper.getSystemUser().getId(), mediaRequestIdsToIgnore));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRequestRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRequestRepository.java
@@ -32,12 +32,14 @@ public interface MediaRequestRepository extends
           SELECT mr2.mer_id
           FROM darts.media_request mr2
           WHERE mr2.request_status = 'OPEN'
+          AND mr2.mer_id NOT IN ( :mediaRequestIdsToIgnore )
           ORDER BY mr2.last_modified_ts ASC
           LIMIT 1
           )
+         
         RETURNING *
         """, nativeQuery = true)
-    MediaRequestEntity updateAndRetrieveMediaRequestToProcessing(int userModifiedId);
+    MediaRequestEntity updateAndRetrieveMediaRequestToProcessing(int userModifiedId, List<Integer> mediaRequestIdsToIgnore);
 
     @Query("""
         SELECT count(distinct(tm.id)) FROM MediaRequestEntity mr, TransformedMediaEntity tm

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -164,6 +164,8 @@ darts:
     post-amble-duration: 30
     re-encode-workspace: ${user.home}/audiotransform/encode
     temp-blob-workspace: ${user.home}/audiotransform/tempworkspace
+    audio-transformation-service:
+      loop-cutoff-minutes: 15 #ATS pod will not pick up any more requests if this many minutes has passed since it started.
     trim-workspace: ${user.home}/audiotransform/trim
   azure:
     active-directory-b2c-base-uri: ${ACTIVE_DIRECTORY_B2C_BASE_URI:https://hmctsstgextid.b2clogin.com}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-3966

Added a list to ensure that if a media request that has audio only in inbound can be ignored and not hold up the processing of other requests.
added a check to make sure it doesn't loop forever.
Added a time check to try to avoid a scenario where the pod has been running for 30m and gets killed by keda, and leaves a media_request stuck in "PROCESSING".