### PR TITLE
DMP-3874 - Update cases int tests to include anonymisation fields in API responses

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminSearchTest.java
@@ -175,6 +175,39 @@ class CaseControllerAdminSearchTest extends IntegrationBase {
         assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
+    @Test
+    void testOkIsAnonymised() throws Exception {
+        CourtCaseEntity caseEntity = dartsDatabase.getCaseRepository()
+            .findByCaseNumberAndCourthouse_CourthouseName("Case1", "SWANSEA").orElseThrow();
+        OffsetDateTime dataAnonymisedTs = OffsetDateTime.parse("2023-01-01T12:00:00Z");
+        caseEntity.setDataAnonymisedTs(dataAnonymisedTs);
+        caseEntity.setDataAnonymised(true);
+        dartsDatabase.getCaseRepository().save(caseEntity);
+
+        String requestBody = """
+            {
+              "courthouse_ids": [
+                <<courthouseId>>
+              ],
+              "case_number": "Case1",
+              "courtroom_name": "courtroom1",
+              "hearing_start_at": "2020-06-18",
+              "hearing_end_at": "2024-06-18"
+            }""";
+
+        requestBody = requestBody.replace("<<courthouseId>>", swanseaCourthouse.getId().toString());
+        MockHttpServletRequestBuilder requestBuilder = post(ENDPOINT_URL)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody);
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk()).andReturn();
+
+        String actualResponse = TestUtils.removeIds(response.getResponse().getContentAsString());
+
+        String expectedResponse = getContentsFromFile(
+            "tests/cases/CaseControllerAdminSearchTest/testOkIsAnonymised/expectedResponse.json");
+        assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
     private void setupUserAccountAndSecurityGroup() {
         var securityGroup = SecurityGroupTestData.createGroupForRole(SUPER_ADMIN);
         securityGroup.setGlobalAccess(true);

--- a/src/integrationTest/resources/tests/cases/CaseControllerAdminSearchTest/testOkIsAnonymised/expectedResponse.json
+++ b/src/integrationTest/resources/tests/cases/CaseControllerAdminSearchTest/testOkIsAnonymised/expectedResponse.json
@@ -1,0 +1,21 @@
+[
+  {
+    "case_number": "Case1",
+    "courthouse": {
+      "display_name": "SWANSEA"
+    },
+    "courtrooms": [
+      {
+        "name": "COURTROOM1"
+      }
+    ],
+    "judges": [
+      "AJUDGE"
+    ],
+    "defendants": [
+      "aDefendant"
+    ],
+    "is_data_anonymised": true,
+    "data_anonymised_at":"2023-01-01T12:00:00Z"
+  }
+]


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-3874)


### Change description ###
The following PR covers tickets DMP-2911, DMP-2912 and DMP-3633:
* https://github.com/hmcts/darts-api/pull/1928

That change added fields `is_data_anonymised` and `data_anonymised_at` to the following endpoints:
* GET /cases/{case_id}
* POST /cases/search
* POST /admin/cases/search

However at the time of writing, the following related controller-level integration tests were disabled, so could not be updated to reflect the new endpoint behaviour:
* CaseControllerGetCaseByIdTest
* CaseControllerSearchPostTest
* CaseControllerAdminSearchTest

This task is to update these integration tests appropriately to reflect presence of the new response fields per the ACs listed on DMP-2911, DMP-2912 and DMP-3633.

Renablement of the above listed test classes (under DMP-3821) is a prerequite to this task.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
