### PR TITLE
DMP-1714 - Return migrated transcription comments in legacy_comments field for get transcription payload

### DIFF
--- a/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponseWithLegacyComment.json
+++ b/src/integrationTest/resources/tests/transcriptions/transcription/expectedResponseWithLegacyComment.json
@@ -1,0 +1,30 @@
+{
+  "case_number": "1",
+  "courthouse_id": $COURTHOUSE_ID,
+  "courthouse": "SOME-COURTHOUSE",
+  "status": "Approved",
+  "received": "2023-06-20T10:00:00Z",
+  "requestor": {
+    "user_id": $USER_ACCOUNT_ID,
+    "user_full_name": "integrationtest.user@example.comFullName"
+  },
+  "defendants": [],
+  "judges": [
+    "1JUDGE1"
+  ],
+  "hearing_date": "2023-01-01",
+  "request_type": "Sentencing remarks",
+  "transcription_start_ts": "2023-01-01T12:00:00Z",
+  "transcription_end_ts": "2023-01-01T12:00:00Z",
+  "is_manual": true,
+  "case_reporting_restrictions": [],
+  "transcription_urgency": {
+    "transcription_urgency_id": 1,
+    "description": "Standard",
+    "priority_order": 999
+  },
+  "courtroom": "SOME-COURTROOM",
+  "transcription_object_id": "legacyObjectId",
+  "hide_request_from_requestor": false,
+  "legacy_comments":["comment1","comment2"]
+}

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -228,6 +228,13 @@ public class TranscriptionResponseMapper {
             transcriptionResponse.setReportingRestriction(reportingRestriction.getEventName());
         }
 
+        List<String> legacyComments = transcriptionEntity.getTranscriptionCommentEntities().stream()
+            .filter(transcriptionCommentEntity -> transcriptionCommentEntity.getTranscriptionWorkflow() == null)
+            .map(TranscriptionCommentEntity::getComment)
+            .toList();
+
+        transcriptionResponse.setLegacyComments(legacyComments.isEmpty() ? null : legacyComments);
+
         return transcriptionResponse;
     }
 

--- a/src/main/resources/openapi/transcriptions.yaml
+++ b/src/main/resources/openapi/transcriptions.yaml
@@ -1405,6 +1405,10 @@ components:
     GetTranscriptionByIdResponse:
       type: object
       properties:
+        legacy_comments:
+          type: array
+          items:
+            type: string
         transcription_id:
           type: integer
           example: 12345

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionTypeEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionUrgencyEntity;
+import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.HearingReportingRestrictionsRepository;
@@ -228,6 +229,27 @@ class TranscriptionResponseMapperTest {
             "Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntity.json");
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
     }
+
+    @Test
+    void mapToTranscriptionResponseWithOutLegacyComments() throws Exception {
+        HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
+        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+
+        transcriptionEntity.getTranscriptionCommentEntities()
+            .forEach(transcriptionCommentEntity -> {
+                transcriptionCommentEntity.setTranscriptionWorkflow(new TranscriptionWorkflowEntity());
+            });
+
+        GetTranscriptionByIdResponse transcriptionResponse =
+            transcriptionResponseMapper.mapToTranscriptionResponse(transcriptionEntity);
+        String actualResponse = objectMapper.writeValueAsString(transcriptionResponse);
+
+        String expectedResponse = getContentsFromFile(
+            "Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityWithoutLegacyComments.json");
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
+    }
+
 
     @Test
     void mapToTranscriptionResponseIsAutomated() throws Exception {

--- a/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseNoStatusSingleEntity.json
+++ b/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseNoStatusSingleEntity.json
@@ -29,5 +29,6 @@
     "priority_order": 999
   },
   "courtroom":"1",
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "legacy_comments":["comment1","comment2"]
 }

--- a/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntity.json
+++ b/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntity.json
@@ -31,5 +31,6 @@
     "priority_order": 999
   },
   "courtroom":"1",
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "legacy_comments":["comment1","comment2"]
 }

--- a/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityAutomated.json
+++ b/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityAutomated.json
@@ -31,5 +31,6 @@
     "priority_order": 999
   },
   "courtroom":"1",
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "legacy_comments":["comment1","comment2"]
 }

--- a/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityNoHearing.json
+++ b/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityNoHearing.json
@@ -30,5 +30,6 @@
     "priority_order": 999
   },
   "courtroom":"1",
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "legacy_comments":["comment1","comment2"]
 }

--- a/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityWithRequestor.json
+++ b/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityWithRequestor.json
@@ -31,5 +31,6 @@
     "priority_order": 999
   },
   "courtroom":"1",
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "legacy_comments":["comment1","comment2"]
 }

--- a/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityWithWorkflow.json
+++ b/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityWithWorkflow.json
@@ -31,5 +31,6 @@
     "priority_order": 999
   },
   "courtroom":"1",
-  "transcription_object_id":"legacyObjectId"
+  "transcription_object_id":"legacyObjectId",
+  "legacy_comments":["comment1","comment2"]
 }

--- a/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityWithoutLegacyComments.json
+++ b/src/test/resources/Tests/transcriptions/mapper/TranscriptionResponseMapper/expectedResponseSingleEntityWithoutLegacyComments.json
@@ -1,13 +1,14 @@
 {
   "transcription_id": 1,
   "case_id": 101,
+  "hearing_id": 102,
   "case_number": "case1",
   "courthouse_id": 1001,
   "courthouse": "case_courthouse",
   "status": "APPROVED",
   "received": "2020-06-20T10:10:00Z",
   "requestor": {
-    "user_full_name": "testUsername",
+    "user_full_name":"testUsername",
     "user_id": 1002
   },
   "requestor_comments": "workflowcommenta1",
@@ -29,6 +30,7 @@
     "description": "STANDARD",
     "priority_order": 999
   },
+  "courtroom":"1",
   "transcription_object_id":"legacyObjectId",
-  "legacy_comments":["comment1","comment2"]
+  "legacy_comments":[]
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/DMP-1714)


### Change description ###
Transcription data being migrated from the legacy system will not be associated to a workflow in modernised DARTS. Therefore, we will just display all transcription comments associated with a transcription where the trw_id is null in a generic 'Migrated legacy data comment' on the portal.

Therefore, a new field needs to be added to the {*}GET /transcriptions/{transcription_id{*}} called 'legacy_comments', which will be an array. 
{code:java}
{
...
   "legacy_comments" : [
      "comment1",
      "comment2"
   ]
...
}{code}

h4.Acceptance Criteria
*AC1: Return comments not associated with a workflow in a new 'legacy comments' list in the payload for GET /transcriptions/\{transcription_id}*

GIVEN

a get transcription request by id is made

WHEN

the request has comments migrated from legacy not associated with a workflow

THEN 

include the comments in a legacy_comments array

 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
