### PR TITLE
DMP-4011 - Remove Transactional from AbstractLockableAutomatedTask

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
@@ -6,7 +6,6 @@ import net.javacrumbs.shedlock.core.LockConfiguration;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
@@ -80,7 +79,6 @@ public abstract class AbstractLockableAutomatedTask implements AutomatedTask, Au
     }
 
     @Override
-    @Transactional
     public void run() {
         executionId = ThreadLocal.withInitial(UUID::randomUUID);
         preRunTask();


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4011)


### Change description ###
A transactional annotation should always be added to lower level i.e in the block of code which is expected to be transactional.

As of now a Transactional annotation has been added to AbstractLockableAutomatedTask.run which can have performance issue. 

Also due to one single use case failure the entire transaction is rolled back.

 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
