### PR TITLE
DMP-3994 - Hide ManualDeletion task if disabled by feature flag

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
@@ -36,8 +36,7 @@ public enum AutomatedTaskName {
     DETS_TO_ARM_TASK_NAME("DetsToArm"),
     CASE_EXPIRY_DELETION_TASK_NAME("CaseExpiryDeletion", "${darts.automated.task.expiry-deletion.enabled:false}"),
     ASSOCIATED_OBJECT_DATA_EXPIRY_DELETION_TASK_NAME("AssociatedObjectDataExpiryDeletion"),
-    MANUAL_DELETION("ManualDeletion");
-
+    MANUAL_DELETION("ManualDeletion", "${darts.manual-deletion.enabled:false}");
     private final String taskName;
     private final String conditionalOnSpEL;
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3994)


### Change description ###
The manual deletion automated task, named "ManualDeletion" and added by DMP-2925, is configured within the database automated_tasks table. In addition, there is a feature flag within application.yaml driven by an env var set in flux, named MANUAL_DELETION_ENABLED

If the task is not enabled then we need to prevent it from being the subject of the following automated tasks endpoints, as follows:

-  GET /admin/automated-tasks - do not include the "ManualDeletion" task in the response
-  GET /admin/automated-tasks/\{task_id} - return 404 (AUTOMATED_TASK_NOT_FOUND)
-  PATCH /admin/automated-tasks/\{task_id} - return 404 (AUTOMATED_TASK_NOT_FOUND)
-  POST /admin/automated-tasks/\{task_id}/run - return 404 (AUTOMATED_TASK_NOT_FOUND)

This will prevent it from showing on the admin portal and prevent consuming the API endpoints directly to amend or run the task.
h4. Acceptance Criteria

*AC1 - task not returned in list*

GIVEN the ManualDeletion task exists in the "automated_tasks" database table
AND the MANUAL_DELETION_ENABLED flag is set to false
WHEN the GET /admin/automated-tasks endpoint is called
THEN the response does not include the ManualDeletion task

*AC2 - task not found (GET)*

GIVEN the ManualDeletion task exists in the "automated_tasks" database table
AND the MANUAL_DELETION_ENABLED flag is set to false
WHEN the GET /admin/automated-tasks/\{task_id} endpoint is called with the ManualDeletion task_id
THEN then a 404 response is received

*AC3 - task not found (PATCH)*

GIVEN the ManualDeletion task exists in the "automated_tasks" database table
AND the MANUAL_DELETION_ENABLED flag is set to false
WHEN the PATCH /admin/automated-tasks/\{task_id} endpoint is called with the ManualDeletion task_id
THEN then a 404 response is received

*AC4 - task not found (POST)*

GIVEN the ManualDeletion task exists in the "automated_tasks" database table
AND the MANUAL_DELETION_ENABLED flag is set to false
WHEN the PATCH /admin/automated-tasks/\{task_id}/run endpoint is called with the ManualDeletion task_id
THEN then a 404 response is received

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
