### PR TITLE
Fix problem whereby we do not consider inactive users unless the endp…

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -12,7 +12,6 @@ services:
       - DARTS_API_DB_USERNAME=darts
       - DARTS_API_DB_PASSWORD=darts
       - DARTS_API_DB_SCHEMA=darts
-      - SPRING_PROFILES_ACTIVE=local
       - AAD_B2C_CLIENT_ID
       - AAD_B2C_CLIENT_SECRET
       - AAD_B2C_TENANT_ID
@@ -55,12 +54,14 @@ services:
       - MAX_FILE_UPLOAD_REQUEST_SIZE_MEGABYTES=360
       - DARTS_INBOUND_STORAGE_SAS_URL
       - DARTS_UNSTRUCTURED_STORAGE_SAS_URL
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,address=*:8003,server=y,suspend=n
     build:
       context: .
       dockerfile: Dockerfile
     image: darts-api:latest
     ports:
       - "4550:4550"
+      - "8003:8003"
     networks:
       - darts-network
 

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/UserIdentity.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/UserIdentity.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.authorisation.component;
 
+import org.springframework.security.oauth2.jwt.Jwt;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 
@@ -10,7 +11,9 @@ public interface UserIdentity {
 
     UserAccountEntity getUserAccount();
 
-    boolean userHasGlobalAccess(Set<SecurityRoleEnum> globalAccessRoles);
+    UserAccountEntity getUserAccount(Jwt jwt);
+
+    boolean userHasGlobalAccess(Set<SecurityRoleEnum> globalAccessRolest);
 
     List<Integer> getListOfCourthouseIdsUserHasAccessTo();
 }

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
@@ -34,78 +34,88 @@ public class UserIdentityImpl implements UserIdentity {
     private final UserRolesCourthousesRepository userRolesCourthousesRepository;
 
     @SuppressWarnings({"PMD.AvoidDeeplyNestedIfStmts", "PMD.CyclomaticComplexity", "PMD.CognitiveComplexity"})
-    private String getEmailAddressFromToken() {
-        if (nonNull(SecurityContextHolder.getContext().getAuthentication())) {
-            Object principalObject = SecurityContextHolder.getContext()
-                .getAuthentication()
-                .getPrincipal();
+    private String getEmailAddressFromToken(Jwt token) {
+        Object principalObject = token;
 
-            if (principalObject instanceof Jwt jwt) {
-                Object emailsAddressesObject = jwt.getClaims().get(EMAILS);
-                if (emailsAddressesObject == null) {
-                    emailsAddressesObject = jwt.getClaims().get(PREFERRED_USERNAME);
+        if (principalObject instanceof Jwt jwt) {
+            Object emailsAddressesObject = jwt.getClaims().get(EMAILS);
+            if (emailsAddressesObject == null) {
+                emailsAddressesObject = jwt.getClaims().get(PREFERRED_USERNAME);
+            }
+            if (emailsAddressesObject instanceof List<?> emails) {
+                if (emails.size() != 1) {
+                    throw new IllegalStateException(String.format(
+                        "Unexpected number of email addresses: %d",
+                        emails.size()
+                    ));
                 }
-                if (emailsAddressesObject instanceof List<?> emails) {
-                    if (emails.size() != 1) {
-                        throw new IllegalStateException(String.format(
-                            "Unexpected number of email addresses: %d",
-                            emails.size()
-                        ));
-                    }
-                    Object emailAddressObject = emails.get(0);
+                Object emailAddressObject = emails.get(0);
 
-                    if (emailAddressObject instanceof String emailAddress && StringUtils.isNotBlank(emailAddress)) {
-                        return emailAddress;
-                    }
-                } else if (emailsAddressesObject instanceof String emailAddress && StringUtils.isNotBlank(emailAddress)) {
+                if (emailAddressObject instanceof String emailAddress && StringUtils.isNotBlank(emailAddress)) {
                     return emailAddress;
                 }
+            } else if (emailsAddressesObject instanceof String emailAddress && StringUtils.isNotBlank(emailAddress)) {
+                return emailAddress;
             }
         }
-        throw new IllegalStateException("Could not obtain email address from principal");
+
+        return "";
     }
 
-    private String getGuidFromToken() {
-        if (nonNull(SecurityContextHolder.getContext().getAuthentication())) {
-            Object principalObject = SecurityContextHolder.getContext()
-                .getAuthentication()
-                .getPrincipal();
+    private String getGuidFromToken(Jwt token) {
+        Object principalObject = token;
 
-            Object oid = null;
-            if (principalObject instanceof Jwt jwt) {
-                oid = jwt.getClaims().get(OID);
-            }
-            if (nonNull(oid) && oid instanceof String guid && StringUtils.isNotBlank(guid)) {
-                return guid;
-            }
+        Object oid = null;
+        if (principalObject instanceof Jwt jwt) {
+            oid = jwt.getClaims().get(OID);
+        }
+        if (nonNull(oid) && oid instanceof String guid && StringUtils.isNotBlank(guid)) {
+            return guid;
         }
         return null;
     }
 
     @Override
     public UserAccountEntity getUserAccount() {
+        if (!(SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof Jwt)) {
+            throw new IllegalStateException("Could not obtain user from token");
+        }
+
+        return getUserAccount((Jwt)SecurityContextHolder.getContext().getAuthentication().getPrincipal());
+    }
+
+    @Override
+    public UserAccountEntity getUserAccount(Jwt jwt) {
         UserAccountEntity userAccount = null;
-        String guid = getGuidFromToken();
+        String guid = getGuidFromToken(jwt);
         if (nonNull(guid)) {
             // System users will use GUID not email address
             userAccount = userAccountRepository.findByAccountGuidAndActive(guid, true).orElse(null);
         }
         if (isNull(userAccount)) {
-            userAccount = userAccountRepository.findByEmailAddressIgnoreCaseAndActive(getEmailAddressFromToken(), true).stream()
+            userAccount = userAccountRepository.findByEmailAddressIgnoreCaseAndActive(getEmailAddressFromToken(jwt), true).stream()
                 .findFirst()
                 .orElseThrow(() -> new DartsApiException(USER_DETAILS_INVALID));
         }
         return userAccount;
     }
 
+    private Jwt getJwt() {
+        if (SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof Jwt) {
+            return (Jwt)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        }
+        return (Jwt)SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+
     @Override
     public boolean userHasGlobalAccess(Set<SecurityRoleEnum> globalAccessRoles) {
         boolean userHasGlobalAccess = false;
+        Jwt token = getJwt();
         String emailAddress = null;
-        String guid = getGuidFromToken();
+        String guid = getGuidFromToken(token);
 
         try {
-            emailAddress = getEmailAddressFromToken();
+            emailAddress = getEmailAddressFromToken(token);
         } catch (IllegalStateException e) {
             if (nonNull(guid)) {
                 log.debug("Guid is present but unable to get email address from token ending ''.....{}'': {}", StringUtils.right(guid, 5), e.getMessage());


### PR DESCRIPTION
### JIRA link (if applicable) ###

NO JIRA


### Change description ###

Always authenticate against the user being inactive.  If the user is inactive we return a 401 across the APIs

This fixes a bug whereby if an endpoint does not have authorisation enabled e.g. /transcriptions/transcriber-view?assigned=false, then an inactive user can use the endpoint successfully.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
