### PR TITLE
DMP-3996 - Manual obfuscation of event text endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
@@ -186,7 +186,7 @@ class EventsControllerTest extends IntegrationBase {
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content("{\"eve_ids\":[" + event.getId() + "," + event2.getId() + "]}");
 
-        mockMvc.perform(requestBuilder).andExpect(status().isNoContent());
+        mockMvc.perform(requestBuilder).andExpect(status().isOk());
 
         EventEntity editedEventEntity = dartsDatabaseStub.getEventRepository().findById(event.getId()).orElseThrow();
         assertThat(editedEventEntity.getEventText()).matches(UUID_REGEX);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
@@ -163,7 +163,7 @@ class EventsControllerTest extends IntegrationBase {
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content("{\"eve_ids\":[" + event.getId() + "]}");
 
-        mockMvc.perform(requestBuilder).andExpect(status().isNoContent());
+        mockMvc.perform(requestBuilder).andExpect(status().isOk());
 
         EventEntity editedEventEntity = dartsDatabaseStub.getEventRepository().findById(event.getId()).orElseThrow();
         assertThat(editedEventEntity.getEventText()).matches(UUID_REGEX);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
@@ -174,6 +174,28 @@ class EventsControllerTest extends IntegrationBase {
     }
 
     @Test
+    void adminObfuscateEveByIdsMultiple() throws Exception {
+        HearingEntity hearing = dartsDatabaseStub.createHearing("Courthouse", "1", "12345", LocalDateTime.now());
+
+        EventEntity event = dartsDatabaseStub.createEvent(hearing);
+        EventEntity event2 = dartsDatabaseStub.createEvent(hearing);
+
+
+        given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
+        MockHttpServletRequestBuilder requestBuilder = post("/admin/events/obfuscate")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content("{\"eve_ids\":[" + event.getId() + "," + event2.getId() + "]}");
+
+        mockMvc.perform(requestBuilder).andExpect(status().isNoContent());
+
+        EventEntity editedEventEntity = dartsDatabaseStub.getEventRepository().findById(event.getId()).orElseThrow();
+        assertThat(editedEventEntity.getEventText()).matches(UUID_REGEX);
+
+        EventEntity editedEventEntity2 = dartsDatabaseStub.getEventRepository().findById(event2.getId()).orElseThrow();
+        assertThat(editedEventEntity2.getEventText()).matches(UUID_REGEX);
+    }
+
+    @Test
     void adminObfuscateEveByIdsNotFound() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
         MockHttpServletRequestBuilder requestBuilder = post("/admin/events/obfuscate")

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.darts.audio.api.AudioApi;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.exception.EventError;
 import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
@@ -28,6 +29,7 @@ import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -37,6 +39,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.CPP;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
+import static uk.gov.hmcts.darts.test.common.TestUtils.UUID_REGEX;
 
 @AutoConfigureMockMvc
 class EventsControllerTest extends IntegrationBase {
@@ -145,5 +148,42 @@ class EventsControllerTest extends IntegrationBase {
 
         // Then
         Assertions.assertEquals(EventError.EVENT_ID_NOT_FOUND_RESULTS.getType(), responseResult.getType());
+    }
+
+    @Test
+    void adminObfuscateEveByIdsSingle() throws Exception {
+        HearingEntity hearing = dartsDatabaseStub.createHearing("Courthouse", "1", "12345", LocalDateTime.now());
+
+        EventEntity event = dartsDatabaseStub.createEvent(hearing);
+        EventEntity event2 = dartsDatabaseStub.createEvent(hearing);
+
+
+        given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
+        MockHttpServletRequestBuilder requestBuilder = post("/admin/events/obfuscate")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content("{\"eve_ids\":[" + event.getId() + "]}");
+
+        mockMvc.perform(requestBuilder).andExpect(status().isNoContent());
+
+        EventEntity editedEventEntity = dartsDatabaseStub.getEventRepository().findById(event.getId()).orElseThrow();
+        assertThat(editedEventEntity.getEventText()).matches(UUID_REGEX);
+
+        EventEntity notEditedEventEntity = dartsDatabaseStub.getEventRepository().findById(event2.getId()).orElseThrow();
+        assertThat(notEditedEventEntity.getEventText()).isEqualTo(event2.getEventText());
+        assertThat(notEditedEventEntity.getEventText()).doesNotMatch(UUID_REGEX);
+    }
+
+    @Test
+    void adminObfuscateEveByIdsNotFound() throws Exception {
+        given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
+        MockHttpServletRequestBuilder requestBuilder = post("/admin/events/obfuscate")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content("{\"eve_ids\":[1]}");
+
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isNotFound())
+            .andReturn();
+
+        Problem responseResult = objectMapper.readValue(response.getResponse().getContentAsString(), Problem.class);
+        Assertions.assertEquals(DartsApiException.DartsApiErrorCommon.NOT_FOUND.getType(), responseResult.getType());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiException.java
@@ -68,6 +68,11 @@ public class DartsApiException extends RuntimeException {
             "FEATURE_FLAG_NOT_ENABLED",
             HttpStatus.NOT_IMPLEMENTED,
             "Feature flag not enabled"
+        ),
+        NOT_FOUND(
+            "NOT_FOUND",
+            HttpStatus.NOT_FOUND,
+            "Resource not found"
         );
 
         private static final String ERROR_TYPE_PREFIX = "COMMON";

--- a/src/main/java/uk/gov/hmcts/darts/common/service/DataAnonymisationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/DataAnonymisationService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.common.service;
 
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
 public interface DataAnonymisationService {
@@ -9,6 +10,8 @@ public interface DataAnonymisationService {
     }
 
     void anonymizeCourtCaseEntity(UserAccountEntity userAccount, CourtCaseEntity courtCase);
+
+    void anonymizeEvent(EventEntity eventEntity);
 
     UserAccountEntity getUserAccount();
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/service/DataAnonymisationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/DataAnonymisationService.java
@@ -4,12 +4,16 @@ import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
+import java.util.List;
+
 public interface DataAnonymisationService {
     default void anonymizeCourtCaseEntity(CourtCaseEntity courtCase) {
         anonymizeCourtCaseEntity(getUserAccount(), courtCase);
     }
 
     void anonymizeCourtCaseEntity(UserAccountEntity userAccount, CourtCaseEntity courtCase);
+
+    void obfuscateEventByIds(List<Integer> eveIds);
 
     void anonymizeEvent(EventEntity eventEntity);
 

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImpl.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.CaseRepository;
+import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
 import uk.gov.hmcts.darts.common.repository.TransientObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
@@ -52,6 +53,7 @@ public class DataAnonymisationServiceImpl implements DataAnonymisationService {
     private final TransformedMediaRepository transformedMediaRepository;
     private final TransientObjectDirectoryRepository transientObjectDirectoryRepository;
     private final LogApi logApi;
+    private final EventRepository eventRepository;
 
     @Override
     public void anonymizeCourtCaseEntity(UserAccountEntity userAccount, CourtCaseEntity courtCase) {
@@ -92,6 +94,7 @@ public class DataAnonymisationServiceImpl implements DataAnonymisationService {
     @Override
     public void anonymizeEvent(EventEntity eventEntity) {
         anonymizeEventEntity(getUserAccount(), eventEntity);
+        eventRepository.save(eventEntity);
     }
 
     void anonymizeEventEntity(UserAccountEntity userAccount, EventEntity eventEntity) {

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImpl.java
@@ -88,6 +88,12 @@ public class DataAnonymisationServiceImpl implements DataAnonymisationService {
         hearingEntity.getEventList().forEach(eventEntity -> anonymizeEventEntity(userAccount, eventEntity));
     }
 
+
+    @Override
+    public void anonymizeEvent(EventEntity eventEntity) {
+        anonymizeEventEntity(getUserAccount(), eventEntity);
+    }
+
     void anonymizeEventEntity(UserAccountEntity userAccount, EventEntity eventEntity) {
         eventEntity.setEventText(UUID.randomUUID().toString());
         eventEntity.setDataAnonymised(true);

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -180,6 +180,6 @@ public class EventsController implements EventApi {
         globalAccessSecurityRoles = {SUPER_ADMIN})
     public ResponseEntity<Void> adminObfuscateEveByIds(AdminObfuscateEveByIdsRequest adminObfuscateEveByIdsRequest) {
         this.dataAnonymisationService.obfuscateEventByIds(adminObfuscateEveByIdsRequest.getEveIds());
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.http.api.EventApi;
 import uk.gov.hmcts.darts.event.model.AdminEventSearch;
 import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
-import uk.gov.hmcts.darts.event.model.AdminObfuscateEventByIdRequest;
+import uk.gov.hmcts.darts.event.model.AdminObfuscateEveByIdsRequest;
 import uk.gov.hmcts.darts.event.model.AdminSearchEventResponseResult;
 import uk.gov.hmcts.darts.event.model.CourtLog;
 import uk.gov.hmcts.darts.event.model.CourtLogsPostRequestBody;
@@ -176,8 +176,8 @@ public class EventsController implements EventApi {
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_ADMIN})
-    public ResponseEntity<Void> adminObfuscateEveByIds(AdminObfuscateEventByIdRequest adminObfuscateEventByIdRequest) {
-        eventService.adminObfuscateEveByIds(adminObfuscateEventByIdRequest.getEveIds());
+    public ResponseEntity<Void> adminObfuscateEveByIds(AdminObfuscateEveByIdsRequest adminObfuscateEveByIdsRequest) {
+        eventService.adminObfuscateEveByIds(adminObfuscateEveByIdsRequest.getEveIds());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.http.api.EventApi;
 import uk.gov.hmcts.darts.event.model.AdminEventSearch;
 import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
+import uk.gov.hmcts.darts.event.model.AdminObfuscateEventByIdRequest;
 import uk.gov.hmcts.darts.event.model.AdminSearchEventResponseResult;
 import uk.gov.hmcts.darts.event.model.CourtLog;
 import uk.gov.hmcts.darts.event.model.CourtLogsPostRequestBody;
@@ -168,6 +169,15 @@ public class EventsController implements EventApi {
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
     public ResponseEntity<AdminGetEventForIdResponseResult> adminGetEventById(Integer eventId) {
-        return  new ResponseEntity<>(eventService.adminGetEventById(eventId), HttpStatus.OK);
+        return new ResponseEntity<>(eventService.adminGetEventById(eventId), HttpStatus.OK);
+    }
+
+    @Override
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = ANY_ENTITY_ID,
+        globalAccessSecurityRoles = {SUPER_ADMIN})
+    public ResponseEntity<Void> adminObfuscateEveByIds(AdminObfuscateEventByIdRequest adminObfuscateEventByIdRequest) {
+        eventService.adminObfuscateEveByIds(adminObfuscateEventByIdRequest.getEveIds());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -177,7 +177,7 @@ public class EventsController implements EventApi {
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_ADMIN})
     public ResponseEntity<Void> adminObfuscateEveByIds(AdminObfuscateEveByIdsRequest adminObfuscateEveByIdsRequest) {
-        eventService.adminObfuscateEveByIds(adminObfuscateEveByIdsRequest.getEveIds());
+        eventService.obfuscateEventByIds(adminObfuscateEveByIdsRequest.getEveIds());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
+import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
 import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.http.api.EventApi;
 import uk.gov.hmcts.darts.event.model.AdminEventSearch;
@@ -58,6 +59,7 @@ public class EventsController implements EventApi {
     private final EventHandlerEnumerator eventHandlers;
     private final EventSearchService eventSearchService;
     private final EventService eventService;
+    private final DataAnonymisationService dataAnonymisationService;
 
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
@@ -177,7 +179,7 @@ public class EventsController implements EventApi {
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_ADMIN})
     public ResponseEntity<Void> adminObfuscateEveByIds(AdminObfuscateEveByIdsRequest adminObfuscateEveByIdsRequest) {
-        eventService.obfuscateEventByIds(adminObfuscateEveByIdsRequest.getEveIds());
+        this.dataAnonymisationService.obfuscateEventByIds(adminObfuscateEveByIdsRequest.getEveIds());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.darts.event.service;
 
+import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
-
-import java.util.List;
 
 public interface EventService {
     AdminGetEventForIdResponseResult adminGetEventById(Integer eventId);
 
-    void obfuscateEventByIds(List<Integer> eveIds);
+    EventEntity getEventEntityById(Integer eveId);
+
+    EventEntity saveEvent(EventEntity eventEntity);
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
@@ -7,5 +7,5 @@ import java.util.List;
 public interface EventService {
     AdminGetEventForIdResponseResult adminGetEventById(Integer eventId);
 
-    void adminObfuscateEveByIds(List<Integer> eveIds);
+    void obfuscateEventByIds(List<Integer> eveIds);
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
@@ -2,6 +2,10 @@ package uk.gov.hmcts.darts.event.service;
 
 import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
 
+import java.util.List;
+
 public interface EventService {
     AdminGetEventForIdResponseResult adminGetEventById(Integer eventId);
+
+    void adminObfuscateEveByIds(List<Integer> eveIds);
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.event.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
@@ -13,7 +12,6 @@ import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
 import uk.gov.hmcts.darts.event.service.EventService;
 import uk.gov.hmcts.darts.event.validation.EventIdValidator;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -33,16 +31,13 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
-    @Transactional
-    public void obfuscateEventByIds(List<Integer> eveIds) {
-        eveIds.stream()
-            .map(this::getEventEntityById)
-            .distinct()
-            .forEach(dataAnonymisationService::anonymizeEvent);
-    }
-
-    EventEntity getEventEntityById(Integer eveId) {
+    public EventEntity getEventEntityById(Integer eveId) {
         return eventRepository.findById(eveId)
             .orElseThrow(() -> new DartsApiException(DartsApiException.DartsApiErrorCommon.NOT_FOUND));
+    }
+
+    @Override
+    public EventEntity saveEvent(EventEntity eventEntity) {
+        return eventRepository.save(eventEntity);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
@@ -13,8 +13,6 @@ import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
 import uk.gov.hmcts.darts.event.service.EventService;
 import uk.gov.hmcts.darts.event.validation.EventIdValidator;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,18 +36,9 @@ public class EventServiceImpl implements EventService {
     @Transactional
     public void adminObfuscateEveByIds(List<Integer> eveIds) {
         eveIds.stream()
-            .map(this::getEventsToObfuscate)
-            .flatMap(List::stream)
+            .map(this::getEventEntityById)
             .distinct()
             .forEach(dataAnonymisationService::anonymizeEvent);
-    }
-
-    List<EventEntity> getEventsToObfuscate(Integer eveId) {
-        EventEntity event = getEventEntityById(eveId);
-        if (event.getEventId() == 0) {
-            return Collections.singletonList(event);
-        }
-        return new ArrayList<>(eventRepository.findAllByEventId(event.getEventId()));
     }
 
     EventEntity getEventEntityById(Integer eveId) {

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
@@ -3,13 +3,19 @@ package uk.gov.hmcts.darts.event.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
+import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
 import uk.gov.hmcts.darts.event.mapper.EventMapper;
 import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
 import uk.gov.hmcts.darts.event.service.EventService;
 import uk.gov.hmcts.darts.event.validation.EventIdValidator;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -19,11 +25,35 @@ public class EventServiceImpl implements EventService {
     private final EventMapper eventMapper;
     private final EventIdValidator eventIdValidator;
     private final EventRepository eventRepository;
+    private final DataAnonymisationService dataAnonymisationService;
 
     @Override
     public AdminGetEventForIdResponseResult adminGetEventById(Integer eventId) {
         eventIdValidator.validate(eventId);
         Optional<EventEntity> eventEntityOptional = eventRepository.findById(eventId);
         return eventMapper.mapToAdminGetEventsResponseForId(eventEntityOptional);
+    }
+
+    @Override
+    @Transactional
+    public void adminObfuscateEveByIds(List<Integer> eveIds) {
+        eveIds.stream()
+            .map(this::getEventsToObfuscate)
+            .flatMap(List::stream)
+            .distinct()
+            .forEach(dataAnonymisationService::anonymizeEvent);
+    }
+
+    List<EventEntity> getEventsToObfuscate(Integer eveId) {
+        EventEntity event = getEventEntityById(eveId);
+        if (event.getEventId() == 0) {
+            return Collections.singletonList(event);
+        }
+        return new ArrayList<>(eventRepository.findAllByEventId(event.getEventId()));
+    }
+
+    EventEntity getEventEntityById(Integer eveId) {
+        return eventRepository.findById(eveId)
+            .orElseThrow(() -> new DartsApiException(DartsApiException.DartsApiErrorCommon.NOT_FOUND));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
@@ -34,7 +34,7 @@ public class EventServiceImpl implements EventService {
 
     @Override
     @Transactional
-    public void adminObfuscateEveByIds(List<Integer> eveIds) {
+    public void obfuscateEventByIds(List<Integer> eveIds) {
         eveIds.stream()
             .map(this::getEventEntityById)
             .distinct()

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
-import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
 import uk.gov.hmcts.darts.event.mapper.EventMapper;
 import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
 import uk.gov.hmcts.darts.event.service.EventService;
@@ -21,7 +20,6 @@ public class EventServiceImpl implements EventService {
     private final EventMapper eventMapper;
     private final EventIdValidator eventIdValidator;
     private final EventRepository eventRepository;
-    private final DataAnonymisationService dataAnonymisationService;
 
     @Override
     public AdminGetEventForIdResponseResult adminGetEventById(Integer eventId) {

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -891,8 +891,7 @@ components:
         MAPPING_INACTIVE,
         MAPPING_IN_USE,
         TOO_MANY_RESULTS,
-        EVENT_ID_NOT_FOUND,
-        ALREADY_OBFUSCATED
+        EVENT_ID_NOT_FOUND
       ]
 
     EventTitleErrors:
@@ -907,7 +906,6 @@ components:
         - "The mapping has already processed events, so cannot be deleted"
         - "The search resulted in too many results"
         - "Event id does not exist"
-        - "This event is already obfuscated"
       x-enum-varnames: [
         EVENT_DATA_NOT_FOUND,
         EVENT_HANDLER_NOT_FOUND_IN_DB,
@@ -917,5 +915,4 @@ components:
         MAPPING_INACTIVE,
         MAPPING_IN_USE,
         TOO_MANY_RESULTS,
-        EVENT_ID_NOT_FOUND,
-        ALREADY_OBFUSCATED ]
+        EVENT_ID_NOT_FOUND]

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -535,6 +535,37 @@ paths:
             application/json+problem:
               schema:
                 $ref: './problem.yaml'
+  /admin/events/obfuscate:
+    post:
+      tags:
+        - Event
+      summary: Obfuscate event text
+      description: |-
+        Obfuscate event text
+      operationId: adminObfuscateEveByIds
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - eve_ids
+              properties:
+                eve_ids:
+                  minLength: 1
+                  type: array
+                  items:
+                    type: integer
+      responses:
+        '201':
+          description: NO_CONTENT
+        '404':
+          description: Not Found - Event id
+          content:
+            application/json+problem:
+              schema:
+                $ref: './problem.yaml'
 components:
   schemas:
 
@@ -828,7 +859,7 @@ components:
       enum:
         - "GET_COURTLOG_101"
         - "GET_COURTLOG_102"
-      x-enum-varnames: [COURTLOG_COURT_HOUSE_NOT_FOUND]
+      x-enum-varnames: [ COURTLOG_COURT_HOUSE_NOT_FOUND ]
 
     PostCourtLogsErrorCode:
       type: string
@@ -836,7 +867,7 @@ components:
         - "ADD_COURTLOG_101"
         - "ADD_COURTLOG_102"
         - "ADD_COURTLOG_103"
-      x-enum-varnames: [COURTLOG_COURT_HOUSE_NOT_FOUND, COURTLOG_DOCUMENT_CANT_BE_PARSED]
+      x-enum-varnames: [ COURTLOG_COURT_HOUSE_NOT_FOUND, COURTLOG_DOCUMENT_CANT_BE_PARSED ]
 
     EventErrorCode:
       type: string
@@ -850,6 +881,7 @@ components:
         - "EVENT_106"
         - "EVENT_107"
         - "EVENT_108"
+        - "EVENT_109"
       x-enum-varnames: [
         EVENT_DATA_NOT_FOUND,
         EVENT_HANDLER_NOT_FOUND_IN_DB,
@@ -860,6 +892,7 @@ components:
         MAPPING_IN_USE,
         TOO_MANY_RESULTS,
         EVENT_ID_NOT_FOUND,
+        ALREADY_OBFUSCATED
       ]
 
     EventTitleErrors:
@@ -874,6 +907,7 @@ components:
         - "The mapping has already processed events, so cannot be deleted"
         - "The search resulted in too many results"
         - "Event id does not exist"
+        - "This event is already obfuscated"
       x-enum-varnames: [
         EVENT_DATA_NOT_FOUND,
         EVENT_HANDLER_NOT_FOUND_IN_DB,
@@ -883,4 +917,5 @@ components:
         MAPPING_INACTIVE,
         MAPPING_IN_USE,
         TOO_MANY_RESULTS,
-        EVENT_ID_NOT_FOUND]
+        EVENT_ID_NOT_FOUND,
+        ALREADY_OBFUSCATED ]

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -558,8 +558,8 @@ paths:
                   items:
                     type: integer
       responses:
-        '204':
-          description: NO_CONTENT
+        '200':
+          description: OK
         '404':
           description: Not Found - Event id
           content:

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -558,7 +558,7 @@ paths:
                   items:
                     type: integer
       responses:
-        '201':
+        '204':
           description: NO_CONTENT
         '404':
           description: Not Found - Event id

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,10 +59,12 @@ class EventServiceImplTest {
         verify(dataAnonymisationService, times(1)).anonymizeEvent(event1);
         verify(dataAnonymisationService, times(1)).anonymizeEvent(event2);
         verify(dataAnonymisationService, times(1)).anonymizeEvent(event3);
+        verifyNoMoreInteractions(dataAnonymisationService);
 
         verify(eventService, times(1)).getEventEntityById(1);
         verify(eventService, times(1)).getEventEntityById(2);
         verify(eventService, times(1)).getEventEntityById(3);
+        verify(eventService, times(1)).getEventEntityById(4);
     }
 
 

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,53 +45,23 @@ class EventServiceImplTest {
         EventEntity event1 = mock(EventEntity.class);
         EventEntity event2 = mock(EventEntity.class);
         EventEntity event3 = mock(EventEntity.class);
-        EventEntity event4 = mock(EventEntity.class);
 
 
-        doReturn(List.of(event1, event2)).when(eventService).getEventsToObfuscate(1);
-        doReturn(List.of(event2, event3)).when(eventService).getEventsToObfuscate(2);
-        doReturn(List.of(event4)).when(eventService).getEventsToObfuscate(3);
+        doReturn(event1).when(eventService).getEventEntityById(1);
+        doReturn(event2).when(eventService).getEventEntityById(2);
+        doReturn(event3).when(eventService).getEventEntityById(3);
+        doReturn(event1).when(eventService).getEventEntityById(4);
 
-        eventService.adminObfuscateEveByIds(List.of(1, 2, 3));
+        eventService.adminObfuscateEveByIds(List.of(1, 2, 3, 4));
 
 
         verify(dataAnonymisationService, times(1)).anonymizeEvent(event1);
         verify(dataAnonymisationService, times(1)).anonymizeEvent(event2);
         verify(dataAnonymisationService, times(1)).anonymizeEvent(event3);
-        verify(dataAnonymisationService, times(1)).anonymizeEvent(event4);
 
-        verify(eventService, times(1)).getEventsToObfuscate(1);
-        verify(eventService, times(1)).getEventsToObfuscate(2);
-        verify(eventService, times(1)).getEventsToObfuscate(3);
-    }
-
-
-    @Test
-    void positiveGetEventsToObfuscateZeroEventId() {
-        EventEntity event = mock(EventEntity.class);
-        when(event.getEventId()).thenReturn(0);
-        doReturn(event).when(eventService).getEventEntityById(123);
-
-        assertThat(eventService.getEventsToObfuscate(123)).containsExactly(event);
-        verify(eventService, times(1)).getEventEntityById(123);
-        verifyNoInteractions(eventRepository);
-    }
-
-    @Test
-    void positiveGetEventsToObfuscateNoneZeroEventId() {
-        EventEntity event1 = mock(EventEntity.class);
-        EventEntity event2 = mock(EventEntity.class);
-        EventEntity event3 = mock(EventEntity.class);
-        EventEntity event4 = mock(EventEntity.class);
-
-        when(event1.getEventId()).thenReturn(1234);
-        doReturn(event1).when(eventService).getEventEntityById(123);
-        doReturn(List.of(event2, event3, event4)).when(eventRepository).findAllByEventId(1234);
-
-        assertThat(eventService.getEventsToObfuscate(123)).containsExactly(event2, event3, event4);
-
-        verify(eventService, times(1)).getEventEntityById(123);
-        verify(eventRepository,times(1)).findAllByEventId(1234);
+        verify(eventService, times(1)).getEventEntityById(1);
+        verify(eventService, times(1)).getEventEntityById(2);
+        verify(eventService, times(1)).getEventEntityById(3);
     }
 
 

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -1,0 +1,118 @@
+package uk.gov.hmcts.darts.event.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.entity.EventEntity;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.EventRepository;
+import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
+import uk.gov.hmcts.darts.event.mapper.EventMapper;
+import uk.gov.hmcts.darts.event.validation.EventIdValidator;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceImplTest {
+
+    @Mock
+    private EventMapper eventMapper;
+    @Mock
+    private EventIdValidator eventIdValidator;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private DataAnonymisationService dataAnonymisationService;
+    @InjectMocks
+    @Spy
+    private EventServiceImpl eventService;
+
+
+    @Test
+    void positiveAdminObfuscateEveByIds() {
+        EventEntity event1 = mock(EventEntity.class);
+        EventEntity event2 = mock(EventEntity.class);
+        EventEntity event3 = mock(EventEntity.class);
+        EventEntity event4 = mock(EventEntity.class);
+
+
+        doReturn(List.of(event1, event2)).when(eventService).getEventsToObfuscate(1);
+        doReturn(List.of(event2, event3)).when(eventService).getEventsToObfuscate(2);
+        doReturn(List.of(event4)).when(eventService).getEventsToObfuscate(3);
+
+        eventService.adminObfuscateEveByIds(List.of(1, 2, 3));
+
+
+        verify(dataAnonymisationService, times(1)).anonymizeEvent(event1);
+        verify(dataAnonymisationService, times(1)).anonymizeEvent(event2);
+        verify(dataAnonymisationService, times(1)).anonymizeEvent(event3);
+        verify(dataAnonymisationService, times(1)).anonymizeEvent(event4);
+
+        verify(eventService, times(1)).getEventsToObfuscate(1);
+        verify(eventService, times(1)).getEventsToObfuscate(2);
+        verify(eventService, times(1)).getEventsToObfuscate(3);
+    }
+
+
+    @Test
+    void positiveGetEventsToObfuscateZeroEventId() {
+        EventEntity event = mock(EventEntity.class);
+        when(event.getEventId()).thenReturn(0);
+        doReturn(event).when(eventService).getEventEntityById(123);
+
+        assertThat(eventService.getEventsToObfuscate(123)).containsExactly(event);
+        verify(eventService, times(1)).getEventEntityById(123);
+        verifyNoInteractions(eventRepository);
+    }
+
+    @Test
+    void positiveGetEventsToObfuscateNoneZeroEventId() {
+        EventEntity event1 = mock(EventEntity.class);
+        EventEntity event2 = mock(EventEntity.class);
+        EventEntity event3 = mock(EventEntity.class);
+        EventEntity event4 = mock(EventEntity.class);
+
+        when(event1.getEventId()).thenReturn(1234);
+        doReturn(event1).when(eventService).getEventEntityById(123);
+        doReturn(List.of(event2, event3, event4)).when(eventRepository).findAllByEventId(1234);
+
+        assertThat(eventService.getEventsToObfuscate(123)).containsExactly(event2, event3, event4);
+
+        verify(eventService, times(1)).getEventEntityById(123);
+        verify(eventRepository,times(1)).findAllByEventId(1234);
+    }
+
+
+    @Test
+    void positiveGetEventEntityById() {
+        EventEntity event = mock(EventEntity.class);
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+        assertThat(eventService.getEventEntityById(1)).isEqualTo(event);
+        verify(eventRepository, times(1)).findById(1);
+    }
+
+
+    @Test
+    void positiveGetEventEntityByIdNotFound() {
+        when(eventRepository.findById(1)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> eventService.getEventEntityById(1))
+            .isInstanceOf(DartsApiException.class)
+            .hasFieldOrPropertyWithValue("error", DartsApiException.DartsApiErrorCommon.NOT_FOUND);
+        verify(eventRepository, times(1)).findById(1);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -42,7 +42,7 @@ class EventServiceImplTest {
 
 
     @Test
-    void positiveAdminObfuscateEveByIds() {
+    void positiveObfuscateEventByIds() {
         EventEntity event1 = mock(EventEntity.class);
         EventEntity event2 = mock(EventEntity.class);
         EventEntity event3 = mock(EventEntity.class);
@@ -53,7 +53,7 @@ class EventServiceImplTest {
         doReturn(event3).when(eventService).getEventEntityById(3);
         doReturn(event1).when(eventService).getEventEntityById(4);
 
-        eventService.adminObfuscateEveByIds(List.of(1, 2, 3, 4));
+        eventService.obfuscateEventByIds(List.of(1, 2, 3, 4));
 
 
         verify(dataAnonymisationService, times(1)).anonymizeEvent(event1);

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -13,16 +13,13 @@ import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
 import uk.gov.hmcts.darts.event.mapper.EventMapper;
 import uk.gov.hmcts.darts.event.validation.EventIdValidator;
 
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,36 +33,10 @@ class EventServiceImplTest {
     private EventRepository eventRepository;
     @Mock
     private DataAnonymisationService dataAnonymisationService;
+
     @InjectMocks
     @Spy
     private EventServiceImpl eventService;
-
-
-    @Test
-    void positiveObfuscateEventByIds() {
-        EventEntity event1 = mock(EventEntity.class);
-        EventEntity event2 = mock(EventEntity.class);
-        EventEntity event3 = mock(EventEntity.class);
-
-
-        doReturn(event1).when(eventService).getEventEntityById(1);
-        doReturn(event2).when(eventService).getEventEntityById(2);
-        doReturn(event3).when(eventService).getEventEntityById(3);
-        doReturn(event1).when(eventService).getEventEntityById(4);
-
-        eventService.obfuscateEventByIds(List.of(1, 2, 3, 4));
-
-
-        verify(dataAnonymisationService, times(1)).anonymizeEvent(event1);
-        verify(dataAnonymisationService, times(1)).anonymizeEvent(event2);
-        verify(dataAnonymisationService, times(1)).anonymizeEvent(event3);
-        verifyNoMoreInteractions(dataAnonymisationService);
-
-        verify(eventService, times(1)).getEventEntityById(1);
-        verify(eventService, times(1)).getEventEntityById(2);
-        verify(eventService, times(1)).getEventEntityById(3);
-        verify(eventService, times(1)).getEventEntityById(4);
-    }
 
 
     @Test
@@ -85,6 +56,14 @@ class EventServiceImplTest {
             .isInstanceOf(DartsApiException.class)
             .hasFieldOrPropertyWithValue("error", DartsApiException.DartsApiErrorCommon.NOT_FOUND);
         verify(eventRepository, times(1)).findById(1);
+    }
+
+    @Test
+    void positiveSaveEvent() {
+        EventEntity event = mock(EventEntity.class);
+        when(eventRepository.save(event)).thenReturn(event);
+        assertThat(eventService.saveEvent(event)).isEqualTo(event);
+        verify(eventRepository, times(1)).save(event);
     }
 
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3996)


### Change description ###
# Summary of Git Diff

This Git diff introduces new functionality for event obfuscation in the DARTS application. It adds tests for obfuscating event texts, updates existing service interfaces, and modifies the controller to include new API endpoints for this feature. Additionally, it implements error handling for scenarios when events are not found.

## Highlights

- **New Tests Added**: 
  - `adminObfuscateEveByIdsSingle`: Tests obfuscation of a single event.
  - `adminObfuscateEveByIdsMultiple`: Tests obfuscation of multiple events.
  - `adminObfuscateEveByIdsNotFound`: Tests API response when trying to obfuscate a non-existent event.
  - `adminObfuscateEveByIdsNotSuperAdmin`: Ensures that non-super admin users cannot obfuscate events.

- **New Methods in Service Interface**:
  - `obfuscateEventByIds(List<Integer> eveIds)`: Added to `DataAnonymisationService`.
  - `getEventEntityById(Integer eveId)`: Retrieves event details by ID.
  - `saveEvent(EventEntity eventEntity)`: Saves the modified event entity.

- **Controller Modification**:
  - New endpoint `/admin/events/obfuscate` for obfuscating event texts added to `EventsController`.

- **Error Handling**:
  - Introduced `DartsApiException.DartsApiErrorCommon.NOT_FOUND` for handling cases where events do not exist.

- **OpenAPI Specification Updated**:
  - The OpenAPI specification (`event.yaml`) reflects the new obfuscation feature and its associated responses.

- **New Unit Tests**: 
  - Added tests for `EventServiceImpl` to validate the behavior of new methods, especially for retrieving and saving events.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
