### PR TITLE
DMP-4024: Update endpoints to GET events to add is_data_anonymised

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -33,7 +33,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
     @Autowired
     private transient MockMvc mockMvc;
 
-    private static String endpointUrl = "/cases/{case_id}/events";
+    private static final String endpointUrl = "/cases/{case_id}/events";
 
     private static final OffsetDateTime SOME_DATE_TIME = OffsetDateTime.parse("2023-01-01T12:00Z");
     private static final String SOME_COURTHOUSE = "SOME-COURTHOUSE";
@@ -94,6 +94,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
             "timestamp":"2023-01-01T12:00:00Z",
             "name":"Section 11 of the Contempt of Court Act 1981",
             "text":"some-event-text-1",
+            "is_data_anonymised": false
             }]
             """;
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -33,7 +33,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
     @Autowired
     private transient MockMvc mockMvc;
 
-    private static final String endpointUrl = "/cases/{case_id}/events";
+    private static final String ENDPOINT_URL = "/cases/{case_id}/events";
 
     private static final OffsetDateTime SOME_DATE_TIME = OffsetDateTime.parse("2023-01-01T12:00Z");
     private static final String SOME_COURTHOUSE = "SOME-COURTHOUSE";
@@ -74,7 +74,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
 
         when(mockUserIdentity.getUserAccount()).thenReturn(null);
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE));
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE));
 
         mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isForbidden());
     }
@@ -82,7 +82,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
     @Test
     void casesGetEventsEndpoint() throws Exception {
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE));
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE));
 
         MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
@@ -107,7 +107,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
     @Test
     void casesGetEventsEndpointCaseNotFound() throws Exception {
 
-        MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, 25);
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, 25);
 
         mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isNotFound());
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
@@ -44,9 +44,6 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
     private EventEntity event;
 
     private static final String SOME_DATE = "2023-01-01";
-    private static final String SOME_COURTHOUSE = "SOME-COURTHOUSE";
-    private static final String SOME_COURTROOM = "some-courtroom";
-    private static final String SOME_CASE_NUMBER = "1";
 
     @BeforeEach
     void setUp() {
@@ -55,7 +52,7 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
         courtCase.addProsecutor(createProsecutorForCase(courtCase));
         courtCase.addDefendant(createDefendantForCase(courtCase));
         courtCase.addDefence(createDefenceForCase(courtCase));
-        var hearing =  PersistableFactory.getHearingTestData().createHearingWith(courtCase, someMinimalCourtRoom(), LocalDate.parse(SOME_DATE));
+        var hearing = PersistableFactory.getHearingTestData().createHearingWith(courtCase, someMinimalCourtRoom(), LocalDate.parse(SOME_DATE));
 
         dartsPersistence.save(hearing);
 
@@ -76,7 +73,13 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
         String actualJson = mvcResult.getResponse().getContentAsString();
         log.info("actualJson: {}", actualJson);
         String expectedJson = """
-            [{"id":<<eventId>>,"timestamp":"2020-06-20T10:00:00Z","name":"Defendant recalled","text":"testEventText"}]
+            [{
+              "id":<<eventId>>,
+              "timestamp":"2020-06-20T10:00:00Z",
+              "name":"Defendant recalled",
+              "text":"testEventText",
+              "is_data_anonymised": false
+            }]
             """;
         expectedJson = expectedJson.replace("<<eventId>>", event.getId().toString());
         JSONAssert.assertEquals(expectedJson, actualJson, JSONCompareMode.NON_EXTENSIBLE);

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
@@ -36,6 +36,7 @@ public class EventMapper {
         event.setTimestamp(eventEntity.getTimestamp());
         event.setName(eventEntity.getEventType().getEventName());
         event.setText(eventEntity.getEventText());
+        event.isDataAnonymised(eventEntity.isDataAnonymised());
 
         return event;
     }

--- a/src/main/java/uk/gov/hmcts/darts/hearings/mapper/GetEventsResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/mapper/GetEventsResponseMapper.java
@@ -30,6 +30,7 @@ public class GetEventsResponseMapper {
         eventResponse.setTimestamp(eventEntity.getTimestamp());
         eventResponse.setName(eventEntity.getEventType().getEventName());
         eventResponse.setText(eventEntity.getEventText());
+        eventResponse.isDataAnonymised(eventEntity.isDataAnonymised());
         return eventResponse;
     }
 

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -657,6 +657,8 @@ components:
         name:
           type: string
           example: "Case called on"
+        is_data_anonymised:
+            $ref: '#/components/schemas/IsDataAnonymised'
         text:
           type: string
           example: "Record:New Case"

--- a/src/main/resources/openapi/hearings.yaml
+++ b/src/main/resources/openapi/hearings.yaml
@@ -259,7 +259,7 @@ components:
 
     events_response:
       type: array
-      default: []
+      default: [ ]
       items:
         $ref: '#/components/schemas/event_response'
     event_response:
@@ -278,6 +278,9 @@ components:
         text:
           type: string
           example: Record:New Case
+        is_data_anonymised:
+          type: boolean
+          example: false
 
     HearingsSearchRequest:
       type: object
@@ -429,7 +432,7 @@ components:
         - "HEARING_100"
         - "HEARING_101"
         - "HEARING_102"
-      x-enum-varnames: [HEARING_NOT_FOUND, TOO_MANY_RESULTS, HEARING_NOT_ACTUAL]
+      x-enum-varnames: [ HEARING_NOT_FOUND, TOO_MANY_RESULTS, HEARING_NOT_ACTUAL ]
 
     HearingsTitleErrors:
       type: string
@@ -437,4 +440,4 @@ components:
         - "The requested hearing cannot be found"
         - "Too many results have been returned. Please change search criteria."
         - "The requested hearing is not an actual hearing."
-      x-enum-varnames: [HEARING_NOT_FOUND, TOO_MANY_RESULTS, HEARING_NOT_ACTUAL]
+      x-enum-varnames: [ HEARING_NOT_FOUND, TOO_MANY_RESULTS, HEARING_NOT_ACTUAL ]

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/EventMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/EventMapperTest.java
@@ -12,6 +12,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.darts.common.util.CommonTestDataUtil.createEventWith;
 
 class EventMapperTest {
@@ -30,7 +32,27 @@ class EventMapperTest {
         assertEquals("eventName", event.getName());
         assertEquals("event text", event.getText());
         assertEquals(hearingDate, event.getTimestamp());
+        assertFalse(event.getIsDataAnonymised());
     }
+
+    @Test
+    void testMapGetEventsByCaseIdDataAnonymised() {
+        OffsetDateTime hearingDate = OffsetDateTime.parse("2024-07-01T12:00Z");
+        HearingEntity hearing = CommonTestDataUtil.createHearing("case1", hearingDate.toLocalDate());
+        EventEntity eventEntity = createEventWith("eventName", "event text", hearing, hearingDate);
+        eventEntity.setDataAnonymised(true);
+        List<EventEntity> eventEntityList = Lists.newArrayList(eventEntity);
+        List<Event> events = EventMapper.mapToEvents(eventEntityList);
+        Event event = events.get(0);
+        assertEquals(1, event.getId());
+        assertEquals(102, event.getHearingId());
+        assertEquals(hearingDate.toLocalDate(), event.getHearingDate());
+        assertEquals("eventName", event.getName());
+        assertEquals("event text", event.getText());
+        assertEquals(hearingDate, event.getTimestamp());
+        assertTrue(event.getIsDataAnonymised());
+    }
+
 
     @Test
     void testMapGetVersionedEventsByCaseId() {

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/EventMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/EventMapperTest.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.darts.cases.mapper;
 
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.hmcts.darts.cases.model.Event;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
@@ -12,35 +14,20 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.darts.common.util.CommonTestDataUtil.createEventWith;
 
 class EventMapperTest {
 
-    @Test
-    void testMapGetEventsByCaseId() {
-        OffsetDateTime hearingDate = OffsetDateTime.parse("2024-07-01T12:00Z");
-        HearingEntity hearing = CommonTestDataUtil.createHearing("case1", hearingDate.toLocalDate());
-        List<EventEntity> eventEntityList = Lists.newArrayList(createEventWith("eventName", "event text", hearing, hearingDate));
 
-        List<Event> events = EventMapper.mapToEvents(eventEntityList);
-        Event event = events.get(0);
-        assertEquals(1, event.getId());
-        assertEquals(102, event.getHearingId());
-        assertEquals(hearingDate.toLocalDate(), event.getHearingDate());
-        assertEquals("eventName", event.getName());
-        assertEquals("event text", event.getText());
-        assertEquals(hearingDate, event.getTimestamp());
-        assertFalse(event.getIsDataAnonymised());
-    }
-
-    @Test
-    void testMapGetEventsByCaseIdDataAnonymised() {
+    @ParameterizedTest(name = "testMapGetEventsByCaseId isAnonymised={0}")
+    @ValueSource(booleans = {true, false})
+    void testMapGetEventsByCaseId(boolean isAnonymised) {
         OffsetDateTime hearingDate = OffsetDateTime.parse("2024-07-01T12:00Z");
         HearingEntity hearing = CommonTestDataUtil.createHearing("case1", hearingDate.toLocalDate());
         EventEntity eventEntity = createEventWith("eventName", "event text", hearing, hearingDate);
-        eventEntity.setDataAnonymised(true);
+        if (isAnonymised) {
+            eventEntity.setDataAnonymised(true);
+        }
         List<EventEntity> eventEntityList = Lists.newArrayList(eventEntity);
         List<Event> events = EventMapper.mapToEvents(eventEntityList);
         Event event = events.get(0);
@@ -50,7 +37,8 @@ class EventMapperTest {
         assertEquals("eventName", event.getName());
         assertEquals("event text", event.getText());
         assertEquals(hearingDate, event.getTimestamp());
-        assertTrue(event.getIsDataAnonymised());
+        assertEquals(isAnonymised, event.getIsDataAnonymised());
+
     }
 
 

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/GetEventsResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/GetEventsResponseMapperTest.java
@@ -49,6 +49,20 @@ class GetEventsResponseMapperTest {
     }
 
     @Test
+    void testMapToEventsEventAnonymised() throws IOException {
+        HearingEntity hearingEntity = CommonTestDataUtil.createHearing("TEST_1", LocalTime.NOON);
+        EventEntity eventEntity = CommonTestDataUtil.createEventWith("Test", hearingEntity, eventType);
+        eventEntity.setDataAnonymised(true);
+        List<EventResponse> eventResponses = GetEventsResponseMapper.mapToEvents(List.of(eventEntity));
+
+        String actualResponse = objectMapper.writeValueAsString(eventResponses);
+        String expectedResponse = getContentsFromFile(
+            "Tests/cases/CasesMapperTest/testMapToEvents/expectedResponseAnonymised.json");
+
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
+    }
+
+    @Test
     void testVersionedEventsFilteredOut() throws IOException {
         OffsetDateTime eventDate = OffsetDateTime.parse("2024-07-01T12:00Z");
 

--- a/src/test/resources/Tests/cases/CaseServiceTest/testGetEventsByCase/expectedResponse.json
+++ b/src/test/resources/Tests/cases/CaseServiceTest/testGetEventsByCase/expectedResponse.json
@@ -1,10 +1,11 @@
 [
   {
     "id": 1,
-    "hearing_id":1,
-    "hearing_date":"2024-07-01",
-    "timestamp":"2024-07-01T12:00:00Z",
-    "name":"eventName",
-    "text":"event"
+    "hearing_id": 1,
+    "hearing_date": "2024-07-01",
+    "timestamp": "2024-07-01T12:00:00Z",
+    "name": "eventName",
+    "text": "event",
+    "is_data_anonymised": false
   }
 ]

--- a/src/test/resources/Tests/cases/CasesMapperTest/testMapToEvents/expectedResponseAnonymised.json
+++ b/src/test/resources/Tests/cases/CasesMapperTest/testMapToEvents/expectedResponseAnonymised.json
@@ -4,6 +4,6 @@
     "timestamp": "2023-07-01T10:00:00Z",
     "name": "TestName",
     "text": "Test",
-    "is_data_anonymised": false
+    "is_data_anonymised": true
   }
 ]

--- a/src/test/resources/Tests/cases/CasesMapperTest/testVersionedEvents/expectedResponseForVersionedEvents.json
+++ b/src/test/resources/Tests/cases/CasesMapperTest/testVersionedEvents/expectedResponseForVersionedEvents.json
@@ -3,6 +3,7 @@
     "id": 3,
     "timestamp": "2024-07-01T12:00:00Z",
     "name": "TestName",
-    "text": "Event3"
+    "text": "Event3",
+    "is_data_anonymised": false
   }
 ]

--- a/src/test/resources/Tests/cases/CasesMapperTest/testVersionedEvents/expectedResponseForVersionedEventsWithGroupedEventsIsCurrentSet.json
+++ b/src/test/resources/Tests/cases/CasesMapperTest/testVersionedEvents/expectedResponseForVersionedEventsWithGroupedEventsIsCurrentSet.json
@@ -3,12 +3,14 @@
     "id": 2,
     "timestamp": "2024-07-01T12:00:00Z",
     "name": "TestName",
-    "text": "Event2"
+    "text": "Event2",
+    "is_data_anonymised": false
   },
   {
     "id": 5,
     "timestamp": "2024-07-01T12:00:00Z",
     "name": "TestName",
-    "text": "Event5"
+    "text": "Event5",
+    "is_data_anonymised": false
   }
 ]

--- a/src/test/resources/Tests/cases/CasesMapperTest/testVersionedEvents/expectedResponseForZeroIdVersionedEvents.json
+++ b/src/test/resources/Tests/cases/CasesMapperTest/testVersionedEvents/expectedResponseForZeroIdVersionedEvents.json
@@ -3,12 +3,14 @@
     "id": 1,
     "timestamp": "2024-07-01T12:00:00Z",
     "name": "TestName",
-    "text": "Event1"
+    "text": "Event1",
+    "is_data_anonymised": false
   },
   {
     "id": 2,
     "timestamp": "2024-07-01T12:00:00Z",
     "name": "TestName",
-    "text": "Event2"
+    "text": "Event2",
+    "is_data_anonymised": false
   }
 ]


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4024)


### Change description ###
# Git Diff Summary

This Git diff introduces changes across several files, primarily focusing on the addition of an `is_data_anonymised` field to event-related data structures, tests, and OpenAPI specifications. It also includes minor refactoring and adjustments to formatting.

## Highlights

- **Added `is_data_anonymised` Field**:
  - New field added to JSON responses in `CaseControllerGetEventByCaseIdTest` and `HearingsGetEventsControllerTest`.
  - Reflected in OpenAPI specifications for cases and hearings.

- **Event Mapping Updates**:
  - The `EventMapper` and `GetEventsResponseMapper` classes have been updated to set the new `is_data_anonymised` property based on the corresponding entity's value.

- **Test Cases Enhancements**:
  - New test cases in `EventMapperTest` and `GetEventsResponseMapperTest` to validate the correct mapping of the `is_data_anonymised` field.
  - Adjustments made to existing test expected results to include the `is_data_anonymised` field.

- **Code Refactoring**:
  - Minor refactoring for consistency, such as changing `String endpointUrl` to `String endpointUrl` as a `final` variable.
  - Formatting improvements in various JSON structures for better readability.

- **New Expected Response Files**:
  - Added expected response files for tests to account for the new `is_data_anonymised` field, including variations for anonymized and non-anonymized events.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
