### PR TITLE
dmp-4067: Viq Header not inserted if TRIM is not performed

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 \
 
 #### Install ffmpeg
 
-This is used to trim and convert audio files, so run this in a mac terminal:-
+This is used to trim, merge, concatenate and convert audio files, so run this in a mac terminal:-
 
 brew install ffmpeg
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileZipGeneratorHelperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileZipGeneratorHelperImpl.java
@@ -150,10 +150,6 @@ public class OutboundFileZipGeneratorHelperImpl implements OutboundFileZipGenera
     @Override
     public Path generateViqFile(AudioFileInfo audioFileInfo, Path viqOutputFile) {
 
-        if (!audioFileInfo.isTrimmed()) {
-            return audioFileInfo.getPath();
-        }
-
         ViqHeader viqHeader = new ViqHeader(audioFileInfo.getStartTime());
 
         try {

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundFileZipGeneratorHelperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundFileZipGeneratorHelperImplTest.java
@@ -325,8 +325,14 @@ class OutboundFileZipGeneratorHelperImplTest {
 
         Path viqFile = outboundFileZipGeneratorHelper.generateViqFile(audioFileInfo, outputFile);
 
-        assertEquals(viqFile, sourceFile);
-        assertTrue(Files.isSameFile(sourceFile, viqFile));
+        assertEquals(viqFile, outputFile);
+        byte[] expectedViqHeader = new ViqHeader(audioFileInfo.getStartTime()).getViqHeaderBytes();
+        int expectedViqHeaderOffset = 0;
+        assertEquals(expectedViqHeaderOffset, searchBytePattern(Files.readAllBytes(viqFile), expectedViqHeader));
+        int expectedSourceFileOffset = expectedViqHeader.length;
+        assertEquals(expectedSourceFileOffset, searchBytePattern(Files.readAllBytes(viqFile), Files.readAllBytes(sourceFile)));
+        long expectedViqFileSize = expectedViqHeader.length + Files.size(sourceFile);
+        assertEquals(expectedViqFileSize, Files.size(viqFile));
     }
 
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
DMP-4067


### Change description ###
The Viq header was not getting updated if no TRIM was performed. Due to this the processed audio contained the Viqheader of original raw audio.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
