### PR TITLE
NO-JIRA: performance fix around loading of eod statuses from DB

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmResponseFilesProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmResponseFilesProcessorIntTest.java
@@ -2,11 +2,13 @@ package uk.gov.hmcts.darts.arm.service;
 
 import com.azure.core.util.BinaryData;
 import com.azure.storage.blob.models.BlobStorageException;
+import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
 import uk.gov.hmcts.darts.arm.component.ArmResponseFilesProcessSingleElement;
@@ -26,6 +28,7 @@ import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.AuthorisationStub;
+import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,7 +65,7 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
     private ArmDataManagementApi armDataManagementApi;
     @MockBean
     private ArmDataManagementConfiguration armDataManagementConfiguration;
-    @MockBean
+    @Autowired
     private UserIdentity userIdentity;
 
     @Autowired
@@ -73,6 +76,24 @@ class ArmResponseFilesProcessorIntTest extends IntegrationBase {
 
     @TempDir
     private File tempDirectory;
+
+    @SuppressWarnings("PMD.TestClassWithoutTestCases")
+    @TestConfiguration
+    public static class TestConfig {
+
+        @Autowired
+        private DartsDatabaseStub dartsDatabase;
+
+        @MockBean
+        private UserIdentity userIdentity;
+
+        @PostConstruct
+        public UserIdentity mockUserIdentity() {
+            UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+            when(userIdentity.getUserAccount()).thenReturn(testUser);
+            return userIdentity;
+        }
+    }
 
     @BeforeEach
     void setupData() {

--- a/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArmResponseFilesProcessSingleElementImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArmResponseFilesProcessSingleElementImpl.java
@@ -78,12 +78,12 @@ public class ArmResponseFilesProcessSingleElementImpl implements ArmResponseFile
 
     @PostConstruct
     public void initialisePreloadedObjects() {
-        storedStatus = objectRecordStatusRepository.findById(STORED.getId()).get();
-        armDropZoneStatus = objectRecordStatusRepository.findById(ARM_DROP_ZONE.getId()).get();
-        armProcessingResponseFilesStatus = objectRecordStatusRepository.findById(ARM_PROCESSING_RESPONSE_FILES.getId()).get();
-        armResponseManifestFailedStatus = objectRecordStatusRepository.findById(ARM_RESPONSE_MANIFEST_FAILED.getId()).get();
-        armResponseProcessingFailedStatus = objectRecordStatusRepository.findById(ARM_RESPONSE_PROCESSING_FAILED.getId()).get();
-        armResponseChecksumVerificationFailedStatus = objectRecordStatusRepository.findById(ARM_RESPONSE_CHECKSUM_VERIFICATION_FAILED.getId()).get();
+        storedStatus = objectRecordStatusRepository.findById(STORED.getId()).orElseThrow();
+        armDropZoneStatus = objectRecordStatusRepository.findById(ARM_DROP_ZONE.getId()).orElseThrow();
+        armProcessingResponseFilesStatus = objectRecordStatusRepository.findById(ARM_PROCESSING_RESPONSE_FILES.getId()).orElseThrow();
+        armResponseManifestFailedStatus = objectRecordStatusRepository.findById(ARM_RESPONSE_MANIFEST_FAILED.getId()).orElseThrow();
+        armResponseProcessingFailedStatus = objectRecordStatusRepository.findById(ARM_RESPONSE_PROCESSING_FAILED.getId()).orElseThrow();
+        armResponseChecksumVerificationFailedStatus = objectRecordStatusRepository.findById(ARM_RESPONSE_CHECKSUM_VERIFICATION_FAILED.getId()).orElseThrow();
     }
 
     @Transactional


### PR DESCRIPTION
### Change description ###
Improving performance by loading EOD statuses once on bean creation rather than every time the task processes an object.
This will reduce the number of SELECTs to the DB

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
