### PR TITLE
DMP-4076: Debug logging for investigation of duplicates in media_link…

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/helper/MediaLinkedCaseHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/helper/MediaLinkedCaseHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.common.helper;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
@@ -11,6 +12,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class MediaLinkedCaseHelper {
 
     private final MediaLinkedCaseRepository mediaLinkedCaseRepository;
@@ -18,11 +20,22 @@ public class MediaLinkedCaseHelper {
     public void addCase(MediaEntity mediaEntity, CourtCaseEntity courtCase) {
         List<MediaLinkedCaseEntity> mediaLinkedCaseEntities = mediaLinkedCaseRepository.findByMedia(mediaEntity);
         List<CourtCaseEntity> linkedCases = mediaLinkedCaseEntities.stream().map(MediaLinkedCaseEntity::getCourtCase).toList();
+        log.debug("Handling med_id {} and cas_id {}. Currently the media has the following cas_ids linked: {}",
+                  mediaEntity.getId(),
+                  courtCase.getId(),
+                  linkedCases.stream()
+                      .map(CourtCaseEntity::getId)
+                      .toList());
         if (!linkedCases.contains(courtCase)) {
             MediaLinkedCaseEntity mediaLinkedCaseEntity = new MediaLinkedCaseEntity();
             mediaLinkedCaseEntity.setMedia(mediaEntity);
             mediaLinkedCaseEntity.setCourtCase(courtCase);
             mediaLinkedCaseRepository.saveAndFlush(mediaLinkedCaseEntity);
+            log.debug("cas_id {} and med_id {} were not linked, Created new link via mlc_id {}",
+                      courtCase.getId(), mediaEntity.getId(), mediaLinkedCaseEntity.getId());
+        } else {
+            log.debug("med_id {} and cas_id {} already linked, nothing to do",
+                      mediaEntity.getId(), courtCase.getId());
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/helper/MediaLinkedCaseHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/helper/MediaLinkedCaseHelper.java
@@ -20,12 +20,14 @@ public class MediaLinkedCaseHelper {
     public void addCase(MediaEntity mediaEntity, CourtCaseEntity courtCase) {
         List<MediaLinkedCaseEntity> mediaLinkedCaseEntities = mediaLinkedCaseRepository.findByMedia(mediaEntity);
         List<CourtCaseEntity> linkedCases = mediaLinkedCaseEntities.stream().map(MediaLinkedCaseEntity::getCourtCase).toList();
-        log.debug("Handling med_id {} and cas_id {}. Currently the media has the following cas_ids linked: {}",
-                  mediaEntity.getId(),
-                  courtCase.getId(),
-                  linkedCases.stream()
-                      .map(CourtCaseEntity::getId)
-                      .toList());
+        if (log.isDebugEnabled()) {
+            log.debug("Handling med_id {} and cas_id {}. Currently the media has the following cas_ids linked: {}",
+                      mediaEntity.getId(),
+                      courtCase.getId(),
+                      linkedCases.stream()
+                          .map(CourtCaseEntity::getId)
+                          .toList());
+        }
         if (!linkedCases.contains(courtCase)) {
             MediaLinkedCaseEntity mediaLinkedCaseEntity = new MediaLinkedCaseEntity();
             mediaLinkedCaseEntity.setMedia(mediaEntity);


### PR DESCRIPTION
Despite my best efforts I've been unable to recreate the issue described by [DMP-4076](https://tools.hmcts.net/jira/browse/DMP-4076) locally.

The `addCase` method within `MediaLinkedCaseHelper` is the only place where we insert into the `media_linked_case` table.

One theoretical reason for why we could see duplicates (no I couldnt' recreate this either) - it's possible the provided `courtCase` has been modified by the calling code since it was retrieved from the DB, meaning that the object equality comparison fails at the `linkedCases.contains(courtCase)` stage, thereby allowing a new record to be inserted.

This PR adds debug logging which should help confirm/deny that, and otherwise may help should we see this issue again in the future.

This PR is dev-only change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
