### PR TITLE
DMP-4088: Requester receiving approval email for their own requests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
@@ -44,6 +44,7 @@ import static java.time.OffsetDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -153,7 +154,9 @@ class TranscriptionControllerRequestTranscriptionIntTest extends IntegrationBase
             .containsExactly(TEST_COMMENT);
 
         List<NotificationEntity> notificationEntities = dartsDatabase.getNotificationRepository().findAll();
-        List<String> templateList = notificationEntities.stream().map(NotificationEntity::getEventId).toList();
+        List<String> templateList = notificationEntities.stream()
+            .peek(notificationEntity -> assertNotEquals(transcriptionEntity.getRequestedBy().getEmailAddress(), notificationEntity.getEmailAddress())).map(
+                NotificationEntity::getEventId).toList();
         assertTrue(templateList.contains(COURT_MANAGER_APPROVE_TRANSCRIPT.toString()));
 
         assertAudit(1);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
@@ -155,8 +155,9 @@ class TranscriptionControllerRequestTranscriptionIntTest extends IntegrationBase
 
         List<NotificationEntity> notificationEntities = dartsDatabase.getNotificationRepository().findAll();
         List<String> templateList = notificationEntities.stream()
-            .peek(notificationEntity -> assertNotEquals(transcriptionEntity.getRequestedBy().getEmailAddress(), notificationEntity.getEmailAddress())).map(
-                NotificationEntity::getEventId).toList();
+            .peek(notificationEntity -> assertNotEquals(transcriptionEntity.getRequestedBy().getEmailAddress(), notificationEntity.getEmailAddress()))
+            .map(NotificationEntity::getEventId)
+            .toList();
         assertTrue(templateList.contains(COURT_MANAGER_APPROVE_TRANSCRIPT.toString()));
 
         assertAudit(1);

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/api/AuthorisationApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/api/AuthorisationApi.java
@@ -17,7 +17,7 @@ public interface AuthorisationApi {
 
     void checkCourthouseAuthorisation(List<CourthouseEntity> courthouses, Set<SecurityRoleEnum> securityRoles);
 
-    List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse);
+    List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse, UserAccountEntity... excludingUsers);
 
     UserAccountEntity getCurrentUser();
 

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/api/impl/AuthorisationApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/api/impl/AuthorisationApiImpl.java
@@ -43,8 +43,8 @@ public class AuthorisationApiImpl implements AuthorisationApi {
     }
 
     @Override
-    public List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse) {
-        return authorisationService.getUsersWithRoleAtCourthouse(securityRole, courthouse);
+    public List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse, UserAccountEntity... excludingUsers) {
+        return authorisationService.getUsersWithRoleAtCourthouse(securityRole, courthouse, excludingUsers);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/api/impl/AuthorisationApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/api/impl/AuthorisationApiImpl.java
@@ -43,7 +43,8 @@ public class AuthorisationApiImpl implements AuthorisationApi {
     }
 
     @Override
-    public List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse, UserAccountEntity... excludingUsers) {
+    public List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse,
+                                                                UserAccountEntity... excludingUsers) {
         return authorisationService.getUsersWithRoleAtCourthouse(securityRole, courthouse, excludingUsers);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationService.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationService.java
@@ -17,6 +17,6 @@ public interface AuthorisationService {
 
     void checkCourthouseAuthorisation(List<CourthouseEntity> courthouses, Set<SecurityRoleEnum> securityRoles);
 
-    List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse);
+    List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole, CourthouseEntity courthouse, UserAccountEntity... excludingUsers);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/service/impl/AuthorisationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/service/impl/AuthorisationServiceImpl.java
@@ -196,8 +196,9 @@ public class AuthorisationServiceImpl implements AuthorisationService {
 
     @Override
     public List<UserAccountEntity> getUsersWithRoleAtCourthouse(SecurityRoleEnum securityRole,
-                                                                CourthouseEntity courthouse) {
-        return userAccountRepository.findByRoleAndCourthouse(securityRole.getId(), courthouse);
+                                                                CourthouseEntity courthouse,
+                                                                UserAccountEntity... excludingUsers) {
+        return userAccountRepository.findByRoleAndCourthouse(securityRole.getId(), courthouse, Set.of(excludingUsers));
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
@@ -35,8 +35,9 @@ public interface UserAccountRepository extends
         WHERE courthouse = :courthouse
         AND securityRole.id = :securityRole
         AND userAccount.active = true
+        and userAccount not in :excludingUsers
         """)
-    List<UserAccountEntity> findByRoleAndCourthouse(int securityRole, CourthouseEntity courthouse);
+    List<UserAccountEntity> findByRoleAndCourthouse(int securityRole, CourthouseEntity courthouse, Set<UserAccountEntity> excludingUsers);
 
     @Query("""
         SELECT userAccount

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionNotifications.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionNotifications.java
@@ -100,7 +100,8 @@ public class TranscriptionNotifications {
     public void notifyApprovers(TranscriptionEntity transcription) {
         List<UserAccountEntity> usersToNotify = authorisationApi.getUsersWithRoleAtCourthouse(
             SecurityRoleEnum.APPROVER,
-            transcription.getCourtCase().getCourthouse()
+            transcription.getCourtCase().getCourthouse(),
+            transcription.getRequestedBy()
         );
         SaveNotificationToDbRequest request = SaveNotificationToDbRequest.builder()
             .eventId(COURT_MANAGER_APPROVE_TRANSCRIPT.toString())

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionNotificationsTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionNotificationsTest.java
@@ -121,7 +121,8 @@ class TranscriptionNotificationsTest {
         approver1.setEmailAddress("approver1@example.com");
         var approver2 = new UserAccountEntity();
         approver2.setEmailAddress("approver2@example.com");
-        when(authorisationApi.getUsersWithRoleAtCourthouse(SecurityRoleEnum.APPROVER, courthouseEntity)).thenReturn(List.of(approver1, approver2));
+        when(authorisationApi.getUsersWithRoleAtCourthouse(SecurityRoleEnum.APPROVER, courthouseEntity, transcriptionEntity.getRequestedBy())).thenReturn(
+            List.of(approver1, approver2));
 
         transcriptionNotifications.notifyApprovers(transcriptionEntity);
 

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionNotificationsTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionNotificationsTest.java
@@ -121,7 +121,11 @@ class TranscriptionNotificationsTest {
         approver1.setEmailAddress("approver1@example.com");
         var approver2 = new UserAccountEntity();
         approver2.setEmailAddress("approver2@example.com");
-        when(authorisationApi.getUsersWithRoleAtCourthouse(SecurityRoleEnum.APPROVER, courthouseEntity, transcriptionEntity.getRequestedBy())).thenReturn(
+        var approver3 = new UserAccountEntity();
+        approver3.setEmailAddress("approver3@example.com");
+        when(transcriptionEntity.getRequestedBy()).thenReturn(approver3);
+
+        when(authorisationApi.getUsersWithRoleAtCourthouse(SecurityRoleEnum.APPROVER, courthouseEntity, approver3)).thenReturn(
             List.of(approver1, approver2));
 
         transcriptionNotifications.notifyApprovers(transcriptionEntity);
@@ -133,6 +137,10 @@ class TranscriptionNotificationsTest {
         assertEquals(actual.getUserAccountsToEmail().size(), 2);
         assertEquals(actual.getUserAccountsToEmail().get(0).getEmailAddress(), approver1.getEmailAddress());
         assertEquals(actual.getUserAccountsToEmail().get(1).getEmailAddress(), approver2.getEmailAddress());
+        verify(authorisationApi, times(1))
+            .getUsersWithRoleAtCourthouse(SecurityRoleEnum.APPROVER, courthouseEntity, approver3);
+        verify(transcriptionEntity, times(1))
+            .getRequestedBy();
     }
 
     @Test


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4088)


### Change description ###
# Summary of Changes

The recent updates in the code involve modifications to how user accounts with specific roles are retrieved from courthouses. The changes allow for the exclusion of certain users when fetching this information, enhancing the functionality of the authorisation process.

## Highlights

- **Method Update**: The method `getUsersWithRoleAtCourthouse` now accepts an additional parameter to exclude specific users from the results.
- **Interface Changes**: The interfaces for both `AuthorisationApi` and `AuthorisationService` have been updated to include the new exclusion functionality.
- **Implementation Adjustments**: The implementation classes reflect the changes made in the interfaces, ensuring consistency.
- **Database Query Update**: The repository method for fetching users has been modified to support the exclusion of specified users.
- **Test Cases Updated**: Tests have been adjusted to accommodate the new method signature and verify the correct functionality of the changes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
