### PR TITLE
DMP-3996: Common Error Codes

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.darts.audio.api.AudioApi;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
-import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.exception.EventError;
 import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
@@ -207,7 +207,7 @@ class EventsControllerTest extends IntegrationBase {
             .andReturn();
 
         Problem responseResult = objectMapper.readValue(response.getResponse().getContentAsString(), Problem.class);
-        Assertions.assertEquals(DartsApiException.DartsApiErrorCommon.NOT_FOUND.getType(), responseResult.getType());
+        Assertions.assertEquals(CommonApiError.NOT_FOUND.getType(), responseResult.getType());
     }
 
     @ParameterizedTest(name = "User with role {0} should not be able to obfuscate events")

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImpl.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
@@ -117,7 +118,7 @@ public class AdminMediaServiceImpl implements AdminMediaService {
     @Override
     public List<PostAdminMediasMarkedForDeletionItem> getMediasMarkedForDeletion() {
         if (!this.isManualDeletionEnabled()) {
-            throw new DartsApiException(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+            throw new DartsApiException(CommonApiError.FEATURE_FLAG_NOT_ENABLED, "Manual deletion is not enabled");
         }
 
         return objectAdminActionRepository.findAllMediaActionsWithAnyDeletionReason().stream()
@@ -145,7 +146,7 @@ public class AdminMediaServiceImpl implements AdminMediaService {
     @Transactional
     public MediaApproveMarkedForDeletionResponse adminApproveMediaMarkedForDeletion(Integer mediaId) {
         if (!this.isManualDeletionEnabled()) {
-            throw new DartsApiException(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+            throw new DartsApiException(CommonApiError.FEATURE_FLAG_NOT_ENABLED, "Manual deletion is not enabled");
         }
 
         mediaApproveMarkForDeletionValidator.validate(mediaId);

--- a/src/main/java/uk/gov/hmcts/darts/audio/validation/MediaHideOrShowValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/validation/MediaHideOrShowValidator.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.darts.audio.model.MediaHideRequest;
 import uk.gov.hmcts.darts.common.component.validation.Validator;
 import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectHiddenReasonEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ObjectAdminActionRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectHiddenReasonRepository;
@@ -57,7 +58,7 @@ public class MediaHideOrShowValidator implements Validator<IdRequest<MediaHideRe
             if (optionalObjectHiddenReasonEntity.isEmpty()) {
                 throw new DartsApiException(AudioApiError.MEDIA_HIDE_ACTION_REASON_NOT_FOUND);
             } else if (!isManualDeletionEnabled() && optionalObjectHiddenReasonEntity.get().isMarkedForDeletion()) {
-                throw new DartsApiException(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+                throw new DartsApiException(CommonApiError.FEATURE_FLAG_NOT_ENABLED, "Manual deletion is not enabled");
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/CommonApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/CommonApiError.java
@@ -14,6 +14,16 @@ public enum CommonApiError implements DartsApiError {
         CommonErrorCode.COURTHOUSE_PROVIDED_DOES_NOT_EXIST.getValue(),
         HttpStatus.BAD_REQUEST,
         CommonTitleErrors.COURTHOUSE_PROVIDED_DOES_NOT_EXIST.toString()
+    ),
+    FEATURE_FLAG_NOT_ENABLED(
+        CommonErrorCode.FEATURE_FLAG_NOT_ENABLED.getValue(),
+        HttpStatus.NOT_IMPLEMENTED,
+        CommonTitleErrors.FEATURE_FLAG_NOT_ENABLED.getValue()
+    ),
+    NOT_FOUND(
+        CommonErrorCode.NOT_FOUND.getValue(),
+        HttpStatus.NOT_FOUND,
+        CommonTitleErrors.NOT_FOUND.getValue()
     );
 
     private static final String ERROR_TYPE_PREFIX = "COMMON";

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiException.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.darts.common.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -60,31 +58,4 @@ public class DartsApiException extends RuntimeException {
         this.error = error;
         this.detail = detail;
     }
-
-    @Getter
-    @RequiredArgsConstructor
-    public enum DartsApiErrorCommon implements DartsApiError {
-        FEATURE_FLAG_NOT_ENABLED(
-            "FEATURE_FLAG_NOT_ENABLED",
-            HttpStatus.NOT_IMPLEMENTED,
-            "Feature flag not enabled"
-        ),
-        NOT_FOUND(
-            "NOT_FOUND",
-            HttpStatus.NOT_FOUND,
-            "Resource not found"
-        );
-
-        private static final String ERROR_TYPE_PREFIX = "COMMON";
-        private final String errorTypeNumeric;
-        private final HttpStatus httpStatus;
-        private final String title;
-
-        @Override
-        public String getErrorTypePrefix() {
-            return ERROR_TYPE_PREFIX;
-        }
-
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.event.mapper.EventMapper;
@@ -31,7 +32,8 @@ public class EventServiceImpl implements EventService {
     @Override
     public EventEntity getEventEntityById(Integer eveId) {
         return eventRepository.findById(eveId)
-            .orElseThrow(() -> new DartsApiException(DartsApiException.DartsApiErrorCommon.NOT_FOUND));
+            .orElseThrow(() -> new DartsApiException(CommonApiError.NOT_FOUND,
+                                                     String.format("Event with id %s not found", eveId)));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceImpl.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.common.entity.ObjectHiddenReasonEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ObjectAdminActionRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectHiddenReasonRepository;
@@ -224,7 +225,7 @@ public class AdminTranscriptionServiceImpl implements AdminTranscriptionService 
     @Transactional
     public AdminApproveDeletionResponse approveDeletionOfTranscriptionDocumentById(Integer transcriptionDocumentId) {
         if (!this.isManualDeletionEnabled()) {
-            throw new DartsApiException(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+            throw new DartsApiException(CommonApiError.FEATURE_FLAG_NOT_ENABLED, "Manual deletion is not enabled");
         }
 
         transcriptionApproveMarkForDeletionValidator.validate(transcriptionDocumentId);

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.exception.PartialFailureException;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
@@ -623,7 +624,7 @@ public class TranscriptionServiceImpl implements TranscriptionService {
     @Override
     public List<AdminMarkedForDeletionResponseItem> adminGetTranscriptionDocumentsMarkedForDeletion() {
         if (!this.isManualDeletionEnabled()) {
-            throw new DartsApiException(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+            throw new DartsApiException(CommonApiError.FEATURE_FLAG_NOT_ENABLED, "Manual deletion is not enabled");
         }
         List<TranscriptionDocumentEntity> transcriptionDocumentEntities = transcriptionDocumentRepository.getMarkedForDeletion();
         List<AdminMarkedForDeletionResponseItem> transcriptionResponsesLst = new ArrayList<>();

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/validator/TranscriptionDocumentHideOrShowValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/validator/TranscriptionDocumentHideOrShowValidator.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.component.validation.Validator;
 import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectHiddenReasonEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ObjectAdminActionRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectHiddenReasonRepository;
@@ -57,7 +58,7 @@ public class TranscriptionDocumentHideOrShowValidator implements Validator<IdReq
             } else {
                 ObjectHiddenReasonEntity objectHiddenReasonEntity = optionalObjectHiddenReasonEntity.get();
                 if (objectHiddenReasonEntity.isMarkedForDeletion() && !isManualDeletionEnabled()) {
-                    throw new DartsApiException(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+                    throw new DartsApiException(CommonApiError.FEATURE_FLAG_NOT_ENABLED, "Manual deletion is not enabled");
                 }
             }
         }

--- a/src/main/resources/openapi/common.yaml
+++ b/src/main/resources/openapi/common.yaml
@@ -172,10 +172,19 @@ components:
       type: string
       enum:
         - "COMMON_100"
-      x-enum-varnames: [ COURTHOUSE_PROVIDED_DOES_NOT_EXIST ]
+        - "COMMON_101"
+        - "COMMON_102"
+      x-enum-varnames: [ COURTHOUSE_PROVIDED_DOES_NOT_EXIST,
+                         FEATURE_FLAG_NOT_ENABLED,
+                         NOT_FOUND ]
 
     CommonTitleErrors:
       type: string
       enum:
         - "Provided courthouse does not exist"
-      x-enum-varnames: [ COURTHOUSE_PROVIDED_DOES_NOT_EXIST ]
+        - "Feature flag not enabled"
+        - "Resource not found"
+      x-enum-varnames: [ COURTHOUSE_PROVIDED_DOES_NOT_EXIST ,
+                         FEATURE_FLAG_NOT_ENABLED,
+                         NOT_FOUND
+      ]

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImplTest.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
@@ -102,14 +103,14 @@ class AdminMediaServiceImplTest {
     void getMediasMarkedForDeletionManualDeletionDisabled() {
         disableManualDeletion();
         DartsApiException dartsApiException = assertThrows(DartsApiException.class, () -> mediaRequestService.getMediasMarkedForDeletion());
-        assertThat(dartsApiException.getError()).isEqualTo(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+        assertThat(dartsApiException.getError()).isEqualTo(CommonApiError.FEATURE_FLAG_NOT_ENABLED);
     }
 
     @Test
     void adminApproveMediaMarkedForDeletionManualDeletionDisabled() {
         disableManualDeletion();
         DartsApiException dartsApiException = assertThrows(DartsApiException.class, () -> mediaRequestService.adminApproveMediaMarkedForDeletion(1));
-        assertThat(dartsApiException.getError()).isEqualTo(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+        assertThat(dartsApiException.getError()).isEqualTo(CommonApiError.FEATURE_FLAG_NOT_ENABLED);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/audio/validation/MediaHideOrShowValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/validation/MediaHideOrShowValidatorTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.audio.model.AdminActionRequest;
 import uk.gov.hmcts.darts.audio.model.MediaHideRequest;
 import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectHiddenReasonEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ObjectAdminActionRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectHiddenReasonRepository;
@@ -213,7 +214,7 @@ class MediaHideOrShowValidatorTest {
 
         DartsApiException exception
             = Assertions.assertThrows(DartsApiException.class, () -> mediaHideOrShowValidator.validate(mediaHideRequestIdRequest));
-        Assertions.assertEquals(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED, exception.getError());
+        Assertions.assertEquals(CommonApiError.FEATURE_FLAG_NOT_ENABLED, exception.getError());
 
         Mockito.verify(mediaIdValidator, times(1)).validate(mediaId);
     }

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
@@ -54,7 +55,7 @@ class EventServiceImplTest {
 
         assertThatThrownBy(() -> eventService.getEventEntityById(1))
             .isInstanceOf(DartsApiException.class)
-            .hasFieldOrPropertyWithValue("error", DartsApiException.DartsApiErrorCommon.NOT_FOUND);
+            .hasFieldOrPropertyWithValue("error", CommonApiError.NOT_FOUND);
         verify(eventRepository, times(1)).findById(1);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.common.entity.ObjectHiddenReasonEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ObjectAdminActionRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectHiddenReasonRepository;
@@ -449,6 +450,6 @@ class AdminTranscriptionServiceTest {
         updateManualDeletion(false);
         DartsApiException dartsApiException = assertThrows(
             DartsApiException.class, () -> adminTranscriptionService.approveDeletionOfTranscriptionDocumentById(1));
-        assertThat(dartsApiException.getError()).isEqualTo(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+        assertThat(dartsApiException.getError()).isEqualTo(CommonApiError.FEATURE_FLAG_NOT_ENABLED);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionUrgencyEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.TranscriptionCommentRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionRepository;
@@ -609,7 +610,7 @@ class TranscriptionServiceImplTest {
         updateManualDeletion(false);
         DartsApiException dartsApiException = assertThrows(
             DartsApiException.class, () -> transcriptionService.adminGetTranscriptionDocumentsMarkedForDeletion());
-        assertThat(dartsApiException.getError()).isEqualTo(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED);
+        assertThat(dartsApiException.getError()).isEqualTo(CommonApiError.FEATURE_FLAG_NOT_ENABLED);
     }
 
     private TranscriptionRequestDetails createTranscriptionRequestDetails(Integer hearingId,

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/validator/TranscriptionDocumentHideOrShowValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/validator/TranscriptionDocumentHideOrShowValidatorTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectHiddenReasonEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ObjectAdminActionRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectHiddenReasonRepository;
@@ -190,7 +191,7 @@ class TranscriptionDocumentHideOrShowValidatorTest {
 
         DartsApiException exception
             = Assertions.assertThrows(DartsApiException.class, () -> transcriptionDocumentHideOrShowValidator.validate(transcriptionDocumentEntityUserId));
-        Assertions.assertEquals(DartsApiException.DartsApiErrorCommon.FEATURE_FLAG_NOT_ENABLED, exception.getError());
+        Assertions.assertEquals(CommonApiError.FEATURE_FLAG_NOT_ENABLED, exception.getError());
 
         Mockito.verify(transcriptionDocumentIdValidator, times(1)).validate(documentId);
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3996)


### Change description ###
# Summary of Changes

This update focuses on improving the error handling in the software by replacing specific error types with a more generalized `CommonApiError`. This makes the code cleaner and more consistent across different parts of the system. 

## Highlights

- **Error Type Replacement**: 
  - The term `DartsApiException.DartsApiErrorCommon` was replaced with `CommonApiError` in various files.
  
- **New Error Definitions**: 
  - Two new common error types were added: `FEATURE_FLAG_NOT_ENABLED` and `NOT_FOUND`, providing clearer messaging for certain error conditions.
  
- **Improved Consistency**: 
  - The changes ensure that all parts of the codebase consistently use the new common errors, enhancing maintainability.
  
- **Updates Across Multiple Files**: 
  - The changes were made in several files, including service implementations, validators, and test cases, ensuring comprehensive coverage of the new error handling approach.
  
- **Cleaner Code**: 
  - By consolidating error types, the code is simplified, making it easier for developers to understand and manage error handling logic.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
