### PR TITLE
Optional DARTS portal deployment on dev

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -155,7 +155,7 @@ withPipeline(type, product, component) {
     before('akschartsinstall') {
         onPR {
             // determine what to deploy on the dev env
-            sh("./bin/ci/pr-labels.sh")
+            sh("./bin/ci/process-pr-labels.sh")
         }
     }
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,51 +11,53 @@ def component = "api"
 def branchesToSync = ['demo', 'perftest', 'ithc']
 
 def secrets = [
-        'darts-${env}': [
-                secret('GovukNotifyTestApiKey', 'GOVUK_NOTIFY_API_KEY'),
-                secret('app-insights-connection-string', 'app-insights-connection-string'),
-                secret('AzureAdB2CTenantId', 'AAD_B2C_TENANT_ID'),
-                secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
-                secret('AzureAdB2CClientSecret', 'AAD_B2C_CLIENT_SECRET'),
-                secret('AzureAdB2CFuncTestROPCUsername', 'FUNC_TEST_ROPC_USERNAME'),
-                secret('AzureAdB2CFuncTestROPCPassword', 'FUNC_TEST_ROPC_PASSWORD'),
-                secret('AzureAdB2CFuncTestROPCClientId', 'AAD_B2C_ROPC_CLIENT_ID'),
-                secret('AzureAdB2CFuncTestROPCClientSecret', 'AAD_B2C_ROPC_CLIENT_SECRET'),
-                secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
-                secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
-                secret('AzureADTenantId', 'AAD_TENANT_ID'),
-                secret('AzureADClientId', 'AAD_CLIENT_ID'),
-                secret('AzureADClientSecret', 'AAD_CLIENT_SECRET'),
-                secret('AzureADTenantIdJustice', 'AAD_TENANT_ID_JUSTICE'),
-                secret('AzureADClientIdJustice', 'AAD_CLIENT_ID_JUSTICE'),
-                secret('AzureADClientSecretJustice', 'AAD_CLIENT_SECRET_JUSTICE'),
-                secret('XhibitUserName', 'XHIBIT_USER_NAME'),
-                secret('XhibitPassword', 'XHIBIT_PASSWORD'),
-                secret('CppUserName', 'CPP_USER_NAME'),
-                secret('CppPassword', 'CPP_PASSWORD'),
-                secret('DarPcUserName', 'DARPC_USER_NAME'),
-                secret('DarPcPassword', 'DARPC_PASSWORD'),
-                secret('DarMidTierUserName', 'DAR_MIDTIER_USER_NAME'),
-                secret('DarMidTierPassword', 'DAR_MIDTIER_PASSWORD'),
-                secret('AzureADFunctionalTestUsername', 'AZURE_AD_FUNCTIONAL_TEST_USERNAME'),
-                secret('AzureADFunctionalTestPassword', 'AZURE_AD_FUNCTIONAL_TEST_PASSWORD'),
-                secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
-                secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
-                secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
-                secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT'),
-                secret('DETSSasURLEndpoint', 'DETS_SAS_URL_ENDPOINT'),
-                secret('DartsInboundStorageSasUrl', 'DARTS_INBOUND_STORAGE_SAS_URL'),
-                secret('DartsUnstructuredStorageSasUrl', 'DARTS_UNSTRUCTURED_STORAGE_SAS_URL'),
-                secret('ArmServiceEntitlement', 'ARM_SERVICE_ENTITLEMENT'),
-                secret('ArmStorageAccountName', 'ARM_STORAGE_ACCOUNT_NAME'),
-                // secrets for staging DB
-                secret('api-POSTGRES-HOST', 'STAGING_DB_HOST'),
-                secret('api-POSTGRES-USER', 'STAGING_DB_USER'),
-                secret('api-POSTGRES-PASS', 'STAGING_DB_PASS'),
-                secret('api-POSTGRES-PORT', 'STAGING_DB_PORT'),
-                secret('api-POSTGRES-SCHEMA', 'STAGING_DB_SCHEMA'),
-                secret('api-POSTGRES-DATABASE', 'STAGING_DB_DATABASE')
-        ],
+    'darts-${env}': [
+        secret('GovukNotifyTestApiKey', 'GOVUK_NOTIFY_API_KEY'),
+        secret('app-insights-connection-string', 'app-insights-connection-string'),
+        secret('AzureAdB2CTenantId', 'AAD_B2C_TENANT_ID'),
+        secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+        secret('AzureAdB2CClientSecret', 'AAD_B2C_CLIENT_SECRET'),
+        secret('AzureAdB2CFuncTestROPCUsername', 'FUNC_TEST_ROPC_USERNAME'),
+        secret('AzureAdB2CFuncTestROPCPassword', 'FUNC_TEST_ROPC_PASSWORD'),
+        secret('AzureAdB2CFuncTestROPCClientId', 'AAD_B2C_ROPC_CLIENT_ID'),
+        secret('AzureAdB2CFuncTestROPCClientSecret', 'AAD_B2C_ROPC_CLIENT_SECRET'),
+        secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
+        secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
+        secret('AzureADTenantId', 'AAD_TENANT_ID'),
+        secret('AzureADClientId', 'AAD_CLIENT_ID'),
+        secret('AzureADClientSecret', 'AAD_CLIENT_SECRET'),
+        secret('AzureADTenantIdJustice', 'AAD_TENANT_ID_JUSTICE'),
+        secret('AzureADClientIdJustice', 'AAD_CLIENT_ID_JUSTICE'),
+        secret('AzureADClientSecretJustice', 'AAD_CLIENT_SECRET_JUSTICE'),
+        secret('XhibitUserName', 'XHIBIT_USER_NAME'),
+        secret('XhibitPassword', 'XHIBIT_PASSWORD'),
+        secret('CppUserName', 'CPP_USER_NAME'),
+        secret('CppPassword', 'CPP_PASSWORD'),
+        secret('DarPcUserName', 'DARPC_USER_NAME'),
+        secret('DarPcPassword', 'DARPC_PASSWORD'),
+        secret('DarMidTierUserName', 'DAR_MIDTIER_USER_NAME'),
+        secret('DarMidTierPassword', 'DAR_MIDTIER_PASSWORD'),
+        secret('AzureADFunctionalTestUsername', 'AZURE_AD_FUNCTIONAL_TEST_USERNAME'),
+        secret('AzureADFunctionalTestPassword', 'AZURE_AD_FUNCTIONAL_TEST_PASSWORD'),
+        secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
+        secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
+        secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
+        secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT'),
+        secret('DETSSasURLEndpoint', 'DETS_SAS_URL_ENDPOINT'),
+        secret('DartsInboundStorageSasUrl', 'DARTS_INBOUND_STORAGE_SAS_URL'),
+        secret('DartsUnstructuredStorageSasUrl', 'DARTS_UNSTRUCTURED_STORAGE_SAS_URL'),
+        secret('ArmServiceEntitlement', 'ARM_SERVICE_ENTITLEMENT'),
+        secret('ArmStorageAccountName', 'ARM_STORAGE_ACCOUNT_NAME'),
+        // secrets for staging DB
+        secret('api-POSTGRES-HOST', 'STAGING_DB_HOST'),
+        secret('api-POSTGRES-USER', 'STAGING_DB_USER'),
+        secret('api-POSTGRES-PASS', 'STAGING_DB_PASS'),
+        secret('api-POSTGRES-PORT', 'STAGING_DB_PORT'),
+        secret('api-POSTGRES-SCHEMA', 'STAGING_DB_SCHEMA'),
+        secret('api-POSTGRES-DATABASE', 'STAGING_DB_DATABASE'),
+        // secret for GitHub CLI
+        secret('GithubApiToken', 'GITHUB_API_TOKEN')
+    ],
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
@@ -80,57 +82,57 @@ withPipeline(type, product, component) {
         builder.gradle('jacocoTestReport')
 
         publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/checkstyle",
-                reportFiles          : "main.html",
-                reportName           : "Checkstyle Main Report"
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/checkstyle",
+            reportFiles          : "main.html",
+            reportName           : "Checkstyle Main Report"
         ]
 
         publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/checkstyle",
-                reportFiles          : "test.html",
-                reportName           : "Checkstyle Test Report"
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/checkstyle",
+            reportFiles          : "test.html",
+            reportName           : "Checkstyle Test Report"
         ]
 
         publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/checkstyle",
-                reportFiles          : "functionalTest.html",
-                reportName           : "Checkstyle Functional Test Report"
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/checkstyle",
+            reportFiles          : "functionalTest.html",
+            reportName           : "Checkstyle Functional Test Report"
         ]
 
         publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/checkstyle",
-                reportFiles          : "integrationTest.html",
-                reportName           : "Checkstyle Integration Test Report"
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/checkstyle",
+            reportFiles          : "integrationTest.html",
+            reportName           : "Checkstyle Integration Test Report"
         ]
 
         publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/tests/test",
-                reportFiles          : "index.html",
-                reportName           : "Unit Tests Report"
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/tests/test",
+            reportFiles          : "index.html",
+            reportName           : "Unit Tests Report"
         ]
 
         publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/pmd",
-                reportFiles          : "main.html",
-                reportName           : "PMD Report"
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/pmd",
+            reportFiles          : "main.html",
+            reportName           : "PMD Report"
         ]
     }
 
@@ -148,10 +150,6 @@ withPipeline(type, product, component) {
 
     before('dbmigrate:ithc') {
         sh("./gradlew --no-daemon --init-script init.gradle assemble")
-    }
-
-    afterAlways('build') {
-        sh("./bin/ci/pr-labels.sh")
     }
 
     afterSuccess('akschartsinstall') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -55,7 +55,7 @@ def secrets = [
         secret('api-POSTGRES-PORT', 'STAGING_DB_PORT'),
         secret('api-POSTGRES-SCHEMA', 'STAGING_DB_SCHEMA'),
         secret('api-POSTGRES-DATABASE', 'STAGING_DB_DATABASE'),
-        // secret for GitHub CLI
+        // secret for GitHub API
         secret('GithubApiToken', 'GITHUB_API_TOKEN')
     ],
 ]
@@ -150,6 +150,13 @@ withPipeline(type, product, component) {
 
     before('dbmigrate:ithc') {
         sh("./gradlew --no-daemon --init-script init.gradle assemble")
+    }
+
+    before('akschartsinstall') {
+        onPR {
+            // determine what to deploy on the dev env
+            sh("./bin/ci/pr-labels.sh")
+        }
     }
 
     afterSuccess('akschartsinstall') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -150,6 +150,10 @@ withPipeline(type, product, component) {
         sh("./gradlew --no-daemon --init-script init.gradle assemble")
     }
 
+    afterAlways('build') {
+        sh("./bin/ci/pr-labels.sh")
+    }
+
     afterSuccess('akschartsinstall') {
         onPR {
             // restore the PR DB from staging

--- a/README.md
+++ b/README.md
@@ -375,6 +375,12 @@ The script will check for required executables and prompt before continuing.
 
 _Disclaimer: The script has been written to work using `bash`._
 
+## Dev/PR environments
+
+Please see the separate [Dev environment](https://tools.hmcts.net/confluence/display/DMP/Dev+environment) page on confluence for details.
+
+This repo contains overrides for the default dev environment configuration. For more details see the  [Dev overrides README](charts-dev-overrides/README.md), within the `charts-dev-overrides` directory.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ _Disclaimer: The script has been written to work using `bash`._
 
 Please see the separate [Dev environment](https://tools.hmcts.net/confluence/display/DMP/Dev+environment) page on confluence for details.
 
-This repo contains overrides for the default dev environment configuration. For more details see the  [Dev overrides README](charts-dev-overrides/README.md), within the `charts-dev-overrides` directory.
+This repo contains overrides for the default dev environment configuration. For more details see the  [Dev chart overrides README](charts-dev-overrides/README.md), within the `charts-dev-overrides` directory.
 
 ## License
 

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -13,3 +13,5 @@ LABELS_ARRAY=$(curl -L \
 # DARTS_PORTAL_REPLICAS is used in charts/darts-api/values.dev.template.yaml to set the number of replicas for the DARTS Portal
 export DARTS_PORTAL_REPLICAS=$(echo $LABELS_ARRAY | jq | grep '"name": "enable_darts_portal"' | wc -l | jq)
 echo "Required DARTS Portal replicas: $DARTS_PORTAL_REPLICAS"
+# replace the replicas value in the values.dev.template.yaml file
+sed -i '' "s/replicas: 0 #DARTS_PORTAL_REPLICAS/replicas: ${DARTS_PORTAL_REPLICAS}/g" charts/darts-api/values.dev.template.yaml

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -14,4 +14,4 @@ LABELS_ARRAY=$(curl -L \
 export DARTS_PORTAL_REPLICAS=$(echo $LABELS_ARRAY | jq | grep '"name": "enable_darts_portal"' | wc -l | jq)
 echo "Required DARTS Portal replicas: $DARTS_PORTAL_REPLICAS"
 # replace the replicas value in the values.dev.template.yaml file
-sed -i '' "s/replicas: 0 #DARTS_PORTAL_REPLICAS/replicas: ${DARTS_PORTAL_REPLICAS}/g" ./charts/darts-api/values.dev.template.yaml
+sed -i "s/replicas: 0 #DARTS_PORTAL_REPLICAS/replicas: ${DARTS_PORTAL_REPLICAS}/g" ./charts/darts-api/values.dev.template.yaml

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -14,4 +14,4 @@ LABELS_ARRAY=$(curl -L \
 export DARTS_PORTAL_REPLICAS=$(echo $LABELS_ARRAY | jq | grep '"name": "enable_darts_portal"' | wc -l | jq)
 echo "Required DARTS Portal replicas: $DARTS_PORTAL_REPLICAS"
 # replace the replicas value in the values.dev.template.yaml file
-sed -i '' "s/replicas: 0 #DARTS_PORTAL_REPLICAS/replicas: ${DARTS_PORTAL_REPLICAS}/g" charts/darts-api/values.dev.template.yaml
+sed -i '' "s/replicas: 0 #DARTS_PORTAL_REPLICAS/replicas: ${DARTS_PORTAL_REPLICAS}/g" ./charts/darts-api/values.dev.template.yaml

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
 set -e
 
-gh pr view $CHANGE_ID --json labels
+echo "Using token: ***${GITHUB_API_TOKEN: -3}"
+echo "Using PR_NUMBER: $CHANGE_ID"
+
+curl -L -i \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/hmcts/darts-api/pulls/$CHANGE_ID
+
+curl -L \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  https://api.github.com/repos/hmcts/darts-api/pulls/$CHANGE_ID | jq .labels

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+gh pr view $CHANGE_ID --json labels

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -15,3 +15,5 @@ export DARTS_PORTAL_REPLICAS=$(echo $LABELS_ARRAY | jq | grep '"name": "enable_d
 echo "Required DARTS Portal replicas: $DARTS_PORTAL_REPLICAS"
 # replace the replicas value in the values.dev.template.yaml file
 sed -i "s/replicas: 0 #DARTS_PORTAL_REPLICAS/replicas: ${DARTS_PORTAL_REPLICAS}/g" ./charts/darts-api/values.dev.template.yaml
+echo "Setting DARTS Portal replicas in values.dev.template.yaml"
+cat ./charts/darts-api/values.dev.template.yaml | grep nodejs -A3

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+echo "env=${env}"
 echo "Using token: ***${GITHUB_API_TOKEN: -3}"
 echo "Using PR_NUMBER: $CHANGE_ID"
 

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -14,6 +14,6 @@ LABELS_ARRAY=$(curl -L \
 export DARTS_PORTAL_REPLICAS=$(echo $LABELS_ARRAY | jq | grep '"name": "enable_darts_portal"' | wc -l | jq)
 echo "Required DARTS Portal replicas: $DARTS_PORTAL_REPLICAS"
 # replace the replicas value in the values.dev.template.yaml file
-sed -i "s/replicas: 0 #DARTS_PORTAL_REPLICAS/replicas: ${DARTS_PORTAL_REPLICAS}/g" ./charts/darts-api/values.dev.template.yaml
+sed -i "s/replicas: 0 #DARTS_PORTAL_REPLICAS/replicas: ${DARTS_PORTAL_REPLICAS} #DARTS_PORTAL_REPLICAS/g" ./charts/darts-api/values.dev.template.yaml
 echo "Setting DARTS Portal replicas in values.dev.template.yaml"
 cat ./charts/darts-api/values.dev.template.yaml | grep nodejs -A3

--- a/bin/ci/pr-labels.sh
+++ b/bin/ci/pr-labels.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
 set -e
 
-echo "env=${env}"
-echo "Using token: ***${GITHUB_API_TOKEN: -3}"
 echo "Using PR_NUMBER: $CHANGE_ID"
 
-curl -L -i \
+LABELS_ARRAY=$(curl -L \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer $GITHUB_API_TOKEN" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
-  https://api.github.com/repos/hmcts/darts-api/pulls/$CHANGE_ID
+  https://api.github.com/repos/hmcts/darts-api/pulls/$CHANGE_ID | jq .labels)
 
-curl -L \
-  -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer $GITHUB_API_TOKEN" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  https://api.github.com/repos/hmcts/darts-api/pulls/$CHANGE_ID | jq .labels
+# if "enable_darts_portal" label is set on the PR, then set the DARTS_PORTAL_REPLICAS to 1, otherwise set it to 0
+# DARTS_PORTAL_REPLICAS is used in charts/darts-api/values.dev.template.yaml to set the number of replicas for the DARTS Portal
+export DARTS_PORTAL_REPLICAS=$(echo $LABELS_ARRAY | jq | grep '"name": "enable_darts_portal"' | wc -l | jq)
+echo "Required DARTS Portal replicas: $DARTS_PORTAL_REPLICAS"

--- a/bin/ci/process-pr-labels.sh
+++ b/bin/ci/process-pr-labels.sh
@@ -13,7 +13,7 @@ LABELS_ARRAY=$(curl -L \
 ENABLE_KEEP_HELM=$(echo $LABELS_ARRAY | jq | grep '"name": "enable_keep_helm"' | wc -l | jq)
 if [[ ENABLE_KEEP_HELM -eq 0 ]]; then
   echo "enable_keep_helm label not found, exiting..."
-  exit 1
+  exit 0
 fi
 
 # used to override files within the charts directory, depends on labels set on the PR

--- a/bin/ci/process-pr-labels.sh
+++ b/bin/ci/process-pr-labels.sh
@@ -9,6 +9,13 @@ LABELS_ARRAY=$(curl -L \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   https://api.github.com/repos/hmcts/darts-api/pulls/$CHANGE_ID | jq .labels)
 
+# don't override unless the `enable_keep_helm` label is set
+ENABLE_KEEP_HELM=$(echo $LABELS_ARRAY | jq | grep '"name": "enable_keep_helm"' | wc -l | jq)
+if [[ ENABLE_KEEP_HELM -eq 0 ]]; then
+  echo "enable_keep_helm label not found, exiting..."
+  exit 1
+fi
+
 # used to override files within the charts directory, depends on labels set on the PR
 CHART_OVERRIDE=''
 

--- a/charts-dev-overrides/README.md
+++ b/charts-dev-overrides/README.md
@@ -1,7 +1,20 @@
-# Charts dev overrides
+# Dev chart overrides
 
-This directory contains overrides for the files in the `charts` directory. These overrides are used to replace the files in the development environment.
+This directory contains overrides for the files in the `charts` directory.
+
+These overrides are used to replace the files in the development environment, when specific labels are set on the PR.
+
+This happens at the start of the AKS deploy dev stage in the pipeline.
+
+_Note: the `enable_keep_helm` label must also be set on the PR for these overrides to be used._
 
 ## Usage
 
-Set a label on a PR, corresponding to the directory in here. For example, if the "enable_darts_portal" label is set then the files in the `enable_darts_portal` directory will be used to replace the files in the `charts` directory.
+Set a label on a PR, corresponding to one of the directories in here. For example, set the `enable_darts_portal` label and the files in the `enable_darts_portal` directory will be used to replace the files in the `charts` directory. This changes the dev deployment and adds a DARTS portal instance.
+
+## Supported labels
+
+| Label                  | Usages                                                                                           |
+|------------------------|--------------------------------------------------------------------------------------------------|
+| enable_darts_portal    | Deploys a DARTS portal instance alongside the API in the dev environment                         |
+| enable_darts_fullstack | Not yet supported, but will deploy the full DARTS stack alongside the API in the dev environment |

--- a/charts-dev-overrides/README.md
+++ b/charts-dev-overrides/README.md
@@ -4,7 +4,13 @@ This directory contains overrides for the files in the `charts` directory.
 
 These overrides are used to replace the files in the development environment, when specific labels are set on the PR.
 
-This happens at the start of the AKS deploy dev stage in the pipeline.
+This happens at the start of the AKS deploy dev stage in the pipeline, where the `./bin/ci/process-pr-labels.sh` script is run. This script requires access to the GitHub API which is granted via a token saved in the DARTS staging key-vault, using secret name and env var below.
+
+| Secret name    | Environment variable |
+|----------------|----------------------|
+| GithubApiToken | GITHUB_API_TOKEN     |
+
+If the GitHub API access stops working please see the [troubleshooting](https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1725401108#Devenvironment-DARTSAPIoptionaldeploymentshavestoppedworking) section on the [Dev environment](https://tools.hmcts.net/confluence/display/DMP/Dev+environment) confluence page.
 
 _Note: the `enable_keep_helm` label must also be set on the PR for these overrides to be used._
 

--- a/charts-dev-overrides/README.md
+++ b/charts-dev-overrides/README.md
@@ -1,0 +1,7 @@
+# Charts dev overrides
+
+This directory contains overrides for the files in the `charts` directory. These overrides are used to replace the files in the development environment.
+
+## Usage
+
+Set a label on a PR, corresponding to the directory in here. For example, if the "enable_darts_portal" label is set then the files in the `enable_darts_portal` directory will be used to replace the files in the `charts` directory.

--- a/charts-dev-overrides/enable_darts_portal/Chart.yaml
+++ b/charts-dev-overrides/enable_darts_portal/Chart.yaml
@@ -1,4 +1,3 @@
-# Attention: if you are changing values in here, please ensure you also update any corresponding files in the charts-dev-overrides directory
 apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for darts-api App
@@ -18,4 +17,7 @@ dependencies:
     version: 1.0.2
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: postgresql.enabled
+  - name: nodejs
+    version: 3.1.1
+    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
 

--- a/charts-dev-overrides/enable_darts_portal/values.dev.template.yaml
+++ b/charts-dev-overrides/enable_darts_portal/values.dev.template.yaml
@@ -93,6 +93,10 @@ java:
           alias: DARTS_INBOUND_STORAGE_SAS_URL
         - name: DartsUnstructuredStorageSasUrl
           alias: DARTS_UNSTRUCTURED_STORAGE_SAS_URL
+        - name: ArmServiceEntitlement
+          alias: ARM_SERVICE_ENTITLEMENT
+        - name: ArmStorageAccountName
+          alias: ARM_STORAGE_ACCOUNT_NAME
   environment:
     ENABLE_FLYWAY: true
     MANUAL_DELETION_ENABLED: true

--- a/charts-dev-overrides/enable_darts_portal/values.dev.template.yaml
+++ b/charts-dev-overrides/enable_darts_portal/values.dev.template.yaml
@@ -1,4 +1,3 @@
-# Attention: if you are changing values in here, please ensure you also update any corresponding files in the charts-dev-overrides directory
 java:
   # Don't modify below here
   image: ${IMAGE_NAME}
@@ -94,10 +93,6 @@ java:
           alias: DARTS_INBOUND_STORAGE_SAS_URL
         - name: DartsUnstructuredStorageSasUrl
           alias: DARTS_UNSTRUCTURED_STORAGE_SAS_URL
-        - name: ArmServiceEntitlement
-          alias: ARM_SERVICE_ENTITLEMENT
-        - name: ArmStorageAccountName
-          alias: ARM_STORAGE_ACCOUNT_NAME
   environment:
     ENABLE_FLYWAY: true
     MANUAL_DELETION_ENABLED: true
@@ -108,7 +103,7 @@ java:
     spring.profiles.active: dev
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
     DARTS_GATEWAY_URL: "http://darts-gateway.staging.platform.hmcts.net"
-    DARTS_PORTAL_URL: "https://darts.staging.apps.hmcts.net"
+    DARTS_PORTAL_URL: "https://darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
     AUTOMATED_TASK_MODE: true
     API_MODE: true
 
@@ -125,72 +120,20 @@ postgresql:
     databases:
       - name: "pr-${CHANGE_ID}-darts"
 
-# function:
-#   scaleType: Job
-#   image: ${IMAGE_NAME}
-#   aadIdentityName: darts
-#   pollingInterval: 300 # every 5 mins, but this should probably be configurable per env
-#   minReplicaCount: 0
-#   maxReplicaCount: 2
-#   scalingStrategy: accurate
-#   keyVaults:
-#     "darts":
-#       secrets:
-#         - name: GovukNotifyApiKey
-#           alias: GOVUK_NOTIFY_API_KEY
-#         - name: api-POSTGRES-USER
-#           alias: DARTS_API_DB_USERNAME
-#         - name: api-POSTGRES-PASS
-#           alias: DARTS_API_DB_PASSWORD
-#         - name: api-POSTGRES-HOST
-#           alias: DARTS_API_DB_HOST
-#         - name: api-POSTGRES-DATABASE
-#           alias: DARTS_API_DB_NAME
-#         - name: api-POSTGRES-SCHEMA
-#           alias: DARTS_API_DB_SCHEMA
-#         - name: AzureAdB2CTenantId
-#           alias: AAD_B2C_TENANT_ID
-#         - name: AzureAdB2CClientId
-#           alias: AAD_B2C_CLIENT_ID
-#         - name: AzureAdB2CClientSecret
-#           alias: AAD_B2C_CLIENT_SECRET
-#         - name: app-insights-connection-string
-#           alias: app-insights-connection-string
-#         - name: AzureAdB2CFuncTestROPCClientId
-#           alias: AAD_B2C_ROPC_CLIENT_ID
-#         - name: AzureAdB2CFuncTestROPCClientSecret
-#           alias: AAD_B2C_ROPC_CLIENT_SECRET
-#         - name: AzureStorageConnectionString
-#           alias: AZURE_STORAGE_CONNECTION_STRING
-#         - name: api-POSTGRES-CONNECTION-STRING
-#           alias: DARTS_API_DB_CONNECTION_STRING
-#         - name: AzureADTenantId
-#           alias: AAD_TENANT_ID
-#         - name: AzureADClientId
-#           alias: AAD_CLIENT_ID
-#         - name: AzureADClientSecret
-#           alias: AAD_CLIENT_SECRET
-#         - name: AzureADTenantIdJustice
-#           alias: AAD_TENANT_ID_JUSTICE
-#         - name: AzureADClientIdJustice
-#           alias: AAD_CLIENT_ID_JUSTICE
-#         - name: AzureADClientSecretJustice
-#           alias: AAD_CLIENT_SECRET_JUSTICE
-#   environment:
-#     ATS_MODE: true
-#     POSTGRES_SSL_MODE: require
-#     RUN_DB_MIGRATION_ON_STARTUP: false
-#     DARTS_GATEWAY_URL: https://darts-gateway.staging.platform.hmcts.net
-#   secrets:
-#     DARTS_API_DB_CONNECTION_STRING:
-#       secretRef: darts-api-{{ .Release.Name }}-postgresql
-#       key: connectionString
-#   job:
-#     activeDeadlineSeconds: 300
-#     parallelism: 1
-#     completions: 1
-#   triggers:
-#     - type: postgres
-#       connectionFromEnv: DARTS_API_DB_CONNECTION_STRING
-#       query: "SELECT count(*) FROM darts.media_request WHERE mer_id = ( SELECT mer_id FROM darts.media_request WHERE request_status = 'OPEN' ORDER BY created_ts LIMIT 1 )"
-#       targetQueryValue: "0.9"
+nodejs:
+  applicationPort: 3000
+  image: 'sdshmctspublic.azurecr.io/darts/portal:latest'
+  replicas: 1
+  ingressHost: "darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
+  aadIdentityName: darts
+  keyVaults:
+    darts:
+      secrets:
+        - redis-connection-string
+        - darts-portal-session-secret
+  environment:
+    ALLOW_CONFIG_MUTATIONS: true
+    DARTS_PORTAL_URL: "https://darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
+    DARTS_API_URL: "https://darts-api-pr-${CHANGE_ID}.dev.platform.hmcts.net"
+    DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsstgextid.b2clogin.com
+    DARTS_AZUREAD_B2C_HOSTNAME: https://darts.staging.apps.hmcts.net

--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.91
+version: 0.0.92
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -17,6 +17,4 @@ dependencies:
     version: 1.0.2
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
     condition: postgresql.enabled
-  - name: nodejs
-    version: 3.1.1
-    repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
+

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -124,24 +124,6 @@ postgresql:
     databases:
       - name: "pr-${CHANGE_ID}-darts"
 
-nodejs:
-  applicationPort: 3000
-  image: 'sdshmctspublic.azurecr.io/darts/portal:latest'
-  replicas: 0 #DARTS_PORTAL_REPLICAS
-  ingressHost: "darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
-  aadIdentityName: darts
-  keyVaults:
-    darts:
-      secrets:
-        - redis-connection-string
-        - darts-portal-session-secret
-  environment:
-    ALLOW_CONFIG_MUTATIONS: true
-    DARTS_PORTAL_URL: "https://darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
-    DARTS_API_URL: "https://darts-api-pr-${CHANGE_ID}.dev.platform.hmcts.net"
-    DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsstgextid.b2clogin.com
-    DARTS_AZUREAD_B2C_HOSTNAME: https://darts.staging.apps.hmcts.net
-
 # function:
 #   scaleType: Job
 #   image: ${IMAGE_NAME}

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -127,7 +127,7 @@ postgresql:
 nodejs:
   applicationPort: 3000
   image: 'sdshmctspublic.azurecr.io/darts/portal:latest'
-  replicas: ${DARTS_PORTAL_REPLICAS:0}
+  replicas: ${DARTS_PORTAL_REPLICAS}
   ingressHost: "darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
   aadIdentityName: darts
   keyVaults:

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -127,7 +127,7 @@ postgresql:
 nodejs:
   applicationPort: 3000
   image: 'sdshmctspublic.azurecr.io/darts/portal:latest'
-  replicas: ${DARTS_PORTAL_REPLICAS}
+  replicas: 0 #DARTS_PORTAL_REPLICAS
   ingressHost: "darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
   aadIdentityName: darts
   keyVaults:

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -106,8 +106,8 @@ java:
     DARTS_API_DB_USERNAME: "hmcts"
     spring.profiles.active: dev
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
-    DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net
-    DARTS_PORTAL_URL: "https://darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
+    DARTS_GATEWAY_URL: "http://darts-gateway.staging.platform.hmcts.net"
+    DARTS_PORTAL_URL: "https://darts.staging.apps.hmcts.net"
     AUTOMATED_TASK_MODE: true
     API_MODE: true
 

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -127,6 +127,7 @@ postgresql:
 nodejs:
   applicationPort: 3000
   image: 'sdshmctspublic.azurecr.io/darts/portal:latest'
+  replicas: ${DARTS_PORTAL_REPLICAS:0}
   ingressHost: "darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
   aadIdentityName: darts
   keyVaults:

--- a/charts/darts-api/values.stg.template.yaml
+++ b/charts/darts-api/values.stg.template.yaml
@@ -8,7 +8,3 @@ java:
     DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net
     ARM_URL: http://darts-stub-services.staging.platform.hmcts.net
     FEIGN_LOG_LEVEL: none
-
-nodejs:
-  image: 'sdshmctspublic.azurecr.io/darts/portal:latest'
-  replicas: 0


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Enabled a DARTS portal dev deployment by adding the "enable_darts_portal" label.

Including support for a `enable_darts_fullstack` label, which can deploy all other DARTS services alongside the API.

This works by overriding the `values.dev.template.yaml` and `Chart.yaml` files as required to deploy the DARTS portal as well as the API.

As this doesn't required any committed changes to the main charts directory, it shouldn't cause any issues with helm releases in other environments.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
