### PR TITLE
DMP-3830 - Add integration test for blob temp file download

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -66,9 +67,10 @@ import java.util.Optional;
  *  </li>
  * </ul>
  */
-@SpringBootTest
+@SpringBootTest()
 @Slf4j
 @ActiveProfiles({"intTest", "h2db", "in-memory-caching"})
+@Import(IntegrationTestConfiguration.class)
 public class IntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationTestConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationTestConfiguration.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.darts.testutils;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.darts.arm.service.ArmService;
+import uk.gov.hmcts.darts.common.datamanagement.component.DataManagementAzureClientFactory;
+import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
+import uk.gov.hmcts.darts.datamanagement.service.DataManagementService;
+import uk.gov.hmcts.darts.datamanagement.service.impl.DataManagementServiceImpl;
+import uk.gov.hmcts.darts.testutils.stubs.ArmServiceStubImpl;
+import uk.gov.hmcts.darts.testutils.stubs.DataManagementServiceStubImpl;
+import uk.gov.hmcts.darts.util.AzureCopyUtil;
+
+@Configuration
+public class TestConfiguration implements ApplicationContextAware {
+
+    private ApplicationContext applicationContext;
+
+    @Bean
+    public ArmService armService() {
+        return new ArmServiceStubImpl();
+    }
+
+    @Bean
+    public DataManagementService getDartsDataManagementService(DataManagementConfiguration configuration,
+                                                               DataManagementAzureClientFactory factory,
+                                                               AzureCopyUtil azureCopyUtil) {
+        String profiles[] = applicationContext.getEnvironment().getActiveProfiles();
+
+        for (String profile: profiles) {
+            if (profile.equals("blobTest")) {
+                return new DataManagementServiceImpl(configuration, factory, azureCopyUtil);
+            }
+        }
+
+        return new DataManagementServiceStubImpl(configuration);
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationTestConfiguration.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationTestConfiguration.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.darts.testutils;
 
-import org.springframework.beans.BeansException;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import uk.gov.hmcts.darts.arm.service.ArmService;
 import uk.gov.hmcts.darts.common.datamanagement.component.DataManagementAzureClientFactory;
 import uk.gov.hmcts.darts.datamanagement.config.DataManagementConfiguration;
@@ -14,24 +14,28 @@ import uk.gov.hmcts.darts.testutils.stubs.ArmServiceStubImpl;
 import uk.gov.hmcts.darts.testutils.stubs.DataManagementServiceStubImpl;
 import uk.gov.hmcts.darts.util.AzureCopyUtil;
 
-@Configuration
-public class TestConfiguration implements ApplicationContextAware {
+@TestConfiguration
+public class IntegrationTestConfiguration implements ApplicationContextAware {
 
     private ApplicationContext applicationContext;
 
+    private static final String BLOB_STORAGE_PROFILE = "blobTest";
+
     @Bean
+    @Primary
     public ArmService armService() {
         return new ArmServiceStubImpl();
     }
 
     @Bean
+    @Primary
     public DataManagementService getDartsDataManagementService(DataManagementConfiguration configuration,
                                                                DataManagementAzureClientFactory factory,
                                                                AzureCopyUtil azureCopyUtil) {
-        String profiles[] = applicationContext.getEnvironment().getActiveProfiles();
+        String[] profiles = applicationContext.getEnvironment().getActiveProfiles();
 
         for (String profile: profiles) {
-            if (profile.equals("blobTest")) {
+            if (BLOB_STORAGE_PROFILE.equals(profile)) {
                 return new DataManagementServiceImpl(configuration, factory, azureCopyUtil);
             }
         }
@@ -40,7 +44,7 @@ public class TestConfiguration implements ApplicationContextAware {
     }
 
     @Override
-    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+    public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/PostgresIntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/PostgresIntegrationBase.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.darts.testutils.stubs.DartsPersistence;
  */
 @SpringBootTest
 @ActiveProfiles({"intTest"})
+@Import(IntegrationTestConfiguration.class)
 public class PostgresIntegrationBase {
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ArmServiceStubImpl.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ArmServiceStubImpl.java
@@ -3,18 +3,14 @@ package uk.gov.hmcts.darts.testutils.stubs;
 import com.azure.core.util.BinaryData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.arm.model.blobs.ContinuationTokenBlobs;
 import uk.gov.hmcts.darts.arm.service.ArmService;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Component
 @Slf4j
 @RequiredArgsConstructor
-@Profile("intTest")
 @Deprecated
 public class ArmServiceStubImpl implements ArmService {
     @Override

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
@@ -39,7 +39,7 @@ import static uk.gov.hmcts.darts.test.common.TestUtils.getFile;
 @Component
 @Slf4j
 @RequiredArgsConstructor
-@Profile("intTest")
+@Profile("intTest && !blobTest")
 @Deprecated
 public class DataManagementServiceStubImpl implements DataManagementService {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DataManagementServiceStubImpl.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.datamanagement.component.impl.DownloadResponseMetaData;
 import uk.gov.hmcts.darts.common.datamanagement.component.impl.FileBasedDownloadResponseMetaData;
 import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
@@ -36,10 +34,8 @@ import static uk.gov.hmcts.darts.test.common.TestUtils.getFile;
  * This class is a test implementation of DataManagementService, intended to mimic the basic behaviour of Azure
  * Blob Storage. TODO: Hopefully this will be replaced by a more functional implementation (see DMP-597).
  */
-@Component
 @Slf4j
 @RequiredArgsConstructor
-@Profile("intTest && !blobTest")
 @Deprecated
 public class DataManagementServiceStubImpl implements DataManagementService {
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmServiceImpl.java
@@ -11,7 +11,6 @@ import com.azure.storage.blob.models.BlobListDetails;
 import com.azure.storage.blob.models.DeleteSnapshotsOptionType;
 import com.azure.storage.blob.models.ListBlobsOptions;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
@@ -37,7 +36,6 @@ import static org.springframework.http.HttpStatus.valueOf;
 
 @Service
 @Slf4j
-@Profile("!intTest")
 public class ArmServiceImpl implements ArmService {
 
     private static final String FILE_PATH_DELIMITER = "/";

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +27,6 @@ import uk.gov.hmcts.darts.audiorequests.model.SearchTransformedMediaRequest;
 import uk.gov.hmcts.darts.audiorequests.model.SearchTransformedMediaResponse;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.common.datamanagement.component.impl.DownloadResponseMetaData;
-import uk.gov.hmcts.darts.common.datamanagement.component.impl.FileBasedDownloadResponseMetaData;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.log.api.LogApi;
 
@@ -77,14 +75,15 @@ public class AudioRequestsController implements AudioRequestsApi {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @SneakyThrows
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = TRANSFORMED_MEDIA_ID,
         securityRoles = {TRANSCRIBER},
         globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER, DARTS})
     public ResponseEntity<Resource> download(Integer transformedMediaId) {
-        FileBasedDownloadResponseMetaData downloadResponseMetadata = (FileBasedDownloadResponseMetaData) mediaRequestService.download(transformedMediaId);
-        return ResponseEntity.ok().body(new FileSystemResource(downloadResponseMetadata.getFileToBeDownloadedTo()));
+        DownloadResponseMetaData downloadResponseMetadata = mediaRequestService.download(transformedMediaId);
+        return ResponseEntity.ok().body(downloadResponseMetadata.getResource());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/common/datamanagement/component/impl/FileBasedDownloadResponseMetaData.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/datamanagement/component/impl/FileBasedDownloadResponseMetaData.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.common.datamanagement.component.impl;
 
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.springframework.core.io.FileUrlResource;
@@ -23,7 +22,6 @@ import java.util.UUID;
 @Slf4j
 public class FileBasedDownloadResponseMetaData extends DownloadResponseMetaData {
 
-    @Getter
     private File fileToBeDownloadedTo;
 
     /**
@@ -80,7 +78,7 @@ public class FileBasedDownloadResponseMetaData extends DownloadResponseMetaData 
 
     class FileInputStreamWrapper extends InputStream {
 
-        private InputStream inputStream;
+        private final InputStream inputStream;
 
         public FileInputStreamWrapper(InputStream inputStream) {
             this.inputStream = inputStream;
@@ -100,6 +98,7 @@ public class FileBasedDownloadResponseMetaData extends DownloadResponseMetaData 
          */
         @Override
         public void close() throws IOException {
+            inputStream.close();
             FileBasedDownloadResponseMetaData.this.close();
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -11,7 +11,6 @@ import com.azure.storage.blob.options.BlobParallelUploadOptions;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.datamanagement.component.DataManagementAzureClientFactory;
@@ -42,7 +41,6 @@ import static org.springframework.http.HttpStatus.valueOf;
 
 @Service
 @Slf4j
-@Profile("!intTest| || blobTest")
 @RequiredArgsConstructor
 @SuppressWarnings("checkstyle:SummaryJavadoc")
 public class DataManagementServiceImpl implements DataManagementService {

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -42,7 +42,7 @@ import static org.springframework.http.HttpStatus.valueOf;
 
 @Service
 @Slf4j
-@Profile("!intTest")
+@Profile("!intTest| || blobTest")
 @RequiredArgsConstructor
 @SuppressWarnings("checkstyle:SummaryJavadoc")
 public class DataManagementServiceImpl implements DataManagementService {
@@ -244,4 +244,5 @@ public class DataManagementServiceImpl implements DataManagementService {
             return containerSasUrl.replace(containerName, containerName + "/" + location);
         }
     }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

[[N/A](https://tools.hmcts.net/jira/browse/DMP-3830)](https://tools.hmcts.net/jira/browse/DMP-3830)

### Change description ###

An extension to the PR https://github.com/hmcts/darts-api/pull/2170. This PR includes an integration test for blob download and temp file removal

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
