### PR TITLE
DMP-4184: Apply v72.1 datamodel updates

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/darts/cases/CasesFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/cases/CasesFunctionalTest.java
@@ -75,7 +75,7 @@ class CasesFunctionalTest extends FunctionalTest {
               "case_numbers": [
                 "<<caseNumber>>"
               ],
-              "event_text": "some text for the event",
+              "event_text": "A temporary event created by functional test",
               "date_time": "2023-08-08T14:01:06Z"
             }""";
 

--- a/src/functionalTest/java/uk/gov/hmcts/darts/events/PostEventsFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/darts/events/PostEventsFunctionalTest.java
@@ -40,7 +40,7 @@ class PostEventsFunctionalTest extends FunctionalTest {
                         "case_numbers": [
                           "func-Swansea_case_1"
                         ],
-                        "event_text": "some text for the event",
+                        "event_text": "A temporary event created by functional test",
                         "date_time": "2023-08-08T14:01:06Z"
                       }""";
         bodyText = bodyText.replace("<<courtHouseName>>", courthouseName);
@@ -74,7 +74,7 @@ class PostEventsFunctionalTest extends FunctionalTest {
                         "case_numbers": [
                           "func-Swansea_case_1"
                         ],
-                        "event_text": "some text for the event",
+                        "event_text": "A temporary event created by functional test",
                         "date_time": "2023-08-08T14:01:06Z"
                       }""")
             .when()

--- a/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1OkJsonAndXml/expectedResponse.json
+++ b/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1OkJsonAndXml/expectedResponse.json
@@ -20,5 +20,5 @@
   "contentObjectId": null,
   "clipId": null,
   "externalLocation": null,
-  "eltId": null
+  "externalLocationTypeEntity": null
 }

--- a/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1OkJsonAndXml/expectedResponse2.json
+++ b/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1OkJsonAndXml/expectedResponse2.json
@@ -20,5 +20,5 @@
   "contentObjectId": null,
   "clipId": null,
   "externalLocation": null,
-  "eltId": null
+  "externalLocationTypeEntity": null
 }

--- a/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1_duplicate_ok/expectedResponse.json
+++ b/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1_duplicate_ok/expectedResponse.json
@@ -20,5 +20,5 @@
   "contentObjectId": null,
   "clipId": null,
   "externalLocation": null,
-  "eltId": null
+  "externalLocationTypeEntity": null
 }

--- a/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1_ok/expectedResponse.json
+++ b/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1_ok/expectedResponse.json
@@ -20,5 +20,5 @@
   "contentObjectId": null,
   "clipId": null,
   "externalLocation": null,
-  "eltId": null
+  "externalLocationTypeEntity": null
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DailyListEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DailyListEntity.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
@@ -100,7 +102,8 @@ public class DailyListEntity extends CreatedModifiedBaseEntity {
     @Column(name = "external_location")
     private UUID externalLocation;
 
-    @Column(name = "elt_id")
-    private Integer eltId;
+    @ManyToOne
+    @JoinColumn(name = "elt_id")
+    private ExternalLocationTypeEntity externalLocationTypeEntity;
 
 }

--- a/src/main/resources/db/migration/common/V1_399__v72_1.sql
+++ b/src/main/resources/db/migration/common/V1_399__v72_1.sql
@@ -1,0 +1,59 @@
+--v72.1 add 2 missing FKs on data_anonymisation
+--    add missing FK on daily_list
+ALTER TABLE daily_list
+    ADD CONSTRAINT daily_list_external_location_type_fk
+        FOREIGN KEY (elt_id) REFERENCES external_location_type (elt_id);
+
+
+--    add 2 FKs on event_linked_case
+DELETE
+FROM event_linked_case -- delete records that conflict with event_linked_case_court_case_fk
+WHERE cas_id IN (SELECT elc.cas_id
+                 FROM event_linked_case elc
+                          LEFT JOIN court_case cc ON elc.cas_id = cc.cas_id
+                 WHERE cc.cas_id IS NULL);
+
+ALTER TABLE event_linked_case
+    ADD CONSTRAINT event_linked_case_court_case_fk
+        FOREIGN KEY (cas_id) REFERENCES court_case (cas_id);
+
+DELETE
+FROM event_linked_case -- delete records that conflict with event_linked_case_event_fk
+WHERE eve_id IN (SELECT elc.eve_id
+                 FROM event_linked_case elc
+                          LEFT JOIN event eve ON elc.eve_id = eve.eve_id
+                 WHERE eve.eve_id IS NULL);
+
+ALTER TABLE event_linked_case
+    ADD CONSTRAINT event_linked_case_event_fk
+        FOREIGN KEY (eve_id) REFERENCES event (eve_id);
+
+
+--    add 2 FKs on media_linked_case
+ALTER TABLE media_linked_case
+    ADD CONSTRAINT media_linked_case_court_case_fk
+        FOREIGN KEY (cas_id) REFERENCES court_case (cas_id);
+
+ALTER TABLE media_linked_case
+    ADD CONSTRAINT media_linked_case_media_fk
+        FOREIGN KEY (med_id) REFERENCES media (med_id);
+
+
+--    add 2 FKs on object_retrieval_queue
+ALTER TABLE object_retrieval_queue
+    ADD CONSTRAINT object_retrieval_queue_media_fk
+        FOREIGN KEY (med_id) REFERENCES media (med_id);
+
+ALTER TABLE object_retrieval_queue
+    ADD CONSTRAINT object_retrieval_queue_transcription_document_fk
+        FOREIGN KEY (trd_id) REFERENCES transcription_document (trd_id);
+
+
+-- Additional changes not captured in change notes
+ALTER TABLE data_anonymisation
+    ADD CONSTRAINT data_anonymisation_requested_by_fk
+        FOREIGN KEY (requested_by) REFERENCES user_account (usr_id);
+
+ALTER TABLE data_anonymisation
+    ADD CONSTRAINT data_anonymisation_approved_by_fk
+        FOREIGN KEY (approved_by) REFERENCES user_account (usr_id);


### PR DESCRIPTION
# [DMP-4184](https://tools.hmcts.net/jira/browse/DMP-4184)

Apply v71.1 datamodel updates per https://github.com/hmcts/darts-api/pull/2201.

Due to the addition of new foreign keys `event_linked_case_court_case_fk` and `event_linked_case_event_fk`, a datafix is included to remove any `event_linked_case` records that point to non-existing cases or events:

```sql
DELETE FROM event_linked_case
WHERE cas_id IN (
    SELECT elc.cas_id
    FROM event_linked_case elc
    LEFT JOIN court_case cc ON elc.cas_id = cc.cas_id
    WHERE cc.cas_id IS NULL
);

DELETE FROM event_linked_case
WHERE eve_id IN (
    SELECT elc.eve_id
    FROM event_linked_case elc
    LEFT JOIN event eve ON elc.eve_id = eve.eve_id
    WHERE eve.eve_id IS NULL
);
```

The problematic data exists in staging due to the functional tests not cleaning up the `event_linked_case` table after deleting cases/events during test tear down. This issue is also resolved by this PR. 

The problem is limited to staging, however the databases in `test`, `demo` and `ithc` were also checked to ensure the new FKs will not conflict with existing data. COUNT 0 for those envs indicate there are no data conflicts, and therefore no records will meet the deletion criteria.

```sql
-- Verify daily_list_external_location_type_fk
-- Staging: 0
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(dal_id)
FROM daily_list dl
LEFT JOIN external_location_type elt ON dl.elt_id = elt.elt_id
WHERE elt.elt_id IS NULL AND dl.elt_id IS NOT NULL;

-- Verify event_linked_case_court_case_fk
-- Staging: 2329
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(elc_id)
FROM event_linked_case elc
LEFT JOIN court_case cc ON elc.cas_id = cc.cas_id
WHERE cc.cas_id IS NULL;

-- Verify event_linked_case_event_fk
-- Staging: 54159
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(elc_id)
FROM event_linked_case elc
LEFT JOIN event eve ON elc.eve_id = eve.eve_id
WHERE eve.eve_id IS NULL;

-- Verify media_linked_case_court_case_fk
-- Staging: 0
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(mlc_id)
FROM media_linked_case mlc
LEFT JOIN court_case cas ON mlc.cas_id = cas.cas_id
WHERE cas.cas_id IS NULL AND mlc.cas_id IS NOT NULL;

-- Verify media_linked_case_media_fk
-- Staging: 0
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(mlc_id)
FROM media_linked_case mlc
LEFT JOIN media med ON mlc.med_id = med.med_id
WHERE med.med_id IS NULL;

-- Verify object_retrieval_queue_media_fk
-- Staging: 0
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(orq_id)
FROM object_retrieval_queue orq
LEFT JOIN media med ON orq.med_id = med.med_id
WHERE med.med_id IS NULL AND orq.med_id IS NOT NULL;

-- Verify object_retrieval_queue_transcription_document_fk
-- Staging: 0
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(orq_id)
FROM object_retrieval_queue orq
LEFT JOIN transcription_document td on orq.trd_id = td.trd_id
WHERE td.trd_id IS NULL AND orq.trd_id IS NOT NULL;

-- Verify data_anonymisation_requested_by_fk
-- Staging: 0
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(dan_id)
FROM data_anonymisation dan
LEFT JOIN user_account ua on dan.requested_by = ua.usr_id
WHERE ua.usr_id IS NULL;

-- Verify data_anonymisation_approved_by_fk
-- Staging: 0
-- Test: 0
-- Demo: 0
-- ITHC: 0
SELECT COUNT(dan_id)
FROM data_anonymisation dan
LEFT JOIN user_account ua on dan.approved_by = ua.usr_id
WHERE ua.usr_id IS NULL AND dan.approved_by IS NOT NULL;
```


Note creation of `dan_seq` is not included here as it was already applied in https://github.com/hmcts/darts-api/pull/2189 as a necessary prerequisite to creating the `DataAnonymisationEntity`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
