### PR TITLE
DMP-4135: Implement getProfileEntitlements for ARM RPO

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoGetProfileEntitlementsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoGetProfileEntitlementsIntTest.java
@@ -1,0 +1,111 @@
+package uk.gov.hmcts.darts.arm.rpo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.darts.arm.client.ArmRpoClient;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProfileEntitlementResponse;
+import uk.gov.hmcts.darts.arm.exception.ArmRpoException;
+import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.ArmRpoStateEnum;
+import uk.gov.hmcts.darts.common.enums.ArmRpoStatusEnum;
+import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@TestPropertySource(properties = {
+    "darts.storage.arm-api.arm-service-entitlement=SRV-DARTS-RW-E"
+})
+class ArmRpoGetProfileEntitlementsIntTest extends PostgresIntegrationBase {
+
+    @MockBean
+    private ArmRpoClient armRpoClient;
+
+    @Autowired
+    private ArmRpoApi armRpoApi;
+
+    private static final String TOKEN = "some token";
+    private static final String ENTITLEMENT_ID = "some entitlement id";
+    private static final String ENTITLEMENT_NAME = "SRV-DARTS-RW-E";
+
+
+    @Test
+    void getProfileEntitlements_shouldSucceed_whenASuccessResponseIsObtainedFromArmThatContainsAMatchingEntitlement() {
+        // Given
+        UserAccountEntity userAccount = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+
+        var executionDetailEntity = createExecutionDetailEntity(userAccount);
+        executionDetailEntity = dartsPersistence.save(executionDetailEntity);
+
+        Integer executionId = executionDetailEntity.getId();
+
+        var profileEntitlement = new ProfileEntitlementResponse.ProfileEntitlement();
+        profileEntitlement.setName(ENTITLEMENT_NAME);
+        profileEntitlement.setEntitlementId(ENTITLEMENT_ID);
+        createEntitlementResponseAndSetMock(Collections.singletonList(profileEntitlement));
+
+        // When
+        armRpoApi.getProfileEntitlements(TOKEN, executionId, userAccount);
+
+        // Then
+        executionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(executionId)
+            .orElseThrow();
+        assertEquals(ArmRpoStateEnum.GET_PROFILE_ENTITLEMENTS.getId(), executionDetailEntity.getArmRpoState().getId());
+        assertEquals(ArmRpoStatusEnum.COMPLETED.getId(), executionDetailEntity.getArmRpoStatus().getId());
+        assertEquals(ENTITLEMENT_ID, executionDetailEntity.getEntitlementId());
+    }
+
+    @Test
+    void getProfileEntitlements_shouldFail_whenArmResponseDoesNotContainAMatchingEntitlement() {
+        // Given
+        UserAccountEntity userAccount = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+
+        var executionDetailEntity = createExecutionDetailEntity(userAccount);
+        executionDetailEntity = dartsPersistence.save(executionDetailEntity);
+
+        Integer executionId = executionDetailEntity.getId();
+
+        var profileEntitlement = new ProfileEntitlementResponse.ProfileEntitlement();
+        profileEntitlement.setName("some other entitlement");
+        createEntitlementResponseAndSetMock(Collections.singletonList(profileEntitlement));
+
+        // When
+        String exceptionMessage = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProfileEntitlements(TOKEN, executionId, userAccount))
+            .getMessage();
+
+        // Then
+        assertThat(exceptionMessage, containsString("No matching entitlements were returned"));
+
+        executionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(executionId)
+            .orElseThrow();
+        assertEquals(ArmRpoStateEnum.GET_PROFILE_ENTITLEMENTS.getId(), executionDetailEntity.getArmRpoState().getId());
+        assertEquals(ArmRpoStatusEnum.FAILED.getId(), executionDetailEntity.getArmRpoStatus().getId());
+        assertNull(executionDetailEntity.getEntitlementId());
+    }
+
+    private ArmRpoExecutionDetailEntity createExecutionDetailEntity(UserAccountEntity userAccount) {
+        ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
+        armRpoExecutionDetailEntity.setCreatedBy(userAccount);
+        armRpoExecutionDetailEntity.setLastModifiedBy(userAccount);
+        return armRpoExecutionDetailEntity;
+    }
+
+    private void createEntitlementResponseAndSetMock(List<ProfileEntitlementResponse.ProfileEntitlement> profileEntitlements) {
+        var response = new ProfileEntitlementResponse();
+        response.setEntitlements(profileEntitlements);
+        when(armRpoClient.getProfileEntitlementResponse(TOKEN))
+            .thenReturn(response);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/ArmRpoClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/ArmRpoClient.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import uk.gov.hmcts.darts.arm.client.model.rpo.MasterIndexFieldByRecordClassSchemaRequest;
 import uk.gov.hmcts.darts.arm.client.model.rpo.MasterIndexFieldByRecordClassSchemaResponse;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProfileEntitlementResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.RecordManagementMatterResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.StorageAccountRequest;
 import uk.gov.hmcts.darts.arm.client.model.rpo.StorageAccountResponse;
@@ -40,4 +41,11 @@ public interface ArmRpoClient {
     )
     MasterIndexFieldByRecordClassSchemaResponse getMasterIndexFieldByRecordClassSchema(
         @RequestHeader(AUTHORIZATION) String bearerAuth, @RequestBody MasterIndexFieldByRecordClassSchemaRequest masterIndexFieldByRecordClassSchemaRequest);
+
+    @PostMapping(value = "${darts.storage.arm-api.rpo-url.get-profile-entitlements-path}",
+        consumes = APPLICATION_JSON_VALUE,
+        produces = APPLICATION_JSON_VALUE
+    )
+    ProfileEntitlementResponse getProfileEntitlementResponse(@RequestHeader(AUTHORIZATION) String bearerAuth);
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ProfileEntitlementResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ProfileEntitlementResponse.java
@@ -1,13 +1,28 @@
 package uk.gov.hmcts.darts.arm.client.model.rpo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
 public class ProfileEntitlementResponse extends AbstractMatterResponse {
+
+    private List<ProfileEntitlement> entitlements;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Data
+    @NoArgsConstructor
+    public static class ProfileEntitlement {
+        @JsonProperty("entitlementID")
+        private String entitlementId;
+        private String name;
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/exception/ArmRpoException.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/exception/ArmRpoException.java
@@ -7,4 +7,5 @@ public class ArmRpoException extends DartsException {
     public ArmRpoException(String message) {
         super(message);
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApi.java
@@ -5,7 +5,6 @@ import uk.gov.hmcts.darts.arm.client.model.rpo.ExtendedProductionsByMatterRespon
 import uk.gov.hmcts.darts.arm.client.model.rpo.ExtendedSearchesByMatterResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.IndexesByMatterIdResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.MasterIndexFieldByRecordClassSchemaResponse;
-import uk.gov.hmcts.darts.arm.client.model.rpo.ProfileEntitlementResponse;
 import uk.gov.hmcts.darts.arm.model.rpo.MasterIndexFieldByRecordClassSchema;
 import uk.gov.hmcts.darts.common.entity.ArmRpoStateEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -21,7 +20,7 @@ public interface ArmRpoApi {
 
     void getStorageAccounts(String bearerToken, Integer executionId, UserAccountEntity userAccount);
 
-    ProfileEntitlementResponse getProfileEntitlements(String bearerToken, Integer executionId, UserAccountEntity userAccount);
+    void getProfileEntitlements(String bearerToken, Integer executionId, UserAccountEntity userAccount);
 
     List<MasterIndexFieldByRecordClassSchema> getMasterIndexFieldByRecordClassSchema(String bearerToken, Integer executionId, ArmRpoStateEntity rpoStateEntity,
                                                                                      UserAccountEntity userAccount);

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -28,6 +28,8 @@ darts:
   storage:
     arm-api:
       url: ${ARM_URL:http://localhost:4551}
+      arm-service-entitlement: "SRV-DARTS-RW-E" # Per the entitlements[*].name value specified in darts-stub-services getProfileEntitlements
+      arm-storage-account-name: "local"
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -287,8 +287,8 @@ darts:
       rpo-url:
         get-record-management-matter-path: /api/v1/getRecordManagementMatter
         get-storage-accounts: /api/v1/getStorageAccounts
-
         get-master-index-field-by-record-class-schema-path: /api/v1/getMasterIndexFieldByRecordClassSchema
+        get-profile-entitlements-path: /api/v1/getProfileEntitlements
     dets:
       sas-endpoint: ${DETS_SAS_URL_ENDPOINT:}
       container-name: darts-migration

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetProfileEntitlementsTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetProfileEntitlementsTest.java
@@ -1,22 +1,235 @@
 package uk.gov.hmcts.darts.arm.rpo.impl;
 
-import org.apache.commons.lang3.NotImplementedException;
+import feign.FeignException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.arm.client.ArmRpoClient;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProfileEntitlementResponse;
+import uk.gov.hmcts.darts.arm.config.ArmApiConfigurationProperties;
+import uk.gov.hmcts.darts.arm.exception.ArmRpoException;
+import uk.gov.hmcts.darts.arm.helper.ArmRpoHelperMocks;
+import uk.gov.hmcts.darts.arm.service.ArmRpoService;
+import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ArmRpoApiGetProfileEntitlementsTest {
 
-    @InjectMocks
     private ArmRpoApiImpl armRpoApi;
 
+    private ArmRpoService armRpoService;
+    private ArmRpoClient armRpoClient;
+
+    private ArmRpoHelperMocks armRpoHelperMocks;
+    private ArgumentCaptor<ArmRpoExecutionDetailEntity> executionDetailCaptor;
+
+    private static final Integer EXECUTION_ID = 1;
+    private static final String TOKEN = "some token";
+    private static final String ENTITLEMENT_NAME = "some entitlement name";
+
+    @BeforeEach
+    void beforeEach() {
+        armRpoService = spy(ArmRpoService.class);
+        armRpoClient = mock(ArmRpoClient.class);
+        executionDetailCaptor = ArgumentCaptor.forClass(ArmRpoExecutionDetailEntity.class);
+
+        armRpoHelperMocks = new ArmRpoHelperMocks(); // Mocks are set via the default constructor call
+
+        ArmApiConfigurationProperties armApiConfigurationProperties = new ArmApiConfigurationProperties();
+        armApiConfigurationProperties.setArmServiceEntitlement(ENTITLEMENT_NAME);
+
+        armRpoApi = new ArmRpoApiImpl(armRpoClient, armRpoService, armApiConfigurationProperties);
+    }
+
+    @AfterEach
+    void afterEach() {
+        armRpoHelperMocks.close();
+    }
+
     @Test
-    void getProfileEntitlements() {
-        assertThrows(NotImplementedException.class, () -> armRpoApi.getProfileEntitlements("token", 1, null));
+    void getProfileEntitlements_shouldSucceed_whenAResponseIsObtainedFromArmThatContainsAMatchingEntitlement() {
+        //  Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        var profileEntitlement = new ProfileEntitlementResponse.ProfileEntitlement();
+        profileEntitlement.setName(ENTITLEMENT_NAME);
+        profileEntitlement.setEntitlementId("some entitlement id");
+        createEntitlementResponseAndSetMock(Collections.singletonList(profileEntitlement));
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        armRpoApi.getProfileEntitlements(TOKEN, EXECUTION_ID, someUserAccount);
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProfileEntitlementsRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to completed as the final operation
+        verify(armRpoService).updateArmRpoStatus(executionDetailCaptor.capture(),
+                                                 eq(armRpoHelperMocks.getCompletedRpoStatus()),
+                                                 eq(someUserAccount));
+        verifyNoMoreInteractions(armRpoService);
+
+        // And verify the entitlement id was set
+        assertEquals("some entitlement id", executionDetailCaptor.getValue().getEntitlementId());
+    }
+
+    @Test
+    void getProfileEntitlements_shouldThrowException_whenArmCallFails() {
+        //  Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        when(armRpoClient.getProfileEntitlementResponse(TOKEN))
+            .thenThrow(mock(FeignException.class));
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProfileEntitlements(TOKEN, EXECUTION_ID, someUserAccount));
+        assertThat(armRpoException.getMessage(), containsString("API call failed"));
+
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProfileEntitlementsRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getFailedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void getProfileEntitlements_shouldThrowException_whenEntitlementsAreNullOrEmpty(List<ProfileEntitlementResponse.ProfileEntitlement> entitlements) {
+        //  Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        createEntitlementResponseAndSetMock(entitlements);
+
+        var someUserAccount = new UserAccountEntity();
+
+        // When
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProfileEntitlements(TOKEN, EXECUTION_ID, someUserAccount));
+        assertThat(armRpoException.getMessage(), containsString("No entitlements were returned"));
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProfileEntitlementsRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getFailedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getProfileEntitlements_shouldThrowException_whenNoMatchingEntitlementIsReturned() {
+        //  Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        var profileEntitlement = new ProfileEntitlementResponse.ProfileEntitlement();
+        profileEntitlement.setName("some lone name that does not match the configured entitlement name");
+        createEntitlementResponseAndSetMock(Collections.singletonList(profileEntitlement));
+
+        var someUserAccount = new UserAccountEntity();
+
+        // When
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProfileEntitlements(TOKEN, EXECUTION_ID, someUserAccount));
+        assertThat(armRpoException.getMessage(), containsString("No matching entitlements were returned"));
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProfileEntitlementsRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getFailedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void getProfileEntitlements_shouldThrowException_whenEntitlementIsReturnedButContainsANullOrEmptyEntitlementId(String entitlementId) {
+        //  Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        var profileEntitlement = new ProfileEntitlementResponse.ProfileEntitlement();
+        profileEntitlement.setName(ENTITLEMENT_NAME);
+        profileEntitlement.setEntitlementId(entitlementId);
+        createEntitlementResponseAndSetMock(Collections.singletonList(profileEntitlement));
+
+        var someUserAccount = new UserAccountEntity();
+
+        // When
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProfileEntitlements(TOKEN, EXECUTION_ID, someUserAccount));
+        assertThat(armRpoException.getMessage(), containsString("The obtained entitlement id was empty"));
+
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProfileEntitlementsRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getFailedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    private ArmRpoExecutionDetailEntity createInitialExecutionDetailEntityAndSetMock() {
+        var armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
+        armRpoExecutionDetailEntity.setId(EXECUTION_ID);
+
+        when(armRpoService.getArmRpoExecutionDetailEntity(EXECUTION_ID))
+            .thenReturn(armRpoExecutionDetailEntity);
+
+        return armRpoExecutionDetailEntity;
+    }
+
+    private void createEntitlementResponseAndSetMock(List<ProfileEntitlementResponse.ProfileEntitlement> profileEntitlements) {
+        var response = new ProfileEntitlementResponse();
+        response.setEntitlements(profileEntitlements);
+        when(armRpoClient.getProfileEntitlementResponse(TOKEN))
+            .thenReturn(response);
     }
 
 }


### PR DESCRIPTION
# [(Dev Only) DMP-4135](https://tools.hmcts.net/jira/browse/DMP-4135)

Implement the ARM RPO getProfileEntitlements service layer.

This PR includes the corresponding Feign client which will be integration tested as part of wider ticket https://tools.hmcts.net/jira/browse/DMP-4143.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
