### PR TITLE
DMP-4156: Enhance add audio duplicate checking to use media_linked_case source

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.MediaLinkedCaseEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.MediaLinkedCaseSourceType;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
@@ -172,7 +173,8 @@ public class AudioUploadServiceImpl implements AudioUploadService {
     private List<MediaEntity> filterMediaEntitiesWithIdenticalCaseList(List<String> caseNumbersToLookFor, List<MediaEntity> mediaEntities) {
         ArrayList<MediaEntity> resultList = new ArrayList<>();
         for (MediaEntity mediaEntity : mediaEntities) {
-            List<MediaLinkedCaseEntity> mediaLinkedCaseEntities = mediaLinkedCaseRepository.findByMediaAndSource(mediaEntity, 1);
+            List<MediaLinkedCaseEntity> mediaLinkedCaseEntities =
+                mediaLinkedCaseRepository.findByMediaAndSource(mediaEntity, MediaLinkedCaseSourceType.ADD_AUDIO_METADATA);
             List<String> mediaCaseNumbers = mediaLinkedCaseEntities.stream()
                 .map(MediaLinkedCaseEntity::getCourtCase)
                 .filter(Objects::nonNull)

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
@@ -172,7 +172,7 @@ public class AudioUploadServiceImpl implements AudioUploadService {
     private List<MediaEntity> filterMediaEntitiesWithIdenticalCaseList(List<String> caseNumbersToLookFor, List<MediaEntity> mediaEntities) {
         ArrayList<MediaEntity> resultList = new ArrayList<>();
         for (MediaEntity mediaEntity : mediaEntities) {
-            List<MediaLinkedCaseEntity> mediaLinkedCaseEntities = mediaLinkedCaseRepository.findByMedia(mediaEntity);
+            List<MediaLinkedCaseEntity> mediaLinkedCaseEntities = mediaLinkedCaseRepository.findByMediaAndSource(mediaEntity, 1);
             List<String> mediaCaseNumbers = mediaLinkedCaseEntities.stream()
                 .map(MediaLinkedCaseEntity::getCourtCase)
                 .filter(Objects::nonNull)

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaLinkedCaseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaLinkedCaseRepository.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.MediaLinkedCaseEntity;
+import uk.gov.hmcts.darts.common.enums.MediaLinkedCaseSourceType;
 
 import java.util.List;
 
@@ -13,7 +14,7 @@ public interface MediaLinkedCaseRepository extends JpaRepository<MediaLinkedCase
 
     List<MediaLinkedCaseEntity> findByMedia(MediaEntity media);
 
-    List<MediaLinkedCaseEntity> findByMediaAndSource(MediaEntity mediaEntity, int source);
+    List<MediaLinkedCaseEntity> findByMediaAndSource(MediaEntity mediaEntity, MediaLinkedCaseSourceType source);
 
     boolean existsByMediaAndCourtCase(MediaEntity media, CourtCaseEntity courtCase);
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaLinkedCaseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaLinkedCaseRepository.java
@@ -13,6 +13,8 @@ public interface MediaLinkedCaseRepository extends JpaRepository<MediaLinkedCase
 
     List<MediaLinkedCaseEntity> findByMedia(MediaEntity media);
 
+    List<MediaLinkedCaseEntity> findByMediaAndSource(MediaEntity mediaEntity, int source);
+
     boolean existsByMediaAndCourtCase(MediaEntity media, CourtCaseEntity courtCase);
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.MediaLinkedCaseSourceType;
 import uk.gov.hmcts.darts.common.helper.MediaLinkedCaseHelper;
 import uk.gov.hmcts.darts.common.repository.CourtLogEventRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
@@ -92,6 +93,8 @@ class AudioUploadServiceImplTest {
     private MediaLinkedCaseHelper mediaLinkedCaseHelper;
     @Mock
     private MediaLinkedCaseRepository mediaLinkedCaseRepository;
+    @Mock
+    private MediaEntity mediaEntityMock;
 
     @BeforeEach
     void setUp() {
@@ -128,6 +131,8 @@ class AudioUploadServiceImplTest {
             any(),
             any()
         )).thenReturn(hearingEntity);
+        when(mediaRepository.findMediaByDetails(any(), any(), any(), any(), any()))
+            .thenReturn(List.of(mediaEntityMock));
 
         CourthouseEntity courthouse = new CourthouseEntity();
         courthouse.setCourthouseName("SWANSEA");
@@ -174,6 +179,8 @@ class AudioUploadServiceImplTest {
         assertEquals(savedMedia.getChecksum(), externalObjectDirectoryEntity.getChecksum());
         assertNotNull(externalObjectDirectoryEntity.getChecksum());
         assertEquals(externalLocation, externalObjectDirectoryEntity.getExternalLocation());
+
+        verify(mediaLinkedCaseRepository).findByMediaAndSource(mediaEntityMock, MediaLinkedCaseSourceType.ADD_AUDIO_METADATA);
     }
 
     private MediaEntity createMediaEntity(OffsetDateTime startedAt, OffsetDateTime endedAt) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-4156

This branch is from the branch for DMP-3986, which contains changes required by this ticket. See related PR:
https://github.com/hmcts/darts-api/pull/2215

Note: there's already an existing integration test that is verifying the new functionality: `AudioControllerAddAudioMetadataIntTest.addAudioMetadataDifferentCases()`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
