### PR TITLE
DMP-4227: GenerateCaseDocumentForRetentionDate Task - ignore isRetentionUpdated

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/casedocument/service/impl/GenerateCaseDocumentForRetentionDateBatchProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/casedocument/service/impl/GenerateCaseDocumentForRetentionDateBatchProcessorImpl.java
@@ -7,10 +7,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.casedocument.service.GenerateCaseDocumentForRetentionDateProcessor;
 import uk.gov.hmcts.darts.casedocument.service.GenerateCaseDocumentSingleCaseProcessor;
+import uk.gov.hmcts.darts.cases.service.CaseService;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.CaseRepository;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -23,28 +26,28 @@ public class GenerateCaseDocumentForRetentionDateBatchProcessorImpl implements G
     private final CaseRepository caseRepository;
     private final GenerateCaseDocumentSingleCaseProcessor singleCaseProcessor;
     private final CurrentTimeHelper currentTimeHelper;
+    private final CaseService caseService;
 
     @Override
     public void processGenerateCaseDocumentForRetentionDate(int batchSize) {
         OffsetDateTime currentTimestamp = currentTimeHelper.currentOffsetDateTime();
         OffsetDateTime caseRetailUntilTimestamp = currentTimestamp.plusDays(caseDocumentExpiryDays);
         OffsetDateTime caseDocumentCreatedAfterTimestamp = currentTimestamp.minusDays(caseDocumentExpiryDays);
-        var cases = caseRepository.findCasesNeedingCaseDocumentForRetentionDateGeneration(caseRetailUntilTimestamp,
-                                                                                          caseDocumentCreatedAfterTimestamp,
-                                                                                          Pageable.ofSize(batchSize));
-        log.debug("Found {} cases needing case document based on retention out of a batch size {}", cases.size(), batchSize);
-        for (var courtCase : cases) {
+        List<Integer> casesIds = caseRepository.findCasesNeedingCaseDocumentForRetentionDateGeneration(caseRetailUntilTimestamp,
+                                                                                                       caseDocumentCreatedAfterTimestamp,
+                                                                                                       Pageable.ofSize(batchSize));
+        log.debug("Found {} cases needing case document based on retention out of a batch size {}", casesIds.size(), batchSize);
+        for (Integer courtCaseId : casesIds) {
             try {
+                CourtCaseEntity courtCase = caseService.getCourtCaseById(courtCaseId);
                 if (!courtCase.isRetentionUpdated()) {
-                    singleCaseProcessor.processGenerateCaseDocument(courtCase.getId());
+                    singleCaseProcessor.processGenerateCaseDocument(courtCaseId);
                 } else {
-                    log.info("Retention calculation is In Progress for case id {}", courtCase.getId());
+                    log.info("Retention calculation is In Progress for case id {}", courtCaseId);
                 }
             } catch (Exception exc) {
-                log.error("Error generating retention date case document for case id '{}'", courtCase.getId(), exc);
+                log.error("Error generating retention date case document for case id '{}'", courtCaseId, exc);
             }
         }
     }
-
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRepository.java
@@ -62,7 +62,7 @@ public interface CaseRepository extends JpaRepository<CourtCaseEntity, Integer> 
     List<CourtCaseEntity> findCasesNeedingCaseDocumentGenerated(OffsetDateTime caseClosedBeforeTimestamp, Pageable pageable);
 
     @Query("""
-            SELECT cc
+            SELECT cc.id
             FROM CourtCaseEntity cc,
             CaseRetentionEntity cr,
             (select cr2.courtCase.id as caseId, max(cr2.createdDateTime) latest_ts
@@ -77,11 +77,11 @@ public interface CaseRepository extends JpaRepository<CourtCaseEntity, Integer> 
                 WHERE cd.courtCase.id = cc.id
                 AND cd.createdDateTime >= :caseDocumentCreatedAfterTimestamp
             )
-            ORDER BY cc.id ASC
+            ORDER BY cc.isRetentionUpdated ASC, cc.id ASC
         """)
-    List<CourtCaseEntity> findCasesNeedingCaseDocumentForRetentionDateGeneration(OffsetDateTime retainUntilTimestamp,
-                                                                                 OffsetDateTime caseDocumentCreatedAfterTimestamp,
-                                                                                 Pageable pageable);
+    List<Integer> findCasesNeedingCaseDocumentForRetentionDateGeneration(OffsetDateTime retainUntilTimestamp,
+                                                                         OffsetDateTime caseDocumentCreatedAfterTimestamp,
+                                                                         Pageable pageable);
 
     @Query(value = """
         select cc from CourtCaseEntity cc


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4227)


### Change description ###
Currently the GenerateCaseDocumentForRetentionDate Task retrieves a list of 5000 potential cases to process. The first thing is done is check if isRetentionUpdated==true, if it is, the case is ignored, so it could be that the first 5000 brought back every time have this set to true and therefore the job never processes any cases.
We need to change the driving SQL in findCasesNeedingCaseDocumentForRetentionDateGeneration to ignore case where isRetentionUpdated==true.

- Change findCasesNeedingCaseDocumentForRetentionDateGeneration to bring back CaseIds', and in the for-loop, bring back a fresh version of the case, before checking the isRetentionUpdated flag.

-  Change findCasesNeedingCaseDocumentForRetentionDateGeneration to order by isRetentionUpdated (false first) then cas_id.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
