### PR TITLE
DMP-4216: Allow inactive tasks to be run manually

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/task/runner/AutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/AutomatedTask.java
@@ -6,6 +6,12 @@ public interface AutomatedTask extends Runnable {
 
     String getTaskName();
 
+    void run(boolean isManualRun);
+
+    default void run() {
+        run(false);
+    }
+
     AutomatedTaskStatus getAutomatedTaskStatus();
 
     String getLastCronExpression();

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
@@ -79,7 +79,7 @@ public abstract class AbstractLockableAutomatedTask implements AutomatedTask, Au
     }
 
     @Override
-    public void run() {
+    public void run(boolean isManualRun) {
         executionId = ThreadLocal.withInitial(UUID::randomUUID);
         preRunTask();
         try {

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
@@ -74,7 +74,7 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
             throw new DartsApiException(AutomatedTaskApiError.AUTOMATED_TASK_NOT_CONFIGURED_CORRECTLY);
         }
 
-        automatedTaskRunner.run(automatedTask.get());
+        automatedTaskRunner.run(automatedTask.get(), true);
 
         auditApi.record(RUN_JOB_MANUALLY, automatedTaskEntity.getTaskName());
     }

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AutomatedTaskRunner.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AutomatedTaskRunner.java
@@ -8,10 +8,9 @@ import uk.gov.hmcts.darts.task.runner.impl.AbstractLockableAutomatedTask;
 @Component
 @Slf4j
 public class AutomatedTaskRunner {
-
     @Async
-    public void run(AbstractLockableAutomatedTask task) {
-        log.info("Attempting manual run of {}", task.getTaskName());
-        task.run();
+    public void run(AbstractLockableAutomatedTask task, boolean isManualRun) {
+        log.info("Attempting {} run of {}", isManualRun ? " manual " : " automated", task.getTaskName());
+        task.run(isManualRun);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImplTest.java
@@ -71,8 +71,8 @@ class AdminAutomatedTasksServiceImplTest {
 
         adminAutomatedTaskService.runAutomatedTask(1);
 
-        verify(automatedTaskRunner, times(1)).run(someAutomatedTask);
-        verify(auditApi, times(1)).record(AuditActivity.RUN_JOB_MANUALLY,"some-task-name");
+        verify(automatedTaskRunner, times(1)).run(someAutomatedTask, true);
+        verify(auditApi, times(1)).record(AuditActivity.RUN_JOB_MANUALLY, "some-task-name");
     }
 
     @Test
@@ -95,7 +95,7 @@ class AdminAutomatedTasksServiceImplTest {
         assertFalse(automatedTaskEntity.getTaskEnabled());
         assertEquals(100, automatedTaskEntity.getBatchSize());
         assertEquals(expectedReturnTask, task);
-        verify(auditApi).record(AuditActivity.ENABLE_DISABLE_JOB,"some-task-name disabled");
+        verify(auditApi).record(AuditActivity.ENABLE_DISABLE_JOB, "some-task-name disabled");
         verifyNoMoreInteractions(auditApi);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/task/service/impl/AutomatedTaskServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/service/impl/AutomatedTaskServiceImplTest.java
@@ -513,7 +513,7 @@ class AutomatedTaskServiceImplTest {
             }
 
             @Override
-            public void run() {
+            public void run(boolean isManualRun) {
                 log.debug("Running test automated task");
             }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4216)


### Change description ###
# Summary of Changes

Updated manual task execution to bypass enabled / disabled checks. Meaning the task will be executed when run manually even if the task is disabled in the database.

## Highlights

- **New Method for Running Tasks**: 
  - A new method `run(boolean isManualRun)` was added to the `AutomatedTask` interface, allowing tasks to indicate whether they are running manually or automatically.
  - A default method `run()` was also added, which defaults to calling the new method with `false` (indicating an automated run).

- **Modifications in Implementations**:
  - The `AbstractLockableAutomatedTask` class was updated to implement the new `run(boolean isManualRun)` method.
  - The `AutomatedTaskRunner` class now takes into account whether a task is being run manually or automatically, logging the type of execution.

- **Service Layer Updates**:
  - The `AdminAutomatedTasksServiceImpl` class now triggers the automated task with the new manual run parameter set to `true` when tasks are run manually.

- **Test Adjustments**:
  - Corresponding tests were updated to match the new method signatures and to ensure that the manual run functionality is tested appropriately. 

These changes collectively improve the control and monitoring of automated tasks, making it easier for developers to distinguish between different execution modes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
