### PR TITLE
DMP-3964 Using postgres v16 in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You may need to install Azure CLI, jq and postgres you can do this by running
 brew update
 brew install azure-cli 
 brew install jq
-brew install postgresql@15
+brew install postgresql@16
 az login
 ```
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -84,7 +84,7 @@ services:
 
   darts-db:
     container_name: darts-db
-    image: postgres:15-alpine # Maintain this such that we track the version deployed in higher environments
+    image: postgres:16-alpine # Maintain this such that we track the version deployed in higher environments
     restart: always
     environment:
       - POSTGRES_USER=darts

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/PostgresIntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/PostgresIntegrationBase.java
@@ -43,7 +43,7 @@ public class PostgresIntegrationBase {
     private static final int SERVER_MAX_CONNECTIONS = 50;
 
     private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(
-        "postgres:15-alpine"
+        "postgres:16-alpine"
     ).withDatabaseName("darts")
         .withUsername("darts")
         .withPassword("darts");


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-3964

### Change description ###

Using postgres v16 in the local docker build.

When using the new version you might need to remove your docker volume. Stop the postgres image and then use the following commands

```
docker volume ls
# find darts api db volume
docker volume rm <darts api db volume>
```

Then you should be able to start the DB using docker once again.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
