### PR TITLE
DMP-4140: Implement getProductionOutputFiles for ARM RPO

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiGetProductionOutputFilesIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiGetProductionOutputFilesIntTest.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.darts.arm.rpo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.hmcts.darts.arm.client.ArmRpoClient;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProductionOutputFilesRequest;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProductionOutputFilesResponse;
+import uk.gov.hmcts.darts.arm.exception.ArmRpoException;
+import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.ArmRpoStateEnum;
+import uk.gov.hmcts.darts.common.enums.ArmRpoStatusEnum;
+import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("checkstyle:linelength")
+class ArmRpoApiGetProductionOutputFilesIntTest extends PostgresIntegrationBase {
+
+    @MockBean
+    private ArmRpoClient armRpoClient;
+
+    @Autowired
+    private ArmRpoApi armRpoApi;
+
+    private static final String TOKEN = "some token";
+    private static final String PRODUCTION_ID = UUID.randomUUID().toString();
+    private static final String PRODUCTION_EXPORT_FILE_ID = UUID.randomUUID().toString();
+
+    @Test
+    void getProductionOutputFiles_shouldSucceedAndReturnASingleItem_whenASuccessResponseIsReturnedFromArmWithASingularProductionExportFile() {
+        // Given
+        var productionOutputFilesResponse = createProductionOutputFilesResponse(PRODUCTION_EXPORT_FILE_ID);
+        when(armRpoClient.getProductionOutputFiles(eq(TOKEN), any(ProductionOutputFilesRequest.class)))
+            .thenReturn(productionOutputFilesResponse);
+
+        UserAccountEntity userAccount = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+        var executionDetailEntity = createExecutionDetailEntity(userAccount);
+        executionDetailEntity = dartsPersistence.save(executionDetailEntity);
+
+        Integer executionId = executionDetailEntity.getId();
+
+        // When
+        List<String> productionOutputFiles = armRpoApi.getProductionOutputFiles(TOKEN, executionId, userAccount);
+
+        // Then
+        assertEquals(1, productionOutputFiles.size());
+        assertEquals(PRODUCTION_EXPORT_FILE_ID, productionOutputFiles.getFirst());
+
+        executionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(executionId)
+            .orElseThrow();
+        assertEquals(ArmRpoStateEnum.GET_PRODUCTION_OUTPUT_FILES.getId(), executionDetailEntity.getArmRpoState().getId());
+        assertEquals(ArmRpoStatusEnum.COMPLETED.getId(), executionDetailEntity.getArmRpoStatus().getId());
+    }
+
+    @Test
+    void getProductionOutputFiles_shouldThrowException_whenArmReturnsNoProductionExportFiles() {
+        // Given
+        var productionOutputFilesResponse = createProductionOutputFilesResponse(null);
+        when(armRpoClient.getProductionOutputFiles(eq(TOKEN), any(ProductionOutputFilesRequest.class)))
+            .thenReturn(productionOutputFilesResponse);
+
+        UserAccountEntity userAccount = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+        var executionDetailEntity = dartsPersistence.save(createExecutionDetailEntity(userAccount));
+        Integer executionId = executionDetailEntity.getId();
+
+        // When
+        String exceptionMessage = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProductionOutputFiles(TOKEN, executionId, userAccount))
+            .getMessage();
+
+        // Then
+        assertThat(exceptionMessage, containsString("No production export file ids were returned"));
+
+        executionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(executionId)
+            .orElseThrow();
+        assertEquals(ArmRpoStateEnum.GET_PRODUCTION_OUTPUT_FILES.getId(), executionDetailEntity.getArmRpoState().getId());
+        assertEquals(ArmRpoStatusEnum.FAILED.getId(), executionDetailEntity.getArmRpoStatus().getId());
+    }
+
+    private ArmRpoExecutionDetailEntity createExecutionDetailEntity(UserAccountEntity userAccount) {
+        ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
+        armRpoExecutionDetailEntity.setCreatedBy(userAccount);
+        armRpoExecutionDetailEntity.setLastModifiedBy(userAccount);
+        armRpoExecutionDetailEntity.setProductionId(PRODUCTION_ID);
+        return armRpoExecutionDetailEntity;
+    }
+
+    private ProductionOutputFilesResponse createProductionOutputFilesResponse(String fileId) {
+        var productionExportFileDetail = new ProductionOutputFilesResponse.ProductionExportFileDetail();
+        productionExportFileDetail.setProductionExportFileId(fileId);
+
+        var productionExportFile = new ProductionOutputFilesResponse.ProductionExportFile();
+        productionExportFile.setProductionExportFileDetails(productionExportFileDetail);
+
+        var response = new ProductionOutputFilesResponse();
+        response.setStatus(200);
+        response.setIsError(false);
+        response.setProductionExportFiles(Collections.singletonList(productionExportFile));
+
+        return response;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/ArmRpoClient.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/ArmRpoClient.java
@@ -10,6 +10,8 @@ import uk.gov.hmcts.darts.arm.client.model.rpo.IndexesByMatterIdRequest;
 import uk.gov.hmcts.darts.arm.client.model.rpo.IndexesByMatterIdResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.MasterIndexFieldByRecordClassSchemaRequest;
 import uk.gov.hmcts.darts.arm.client.model.rpo.MasterIndexFieldByRecordClassSchemaResponse;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProductionOutputFilesRequest;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProductionOutputFilesResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.ProfileEntitlementResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.RecordManagementMatterResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.SaveBackgroundSearchRequest;
@@ -79,4 +81,12 @@ public interface ArmRpoClient {
     )
     ExtendedSearchesByMatterResponse getExtendedSearchesByMatter(@RequestHeader(AUTHORIZATION) String bearerToken,
                                                                  @RequestBody String body);
+
+    @PostMapping(value = "${darts.storage.arm-api.rpo-url.get-production-output-files-path}",
+        consumes = APPLICATION_JSON_VALUE,
+        produces = APPLICATION_JSON_VALUE
+    )
+    ProductionOutputFilesResponse getProductionOutputFiles(@RequestHeader(AUTHORIZATION) String bearerToken,
+                                                           @RequestBody ProductionOutputFilesRequest productionOutputFilesRequest);
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ProductionOutputFilesRequest.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ProductionOutputFilesRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.darts.arm.client.model.rpo;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class ProductionOutputFilesRequest {
+
+    private String productionId;
+
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ProductionOutputFilesResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ProductionOutputFilesResponse.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.darts.arm.client.model.rpo;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ProductionOutputFilesResponse extends BaseRpoResponse {
+
+    @JsonProperty("productionID")
+    private String productionId;
+
+    @JsonProperty("productionExportFile")
+    private List<ProductionExportFile> productionExportFiles;
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Data
+    @NoArgsConstructor
+    public static class ProductionExportFile {
+        @JsonProperty("productionExportFile")
+        private ProductionExportFileDetail productionExportFileDetails;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Data
+    @NoArgsConstructor
+    public static class ProductionExportFileDetail {
+        @JsonProperty("productionExportFileID")
+        private String productionExportFileId;
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -293,7 +293,7 @@ darts:
         add-async-search-path: /api/v1/addAsyncSearch
         save-background-search-path: /api/v1/SaveBackgroundSearch
         get-extended-searches-by-matter-path: /api/v1/getExtendedSearchesByMatter
-    
+        get-production-output-files-path: /api/v1/getProductionOutputFiles
     dets:
       sas-endpoint: ${DETS_SAS_URL_ENDPOINT:}
       container-name: darts-migration

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetProductionOutputFilesTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetProductionOutputFilesTest.java
@@ -1,22 +1,347 @@
 package uk.gov.hmcts.darts.arm.rpo.impl;
 
-import org.apache.commons.lang3.NotImplementedException;
+import feign.FeignException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.arm.client.ArmRpoClient;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProductionOutputFilesRequest;
+import uk.gov.hmcts.darts.arm.client.model.rpo.ProductionOutputFilesResponse;
+import uk.gov.hmcts.darts.arm.config.ArmApiConfigurationProperties;
+import uk.gov.hmcts.darts.arm.exception.ArmRpoException;
+import uk.gov.hmcts.darts.arm.helper.ArmRpoHelperMocks;
+import uk.gov.hmcts.darts.arm.service.ArmRpoService;
+import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.ArmAutomatedTaskRepository;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+@SuppressWarnings("checkstyle:linelength")
 @ExtendWith(MockitoExtension.class)
 class ArmRpoApiGetProductionOutputFilesTest {
 
-    @InjectMocks
     private ArmRpoApiImpl armRpoApi;
+    private ArmRpoService armRpoService;
+    private ArmRpoClient armRpoClient;
+
+    private ArmRpoHelperMocks armRpoHelperMocks;
+
+    private static final Integer EXECUTION_ID = 1;
+    private static final String TOKEN = "some token";
+    private static final String PRODUCTION_ID = UUID.randomUUID().toString();
+    private static final String PRODUCTION_EXPORT_FILE_ID_1 = UUID.randomUUID().toString();
+    private static final String PRODUCTION_EXPORT_FILE_ID_2 = UUID.randomUUID().toString();
+
+    @BeforeEach
+    void setUp() {
+        armRpoService = spy(ArmRpoService.class);
+        armRpoClient = spy(ArmRpoClient.class);
+        var armAutomatedTaskRepository = mock(ArmAutomatedTaskRepository.class);
+        var currentTimeHelper = mock(CurrentTimeHelper.class);
+
+        ArmApiConfigurationProperties armApiConfigurationProperties = new ArmApiConfigurationProperties();
+
+        armRpoApi = new ArmRpoApiImpl(armRpoClient, armRpoService, armApiConfigurationProperties, armAutomatedTaskRepository, currentTimeHelper);
+
+        armRpoHelperMocks = new ArmRpoHelperMocks(); // Mocks are set via the default constructor call
+    }
+
+    @AfterEach
+    void afterEach() {
+        armRpoHelperMocks.close();
+    }
 
     @Test
-    void getProductionOutputFiles() {
-        assertThrows(NotImplementedException.class, () -> armRpoApi.getProductionOutputFiles("token", 1, null));
+    void getProductionOutputFiles_shouldSucceedAndReturnASingleItem_whenASuccessResponseIsReturnedFromArmWithASingularProductionExportFile() {
+        // Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        var response = createProductionOutputFilesResponse(Collections.singletonList(
+                                                               createProductionExportFile(
+                                                                   createProductionExportFileDetail(PRODUCTION_EXPORT_FILE_ID_1))
+                                                           )
+        );
+
+        when(armRpoClient.getProductionOutputFiles(eq(TOKEN), any(ProductionOutputFilesRequest.class)))
+            .thenReturn(response);
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        List<String> productionOutputFiles = armRpoApi.getProductionOutputFiles(TOKEN, EXECUTION_ID, someUserAccount);
+
+        // Then
+        assertEquals(1, productionOutputFiles.size());
+        assertEquals(PRODUCTION_EXPORT_FILE_ID_1, productionOutputFiles.getFirst());
+
+        // And verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProductionOutputFilesRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getCompletedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getProductionOutputFiles_shouldSucceedAndReturnMultipleItems_whenASuccessResponseIsReturnedFromArmWithMultipleProductionExportFile() {
+        // Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        var response = createProductionOutputFilesResponse(List.of(
+                                                               createProductionExportFile(createProductionExportFileDetail(PRODUCTION_EXPORT_FILE_ID_1)),
+                                                               createProductionExportFile(createProductionExportFileDetail(PRODUCTION_EXPORT_FILE_ID_2))
+                                                           )
+        );
+
+        when(armRpoClient.getProductionOutputFiles(eq(TOKEN), any(ProductionOutputFilesRequest.class)))
+            .thenReturn(response);
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        List<String> productionOutputFiles = armRpoApi.getProductionOutputFiles(TOKEN, EXECUTION_ID, someUserAccount);
+
+        // Then
+        assertEquals(2, productionOutputFiles.size());
+        assertThat(productionOutputFiles).containsExactlyInAnyOrder(PRODUCTION_EXPORT_FILE_ID_1, PRODUCTION_EXPORT_FILE_ID_2);
+
+        // And verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProductionOutputFilesRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getCompletedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    void getProductionOutputFiles_shouldSucceedAndReturnSingleItem_whenASuccessResponseIsReturnedFromArmWithMixtureOfPopulatedAndUnpopulatedExportFileIds(String productionExportFileId) {
+        // Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        var response = createProductionOutputFilesResponse(List.of(
+                                                               createProductionExportFile(createProductionExportFileDetail(productionExportFileId)),
+                                                               createProductionExportFile(createProductionExportFileDetail(PRODUCTION_EXPORT_FILE_ID_1))
+                                                           )
+        );
+
+        when(armRpoClient.getProductionOutputFiles(eq(TOKEN), any(ProductionOutputFilesRequest.class)))
+            .thenReturn(response);
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        List<String> productionOutputFiles = armRpoApi.getProductionOutputFiles(TOKEN, EXECUTION_ID, someUserAccount);
+
+        // Then
+        assertEquals(1, productionOutputFiles.size());
+        assertEquals(PRODUCTION_EXPORT_FILE_ID_1, productionOutputFiles.getFirst());
+
+        // And verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProductionOutputFilesRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getCompletedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    void getProductionOutputFiles_shouldThrowException_whenExecutionDetailHasNoProductionId(String productionId) {
+        // Given
+        var armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
+        armRpoExecutionDetailEntity.setId(EXECUTION_ID);
+        armRpoExecutionDetailEntity.setProductionId(productionId);
+
+        when(armRpoService.getArmRpoExecutionDetailEntity(EXECUTION_ID))
+            .thenReturn(armRpoExecutionDetailEntity);
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProductionOutputFiles(TOKEN, EXECUTION_ID, someUserAccount));
+        assertThat(armRpoException.getMessage(), containsString("production id was blank for execution id"));
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProductionOutputFilesRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getFailedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getProductionOutputFiles_shouldThrowException_whenArmCallFails() {
+        // Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        when(armRpoClient.getProductionOutputFiles(eq(TOKEN), any(ProductionOutputFilesRequest.class)))
+            .thenThrow(mock(FeignException.class));
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProductionOutputFiles(TOKEN, EXECUTION_ID, someUserAccount));
+        assertThat(armRpoException.getMessage(), containsString("API call failed"));
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProductionOutputFilesRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getFailedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    void getProductionOutputFiles_shouldThrowException_whenArmReturnsNoProductionExportFiles(List<ProductionOutputFilesResponse.ProductionExportFile> productionExportFiles) {
+        // Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        var response = createProductionOutputFilesResponse(productionExportFiles);
+
+        when(armRpoClient.getProductionOutputFiles(eq(TOKEN), any(ProductionOutputFilesRequest.class)))
+            .thenReturn(response);
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProductionOutputFiles(TOKEN, EXECUTION_ID, someUserAccount));
+        assertThat(armRpoException.getMessage(), containsString("No production export files were returned"));
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProductionOutputFilesRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getFailedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    void getProductionOutputFiles_shouldThrowException_whenArmReturnsNoProductionExportFileIds(String productionExportFileId) {
+        // Given
+        var armRpoExecutionDetailEntity = createInitialExecutionDetailEntityAndSetMock();
+
+        var response = createProductionOutputFilesResponse(Collections.singletonList(
+                                                               createProductionExportFile(
+                                                                   createProductionExportFileDetail(productionExportFileId))
+                                                           )
+        );
+
+        when(armRpoClient.getProductionOutputFiles(eq(TOKEN), any(ProductionOutputFilesRequest.class)))
+            .thenReturn(response);
+
+        UserAccountEntity someUserAccount = new UserAccountEntity();
+
+        // When
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getProductionOutputFiles(TOKEN, EXECUTION_ID, someUserAccount));
+        assertThat(armRpoException.getMessage(), containsString("No production export file ids were returned"));
+
+        // Then verify execution detail state moves to in progress
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntity,
+                                                         armRpoHelperMocks.getGetProductionOutputFilesRpoState(),
+                                                         armRpoHelperMocks.getInProgressRpoStatus(),
+                                                         someUserAccount);
+
+        // And verify execution detail status moves to failed as the final operation
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity,
+                                                 armRpoHelperMocks.getFailedRpoStatus(),
+                                                 someUserAccount);
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    private ProductionOutputFilesResponse createProductionOutputFilesResponse(
+        List<ProductionOutputFilesResponse.ProductionExportFile> productionExportFiles) {
+        var response = new ProductionOutputFilesResponse();
+        response.setStatus(200);
+        response.setIsError(false);
+        response.setProductionExportFiles(productionExportFiles);
+        return response;
+    }
+
+    private ProductionOutputFilesResponse.ProductionExportFile createProductionExportFile(
+        ProductionOutputFilesResponse.ProductionExportFileDetail productionExportFileDetail) {
+        var productionExportFile = new ProductionOutputFilesResponse.ProductionExportFile();
+        productionExportFile.setProductionExportFileDetails(productionExportFileDetail);
+        return productionExportFile;
+    }
+
+    private ProductionOutputFilesResponse.ProductionExportFileDetail createProductionExportFileDetail(String fileId) {
+        var productionExportFileDetail = new ProductionOutputFilesResponse.ProductionExportFileDetail();
+        productionExportFileDetail.setProductionExportFileId(fileId);
+        return productionExportFileDetail;
+    }
+
+    private ArmRpoExecutionDetailEntity createInitialExecutionDetailEntityAndSetMock() {
+        var armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
+        armRpoExecutionDetailEntity.setId(EXECUTION_ID);
+        armRpoExecutionDetailEntity.setProductionId(PRODUCTION_ID);
+
+        when(armRpoService.getArmRpoExecutionDetailEntity(EXECUTION_ID))
+            .thenReturn(armRpoExecutionDetailEntity);
+
+        return armRpoExecutionDetailEntity;
     }
 
 }


### PR DESCRIPTION
# [(Dev Only) DMP-4140](https://tools.hmcts.net/jira/browse/DMP-4140)

Implement the ARM RPO getProductionOutputFiles service layer.

This PR includes the corresponding Feign client which will be integration tested as part of wider ticket https://tools.hmcts.net/jira/browse/DMP-4143.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
