### PR TITLE
Default darts-portal chart to not enabled

### DIFF
--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.93
+version: 0.0.94
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -241,3 +241,6 @@ function:
       connectionFromEnv: DARTS_API_DB_CONNECTION_STRING
       query: "SELECT count(*) FROM darts.media_request WHERE mer_id = ( SELECT mer_id FROM darts.media_request WHERE request_status = 'OPEN' ORDER BY created_ts LIMIT 1 )"
       targetQueryValue: "0.9"
+
+darts-portal:
+  enabled: false


### PR DESCRIPTION
### JIRA link (if applicable) ###

NOJIRA

### Change description ###

Default the `darts-portal` chart to disabled to ensure no pods are created on environments other than dev.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
