### PR TITLE
DMP-3485: Automated task for Deletion from ARM's response folder

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DartsBatchCleanupArmResponseFilesServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DartsBatchCleanupArmResponseFilesServiceIntTest.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.darts.arm.service;
+
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.darts.arm.service.impl.DartsBatchCleanupArmResponseFilesServiceImpl;
+
+@SuppressWarnings("PMD.TestClassWithoutTestCases")//False positive tests done via inheritanc
+class DartsBatchCleanupArmResponseFilesServiceIntTest extends AbstractBatchCleanupArmResponseFilesServiceIntTest {
+
+
+    @Autowired
+    @Getter
+    private DartsBatchCleanupArmResponseFilesServiceImpl cleanupArmResponseFilesService;
+
+    protected DartsBatchCleanupArmResponseFilesServiceIntTest() {
+        super("DARTS");
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsBatchCleanupArmResponseFilesServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsBatchCleanupArmResponseFilesServiceIntTest.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.darts.arm.service;
+
+
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.darts.arm.service.impl.DetsBatchCleanupArmResponseFilesServiceImpl;
+
+@SuppressWarnings("PMD.TestClassWithoutTestCases")//False positive tests done via inheritance
+class DetsBatchCleanupArmResponseFilesServiceIntTest extends AbstractBatchCleanupArmResponseFilesServiceIntTest {
+
+    @Autowired
+    private DetsBatchCleanupArmResponseFilesServiceImpl cleanupArmResponseFilesService;
+
+    protected DetsBatchCleanupArmResponseFilesServiceIntTest() {
+        super("DETS");
+    }
+
+    @Override
+    protected BatchCleanupArmResponseFilesService getCleanupArmResponseFilesService() {
+        return cleanupArmResponseFilesService;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/helper/ArmResponseFileHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/helper/ArmResponseFileHelper.java
@@ -28,10 +28,10 @@ public class ArmResponseFileHelper {
     private final ArmDataManagementApi armDataManagementApi;
     private final ArmResponseUploadFileMapper uploadFileMapper;
 
-    public List<InputUploadAndAssociatedFilenames> getCorrespondingArmFilesForManifestFilename(String manifestFileName) throws UnableToReadArmFileException {
+    public List<InputUploadAndAssociatedFilenames> getCorrespondingArmFilesForManifestFilename(String manifestFilePrefix, String manifestFileName)
+        throws UnableToReadArmFileException {
 
         List<InputUploadAndAssociatedFilenames> responseList = new ArrayList<>();
-        String manifestFilePrefix = armDataManagementConfiguration.getManifestFilePrefix();
         if (manifestFileName.startsWith(manifestFilePrefix)
             && manifestFileName.endsWith(armBatchCleanupConfiguration.getManifestFileSuffix())) {
             //is a Batch response UI file.

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
@@ -52,6 +52,7 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
 
     @Override
     public void cleanupResponseFiles(int batchsize) {
+        System.out.println("TMP: " + manifestFilePrefix);
         if (batchsize == 0) {
             log.warn("{}: Batch Cleanup ARM Response Files - Batch size is 0, so not running", manifestFilePrefix);
             return;
@@ -114,7 +115,7 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
 
             log.debug("{}: Found ARM manifest file {} for cleanup", manifestFilePrefix, manifestFilename);
             List<InputUploadAndAssociatedFilenames> inputUploadAndAssociatedList = armResponseFileHelper.getCorrespondingArmFilesForManifestFilename(
-                manifestFilename);
+                manifestFilePrefix, manifestFilename);
             //inputUploadAndAssociatedList should only contain 1 matching InputUpload file, but looping through it just in case.
             for (InputUploadAndAssociatedFilenames inputUploadAndAssociates : inputUploadAndAssociatedList) {
                 deleteResponseFiles(userAccount, inputUploadAndAssociates, eodEntriesWithManifestFilename);

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
@@ -53,7 +53,7 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
     @Override
     public void cleanupResponseFiles(int batchsize) {
         if (batchsize == 0) {
-            log.warn("{}: {}: Batch Cleanup ARM Response Files - Batch size is 0, so not running", manifestFilePrefix);
+            log.warn("{}: Batch Cleanup ARM Response Files - Batch size is 0, so not running", manifestFilePrefix);
             return;
         }
         List<ObjectRecordStatusEntity> statusToSearch = objectRecordStatusRepository.getReferencesByStatus(
@@ -135,8 +135,9 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
             boolean successfullyDeletedAssociatedFiles = true;
             Integer eodId = eodIdAndAssociatedFilenames.getEodId();
             List<String> associatedFiles = eodIdAndAssociatedFilenames.getAssociatedFiles();
-            log.info("{}: {}: There are {} response files for EOD {}, linked to inputUpload filename {}", manifestFilePrefix, associatedFiles.size(), eodId,
-                     inputUploadFilename);
+            log.info("{}: There are {} response files for EOD {}, linked to inputUpload filename {}",
+                     manifestFilePrefix, associatedFiles.size(), eodId, inputUploadFilename);
+
             for (String associatedFile : associatedFiles) {
                 try {
                     log.info("{}: About to delete file {} for EOD {}, linked to inputUpload filename {}", manifestFilePrefix, associatedFile, eodId,
@@ -147,7 +148,7 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
                         successfullyDeletedAssociatedFiles = false;
                     }
                 } catch (Exception e) {
-                    log.error("Failure to delete response file {} for EOD {} - {}", manifestFilePrefix, associatedFile, eodId, e.getMessage(), e);
+                    log.error("{}: Failure to delete response file {} for EOD {} - {}", manifestFilePrefix, associatedFile, eodId, e.getMessage(), e);
                     successfullyDeletedAssociatedFiles = false;
                 }
                 if (!successfullyDeletedAssociatedFiles) {
@@ -158,7 +159,7 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
             if (successfullyDeletedAssociatedFiles) {
                 Optional<ExternalObjectDirectoryEntity> eodEntityOpt = externalObjectDirectoryRepository.findById(eodId);
                 if (eodEntityOpt.isEmpty()) {
-                    log.error("EodEntity {} in response file for {} cannot be found.", manifestFilePrefix, eodId, inputUploadFilename);
+                    log.error("{}: EodEntity {} in response file for {} cannot be found.", manifestFilePrefix, eodId, inputUploadFilename);
                     break;
                 }
                 ExternalObjectDirectoryEntity eodEntityFromRelationId = eodEntityOpt.get();

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.data.domain.Limit;
-import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
 import uk.gov.hmcts.darts.arm.config.ArmBatchCleanupConfiguration;
 import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
@@ -34,41 +33,32 @@ import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONS
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_PROCESSING_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RPO_PENDING;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
-import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
 
-@Service
 @RequiredArgsConstructor
 @Slf4j
-public class BatchCleanupArmResponseFilesServiceImpl implements BatchCleanupArmResponseFilesService {
-
-    private static final String taskName = BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME.getTaskName();
+public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupArmResponseFilesService {
 
     private final ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
-
     private final ObjectRecordStatusRepository objectRecordStatusRepository;
     private final ExternalLocationTypeRepository externalLocationTypeRepository;
-
     private final ArmDataManagementApi armDataManagementApi;
     private final UserIdentity userIdentity;
     private final ArmBatchCleanupConfiguration batchCleanupConfiguration;
     private final ArmDataManagementConfiguration armDataManagementConfiguration;
     private final CurrentTimeHelper currentTimeHelper;
     private final ArmResponseFileHelper armResponseFileHelper;
-
-    private UserAccountEntity userAccount;
+    private final String manifestFilePrefix;
 
 
     @Override
     public void cleanupResponseFiles(int batchsize) {
         if (batchsize == 0) {
-            log.warn("Batch Cleanup ARM Response Files - Batch size is 0, so not running");
+            log.warn("{}: {}: Batch Cleanup ARM Response Files - Batch size is 0, so not running", manifestFilePrefix);
             return;
         }
         List<ObjectRecordStatusEntity> statusToSearch = objectRecordStatusRepository.getReferencesByStatus(
             List.of(STORED, ARM_RPO_PENDING, ARM_RESPONSE_PROCESSING_FAILED, ARM_RESPONSE_MANIFEST_FAILED, ARM_RESPONSE_CHECKSUM_VERIFICATION_FAILED));
         ExternalLocationTypeEntity armLocation = externalLocationTypeRepository.getReferenceById(ExternalLocationTypeEnum.ARM.getId());
-
-        userAccount = userIdentity.getUserAccount();
 
         Integer cleanupBufferMinutes = batchCleanupConfiguration.getBufferMinutes();
         OffsetDateTime dateTimeForDeletion = currentTimeHelper.currentOffsetDateTime().minusMinutes(cleanupBufferMinutes);
@@ -79,61 +69,64 @@ public class BatchCleanupArmResponseFilesServiceImpl implements BatchCleanupArmR
                 armLocation,
                 false,
                 dateTimeForDeletion,
-                armDataManagementConfiguration.getManifestFilePrefix(),
+                manifestFilePrefix,
                 Limit.of(batchsize)
             );
         if (manifestFilenames.isEmpty()) {
-            log.info("Batch Cleanup ARM Response Files - 0 rows returned, so stopping.");
+            log.info("{}: Batch Cleanup ARM Response Files - 0 rows returned, so stopping.", manifestFilePrefix);
             return;
         }
 
         if (CollectionUtils.isNotEmpty(manifestFilenames)) {
             int counter = 1;
+            UserAccountEntity userAccount = userIdentity.getUserAccount();
             for (String manifestFilename : manifestFilenames) {
-                log.info("Batch Cleanup ARM Response Files - about to process manifest filename {}, row {} of {} rows", manifestFilename, counter++,
+                log.info("{}: Batch Cleanup ARM Response Files - about to process manifest filename {}, row {} of {} rows", manifestFilePrefix,
+                         manifestFilename, counter++,
                          manifestFilenames.size());
-                cleanupFilesByManifestFilename(armLocation, statusToSearch, dateTimeForDeletion, manifestFilename);
+                cleanupFilesByManifestFilename(userAccount, armLocation, statusToSearch, dateTimeForDeletion, manifestFilename);
             }
         } else {
-            log.info("No ARM responses found to be deleted}");
+            log.info("{}: No ARM responses found to be deleted", manifestFilePrefix);
         }
     }
 
-    private void cleanupFilesByManifestFilename(ExternalLocationTypeEntity armLocation, List<ObjectRecordStatusEntity> statusToSearch,
+    private void cleanupFilesByManifestFilename(UserAccountEntity userAccount, ExternalLocationTypeEntity armLocation,
+                                                List<ObjectRecordStatusEntity> statusToSearch,
                                                 OffsetDateTime dateTimeForDeletion, String manifestFilename) {
         try {
-            log.debug("Finding associated eodEntries for manifest filename {}", manifestFilename);
+            log.debug("{}: Finding associated eodEntries for manifest filename {}", manifestFilePrefix, manifestFilename);
             List<ExternalObjectDirectoryEntity> eodEntriesWithManifestFilename = externalObjectDirectoryRepository.findBatchCleanupEntriesByManifestFilename(
                 armLocation, false, manifestFilename);
 
             List<Integer> statusIdList = statusToSearch.stream().map(ObjectRecordStatusEntity::getId).toList();
             boolean statusAllValid = eodEntriesWithManifestFilename.stream().allMatch(eodEntity -> statusIdList.contains(eodEntity.getStatusId()));
             if (!statusAllValid) {
-                log.warn("Not all statuses are valid for manifestFilename {}, so skipping to next manifestFilename.", manifestFilename);
+                log.warn("{}: Not all statuses are valid for manifestFilename {}, so skipping to next manifestFilename.", manifestFilePrefix, manifestFilename);
             }
 
             boolean lastModifiedAllValid = eodEntriesWithManifestFilename.stream().allMatch(
                 eodEntity -> eodEntity.getLastModifiedDateTime().isBefore(dateTimeForDeletion));
             if (!lastModifiedAllValid) {
-                log.warn("Not all entries have been modified before {} for manifestFilename {}, so skipping to next manifestFilename.", dateTimeForDeletion,
-                         manifestFilename);
+                log.warn("{}: Not all entries have been modified before {} for manifestFilename {}, so skipping to next manifestFilename.",
+                         manifestFilePrefix, dateTimeForDeletion, manifestFilename);
             }
 
-            log.debug("Found ARM manifest file {} for cleanup", manifestFilename);
+            log.debug("{}: Found ARM manifest file {} for cleanup", manifestFilePrefix, manifestFilename);
             List<InputUploadAndAssociatedFilenames> inputUploadAndAssociatedList = armResponseFileHelper.getCorrespondingArmFilesForManifestFilename(
                 manifestFilename);
             //inputUploadAndAssociatedList should only contain 1 matching InputUpload file, but looping through it just in case.
             for (InputUploadAndAssociatedFilenames inputUploadAndAssociates : inputUploadAndAssociatedList) {
-                deleteResponseFiles(inputUploadAndAssociates, eodEntriesWithManifestFilename);
+                deleteResponseFiles(userAccount, inputUploadAndAssociates, eodEntriesWithManifestFilename);
             }
 
         } catch (UnableToReadArmFileException e) {
-            log.error("Cannot process manifest filename {} due to corrupt ARM file.", manifestFilename);
+            log.error("{}: Cannot process manifest filename {} due to corrupt ARM file.", manifestFilePrefix, manifestFilename);
         }
 
     }
 
-    private void deleteResponseFiles(InputUploadAndAssociatedFilenames inputUploadAndAssociates,
+    private void deleteResponseFiles(UserAccountEntity userAccount, InputUploadAndAssociatedFilenames inputUploadAndAssociates,
                                      List<ExternalObjectDirectoryEntity> eodEntriesWithManifestFilename) {
         List<EodIdAndAssociatedFilenames> eodIdAndAssociatedFilenamesList = inputUploadAndAssociates.getEodIdAndAssociatedFilenamesList();
         List<Boolean> deletedFileStatuses = new ArrayList<>();
@@ -142,19 +135,19 @@ public class BatchCleanupArmResponseFilesServiceImpl implements BatchCleanupArmR
             boolean successfullyDeletedAssociatedFiles = true;
             Integer eodId = eodIdAndAssociatedFilenames.getEodId();
             List<String> associatedFiles = eodIdAndAssociatedFilenames.getAssociatedFiles();
-            log.info("There are {} response files for EOD {}, linked to inputUpload filename {}", associatedFiles.size(), eodId,
+            log.info("{}: {}: There are {} response files for EOD {}, linked to inputUpload filename {}", manifestFilePrefix, associatedFiles.size(), eodId,
                      inputUploadFilename);
             for (String associatedFile : associatedFiles) {
                 try {
-                    log.info("About to delete file {} for EOD {}, linked to inputUpload filename {}", associatedFile, eodId,
+                    log.info("{}: About to delete file {} for EOD {}, linked to inputUpload filename {}", manifestFilePrefix, associatedFile, eodId,
                              inputUploadFilename);
                     boolean responseFileDeletedSuccessfully = armDataManagementApi.deleteBlobData(associatedFile);
                     if (!responseFileDeletedSuccessfully) {
-                        log.warn("Response file {} failed to delete successfully.", associatedFile);
+                        log.warn("{}: Response file {} failed to delete successfully.", manifestFilePrefix, associatedFile);
                         successfullyDeletedAssociatedFiles = false;
                     }
                 } catch (Exception e) {
-                    log.error("Failure to delete response file {} for EOD {} - {}", associatedFile, eodId, e.getMessage(), e);
+                    log.error("Failure to delete response file {} for EOD {} - {}", manifestFilePrefix, associatedFile, eodId, e.getMessage(), e);
                     successfullyDeletedAssociatedFiles = false;
                 }
                 if (!successfullyDeletedAssociatedFiles) {
@@ -165,7 +158,7 @@ public class BatchCleanupArmResponseFilesServiceImpl implements BatchCleanupArmR
             if (successfullyDeletedAssociatedFiles) {
                 Optional<ExternalObjectDirectoryEntity> eodEntityOpt = externalObjectDirectoryRepository.findById(eodId);
                 if (eodEntityOpt.isEmpty()) {
-                    log.error("EodEntity {} in response file for {} cannot be found.", eodId, inputUploadFilename);
+                    log.error("EodEntity {} in response file for {} cannot be found.", manifestFilePrefix, eodId, inputUploadFilename);
                     break;
                 }
                 ExternalObjectDirectoryEntity eodEntityFromRelationId = eodEntityOpt.get();
@@ -180,37 +173,36 @@ public class BatchCleanupArmResponseFilesServiceImpl implements BatchCleanupArmR
                 }
 
                 if (!matchesEodWithManifestFile) {
-                    log.warn("Deleted arm response file is not associated with any eodEntity with manifest file {}, but mentions relationId {}.",
-                             inputUploadFilename, eodEntityFromRelationId);
+                    log.warn("{}: Deleted arm response file is not associated with any eodEntity with manifest file {}, but mentions relationId {}.",
+                             manifestFilePrefix, inputUploadFilename, eodEntityFromRelationId);
                 }
-                setResponseCleaned(eodEntityFromRelationId);
+                setResponseCleaned(userAccount, eodEntityFromRelationId);
             }
         }
 
         if (CollectionUtils.isNotEmpty(eodEntriesWithManifestFilename)) {
-            log.warn("All ARM response files related to InputUpload file {} have been deleted, but none referred to the following eodId's - {}.",
-                     inputUploadFilename, eodEntriesWithManifestFilename.stream().map(ExternalObjectDirectoryEntity::getId).toList());
+            log.warn("{}: All ARM response files related to InputUpload file {} have been deleted, but none referred to the following eodId's - {}.",
+                     manifestFilePrefix, inputUploadFilename, eodEntriesWithManifestFilename.stream().map(ExternalObjectDirectoryEntity::getId).toList());
         }
 
         if (deletedFileStatuses.stream().allMatch(Boolean.TRUE::equals)) {
-            log.info("All associated Eod entries deleted, about to delete InputUpload file {}", inputUploadFilename);
+            log.info("{}: All associated Eod entries deleted, about to delete InputUpload file {}", manifestFilePrefix, inputUploadFilename);
             // Make sure to only delete the Input Upload filename after the other response files have been deleted as once this is deleted
             // you cannot find the other response files
             boolean inputUploadFileDeletedSuccessfully = armDataManagementApi.deleteBlobData(inputUploadFilename);
             if (inputUploadFileDeletedSuccessfully) {
-                log.info("Successfully cleaned up response files for InputUpload file {}", inputUploadFilename);
+                log.info("{}: Successfully cleaned up response files for InputUpload file {}", manifestFilePrefix, inputUploadFilename);
             } else {
-                log.warn("Unable to delete input upload response file {}", inputUploadFilename);
+                log.warn("{}: Unable to delete input upload response file {}", manifestFilePrefix, inputUploadFilename);
             }
         } else {
-            log.warn("Unable to delete all response files for InputUpload file {}", inputUploadFilename);
+            log.warn("{}: Unable to delete all response files for InputUpload file {}", manifestFilePrefix, inputUploadFilename);
         }
     }
 
-    private void setResponseCleaned(ExternalObjectDirectoryEntity externalObjectDirectory) {
+    private void setResponseCleaned(UserAccountEntity userAccount, ExternalObjectDirectoryEntity externalObjectDirectory) {
         externalObjectDirectory.setResponseCleaned(true);
         externalObjectDirectory.setLastModifiedBy(userAccount);
         externalObjectDirectoryRepository.saveAndFlush(externalObjectDirectory);
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImpl.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.darts.arm.service.impl;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
+import uk.gov.hmcts.darts.arm.config.ArmBatchCleanupConfiguration;
+import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
+import uk.gov.hmcts.darts.arm.helper.ArmResponseFileHelper;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
+import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
+
+@Service
+public class DartsBatchCleanupArmResponseFilesServiceImpl extends BatchCleanupArmResponseFilesServiceCommon {
+
+
+    public DartsBatchCleanupArmResponseFilesServiceImpl(ExternalObjectDirectoryRepository externalObjectDirectoryRepository,
+                                                        ObjectRecordStatusRepository objectRecordStatusRepository,
+                                                        ExternalLocationTypeRepository externalLocationTypeRepository,
+                                                        ArmDataManagementApi armDataManagementApi,
+                                                        UserIdentity userIdentity, ArmBatchCleanupConfiguration batchCleanupConfiguration,
+                                                        ArmDataManagementConfiguration armDataManagementConfiguration, CurrentTimeHelper currentTimeHelper,
+                                                        ArmResponseFileHelper armResponseFileHelper) {
+        super(externalObjectDirectoryRepository, objectRecordStatusRepository, externalLocationTypeRepository, armDataManagementApi, userIdentity,
+              batchCleanupConfiguration, armDataManagementConfiguration, currentTimeHelper, armResponseFileHelper,
+              armDataManagementConfiguration.getManifestFilePrefix()
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImpl.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.darts.arm.service.impl;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
+import uk.gov.hmcts.darts.arm.config.ArmBatchCleanupConfiguration;
+import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
+import uk.gov.hmcts.darts.arm.helper.ArmResponseFileHelper;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
+import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
+
+@Service
+public class DetsBatchCleanupArmResponseFilesServiceImpl extends BatchCleanupArmResponseFilesServiceCommon {
+
+
+    public DetsBatchCleanupArmResponseFilesServiceImpl(ExternalObjectDirectoryRepository externalObjectDirectoryRepository,
+                                                         ObjectRecordStatusRepository objectRecordStatusRepository,
+                                                         ExternalLocationTypeRepository externalLocationTypeRepository,
+                                                         ArmDataManagementApi armDataManagementApi,
+                                                         UserIdentity userIdentity, ArmBatchCleanupConfiguration batchCleanupConfiguration,
+                                                         ArmDataManagementConfiguration armDataManagementConfiguration, CurrentTimeHelper currentTimeHelper,
+                                                         ArmResponseFileHelper armResponseFileHelper,
+                                                         @Value("${darts.storage.dets.dets-manifest-file-prefix}") String manifestFilePrefix) {
+        super(externalObjectDirectoryRepository, objectRecordStatusRepository, externalLocationTypeRepository, armDataManagementApi, userIdentity,
+              batchCleanupConfiguration, armDataManagementConfiguration, currentTimeHelper, armResponseFileHelper,
+              manifestFilePrefix
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
@@ -40,7 +40,8 @@ public enum AutomatedTaskName {
     AUDIO_LINKING_TASK_NAME("AudioLinking"),
     PROCESS_E2E_ARM_PENDING_TASK_NAME("ProcessE2EArmRpoPending", "${darts.automated.task.process-e2e-arm-rpo-pending.process-e2e-arm-rpo:false}"),
     ARM_RPO_POLL_TASK_NAME("ArmRpoPoll"),
-    ARM_RPO_REPLAY_TASK_NAME("ArmRpoReplay");
+    ARM_RPO_REPLAY_TASK_NAME("ArmRpoReplay"),
+    DETS_CLEANUP_ARM_RESPONSE_FILES("DETSCleanupArmResponseFiles");
     
     private final String taskName;
     private final String conditionalOnSpEL;

--- a/src/main/java/uk/gov/hmcts/darts/task/config/DartsBatchCleanupArmResponseFilesAutomatedTaskConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/config/DartsBatchCleanupArmResponseFilesAutomatedTaskConfig.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.darts.task.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationProperties("darts.automated.task.darts-batch-cleanup-arm-response-files")
+@Getter
+@Setter
+@Configuration
+public class DartsBatchCleanupArmResponseFilesAutomatedTaskConfig extends AbstractAutomatedTaskConfig {
+}

--- a/src/main/java/uk/gov/hmcts/darts/task/config/DetsBatchCleanupArmResponseFilesAutomatedTaskConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/config/DetsBatchCleanupArmResponseFilesAutomatedTaskConfig.java
@@ -5,9 +5,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@ConfigurationProperties("darts.automated.task.batch-cleanup-arm-response-files")
+@ConfigurationProperties("darts.automated.task.dets-batch-cleanup-arm-response-files")
 @Getter
 @Setter
 @Configuration
-public class BatchCleanupArmResponseFilesAutomatedTaskConfig extends AbstractAutomatedTaskConfig {
+public class DetsBatchCleanupArmResponseFilesAutomatedTaskConfig extends AbstractAutomatedTaskConfig {
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTask.java
@@ -8,7 +8,7 @@ import uk.gov.hmcts.darts.arm.service.impl.DartsBatchCleanupArmResponseFilesServ
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.api.AutomatedTaskName;
-import uk.gov.hmcts.darts.task.config.BatchCleanupArmResponseFilesAutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.config.DartsBatchCleanupArmResponseFilesAutomatedTaskConfig;
 import uk.gov.hmcts.darts.task.runner.AutoloadingManualTask;
 import uk.gov.hmcts.darts.task.service.LockService;
 
@@ -22,7 +22,7 @@ public class BatchCleanupArmResponseFilesAutomatedTask extends AbstractLockableA
 
     @Autowired
     public BatchCleanupArmResponseFilesAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                     BatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties,
+                                                     DartsBatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties,
                                                      DartsBatchCleanupArmResponseFilesServiceImpl batchCleanupArmResponseFilesService,
                                                      LogApi logApi, LockService lockService) {
         super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DetsCleanupArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DetsCleanupArmResponseFilesAutomatedTask.java
@@ -4,7 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.arm.service.BatchCleanupArmResponseFilesService;
-import uk.gov.hmcts.darts.arm.service.impl.DartsBatchCleanupArmResponseFilesServiceImpl;
+import uk.gov.hmcts.darts.arm.service.impl.DetsBatchCleanupArmResponseFilesServiceImpl;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.api.AutomatedTaskName;
@@ -12,26 +12,26 @@ import uk.gov.hmcts.darts.task.config.BatchCleanupArmResponseFilesAutomatedTaskC
 import uk.gov.hmcts.darts.task.runner.AutoloadingManualTask;
 import uk.gov.hmcts.darts.task.service.LockService;
 
-import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.DETS_CLEANUP_ARM_RESPONSE_FILES;
 
 @Slf4j
 @Component
-public class BatchCleanupArmResponseFilesAutomatedTask extends AbstractLockableAutomatedTask
+public class DetsCleanupArmResponseFilesAutomatedTask extends AbstractLockableAutomatedTask
     implements AutoloadingManualTask {
     private final BatchCleanupArmResponseFilesService batchCleanupArmResponseFilesService;
 
     @Autowired
-    public BatchCleanupArmResponseFilesAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                     BatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties,
-                                                     DartsBatchCleanupArmResponseFilesServiceImpl batchCleanupArmResponseFilesService,
-                                                     LogApi logApi, LockService lockService) {
+    public DetsCleanupArmResponseFilesAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
+                                                    BatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties,
+                                                    DetsBatchCleanupArmResponseFilesServiceImpl batchCleanupArmResponseFilesService,
+                                                    LogApi logApi, LockService lockService) {
         super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);
         this.batchCleanupArmResponseFilesService = batchCleanupArmResponseFilesService;
     }
 
     @Override
     public AutomatedTaskName getAutomatedTaskName() {
-        return BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
+        return DETS_CLEANUP_ARM_RESPONSE_FILES;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DetsCleanupArmResponseFilesAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DetsCleanupArmResponseFilesAutomatedTask.java
@@ -8,7 +8,7 @@ import uk.gov.hmcts.darts.arm.service.impl.DetsBatchCleanupArmResponseFilesServi
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.task.api.AutomatedTaskName;
-import uk.gov.hmcts.darts.task.config.BatchCleanupArmResponseFilesAutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.config.DetsBatchCleanupArmResponseFilesAutomatedTaskConfig;
 import uk.gov.hmcts.darts.task.runner.AutoloadingManualTask;
 import uk.gov.hmcts.darts.task.service.LockService;
 
@@ -22,7 +22,7 @@ public class DetsCleanupArmResponseFilesAutomatedTask extends AbstractLockableAu
 
     @Autowired
     public DetsCleanupArmResponseFilesAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
-                                                    BatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties,
+                                                    DetsBatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties,
                                                     DetsBatchCleanupArmResponseFilesServiceImpl batchCleanupArmResponseFilesService,
                                                     LogApi logApi, LockService lockService) {
         super(automatedTaskRepository, automatedTaskConfigurationProperties, logApi, lockService);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -381,8 +381,13 @@ darts:
         lock:
           at-least-for: PT1M
           at-most-for: PT90M
-      batch-cleanup-arm-response-files:
+      darts-batch-cleanup-arm-response-files:
         system-user-email: ${darts.automated.task.common-config.system-user-email:}
+        lock:
+          at-least-for: PT1M
+          at-most-for: PT90M
+      dets-batch-cleanup-arm-response-files:
+        system-user-email: systemDETSCleanupArmResponseFilesAutomatedTask@hmcts.net
         lock:
           at-least-for: PT1M
           at-most-for: PT90M

--- a/src/main/resources/db/migration/common/V1_413__DETSCleanupArmResponseFiles_automated_task.sql
+++ b/src/main/resources/db/migration/common/V1_413__DETSCleanupArmResponseFiles_automated_task.sql
@@ -1,4 +1,8 @@
 INSERT INTO darts.automated_task (aut_id,task_name,task_description,cron_expression,cron_editable, batch_size,
 created_ts, created_by,last_modified_ts,last_modified_by, task_enabled)
-VALUES (nextval('aut_seq'),'DETSCleanupArmResponseFiles','Clean up data from ARM response folders Asynchronously. ','0 27 23 * * ?',true,4000,
+VALUES (32,'DETSCleanupArmResponseFiles','Clean up data from ARM response folders (Dets). ','0 27 23 * * ?',true,4000,
 current_timestamp, 0 , current_timestamp,0, false);
+
+INSERT INTO user_account VALUES (-37, NULL, '', 'systemDETSCleanupArmResponseFilesAutomatedTask@hmcts.net',
+    'systemDETSCleanupArmResponseFilesAutomatedTask', '2024-01-01 00:00:00+00', '2024-01-01 00:00:00+00', NULL, 0, 0, NULL, true,
+    true, 'systemDETSCleanupArmResponseFilesAutomatedTask');

--- a/src/main/resources/db/migration/common/V1_413__DETSCleanupArmResponseFiles_automated_task.sql
+++ b/src/main/resources/db/migration/common/V1_413__DETSCleanupArmResponseFiles_automated_task.sql
@@ -1,0 +1,4 @@
+INSERT INTO darts.automated_task (aut_id,task_name,task_description,cron_expression,cron_editable, batch_size,
+created_ts, created_by,last_modified_ts,last_modified_by, task_enabled)
+VALUES (nextval('aut_seq'),'DETSCleanupArmResponseFiles','Clean up data from ARM response folders Asynchronously. ','0 27 23 * * ?',true,4000,
+current_timestamp, 0 , current_timestamp,0, false);

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/AbstractBatchCleanupArmResponseFilesServiceCommonTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/AbstractBatchCleanupArmResponseFilesServiceCommonTest.java
@@ -168,7 +168,8 @@ class AbstractBatchCleanupArmResponseFilesServiceCommonTest {
         inputUploadAndAssociatedFilenames.setInputUploadFilename(inputUploadBlobFilename);
         inputUploadAndAssociatedFilenames.addAssociatedFile(eodEntityForAssociatedFiles1.getId(), createRecordFilename);
         inputUploadAndAssociatedFilenames.addAssociatedFile(eodEntityForAssociatedFiles1.getId(), uploadFileFilename);
-        when(armResponseFileHelper.getCorrespondingArmFilesForManifestFilename(anyString())).thenReturn(List.of(inputUploadAndAssociatedFilenames));
+        when(armResponseFileHelper.getCorrespondingArmFilesForManifestFilename(anyString(), anyString()))
+            .thenReturn(List.of(inputUploadAndAssociatedFilenames));
 
 
         when(externalObjectDirectoryRepository.findById(eodEntityForAssociatedFiles1.getId())).thenReturn(Optional.of(eodEntityForAssociatedFiles1));
@@ -216,7 +217,8 @@ class AbstractBatchCleanupArmResponseFilesServiceCommonTest {
 
         InputUploadAndAssociatedFilenames inputUploadAndAssociatedFilenames = new InputUploadAndAssociatedFilenames();
         inputUploadAndAssociatedFilenames.setInputUploadFilename(inputUploadBlobFilename);
-        when(armResponseFileHelper.getCorrespondingArmFilesForManifestFilename(anyString())).thenReturn(List.of(inputUploadAndAssociatedFilenames));
+        when(armResponseFileHelper.getCorrespondingArmFilesForManifestFilename(anyString(), anyString()))
+            .thenReturn(List.of(inputUploadAndAssociatedFilenames));
 
 
         when(armDataManagementApi.deleteBlobData(any())).thenReturn(true);

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImplTest.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.darts.arm.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
+import uk.gov.hmcts.darts.arm.config.ArmBatchCleanupConfiguration;
+import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
+import uk.gov.hmcts.darts.arm.helper.ArmResponseFileHelper;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
+import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DartsBatchCleanupArmResponseFilesServiceImplTest {
+
+    @Mock
+    private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
+    @Mock
+    private ObjectRecordStatusRepository objectRecordStatusRepository;
+    @Mock
+    private ExternalLocationTypeRepository externalLocationTypeRepository;
+    @Mock
+    private ArmDataManagementApi armDataManagementApi;
+    @Mock
+    private UserIdentity userIdentity;
+    @Mock
+    private ArmDataManagementConfiguration armDataManagementConfiguration;
+
+    @Mock
+    private ArmBatchCleanupConfiguration batchCleanupConfiguration;
+    @Mock
+    private CurrentTimeHelper currentTimeHelper;
+    @Mock
+    private ArmResponseFileHelper armResponseFileHelper;
+
+    private static final String MANIFEST_FILE_PREFIX = "TEST";
+
+    @Test
+    void positiveConstructorTest() {
+        when(armDataManagementConfiguration.getManifestFilePrefix()).thenReturn(MANIFEST_FILE_PREFIX);
+        DartsBatchCleanupArmResponseFilesServiceImpl cleanupArmResponseFilesService = new DartsBatchCleanupArmResponseFilesServiceImpl(
+            externalObjectDirectoryRepository,
+            objectRecordStatusRepository,
+            externalLocationTypeRepository,
+            armDataManagementApi,
+            userIdentity,
+            batchCleanupConfiguration,
+            armDataManagementConfiguration,
+            currentTimeHelper,
+            armResponseFileHelper
+        );
+
+        verify(armDataManagementConfiguration).getManifestFilePrefix();
+
+        assertThat(cleanupArmResponseFilesService)
+            .hasFieldOrPropertyWithValue("externalObjectDirectoryRepository", externalObjectDirectoryRepository)
+            .hasFieldOrPropertyWithValue("objectRecordStatusRepository", objectRecordStatusRepository)
+            .hasFieldOrPropertyWithValue("externalLocationTypeRepository", externalLocationTypeRepository)
+            .hasFieldOrPropertyWithValue("armDataManagementApi", armDataManagementApi)
+            .hasFieldOrPropertyWithValue("userIdentity", userIdentity)
+            .hasFieldOrPropertyWithValue("batchCleanupConfiguration", batchCleanupConfiguration)
+            .hasFieldOrPropertyWithValue("armDataManagementConfiguration", armDataManagementConfiguration)
+            .hasFieldOrPropertyWithValue("currentTimeHelper", currentTimeHelper)
+            .hasFieldOrPropertyWithValue("armResponseFileHelper", armResponseFileHelper)
+            .hasFieldOrPropertyWithValue("manifestFilePrefix", MANIFEST_FILE_PREFIX);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImplTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.darts.arm.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
+import uk.gov.hmcts.darts.arm.config.ArmBatchCleanupConfiguration;
+import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
+import uk.gov.hmcts.darts.arm.helper.ArmResponseFileHelper;
+import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
+import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
+import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class DetsBatchCleanupArmResponseFilesServiceImplTest {
+    @Mock
+    private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
+    @Mock
+    private ObjectRecordStatusRepository objectRecordStatusRepository;
+    @Mock
+    private ExternalLocationTypeRepository externalLocationTypeRepository;
+    @Mock
+    private ArmDataManagementApi armDataManagementApi;
+    @Mock
+    private UserIdentity userIdentity;
+    @Mock
+    private ArmDataManagementConfiguration armDataManagementConfiguration;
+
+    @Mock
+    private ArmBatchCleanupConfiguration batchCleanupConfiguration;
+    @Mock
+    private CurrentTimeHelper currentTimeHelper;
+    @Mock
+    private ArmResponseFileHelper armResponseFileHelper;
+
+    private static final String MANIFEST_FILE_PREFIX = "TEST";
+
+    @Test
+    void positiveConstructorTest() {
+        DetsBatchCleanupArmResponseFilesServiceImpl cleanupArmResponseFilesService = new DetsBatchCleanupArmResponseFilesServiceImpl(
+            externalObjectDirectoryRepository,
+            objectRecordStatusRepository,
+            externalLocationTypeRepository,
+            armDataManagementApi,
+            userIdentity,
+            batchCleanupConfiguration,
+            armDataManagementConfiguration,
+            currentTimeHelper,
+            armResponseFileHelper,
+            MANIFEST_FILE_PREFIX
+        );
+
+        verifyNoInteractions(armDataManagementConfiguration);
+
+        assertThat(cleanupArmResponseFilesService)
+            .hasFieldOrPropertyWithValue("externalObjectDirectoryRepository", externalObjectDirectoryRepository)
+            .hasFieldOrPropertyWithValue("objectRecordStatusRepository", objectRecordStatusRepository)
+            .hasFieldOrPropertyWithValue("externalLocationTypeRepository", externalLocationTypeRepository)
+            .hasFieldOrPropertyWithValue("armDataManagementApi", armDataManagementApi)
+            .hasFieldOrPropertyWithValue("userIdentity", userIdentity)
+            .hasFieldOrPropertyWithValue("batchCleanupConfiguration", batchCleanupConfiguration)
+            .hasFieldOrPropertyWithValue("armDataManagementConfiguration", armDataManagementConfiguration)
+            .hasFieldOrPropertyWithValue("currentTimeHelper", currentTimeHelper)
+            .hasFieldOrPropertyWithValue("armResponseFileHelper", armResponseFileHelper)
+            .hasFieldOrPropertyWithValue("manifestFilePrefix", MANIFEST_FILE_PREFIX);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTaskTest.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.darts.task.runner.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.arm.service.impl.DartsBatchCleanupArmResponseFilesServiceImpl;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.config.BatchCleanupArmResponseFilesAutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.service.LockService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME;
+
+@ExtendWith(MockitoExtension.class)
+class BatchCleanupArmResponseFilesAutomatedTaskTest {
+
+    @Mock
+    private AutomatedTaskRepository automatedTaskRepository;
+    @Mock
+    private BatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties;
+    @Mock
+    private DartsBatchCleanupArmResponseFilesServiceImpl batchCleanupArmResponseFilesService;
+    @Mock
+    private LogApi logApi;
+    @Mock
+    private LockService lockService;
+    @InjectMocks
+    private BatchCleanupArmResponseFilesAutomatedTask batchCleanupArmResponseFilesAutomatedTask;
+
+    @Test
+    void positiveGetAutomatedTaskName() {
+        assertEquals(BATCH_CLEANUP_ARM_RESPONSE_FILES_TASK_NAME, batchCleanupArmResponseFilesAutomatedTask.getAutomatedTaskName());
+    }
+
+    @Test
+    void positiveRunTask() {
+        batchCleanupArmResponseFilesAutomatedTask = spy(batchCleanupArmResponseFilesAutomatedTask);
+        doReturn(100).when(batchCleanupArmResponseFilesAutomatedTask).getAutomatedTaskBatchSize();
+        batchCleanupArmResponseFilesAutomatedTask.runTask();
+
+        verify(batchCleanupArmResponseFilesService).cleanupResponseFiles(100);
+        verify(batchCleanupArmResponseFilesAutomatedTask).getAutomatedTaskBatchSize();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/BatchCleanupArmResponseFilesAutomatedTaskTest.java
@@ -8,7 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.arm.service.impl.DartsBatchCleanupArmResponseFilesServiceImpl;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
-import uk.gov.hmcts.darts.task.config.BatchCleanupArmResponseFilesAutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.config.DartsBatchCleanupArmResponseFilesAutomatedTaskConfig;
 import uk.gov.hmcts.darts.task.service.LockService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,7 +23,7 @@ class BatchCleanupArmResponseFilesAutomatedTaskTest {
     @Mock
     private AutomatedTaskRepository automatedTaskRepository;
     @Mock
-    private BatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties;
+    private DartsBatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties;
     @Mock
     private DartsBatchCleanupArmResponseFilesServiceImpl batchCleanupArmResponseFilesService;
     @Mock

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/DetsCleanupArmResponseFilesAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/DetsCleanupArmResponseFilesAutomatedTaskTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.darts.task.runner.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.arm.service.impl.DetsBatchCleanupArmResponseFilesServiceImpl;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.config.BatchCleanupArmResponseFilesAutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.service.LockService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.DETS_CLEANUP_ARM_RESPONSE_FILES;
+
+@ExtendWith(MockitoExtension.class)
+class DetsCleanupArmResponseFilesAutomatedTaskTest {
+
+    @Mock
+    private AutomatedTaskRepository automatedTaskRepository;
+    @Mock
+    private BatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties;
+    @Mock
+    private DetsBatchCleanupArmResponseFilesServiceImpl batchCleanupArmResponseFilesService;
+    @Mock
+    private LogApi logApi;
+    @Mock
+    private LockService lockService;
+
+    @InjectMocks
+    private DetsCleanupArmResponseFilesAutomatedTask detsCleanupArmResponseFilesAutomatedTask;
+
+    @Test
+    void positiveGetAutomatedTaskName() {
+        assertEquals(DETS_CLEANUP_ARM_RESPONSE_FILES, detsCleanupArmResponseFilesAutomatedTask.getAutomatedTaskName());
+    }
+
+    @Test
+    void positiveRunTask() {
+        detsCleanupArmResponseFilesAutomatedTask = spy(detsCleanupArmResponseFilesAutomatedTask);
+        doReturn(100).when(detsCleanupArmResponseFilesAutomatedTask).getAutomatedTaskBatchSize();
+        detsCleanupArmResponseFilesAutomatedTask.runTask();
+
+        verify(batchCleanupArmResponseFilesService).cleanupResponseFiles(100);
+        verify(detsCleanupArmResponseFilesAutomatedTask).getAutomatedTaskBatchSize();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/DetsCleanupArmResponseFilesAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/DetsCleanupArmResponseFilesAutomatedTaskTest.java
@@ -8,7 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.arm.service.impl.DetsBatchCleanupArmResponseFilesServiceImpl;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
-import uk.gov.hmcts.darts.task.config.BatchCleanupArmResponseFilesAutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.config.DartsBatchCleanupArmResponseFilesAutomatedTaskConfig;
 import uk.gov.hmcts.darts.task.service.LockService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,7 +23,7 @@ class DetsCleanupArmResponseFilesAutomatedTaskTest {
     @Mock
     private AutomatedTaskRepository automatedTaskRepository;
     @Mock
-    private BatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties;
+    private DartsBatchCleanupArmResponseFilesAutomatedTaskConfig automatedTaskConfigurationProperties;
     @Mock
     private DetsBatchCleanupArmResponseFilesServiceImpl batchCleanupArmResponseFilesService;
     @Mock


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3485)


### Change description ###
Once ARM produces the response files, DETS-ARM pull response automated job will start pulling the response files and process it.

As soon as the files associated with a transaction are processed, DARTS should delete the corresponding response files from ARM's response folder.

Along with Synchronous deletion an automated job will also be required to make sure any deletion which is missed during Synchronous deletion are handled in a asynchronous way. The purpose of the job is to clean up data from  ARM response folders Asynchronously.
 * Create flyway script for new automated task
 ** Task name : DETSCleanupArmResponseFiles
 ** Batchsize : 4000
 ** Cron : Runs daily at 23:27
 ** Make sure the job is disabled
 * Create Automated job in darts-api - DETSCleanupArmResponseFilesAutomatedTask
 * The job will use the exact logic to fetch the EOD objects from external_object_directory with only dofference is the manifest file prefix would be 'DETS'. Refer BatchCleanupArmResponseFilesServiceImpl.cleanupResponseFiles.
 ** Location Type = ARM

 * 
 ** Status in (
STORED, ARM_RPO_PENDING, ARM_RESPONSE_PROCESSING_FAILED, ARM_RESPONSE_MANIFEST_FAILED, ARM_RESPONSE_CHECKSUM_VERIFICATION_FAILED)
 ** isResponseCleaned = false
 ** prefix=DETS

+*Acceptance Criteria:*+

*GIVEN*

I am system user and there exist EOD objects which false in Delete criteria

*WHEN*

the automate job DETSCleanupArmResponseFiles runs successfully

*THEN*

the corresponding response files (IU, CR, UF & IL) will be deleted in ARM's response folder

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
