### PR TITLE
DMP-3816: ARM RPO - Update the RPO CSV & Replay Time Range

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AdminPatchAutomatedTaskTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/AdminPatchAutomatedTaskTest.java
@@ -6,14 +6,18 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.darts.common.entity.ArmAutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
+import uk.gov.hmcts.darts.common.repository.ArmAutomatedTaskRepository;
 import uk.gov.hmcts.darts.testutils.GivenBuilder;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.net.URI;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.EnumSource.Mode;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
@@ -28,6 +32,9 @@ class AdminPatchAutomatedTaskTest extends IntegrationBase {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    ArmAutomatedTaskRepository armAutomatedTaskRepository;
 
     @ParameterizedTest
     @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_ADMIN"}, mode = Mode.INCLUDE)
@@ -83,5 +90,41 @@ class AdminPatchAutomatedTaskTest extends IntegrationBase {
             .andReturn();
     }
 
+    @Test
+    void returns422InvalidAutomatedTaskTypeWhenTheTaskIsNotArmButHasArmUpdateFields() throws Exception {
+        given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
 
+        mockMvc.perform(
+                patch(ENDPOINT + "/1")
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .content("""
+                                 { "rpo_csv_end_hour": 1 }
+                                 """))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("$.type").value("AUTOMATED_TASK_103"))
+            .andExpect(jsonPath("$.title").value("The automated task type is incorrect"))
+            .andReturn();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_ADMIN"}, mode = Mode.INCLUDE)
+    void superAdminCanSuccessfullyPatchArmAutomatedTask(SecurityRoleEnum role) throws Exception {
+        given.anAuthenticatedUserWithGlobalAccessAndRole(role);
+
+        ArmAutomatedTaskEntity armAutomatedTaskEntity = armAutomatedTaskRepository.findById(2).orElseThrow();
+        armAutomatedTaskEntity.setRpoCsvEndHour(1);
+        armAutomatedTaskRepository.save(armAutomatedTaskEntity);
+
+        mockMvc.perform(
+                patch(ENDPOINT + "/30")
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .content("""
+                                 { "rpo_csv_end_hour": 2 }
+                                 """))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        armAutomatedTaskEntity = armAutomatedTaskRepository.findById(2).orElseThrow();
+        assertEquals(2, armAutomatedTaskEntity.getRpoCsvEndHour());
+    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ArmAutomatedTaskEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ArmAutomatedTaskEntity.java
@@ -2,11 +2,12 @@ package uk.gov.hmcts.darts.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
@@ -28,7 +29,7 @@ public class ArmAutomatedTaskEntity {
     @Column(name = "aat_id", nullable = false)
     private Integer id;
 
-    @ManyToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "aut_id", nullable = false)
     private AutomatedTaskEntity automatedTask;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AutomatedTaskEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AutomatedTaskEntity.java
@@ -2,15 +2,18 @@ package uk.gov.hmcts.darts.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
+import org.hibernate.envers.NotAudited;
 import uk.gov.hmcts.darts.common.entity.base.MandatoryCreatedModifiedBaseEntity;
 
 @Entity
@@ -55,4 +58,8 @@ public class AutomatedTaskEntity extends MandatoryCreatedModifiedBaseEntity {
 
     @Column(name = BATCH_SIZE)
     private Integer batchSize;
+
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "automatedTask")
+    @NotAudited
+    private ArmAutomatedTaskEntity armAutomatedTaskEntity;
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/exception/AutomatedTaskApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/exception/AutomatedTaskApiError.java
@@ -25,6 +25,11 @@ public enum AutomatedTaskApiError implements DartsApiError {
         AutomatedTaskErrorCode.AUTOMATED_TASK_NOT_CONFIGURED.getValue(),
         HttpStatus.INTERNAL_SERVER_ERROR,
         AutomatedTaskTitleErrors.AUTOMATED_TASK_NOT_CONFIGURED.toString()
+    ),
+    INCORRECT_AUTOMATED_TASK_TYPE(
+        AutomatedTaskErrorCode.INCORRECT_AUTOMATED_TASK_TYPE.getValue(),
+        HttpStatus.UNPROCESSABLE_ENTITY,
+        AutomatedTaskTitleErrors.INCORRECT_AUTOMATED_TASK_TYPE.toString()
     );
 
     private static final String ERROR_TYPE_PREFIX = "AUTOMATED_TASK";

--- a/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/service/impl/AdminAutomatedTasksServiceImpl.java
@@ -6,9 +6,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
+import uk.gov.hmcts.darts.common.entity.ArmAutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.ArmAutomatedTaskRepository;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.task.api.AutomatedTaskName;
 import uk.gov.hmcts.darts.task.exception.AutomatedTaskApiError;
@@ -19,13 +22,16 @@ import uk.gov.hmcts.darts.tasks.model.AutomatedTaskPatch;
 import uk.gov.hmcts.darts.tasks.model.AutomatedTaskSummary;
 import uk.gov.hmcts.darts.tasks.model.DetailedAutomatedTask;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import static uk.gov.hmcts.darts.audit.api.AuditActivity.ENABLE_DISABLE_JOB;
 import static uk.gov.hmcts.darts.audit.api.AuditActivity.RUN_JOB_MANUALLY;
 import static uk.gov.hmcts.darts.task.exception.AutomatedTaskApiError.AUTOMATED_TASK_ALREADY_RUNNING;
 import static uk.gov.hmcts.darts.task.exception.AutomatedTaskApiError.AUTOMATED_TASK_NOT_FOUND;
+import static uk.gov.hmcts.darts.task.exception.AutomatedTaskApiError.INCORRECT_AUTOMATED_TASK_TYPE;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +40,7 @@ import static uk.gov.hmcts.darts.task.exception.AutomatedTaskApiError.AUTOMATED_
 public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService {
 
     private final AutomatedTaskRepository automatedTaskRepository;
+    private final ArmAutomatedTaskRepository armAutomatedTaskRepository;
     private final AutomatedTasksMapper mapper;
     private final AutomatedTaskRunner automatedTaskRunner;
     private final AuditApi auditApi;
@@ -89,6 +96,7 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
     }
 
     @Override
+    @Transactional
     public DetailedAutomatedTask updateAutomatedTask(Integer taskId, AutomatedTaskPatch automatedTaskPatch) {
         var automatedTask = getAutomatedTaskEntityById(taskId);
 
@@ -101,6 +109,48 @@ public class AdminAutomatedTasksServiceImpl implements AdminAutomatedTaskService
         if (automatedTaskPatch.getBatchSize() != null) {
             automatedTask.setBatchSize(automatedTaskPatch.getBatchSize());
             log.info("Batch size for {} updated to {}", automatedTask.getTaskName(), automatedTaskPatch.getBatchSize());
+        }
+
+        //Arm Autoamted Task updates
+        List<Consumer<ArmAutomatedTaskEntity>> armAutomatedTaskEntityConsumer = new ArrayList<>();
+
+        if (automatedTaskPatch.getArmReplayStartTs() != null) {
+            armAutomatedTaskEntityConsumer.add(armAutomatedTaskEntity -> {
+                armAutomatedTaskEntity.setArmReplayStartTs(automatedTaskPatch.getArmReplayStartTs());
+                log.info("ARM replay start timestamp for {} updated to {}", automatedTask.getTaskName(), automatedTaskPatch.getArmReplayStartTs());
+            });
+        }
+
+        if (automatedTaskPatch.getArmReplayEndTs() != null) {
+            armAutomatedTaskEntityConsumer.add(armAutomatedTaskEntity -> {
+                armAutomatedTaskEntity.setArmReplayEndTs(automatedTaskPatch.getArmReplayEndTs());
+                log.info("ARM replay end timestamp for {} updated to {}", automatedTask.getTaskName(), automatedTaskPatch.getArmReplayEndTs());
+            });
+        }
+
+        if (automatedTaskPatch.getRpoCsvStartHour() != null) {
+            armAutomatedTaskEntityConsumer.add(armAutomatedTaskEntity -> {
+                armAutomatedTaskEntity.setRpoCsvStartHour(automatedTaskPatch.getRpoCsvStartHour());
+                log.info("RPO CSV start hour for {} updated to {}", automatedTask.getTaskName(), automatedTaskPatch.getRpoCsvStartHour());
+            });
+        }
+
+        if (automatedTaskPatch.getRpoCsvEndHour() != null) {
+            armAutomatedTaskEntityConsumer.add(armAutomatedTaskEntity -> {
+                armAutomatedTaskEntity.setRpoCsvEndHour(automatedTaskPatch.getRpoCsvEndHour());
+                log.info("RPO CSV end hour for {} updated to {}", automatedTask.getTaskName(), automatedTaskPatch.getRpoCsvEndHour());
+            });
+        }
+
+        if (armAutomatedTaskEntityConsumer.size() > 0) {
+            ArmAutomatedTaskEntity armAutomatedTaskEntity = automatedTask.getArmAutomatedTaskEntity();
+            if (armAutomatedTaskEntity == null) {
+                throw new DartsApiException(INCORRECT_AUTOMATED_TASK_TYPE,
+                                            "Task " + automatedTask.getTaskName() + " is not an arm automated task as such can not update arm related fields");
+            }
+            armAutomatedTaskEntityConsumer.forEach(consumer -> consumer.accept(armAutomatedTaskEntity));
+            automatedTask.setArmAutomatedTaskEntity(armAutomatedTaskEntity);
+            armAutomatedTaskRepository.save(armAutomatedTaskEntity);
         }
 
         var updatedTask = automatedTaskRepository.save(automatedTask);

--- a/src/main/resources/openapi/tasks.yaml
+++ b/src/main/resources/openapi/tasks.yaml
@@ -119,6 +119,19 @@ components:
           $ref: '#/components/schemas/IsActive'
         batch_size:
           type: integer
+
+        rpo_csv_start_hour:
+          type: integer
+        rpo_csv_end_hour:
+          type: integer
+        arm_replay_start_ts:
+          type: string
+          format: date-time
+        arm_replay_end_ts:
+          type: string
+          format: date-time
+
+
     AutomatedTaskSummary:
       type: object
       properties:
@@ -187,7 +200,8 @@ components:
         - "AUTOMATED_TASK_100"
         - "AUTOMATED_TASK_101"
         - "AUTOMATED_TASK_102"
-      x-enum-varnames: [ AUTOMATED_TASK_NOT_FOUND, AUTOMATED_TASK_ALREADY_RUNNING, AUTOMATED_TASK_NOT_CONFIGURED ]
+        - "AUTOMATED_TASK_103"
+      x-enum-varnames: [ AUTOMATED_TASK_NOT_FOUND, AUTOMATED_TASK_ALREADY_RUNNING, AUTOMATED_TASK_NOT_CONFIGURED, INCORRECT_AUTOMATED_TASK_TYPE ]
 
     AutomatedTaskTitleErrors:
       type: string
@@ -195,9 +209,8 @@ components:
         - "The provided task_id does not exist"
         - "The automated task is already running"
         - "The automated task has not been initialized correctly on application start up and can not be run manually."
-      x-enum-varnames: [ AUTOMATED_TASK_NOT_FOUND, AUTOMATED_TASK_ALREADY_RUNNING, AUTOMATED_TASK_NOT_CONFIGURED ]
-
-
+        - "The automated task type is incorrect"
+      x-enum-varnames: [ AUTOMATED_TASK_NOT_FOUND, AUTOMATED_TASK_ALREADY_RUNNING, AUTOMATED_TASK_NOT_CONFIGURED, INCORRECT_AUTOMATED_TASK_TYPE ]
   parameters:
     TaskId:
       in: path


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3816)


### Change description ###
# Summary of Git Diff

This Git diff introduces several modifications primarily to the `AdminPatchAutomatedTaskTest` and related classes. The changes include new methods to handle ARM automated tasks, updates to existing entities and services, and the introduction of error handling for incorrect task types. Additionally, new tests have been added to ensure the functionality of the updated features.

## Highlights

- **New Test Cases**:
  - Added tests in `AdminPatchAutomatedTaskTest` to verify:
    - Successful patching of ARM automated tasks by super admins.
    - Handling of invalid automated task types when attempting to patch.
  
- **Entity Updates**:
  - Modified `ArmAutomatedTaskEntity` to use `@OneToOne` relationship with `AutomatedTaskEntity`, changing the fetch type to `FetchType.LAZY`.
  - Updated `AutomatedTaskEntity` to include a `@OneToOne` relationship back to `ArmAutomatedTaskEntity` with `@NotAudited`.

- **Service Implementation Changes**:
  - In `AdminAutomatedTasksServiceImpl`, added transactional support for updates to ARM automated tasks.
  - Enhanced the `updateAutomatedTask` method to handle ARM-specific fields and throw an exception if a non-ARM task attempts to update ARM fields.

- **Error Handling**:
  - Introduced a new error type `INCORRECT_AUTOMATED_TASK_TYPE` in `AutomatedTaskApiError` for improved error reporting.

- **OpenAPI Specification**:
  - Updated `tasks.yaml` to include new fields for ARM automated tasks, ensuring API documentation reflects recent changes.

- **Unit Test Enhancements**:
  - In `AdminAutomatedTasksServiceImplTest`, added tests to verify:
    - Proper handling of ARM fields during updates.
    - Validation when updating a non-ARM task with ARM-specific fields.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
