### PR TITLE
DMP:4143: Correct response structure and logic for getStorageAccount …

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/client/ArmRpoClientIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/client/ArmRpoClientIntTest.java
@@ -216,9 +216,9 @@ class ArmRpoClientIntTest extends IntegrationBaseWithWiremock {
         );
 
         assertEquals("Failed to get storage account index name", "rm5",
-                     getStorageAccountsResponse.getIndexes().getFirst().getIndex().getName());
+                     getStorageAccountsResponse.getDataDetails().getFirst().getId());
         assertEquals("Failed to get storage account index id", "c19454c6-c378-43c1-ae59-d0d013e30915",
-                     getStorageAccountsResponse.getIndexes().getFirst().getIndex().getIndexId());
+                     getStorageAccountsResponse.getDataDetails().getFirst().getName());
 
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArpRpoApiGetStorageAccountsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArpRpoApiGetStorageAccountsIntTest.java
@@ -39,25 +39,21 @@ class ArpRpoApiGetStorageAccountsIntTest extends IntegrationBase {
 
     @Test
     void getStorageAccountsSuccess() {
-
         // given
         when(armApiConfigurationProperties.getArmStorageAccountName()).thenReturn("expectedAccountName");
 
-        StorageAccountResponse.IndexDetails indexDetails1 = new StorageAccountResponse.IndexDetails();
-        indexDetails1.setIndexId("indexId1");
-        indexDetails1.setName("unexpectedAccountName");
-        StorageAccountResponse.IndexDetails indexDetails2 = new StorageAccountResponse.IndexDetails();
-        indexDetails2.setIndexId("indexId2");
-        indexDetails2.setName("expectedAccountName");
-        StorageAccountResponse.Index index1 = new StorageAccountResponse.Index();
-        index1.setIndex(indexDetails1);
-        StorageAccountResponse.Index index2 = new StorageAccountResponse.Index();
-        index2.setIndex(indexDetails2);
+        StorageAccountResponse.DataDetails dataDetails1 = new StorageAccountResponse.DataDetails();
+        dataDetails1.setId("indexId1");
+        dataDetails1.setName("unexpectedAccountName");
+
+        StorageAccountResponse.DataDetails dataDetails2 = new StorageAccountResponse.DataDetails();
+        dataDetails2.setId("indexId2");
+        dataDetails2.setName("expectedAccountName");
 
         StorageAccountResponse storageAccountResponse = new StorageAccountResponse();
-        storageAccountResponse.setIndexes(List.of(index1, index2));
         storageAccountResponse.setStatus(200);
         storageAccountResponse.setIsError(false);
+        storageAccountResponse.setDataDetails(List.of(dataDetails1, dataDetails2));
 
         var bearerAuth = "Bearer some-token";
         when(armRpoClient.getStorageAccounts(any(), any())).thenReturn(storageAccountResponse);
@@ -68,7 +64,6 @@ class ArpRpoApiGetStorageAccountsIntTest extends IntegrationBase {
         armRpoExecutionDetailEntity.setLastModifiedBy(userAccount);
         var armRpoExecutionDetail = dartsPersistence.save(armRpoExecutionDetailEntity);
 
-
         // when
         armRpoApi.getStorageAccounts(bearerAuth, armRpoExecutionDetail.getId(), userAccount);
 
@@ -77,7 +72,6 @@ class ArpRpoApiGetStorageAccountsIntTest extends IntegrationBase {
         assertEquals(ArmRpoStateEnum.GET_STORAGE_ACCOUNTS.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoState().getId());
         assertEquals(ArmRpoStatusEnum.COMPLETED.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoStatus().getId());
         assertEquals("indexId2", armRpoExecutionDetailEntityUpdated.getStorageAccountId());
-
     }
 
     @Test
@@ -103,7 +97,7 @@ class ArpRpoApiGetStorageAccountsIntTest extends IntegrationBase {
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
-            "Failure during ARM get storage accounts: Unable to get indexes from storage account response"));
+            "Failure during ARM get storage accounts: No data details were present in the storage account response"));
 
         var armRpoExecutionDetailEntityUpdated = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetail.getId()).get();
         assertEquals(ArmRpoStateEnum.GET_STORAGE_ACCOUNTS.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoState().getId());

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/StorageAccountResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/StorageAccountResponse.java
@@ -14,24 +14,15 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class StorageAccountResponse extends BaseRpoResponse {
 
-    private List<Index> indexes;
+    @JsonProperty("data")
+    private List<DataDetails> dataDetails;
 
     @Data
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @EqualsAndHashCode
-    public static class Index {
-        private IndexDetails index;
-    }
-
-    @Data
-    @NoArgsConstructor
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class IndexDetails {
-        @JsonProperty("indexID")
-        private String indexId;
+    public static class DataDetails {
+        private String id;
         private String name;
-
     }
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -286,7 +286,7 @@ darts:
         download-data-path: /api/v1/downloadBlob/{cabinet_id}/{record_id}/{file_id}
       rpo-url:
         get-record-management-matter-path: /api/v1/getRecordManagementMatter
-        get-storage-accounts: /api/v1/getStorageAccounts
+        get-storage-accounts-path: /api/v1/getStorageAccounts
         get-indexes-by-matter-id-path: /api/v1/getIndexesByMatterId
         get-master-index-field-by-record-class-schema-path: /api/v1/getMasterIndexFieldByRecordClassSchema
         get-profile-entitlements-path: /api/v1/getProfileEntitlements

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetStorageAccountsTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetStorageAccountsTest.java
@@ -5,6 +5,10 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,13 +23,18 @@ import uk.gov.hmcts.darts.arm.service.ArmRpoService;
 import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
+import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +55,8 @@ class ArmRpoApiGetStorageAccountsTest {
     @InjectMocks
     private ArmRpoApiImpl armRpoApi;
 
+    private ArgumentCaptor<ArmRpoExecutionDetailEntity> executionDetailCaptor;
+
     private UserAccountEntity userAccount;
     private static final Integer EXECUTION_ID = 1;
     private static final ArmRpoHelperMocks ARM_RPO_HELPER_MOCKS = new ArmRpoHelperMocks();
@@ -58,26 +69,25 @@ class ArmRpoApiGetStorageAccountsTest {
         ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
         armRpoExecutionDetailEntity.setId(EXECUTION_ID);
         when(armRpoService.getArmRpoExecutionDetailEntity(EXECUTION_ID)).thenReturn(armRpoExecutionDetailEntity);
+
+        executionDetailCaptor = ArgumentCaptor.forClass(ArmRpoExecutionDetailEntity.class);
     }
 
     @Test
-    void getStorageAccountsReturnsSuccess() {
+    void getStorageAccounts_shouldReturnsSuccess_whenSingularMatchingNamesExist() {
         // given
-        StorageAccountResponse.IndexDetails indexDetails1 = new StorageAccountResponse.IndexDetails();
-        indexDetails1.setIndexId("indexId1");
-        indexDetails1.setName("unexpectedAccountName");
-        StorageAccountResponse.IndexDetails indexDetails2 = new StorageAccountResponse.IndexDetails();
-        indexDetails2.setIndexId("indexId2");
-        indexDetails2.setName("expectedAccountName");
-        StorageAccountResponse.Index index1 = new StorageAccountResponse.Index();
-        index1.setIndex(indexDetails1);
-        StorageAccountResponse.Index index2 = new StorageAccountResponse.Index();
-        index2.setIndex(indexDetails2);
+        StorageAccountResponse.DataDetails dataDetails1 = new StorageAccountResponse.DataDetails();
+        dataDetails1.setId("indexId1");
+        dataDetails1.setName("unexpectedAccountName");
+
+        StorageAccountResponse.DataDetails dataDetails2 = new StorageAccountResponse.DataDetails();
+        dataDetails2.setId("indexId2");
+        dataDetails2.setName("expectedAccountName");
 
         StorageAccountResponse storageAccountResponse = new StorageAccountResponse();
         storageAccountResponse.setStatus(200);
         storageAccountResponse.setIsError(false);
-        storageAccountResponse.setIndexes(List.of(index1, index2));
+        storageAccountResponse.setDataDetails(List.of(dataDetails1, dataDetails2));
         when(armRpoClient.getStorageAccounts(anyString(), any(StorageAccountRequest.class))).thenReturn(storageAccountResponse);
         when(armApiConfigurationProperties.getArmStorageAccountName()).thenReturn("expectedAccountName");
 
@@ -89,34 +99,135 @@ class ArmRpoApiGetStorageAccountsTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetStorageAccountsRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          any());
-        verify(armRpoService).updateArmRpoStatus(any(), eq(ARM_RPO_HELPER_MOCKS.getCompletedRpoStatus()), any());
+        verify(armRpoService).updateArmRpoStatus(executionDetailCaptor.capture(),
+                                                 eq(ARM_RPO_HELPER_MOCKS.getCompletedRpoStatus()),
+                                                 any());
+
+        assertEquals("indexId2", executionDetailCaptor.getValue().getStorageAccountId());
+    }
+
+    @Test
+    void getStorageAccounts_shouldReturnsSuccess_andSelectFirstMatchingName_whenMultipleMatchingNamesExist() {
+        // Given
+        StorageAccountResponse.DataDetails dataDetails1 = new StorageAccountResponse.DataDetails();
+        dataDetails1.setId("indexId1");
+        dataDetails1.setName("unexpectedAccountName");
+
+        StorageAccountResponse.DataDetails dataDetails2 = new StorageAccountResponse.DataDetails();
+        dataDetails2.setId("indexId2");
+        dataDetails2.setName("expectedAccountName");
+
+        StorageAccountResponse.DataDetails dataDetails3 = new StorageAccountResponse.DataDetails();
+        dataDetails3.setId("indexId3");
+        dataDetails3.setName("expectedAccountName"); // Duplicate name
+
+        StorageAccountResponse storageAccountResponse = new StorageAccountResponse();
+        storageAccountResponse.setStatus(200);
+        storageAccountResponse.setIsError(false);
+        storageAccountResponse.setDataDetails(List.of(dataDetails1, dataDetails2, dataDetails3));
+        when(armRpoClient.getStorageAccounts(anyString(), any(StorageAccountRequest.class))).thenReturn(storageAccountResponse);
+        when(armApiConfigurationProperties.getArmStorageAccountName()).thenReturn("expectedAccountName");
+
+        // When
+        armRpoApi.getStorageAccounts("token", 1, userAccount);
+
+        // Then
+        verify(armRpoService).updateArmRpoStateAndStatus(any(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetStorageAccountsRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(executionDetailCaptor.capture(),
+                                                 eq(ARM_RPO_HELPER_MOCKS.getCompletedRpoStatus()),
+                                                 any());
+
+        assertEquals("indexId2", executionDetailCaptor.getValue().getStorageAccountId());
     }
 
     @Test
     void getStorageAccountsReturnsNonMatchingStorageName() {
         // given
+        StorageAccountResponse.DataDetails dataDetails1 = new StorageAccountResponse.DataDetails();
+        dataDetails1.setId("indexId1");
+        dataDetails1.setName("unexpectedAccountName");
+
         StorageAccountResponse storageAccountResponse = new StorageAccountResponse();
         storageAccountResponse.setStatus(200);
         storageAccountResponse.setIsError(false);
-        StorageAccountResponse.IndexDetails indexDetails1 = new StorageAccountResponse.IndexDetails();
-        indexDetails1.setIndexId("indexId1");
-        indexDetails1.setName("unexpectedAccountName");
-        StorageAccountResponse.Index index1 = new StorageAccountResponse.Index();
-        index1.setIndex(indexDetails1);
+        storageAccountResponse.setDataDetails(Collections.singletonList(dataDetails1));
 
-        storageAccountResponse.setIndexes(List.of(index1));
         when(armRpoClient.getStorageAccounts(anyString(), any(StorageAccountRequest.class))).thenReturn(storageAccountResponse);
         when(armApiConfigurationProperties.getArmStorageAccountName()).thenReturn("expectedAccountName");
 
         // when
-        assertThrows(ArmRpoException.class, () -> armRpoApi.getStorageAccounts("token", 1, userAccount));
+        ArmRpoException exception = assertThrows(ArmRpoException.class, () -> armRpoApi.getStorageAccounts("token", 1, userAccount));
 
         // then
+        assertThat(exception.getMessage(), containsString(
+            "Unable to find ARM RPO storage account in response"));
         verify(armRpoService).updateArmRpoStateAndStatus(any(),
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetStorageAccountsRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          any());
         verify(armRpoService).updateArmRpoStatus(any(), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), any());
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    void getStorageAccounts_shouldThrowException_whenArmReturnsNullOrEmptyDataDetails(List<StorageAccountResponse.DataDetails> dataDetails) {
+        // Given
+        StorageAccountResponse storageAccountResponse = new StorageAccountResponse();
+        storageAccountResponse.setStatus(200);
+        storageAccountResponse.setIsError(false);
+        storageAccountResponse.setDataDetails(dataDetails);
+
+        when(armRpoClient.getStorageAccounts(anyString(), any(StorageAccountRequest.class))).thenReturn(storageAccountResponse);
+
+        // When
+        ArmRpoException exception = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getStorageAccounts("token", EXECUTION_ID, userAccount));
+
+        // Then
+        assertThat(exception.getMessage(), containsString(
+            "No data details were present in the storage account response"));
+        verify(armRpoService).updateArmRpoStateAndStatus(any(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetStorageAccountsRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), any());
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    void getStorageAccounts_shouldThrowException_whenArmReturnsNullOrEmptyId(String id) {
+        // Given
+        StorageAccountResponse.DataDetails dataDetails = new StorageAccountResponse.DataDetails();
+        dataDetails.setName("expectedAccountName");
+        dataDetails.setId(id);
+
+        StorageAccountResponse storageAccountResponse = new StorageAccountResponse();
+        storageAccountResponse.setStatus(200);
+        storageAccountResponse.setIsError(false);
+        storageAccountResponse.setDataDetails(Collections.singletonList(dataDetails));
+
+        when(armRpoClient.getStorageAccounts(anyString(), any(StorageAccountRequest.class))).thenReturn(storageAccountResponse);
+        when(armApiConfigurationProperties.getArmStorageAccountName()).thenReturn("expectedAccountName");
+
+        // When
+        ArmRpoException exception = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getStorageAccounts("token", EXECUTION_ID, userAccount));
+
+        // Then
+        assertThat(exception.getMessage(), containsString(
+            "Unable to find ARM RPO storage account in response"));
+        verify(armRpoService).updateArmRpoStateAndStatus(any(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetStorageAccountsRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), any());
+        verifyNoMoreInteractions(armRpoService);
     }
 
     @Test


### PR DESCRIPTION
The Feign client for ARM RPO `getStorageAccounts` is expecting the wrong response structure. This PR corrects it to align with the ARM RPO LLD per https://tools.hmcts.net/confluence/display/DMP/ARM+RPO.

This issue was spotted whilst working on DMP-4134. A separate PR (https://github.com/hmcts/darts-api/pull/2270) will conclude DMP-4143.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
