### PR TITLE
DMP-4251: Introduce and use event obfuscation feature flag

### DIFF
--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -101,6 +101,7 @@ java:
   environment:
     ENABLE_FLYWAY: true
     MANUAL_DELETION_ENABLED: true
+    EVENT_OBFUSCATION_ENABLED: true
     CASE_EXPIRY_DELETION_ENABLED: true
     RUN_DB_MIGRATION_ON_STARTUP: true
     DARTS_API_DB_HOST: "darts-modernisation-dev.postgres.database.azure.com"
@@ -146,6 +147,7 @@ darts-portal:
       DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsstgextid.b2clogin.com
       DARTS_AZUREAD_B2C_HOSTNAME: https://darts.staging.apps.hmcts.net
       MANUAL_DELETION_ENABLED: true
+      EVENT_OBFUSCATION_ENABLED: true
 
 # function:
 #   scaleType: Job

--- a/charts/darts-api/values.stg.template.yaml
+++ b/charts/darts-api/values.stg.template.yaml
@@ -4,6 +4,7 @@ java:
   ingressHost: ${SERVICE_FQDN}
   environment:
     MANUAL_DELETION_ENABLED: true
+    EVENT_OBFUSCATION_ENABLED: true
     CASE_EXPIRY_DELETION_ENABLED: true
     TESTING_SUPPORT_ENDPOINTS_ENABLED: true
     DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net

--- a/src/integrationTest/resources/application-intTest.yaml
+++ b/src/integrationTest/resources/application-intTest.yaml
@@ -49,6 +49,8 @@ spring:
     hikari:
       maximum-pool-size: 10 # Overrides the value in `application.yaml` to a smaller value more appropriate for integration tests, sized below the `max_connections` limit specified in PostgresIntegrationBase.
 darts:
+  event-obfuscation:
+    enabled: true
   manual-deletion:
     enabled: true
   hearings:

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -68,7 +68,7 @@ public class EventsController implements EventApi {
     private final UserIdentity userIdentity;
 
     @Value("${darts.event-obfuscation.enabled}")
-    private final boolean eveventObfuscationEnabled;
+    private final boolean eventObfuscationEnabled;
 
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
@@ -189,7 +189,7 @@ public class EventsController implements EventApi {
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_ADMIN})
     public ResponseEntity<Void> adminObfuscateEveByIds(AdminObfuscateEveByIdsRequest adminObfuscateEveByIdsRequest) {
-        if (!eveventObfuscationEnabled) {
+        if (!eventObfuscationEnabled) {
             throw new DartsApiException(CommonApiError.FEATURE_FLAG_NOT_ENABLED, "Event obfuscation is not enabled");
         }
         this.dataAnonymisationService.anonymiseEventByIds(userIdentity.getUserAccount(), adminObfuscateEveByIdsRequest.getEveIds());

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -18,6 +18,8 @@ spring:
         format_sql: true
         generate_statistics: false
 darts:
+  event-obfuscation:
+    enabled: true
   daily-list:
     housekeeping:
       enabled: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -113,6 +113,8 @@ spring:
             loggerLevel: ${FEIGN_LOG_LEVEL:none}
 
 darts:
+  event-obfuscation:
+    enabled: ${EVENT_OBFUSCATION_ENABLED:false}
   manual-deletion:
     enabled: ${MANUAL_DELETION_ENABLED:false}
     grace-period: ${MANUAL_DELETION_GRACE_PERIOD:24h}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4251)


### Change description ###
*Add feature flag*

If this flag has not already been created, add the new config to DARTS API application.yaml, to act as a feature flag for event obfuscation
{code:java}
darts:
  event-obfuscation:
    enabled: ${EVENT_OBFUSCATION_ENABLED:false} {code}
Check the env var "EVENT_OBFUSCATION_ENABLED" exists in flux for the darts-api service staging environment, set to true. Ensure it is not set or set to false for all other environments.

The feature should also be enabled on the dev and staging pipeline deployments, in order to facilitate testing.

*Hide endpoint*

The _POST /admin/events/obfuscate_ endpoint should be hidden if the feature is not enabled. Any requests should received a 501 not implemented response.
h3. *Acceptance Criteria*

*AC1 - feature enabled*

GIVEN the event obfuscation feature is enabled
WHEN the POST /admin/events/obfuscate endpoint is called
THEN a 200 response is received
AND the event text is obfuscated

*AC2 - feature not enabled*

GIVEN the event obfuscation feature is not enabled
WHEN the POST /admin/events/obfuscate endpoint is called
THEN a 501 response is received
AND the event text is not obfuscated

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
