### PR TITLE
DMP-4315: Remove synchronous DETS Cleanup logic

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchProcessResponseFilesIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchProcessResponseFilesIntTest.java
@@ -5,10 +5,8 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.darts.arm.model.blobs.ContinuationTokenBlobs;
 import uk.gov.hmcts.darts.arm.service.impl.DetsToArmBatchProcessResponseFilesImpl;
-import uk.gov.hmcts.darts.audio.deleter.impl.dets.DetsDataStoreDeleter;
 import uk.gov.hmcts.darts.audio.deleter.impl.dets.ExternalDetsDataStoreDeleter;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -19,7 +17,6 @@ import uk.gov.hmcts.darts.common.entity.ObjectStateRecordEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.common.repository.ObjectStateRecordRepository;
 import uk.gov.hmcts.darts.dets.config.DetsDataManagementConfiguration;
 import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
@@ -33,7 +30,6 @@ import java.util.UUID;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.DETS;
@@ -48,9 +44,7 @@ class DetsToArmBatchProcessResponseFilesIntTest extends AbstractArmBatchProcessR
     private ObjectStateRecordRepository osrRepository;
     @Autowired
     private ExternalDetsDataStoreDeleter externalDetsDataStoreDeleter;
-    @MockBean
-    private DetsDataStoreDeleter detsDataStoreDeleter;
-    
+
     @BeforeEach
     void setupData() {
         armBatchProcessResponseFiles = new DetsToArmBatchProcessResponseFilesImpl(
@@ -64,11 +58,10 @@ class DetsToArmBatchProcessResponseFilesIntTest extends AbstractArmBatchProcessR
             externalObjectDirectoryService,
             logApi,
             detsDataManagementConfiguration,
-            osrRepository,
-            externalDetsDataStoreDeleter
+            osrRepository
         );
     }
-    
+
     @Override
     protected String prefix() {
         return "DETS";
@@ -132,8 +125,6 @@ class DetsToArmBatchProcessResponseFilesIntTest extends AbstractArmBatchProcessR
             .media(media2).status(dartsDatabase.getObjectRecordStatusEntity(ARM_DROP_ZONE))
             .externalLocationType(dartsDatabase.getExternalLocationTypeEntity(DETS)).externalLocation(UUID.randomUUID()).build();
         detsEod2 = dartsPersistence.save(detsEod2);
-
-        doThrow(AzureDeleteBlobException.class).when(detsDataStoreDeleter).delete(detsEod2.getExternalLocation());
 
         ObjectStateRecordEntity osr2 = new ObjectStateRecordEntity();
         osr2.setUuid(2L);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchProcessResponseFilesIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchProcessResponseFilesIntTest.java
@@ -102,7 +102,7 @@ class DetsToArmBatchProcessResponseFilesIntTest extends AbstractArmBatchProcessR
         ExternalObjectDirectoryEntity detsEod1 = PersistableFactory.getExternalObjectDirectoryTestData().someMinimalBuilder()
             .media(media1).status(dartsDatabase.getObjectRecordStatusEntity(ARM_DROP_ZONE))
             .externalLocationType(dartsDatabase.getExternalLocationTypeEntity(DETS)).externalLocation(UUID.randomUUID()).build();
-        detsEod1 = dartsPersistence.save(detsEod1);
+        dartsPersistence.save(detsEod1);
 
         ObjectStateRecordEntity osr1 = new ObjectStateRecordEntity();
         osr1.setUuid(1L);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchProcessResponseFilesIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchProcessResponseFilesIntTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.darts.arm.model.blobs.ContinuationTokenBlobs;
 import uk.gov.hmcts.darts.arm.service.impl.DetsToArmBatchProcessResponseFilesImpl;
-import uk.gov.hmcts.darts.audio.deleter.impl.dets.ExternalDetsDataStoreDeleter;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
@@ -42,8 +41,6 @@ class DetsToArmBatchProcessResponseFilesIntTest extends AbstractArmBatchProcessR
     private DetsDataManagementConfiguration detsDataManagementConfiguration;
     @Autowired
     private ObjectStateRecordRepository osrRepository;
-    @Autowired
-    private ExternalDetsDataStoreDeleter externalDetsDataStoreDeleter;
 
     @BeforeEach
     void setupData() {
@@ -247,10 +244,7 @@ class DetsToArmBatchProcessResponseFilesIntTest extends AbstractArmBatchProcessR
             String.format("DETS_%s_6a374f19a9ce7dc9cc480ea8d4eca0fb_1_iu.rsp", manifest1Uuid));
         assertThat(dbOsr1.getIdResponseCrFile()).isEqualTo("6a374f19a9ce7dc9cc480ea8d4eca0fb_a17b9015-e6ad-77c5-8d1e-13259aae1895_1_cr.rsp");
         assertThat(dbOsr1.getIdResponseUfFile()).isEqualTo("6a374f19a9ce7dc9cc480ea8d4eca0fb_04e6bc3b-952a-79b6-8362-13259aae1895_1_uf.rsp");
-        assertThat(dbOsr1.getFlagFileDetsCleanupStatus()).isTrue();
-        assertThat(dbOsr1.getDateFileDetsCleanup()).isEqualTo(endTime2);
         assertThat(dbOsr1.getObjectStatus()).isNull();
-        assertThat(externalObjectDirectoryRepository.findById(detsEod1.getId())).isEmpty();
 
         ObjectStateRecordEntity dbOsr2 = osrRepository.findByArmEodId(String.valueOf(armEod2.getId())).orElseThrow();
         assertThat(dbOsr2.getFlagRspnRecvdFromArml()).isTrue();

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchProcessResponseFilesImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchProcessResponseFilesImpl.java
@@ -75,9 +75,10 @@ public class DetsToArmBatchProcessResponseFilesImpl extends AbstractArmBatchProc
                                                     armEod,
                                                     objectChecksum);
 
-        getObjectStateRecord(armEod.getId()).ifPresent(osr -> {
-            updateOsrFileIngestStatusToSuccess(batchUploadFileFilenameProcessor, armResponseBatchData, objectChecksum, osr);
-        });
+        getObjectStateRecord(armEod.getId())
+            .ifPresent(osr ->
+                           updateOsrFileIngestStatusToSuccess(batchUploadFileFilenameProcessor, armResponseBatchData, objectChecksum, osr)
+            );
     }
 
     @Override


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4315)


### Change description ###
In DETS to ARM pull process, once the response files are processed and the checksum validation is successful, the record in EOD is marked as 'ARM_RPO_PENDING' alongwith deleting the object from DETS location as well. 

We will have to remove the DETS deletion logic from the current process. The DETS Deletion logic will be put into a new ticket which will delete the DETS object asynchronously.

 

+*Steps:*+

Remove the following logic from DETS to ARM Pull Response logic:
 * {color:#172b4d}Fetch the corresponding DETS record from EOD using the ARM record. Key would be med_id or trd_id. {color}
 * {color:#172b4d}delete the object from  DETS storage using the EDO entity retrieved in previous step{color}
 * {color:#172b4d}delete the record from external_object_directory table where elt_id=4 (DETS){color}
 * {color:#172b4d}update object_state_record table's following attributes:{color}
 ** {color:#172b4d}flag_file_dets_cleanup_status : true{color}
 ** {color:#172b4d}date_file_dets_cleanup : current timestamp{color}

{color:#172b4d}Code Reference :{color}
From DetsToArmBatchProcessResponseFilesImpl.onUploadFileChecksumValidationSuccess method remove deleteBlobDataAndEod call.

*Acceptance Criteria:*

*AC1: Pull DETS Response files* 

GIVEN

I am a system user

WHEN

the Automated job runs every hour AND the Response files exists in ARM

AND 

the response file contain _1_ in the name i.e. SUCCESS

THEN

the process will extract record_id, file_id and md5 checksum from the file which ends with '_UF'

AND

updates the record  external_object_directory with status as '{*}ARM_RPO_PENDING{*}'

AND

the corresponding object should *NOT* get deleted from DETS blob storage.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
