### PR TITLE
DMP-4304 Fixing hidden/deleted audio and transcripts still accessible

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetAdminMediasByIdIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetAdminMediasByIdIntTest.java
@@ -127,7 +127,7 @@ class AudioControllerGetAdminMediasByIdIntTest extends IntegrationBase {
 
     @ParameterizedTest
     @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_USER", "SUPER_ADMIN"}, mode = INCLUDE)
-    void shouldReturnExpectedMediaObjectAndChildrenWithHiddenAndDeletedAndCurrentSetFalse(SecurityRoleEnum role) throws Exception {
+    void shouldReturnExpectedMediaObjectAndChildrenWithHiddenAndCurrentSetFalse(SecurityRoleEnum role) throws Exception {
         // Given
         given.anAuthenticatedUserWithGlobalAccessAndRole(role);
 
@@ -301,10 +301,9 @@ class AudioControllerGetAdminMediasByIdIntTest extends IntegrationBase {
     }
 
     private MediaEntity createAndSaveMediaEntityWithHiddenAndDeletedAndCurrentSetFalse(HearingEntity hearingEntity, UserAccountEntity userAccountEntity) {
-        var mediaEntity = createAndSaveMediaEntity(hearingEntity, userAccountEntity);
+        var mediaEntity = createAndSaveMediaEntity(hearingEntity, userAccountEntity, false);
 
         mediaEntity.setHidden(false);
-        mediaEntity.setDeleted(false);
         mediaEntity.setIsCurrent(false);
 
         return databaseStub.getMediaRepository().save(mediaEntity);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsControllerGetTranscriptsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsControllerGetTranscriptsTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.util.DateConverterUtil;
+import uk.gov.hmcts.darts.hearings.model.Transcript;
 import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
@@ -108,6 +109,20 @@ class HearingsControllerGetTranscriptsTest extends IntegrationBase {
         JSONAssert.assertEquals(expected, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
+    @Test
+    void hearingsGetTranscriptEndpointTranscriptWithHiddenDocumentNotReturned() throws Exception {
+        HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);
+
+        dartsDatabase.getTranscriptionStub().createAndSaveCompletedTranscriptionWithDocument(
+            mockUserIdentity.getUserAccount(), hearingEntity.getCourtCase(), hearingEntity, SOME_DATE_TIME, true
+        );
+
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_HEARINGS, hearingEntity.getId());
+        MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+        Transcript[] transcriptResultList = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), Transcript[].class);
+
+        assertEquals(0, transcriptResultList.length);
+    }
 
     @Test
     void ignoreAutomaticTranscripts() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriptionTest.java
@@ -96,6 +96,34 @@ class TranscriptionControllerGetTranscriptionTest extends IntegrationBase {
         JSONAssert.assertEquals(expected, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
+
+    @Test
+    void getTranscriptionWithHiddenDocumentReturnsNotFound() throws Exception {
+        HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);
+        UserAccountEntity userAccount = hearingEntity.getCreatedBy();
+
+        TranscriptionEntity transcription = dartsDatabase.getTranscriptionStub().createAndSaveCompletedTranscriptionWithDocument(
+            userAccount, hearingEntity.getCourtCase(), hearingEntity, SOME_DATE_TIME, true
+        );
+
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION, transcription.getId());
+        mockMvc.perform(requestBuilder).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void getTranscriptionWithHiddenDocumentCanBeSeenBySuperAdmin() throws Exception {
+        superAdminUserStub.givenUserIsAuthorised(mockUserIdentity);
+        HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);
+        UserAccountEntity userAccount = hearingEntity.getCreatedBy();
+
+        TranscriptionEntity transcription = dartsDatabase.getTranscriptionStub().createAndSaveCompletedTranscriptionWithDocument(
+            userAccount, hearingEntity.getCourtCase(), hearingEntity, SOME_DATE_TIME, true
+        );
+
+        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_TRANSCRIPTION, transcription.getId());
+        mockMvc.perform(requestBuilder).andExpect(status().isOk());
+    }
+
     @Test
     void getTranscriptionWithLegacyComments() throws Exception {
         HearingEntity hearingEntity = dartsDatabase.getHearingRepository().findAll().get(0);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImpl.java
@@ -67,7 +67,7 @@ public class AdminMediaServiceImpl implements AdminMediaService {
     private boolean manualDeletionEnabled;
 
     public AdminMediaResponse getMediasById(Integer id) {
-        var mediaEntity = mediaRepository.findByIdIncludeDeleted(id)
+        var mediaEntity = mediaRepository.findById(id)
             .orElseThrow(() -> new DartsApiException(AudioApiError.MEDIA_NOT_FOUND));
 
         return adminMediaMapper.toApiModel(mediaEntity);

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearing.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearing.java
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.darts.cases.model.Hearing;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
+import uk.gov.hmcts.darts.common.repository.TranscriptionDocumentRepository;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,14 +13,14 @@ import java.util.List;
 @UtilityClass
 public class HearingEntityToCaseHearing {
 
-    public List<Hearing> mapToHearingList(List<HearingEntity> hearingEntities) {
+    public List<Hearing> mapToHearingList(List<HearingEntity> hearingEntities, TranscriptionDocumentRepository transcriptionDocumentRepository) {
 
         List<Hearing> hearings = new ArrayList<>();
 
         if (!hearingEntities.isEmpty()) {
 
             for (HearingEntity entity : hearingEntities) {
-                hearings.add(mapToHearing(entity));
+                hearings.add(mapToHearing(entity, transcriptionDocumentRepository));
             }
 
         }
@@ -28,7 +28,7 @@ public class HearingEntityToCaseHearing {
         return hearings;
     }
 
-    private Hearing mapToHearing(HearingEntity entity) {
+    private Hearing mapToHearing(HearingEntity entity, TranscriptionDocumentRepository transcriptionDocumentRepository) {
 
         Hearing hearing = new Hearing();
 
@@ -41,8 +41,8 @@ public class HearingEntityToCaseHearing {
             .filter(transcriptionEntity -> BooleanUtils.isTrue(transcriptionEntity.getIsManualTranscription())
                 || StringUtils.isNotBlank(transcriptionEntity.getLegacyObjectId())
             )
-            .filter(transcriptionEntity -> transcriptionEntity.getTranscriptionDocumentEntities().isEmpty()
-                || transcriptionEntity.getTranscriptionDocumentEntities().stream().noneMatch(TranscriptionDocumentEntity::isHidden)
+            .filter(transcriptionEntity ->
+                transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionEntity.getId()).isEmpty()
             )
             .toList();
         hearing.setTranscriptCount(transcripts.size());

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -45,6 +45,7 @@ import uk.gov.hmcts.darts.common.repository.AnnotationRepository;
 import uk.gov.hmcts.darts.common.repository.CaseRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
+import uk.gov.hmcts.darts.common.repository.TranscriptionDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionRepository;
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.log.api.LogApi;
@@ -72,6 +73,7 @@ public class CaseServiceImpl implements CaseService {
     private final AdvancedSearchRequestHelper advancedSearchRequestHelper;
     private final AdminCasesSearchRequestHelper adminCasesSearchRequestHelper;
     private final TranscriptionRepository transcriptionRepository;
+    private final TranscriptionDocumentRepository transcriptionDocumentRepository;
     private final AuthorisationApi authorisationApi;
     private final LogApi logApi;
     private final CaseTranscriptionMapper transcriptionMapper;
@@ -111,7 +113,7 @@ public class CaseServiceImpl implements CaseService {
             .filter(HearingEntity::getHearingIsActual)
             .toList();
 
-        return HearingEntityToCaseHearing.mapToHearingList(filteredHearings);
+        return HearingEntityToCaseHearing.mapToHearingList(filteredHearings, transcriptionDocumentRepository);
 
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentRepository.java
@@ -67,4 +67,8 @@ public interface TranscriptionDocumentRepository extends JpaRepository<Transcrip
                WHERE ae.markedForManualDeletion = false AND hr.markedForDeletion = true
         """)
     List<TranscriptionDocumentEntity> getMarkedForDeletion();
+
+    // native query to bypass @SQLRestriction
+    @Query(value = "SELECT trd.* FROM darts.transcription_document trd WHERE trd.tra_id = :trdId AND trd.is_hidden = true", nativeQuery = true)
+    List<TranscriptionDocumentEntity> findByTranscriptionIdAndHiddenTrueIncludeDeleted(Integer trdId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
@@ -77,7 +77,8 @@ public class HearingsServiceImpl implements HearingsService {
     @Override
     public List<Transcript> getTranscriptsByHearingId(Integer hearingId) {
         validateCaseIsNotExpiredFromHearingId(hearingId);
-        List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByHearingIdManualOrLegacy(hearingId);
+        List<TranscriptionEntity> transcriptionEntities =
+            transcriptionRepository.findByHearingIdManualOrLegacyIncludeDeletedTranscriptionDocuments(hearingId);
         List<HearingTranscriptModel> hearingTranscriptModel = transcriptionMapper.mapResponse(transcriptionEntities);
         return transcriptionMapper.getTranscriptList(hearingTranscriptModel);
     }

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -564,8 +564,7 @@ public class TranscriptionServiceImpl implements TranscriptionService {
             .filter(TranscriptionEntity::getIsCurrent)
             // Only SUPER_ADMIN users are allowed to view transcription requests with hidden documents
             .filter(transcriptionEntity -> userIsSuperAdmin
-                || transcriptionEntity.getTranscriptionDocumentEntities().isEmpty()
-                || transcriptionEntity.getTranscriptionDocumentEntities().stream().noneMatch(TranscriptionDocumentEntity::isHidden)
+                || transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionEntity.getId()).isEmpty()
             )
             .orElseThrow(() -> new DartsApiException(TRANSCRIPTION_NOT_FOUND));
         return transcriptionResponseMapper.mapToTranscriptionResponse(transcription);

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearingTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearingTest.java
@@ -24,6 +24,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
@@ -50,7 +53,6 @@ class HearingEntityToCaseHearingTest {
 
     @Test
     void testWorksWithOneHearing() throws Exception {
-
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(1);
 
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
@@ -61,11 +63,12 @@ class HearingEntityToCaseHearingTest {
             "Tests/cases/HearingEntityToCaseHearingTest/testWithSingleHearing/expectedResponse.json");
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
 
+        var transcriptionId = hearings.get(0).getTranscriptions().get(0).getId();
+        verify(transcriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionId);
     }
 
     @Test
     void testMappingToMultipleHearings() throws Exception {
-
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(5);
 
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
@@ -76,6 +79,7 @@ class HearingEntityToCaseHearingTest {
             "Tests/cases/HearingEntityToCaseHearingTest/testWithMultipleHearings/expectedResponse.json");
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
 
+        verify(transcriptionDocumentRepository, times(hearings.size())).findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt());
     }
 
     @Test
@@ -88,6 +92,7 @@ class HearingEntityToCaseHearingTest {
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(0, hearingList.get(0).getTranscriptCount());
+        verifyNoInteractions(transcriptionDocumentRepository);
     }
 
     @Test
@@ -99,6 +104,7 @@ class HearingEntityToCaseHearingTest {
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(1, hearingList.get(0).getTranscriptCount());
+        verify(transcriptionDocumentRepository, times(hearings.size())).findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt());
     }
 
     @Test
@@ -111,6 +117,7 @@ class HearingEntityToCaseHearingTest {
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(1, hearingList.get(0).getTranscriptCount());
+        verify(transcriptionDocumentRepository, times(hearings.size())).findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt());
     }
 
     @Test
@@ -126,6 +133,8 @@ class HearingEntityToCaseHearingTest {
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(0, hearingList.get(0).getTranscriptCount());
+        var transcriptionId = hearings.get(0).getTranscriptions().get(0).getId();
+        verify(transcriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionId);
     }
 
     @Test
@@ -144,6 +153,8 @@ class HearingEntityToCaseHearingTest {
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(0, hearingList.get(0).getTranscriptCount());
+        var transcriptionId = hearings.get(0).getTranscriptions().get(0).getId();
+        verify(transcriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionId);
     }
 
     @Test
@@ -159,6 +170,7 @@ class HearingEntityToCaseHearingTest {
             "Tests/cases/HearingEntityToCaseHearingTest/testWithNoHearings/expectedResponse.json");
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
 
+        verifyNoInteractions(transcriptionDocumentRepository);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearingTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearingTest.java
@@ -2,24 +2,37 @@ package uk.gov.hmcts.darts.cases.mapper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import uk.gov.hmcts.darts.cases.model.Hearing;
 import uk.gov.hmcts.darts.common.config.ObjectMapperConfig;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
+import uk.gov.hmcts.darts.common.repository.TranscriptionDocumentRepository;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
 class HearingEntityToCaseHearingTest {
+
+    @Mock
+    private TranscriptionDocumentRepository transcriptionDocumentRepository;
 
     ObjectMapper objectMapper;
 
@@ -29,12 +42,18 @@ class HearingEntityToCaseHearingTest {
         objectMapper = objectMapperConfig.objectMapper();
     }
 
+    @BeforeEach
+    void beforeEach() {
+        lenient().when(transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt()))
+            .thenReturn(Collections.emptyList());
+    }
+
     @Test
     void testWorksWithOneHearing() throws Exception {
 
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(1);
 
-        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings);
+        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         String actualResponse = objectMapper.writeValueAsString(hearingList);
 
@@ -49,7 +68,7 @@ class HearingEntityToCaseHearingTest {
 
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(5);
 
-        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings);
+        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         String actualResponse = objectMapper.writeValueAsString(hearingList);
 
@@ -66,7 +85,7 @@ class HearingEntityToCaseHearingTest {
         hearingTranscripts.get(0).setIsManualTranscription(false);
         hearingTranscripts.get(0).setLegacyObjectId(null);
 
-        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings);
+        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(0, hearingList.get(0).getTranscriptCount());
     }
@@ -77,7 +96,7 @@ class HearingEntityToCaseHearingTest {
         var hearingTranscripts = hearings.get(0).getTranscriptions();
         hearingTranscripts.get(0).setLegacyObjectId("something");
 
-        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings);
+        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(1, hearingList.get(0).getTranscriptCount());
     }
@@ -89,25 +108,31 @@ class HearingEntityToCaseHearingTest {
         hearingTranscripts.get(0).setIsManualTranscription(false);
         hearingTranscripts.get(0).setLegacyObjectId("something");
 
-        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings);
+        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(1, hearingList.get(0).getTranscriptCount());
     }
 
     @Test
     void testMappingToHearingsWithTranscriptsWithHiddenDocument() {
+        when(transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt()))
+            .thenReturn(List.of(new TranscriptionDocumentEntity()));
+
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(1);
         var hearingTranscripts = hearings.get(0).getTranscriptions();
         var transcriptDocs = hearingTranscripts.get(0).getTranscriptionDocumentEntities();
         transcriptDocs.get(0).setHidden(true);
 
-        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings);
+        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(0, hearingList.get(0).getTranscriptCount());
     }
 
     @Test
     void testMappingToHearingsWithTranscriptsWithOnlyOneHiddenDocument() {
+        when(transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt()))
+            .thenReturn(List.of(new TranscriptionDocumentEntity()));
+
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(1);
         var hearingTranscripts = hearings.get(0).getTranscriptions();
         var transcriptDocs = hearingTranscripts.get(0).getTranscriptionDocumentEntities();
@@ -116,7 +141,7 @@ class HearingEntityToCaseHearingTest {
         transcriptionDocumentEntity.setHidden(true);
         transcriptDocs.add(transcriptionDocumentEntity);
 
-        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings);
+        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(0, hearingList.get(0).getTranscriptCount());
     }
@@ -126,7 +151,7 @@ class HearingEntityToCaseHearingTest {
 
         List<HearingEntity> hearings = new ArrayList<>();
 
-        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings);
+        List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         String actualResponse = objectMapper.writeValueAsString(hearingList);
 

--- a/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
@@ -40,6 +40,7 @@ import uk.gov.hmcts.darts.common.repository.CaseRetentionRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.HearingReportingRestrictionsRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
+import uk.gov.hmcts.darts.common.repository.TranscriptionDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionRepository;
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
@@ -106,6 +107,8 @@ class CaseServiceImplTest {
 
     @Mock
     TranscriptionRepository transcriptionRepository;
+    @Mock
+    TranscriptionDocumentRepository transcriptionDocumentRepository;
     @Captor
     ArgumentCaptor<CourtCaseEntity> caseEntityArgumentCaptor;
 
@@ -138,6 +141,7 @@ class CaseServiceImplTest {
             advancedSearchRequestHelper,
             adminCasesSearchRequestHelper,
             transcriptionRepository,
+            transcriptionDocumentRepository,
             authorisationApi,
             logApi,
             new CaseTranscriptionMapper()

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionDownloaderTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionDownloaderTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+import uk.gov.hmcts.darts.common.repository.TranscriptionDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionRepository;
 import uk.gov.hmcts.darts.datamanagement.exception.FileNotDownloadedException;
 
@@ -37,6 +38,7 @@ import static java.util.stream.IntStream.rangeClosed;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -54,6 +56,8 @@ class TranscriptionDownloaderTest {
     @Mock
     private TranscriptionRepository transcriptionRepository;
     @Mock
+    private TranscriptionDocumentRepository transcriptionDocumentRepository;
+    @Mock
     private DataManagementFacade dataManagementFacade;
     @Mock
     private AuditApi auditApi;
@@ -66,7 +70,10 @@ class TranscriptionDownloaderTest {
 
     @BeforeEach
     void setUp() {
-        transcriptionDownloader = new TranscriptionDownloader(transcriptionRepository, dataManagementFacade, auditApi, userIdentity);
+        transcriptionDownloader = new TranscriptionDownloader(
+            transcriptionRepository, transcriptionDocumentRepository,
+            dataManagementFacade, auditApi, userIdentity
+        );
 
         var testUser = new UserAccountEntity();
         testUser.setEmailAddress("test.user@example.com");
@@ -172,6 +179,9 @@ class TranscriptionDownloaderTest {
 
     @Test
     void throwsNotFoundExceptionIfTranscriptionDocumentHiddenAndUserIsNotSuperAdmin() {
+        when(transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt()))
+            .thenReturn(List.of(new TranscriptionDocumentEntity()));
+
         var transcriptionDocuments = someTranscriptionDocumentsUploadedAtLeast2DaysAgo(1);
         transcriptionDocuments.get(0).setHidden(true);
 

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionDownloaderTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionDownloaderTest.java
@@ -192,6 +192,7 @@ class TranscriptionDownloaderTest {
             .isExactlyInstanceOf(DartsApiException.class)
             .hasFieldOrPropertyWithValue("error", TRANSCRIPTION_NOT_FOUND);
 
+        verify(transcriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcription.getId());
         verifyNoInteractions(dataManagementFacade);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
@@ -676,6 +676,7 @@ class TranscriptionServiceImplTest {
         assertThatThrownBy(() -> transcriptionService.getTranscription(transcriptionId))
             .isExactlyInstanceOf(DartsApiException.class)
             .hasFieldOrPropertyWithValue("error", TRANSCRIPTION_NOT_FOUND);
+        verify(mockTranscriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionId);
     }
 
     private TranscriptionRequestDetails createTranscriptionRequestDetails(Integer hearingId,

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.TranscriptionCommentRepository;
+import uk.gov.hmcts.darts.common.repository.TranscriptionDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionStatusRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionTypeRepository;
@@ -47,6 +48,7 @@ import uk.gov.hmcts.darts.transcriptions.model.TranscriptionRequestDetails;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -56,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
@@ -81,6 +84,8 @@ class TranscriptionServiceImplTest {
 
     @Mock
     private TranscriptionRepository mockTranscriptionRepository;
+    @Mock
+    private TranscriptionDocumentRepository mockTranscriptionDocumentRepository;
     @Mock
     private TranscriptionStatusRepository mockTranscriptionStatusRepository;
     @Mock
@@ -171,6 +176,8 @@ class TranscriptionServiceImplTest {
         approvers.add(approver2);
 
         lenient().when(authorisationApi.getUsersWithRoleAtCourthouse(eq(SecurityRoleEnum.APPROVER), any())).thenReturn(approvers);
+        lenient().when(mockTranscriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt()))
+            .thenReturn(Collections.emptyList());
     }
 
     private void updateManualDeletion(boolean manualDeletionEnabled) {
@@ -658,10 +665,13 @@ class TranscriptionServiceImplTest {
         var transcriptionId = 1;
         var transcription = new TranscriptionEntity();
         transcription.setIsCurrent(true);
+        transcription.setId(transcriptionId);
         var transcriptionDocument = new TranscriptionDocumentEntity();
         transcriptionDocument.setHidden(true);
         transcription.setTranscriptionDocumentEntities(List.of(transcriptionDocument));
         when(mockTranscriptionRepository.findById(transcriptionId)).thenReturn(Optional.of(transcription));
+        when(mockTranscriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt()))
+            .thenReturn(List.of(new TranscriptionDocumentEntity()));
 
         assertThatThrownBy(() -> transcriptionService.getTranscription(transcriptionId))
             .isExactlyInstanceOf(DartsApiException.class)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4304

### Change description ###

This PR fixes the following issues
- Audio file detail still visible to admin after the file is deleted by manual deletion job
- Transcription request for deleted document is still visible on the user portal

**Changes**

[Prevent viewing deleted audio files](https://github.com/hmcts/darts-api/commit/7f283524f338492dc8913e33a0ac34c6f8fdbd66)

[Fix for preventing viewing of transcription requests with deleted documents](https://github.com/hmcts/darts-api/commit/8a679a511dd909313087914ed2283b7accbef062) 

- document is not fetched by default once deleted due to the SQLRestriction
- override this with a custom query to detect hidden documents, even when deleted
- if any are found, the transcription request should not be viewable
- extending this fix for hearing transcript counts and transcription get document

[Fixing hearing transcripts endpoint](https://github.com/hmcts/darts-api/pull/2297/commits/97cff97eca09e8dfcc8c88134572b7cea15efa00) 

- to only return transcripts which have no hidden documents

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
