### PR TITLE
DMP-4461: ArmMissingResponseFile Task not processing any EOD records

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/arm/helper/ArmResponseFileHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/helper/ArmResponseFileHelper.java
@@ -55,7 +55,7 @@ public class ArmResponseFileHelper {
                 responseList.add(inputUploadAndAssociatedFilenames);
             }
         } else {
-            log.warn("Manifest filename format of ''{}'' not recognised", manifestFileName);
+            log.warn("Manifest filename format of '{}' not recognised", manifestFileName);
         }
         return responseList;
     }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmMissingResponseCleanupImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmMissingResponseCleanupImpl.java
@@ -36,7 +36,7 @@ public class ArmMissingResponseCleanupImpl extends BatchCleanupArmResponseFilesS
                                          ArmResponseFileHelper armResponseFileHelper) {
         super(externalObjectDirectoryRepository, objectRecordStatusRepository, externalLocationTypeRepository, armDataManagementApi, userIdentity,
               batchCleanupConfiguration, armDataManagementConfiguration, currentTimeHelper, armResponseFileHelper,
-              "ArmMissingResponseCleanup");
+              "", "ArmMissingResponseCleanup");
         this.armRawDataFailed = objectRecordStatusRepository.getReferenceById(ARM_RAW_DATA_FAILED.getId());
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
@@ -50,6 +50,21 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
     protected final String manifestFilePrefix;
     protected final String loggingPrefix;
 
+    public BatchCleanupArmResponseFilesServiceCommon(ExternalObjectDirectoryRepository externalObjectDirectoryRepository,
+                                                     ObjectRecordStatusRepository objectRecordStatusRepository,
+                                                     ExternalLocationTypeRepository externalLocationTypeRepository,
+                                                     ArmDataManagementApi armDataManagementApi,
+                                                     UserIdentity userIdentity,
+                                                     ArmBatchCleanupConfiguration batchCleanupConfiguration,
+                                                     ArmDataManagementConfiguration armDataManagementConfiguration,
+                                                     CurrentTimeHelper currentTimeHelper,
+                                                     ArmResponseFileHelper armResponseFileHelper,
+                                                     String manifestFilePrefix) {
+        this(externalObjectDirectoryRepository, objectRecordStatusRepository, externalLocationTypeRepository, armDataManagementApi, userIdentity,
+             batchCleanupConfiguration, armDataManagementConfiguration, currentTimeHelper, armResponseFileHelper,
+             manifestFilePrefix, manifestFilePrefix);
+    }
+
 
     @Override
     public void cleanupResponseFiles(int batchsize) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/BatchCleanupArmResponseFilesServiceCommon.java
@@ -48,18 +48,19 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
     protected final CurrentTimeHelper currentTimeHelper;
     protected final ArmResponseFileHelper armResponseFileHelper;
     protected final String manifestFilePrefix;
+    protected final String loggingPrefix;
 
 
     @Override
     public void cleanupResponseFiles(int batchsize) {
         if (batchsize == 0) {
-            log.warn("{}: Batch Cleanup ARM Response Files - Batch size is 0, so not running", manifestFilePrefix);
+            log.warn("{}: Batch Cleanup ARM Response Files - Batch size is 0, so not running", loggingPrefix);
             return;
         }
 
         List<String> manifestFilenames = getManifestFileNames(batchsize);
         if (manifestFilenames.isEmpty()) {
-            log.info("{}: Batch Cleanup ARM Response Files - 0 rows returned, so stopping.", manifestFilePrefix);
+            log.info("{}: Batch Cleanup ARM Response Files - 0 rows returned, so stopping.", loggingPrefix);
             return;
         }
         OffsetDateTime dateTimeForDeletion = getDateTimeForDeletion();
@@ -68,13 +69,13 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
             int counter = 1;
             UserAccountEntity userAccount = userIdentity.getUserAccount();
             for (String manifestFilename : manifestFilenames) {
-                log.info("{}: Batch Cleanup ARM Response Files - about to process manifest filename {}, row {} of {} rows", manifestFilePrefix,
+                log.info("{}: Batch Cleanup ARM Response Files - about to process manifest filename {}, row {} of {} rows", loggingPrefix,
                          manifestFilename, counter++,
                          manifestFilenames.size());
                 cleanupFilesByManifestFilename(userAccount, EodHelper.armLocation(), statusToSearch, dateTimeForDeletion, manifestFilename);
             }
         } else {
-            log.info("{}: No ARM responses found to be deleted", manifestFilePrefix);
+            log.info("{}: No ARM responses found to be deleted", loggingPrefix);
         }
     }
 
@@ -103,24 +104,24 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
                                                 List<ObjectRecordStatusEntity> statusToSearch,
                                                 OffsetDateTime dateTimeForDeletion, String manifestFilename) {
         try {
-            log.debug("{}: Finding associated eodEntries for manifest filename {}", manifestFilePrefix, manifestFilename);
+            log.debug("{}: Finding associated eodEntries for manifest filename {}", loggingPrefix, manifestFilename);
             List<ExternalObjectDirectoryEntity> eodEntriesWithManifestFilename = externalObjectDirectoryRepository.findBatchCleanupEntriesByManifestFilename(
                 armLocation, false, manifestFilename);
 
             List<Integer> statusIdList = statusToSearch.stream().map(ObjectRecordStatusEntity::getId).toList();
             boolean statusAllValid = eodEntriesWithManifestFilename.stream().allMatch(eodEntity -> statusIdList.contains(eodEntity.getStatusId()));
             if (!statusAllValid) {
-                log.warn("{}: Not all statuses are valid for manifestFilename {}, so skipping to next manifestFilename.", manifestFilePrefix, manifestFilename);
+                log.warn("{}: Not all statuses are valid for manifestFilename {}, so skipping to next manifestFilename.", loggingPrefix, manifestFilename);
             }
 
             boolean lastModifiedAllValid = eodEntriesWithManifestFilename.stream().allMatch(
                 eodEntity -> eodEntity.getLastModifiedDateTime().isBefore(dateTimeForDeletion));
             if (!lastModifiedAllValid) {
                 log.warn("{}: Not all entries have been modified before {} for manifestFilename {}, so skipping to next manifestFilename.",
-                         manifestFilePrefix, dateTimeForDeletion, manifestFilename);
+                         loggingPrefix, dateTimeForDeletion, manifestFilename);
             }
 
-            log.debug("{}: Found ARM manifest file {} for cleanup", manifestFilePrefix, manifestFilename);
+            log.debug("{}: Found ARM manifest file {} for cleanup", loggingPrefix, manifestFilename);
             List<InputUploadAndAssociatedFilenames> inputUploadAndAssociatedList = armResponseFileHelper.getCorrespondingArmFilesForManifestFilename(
                 manifestFilePrefix, manifestFilename);
             //inputUploadAndAssociatedList should only contain 1 matching InputUpload file, but looping through it just in case.
@@ -129,7 +130,7 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
             }
 
         } catch (UnableToReadArmFileException e) {
-            log.error("{}: Cannot process manifest filename {} due to corrupt ARM file.", manifestFilePrefix, manifestFilename);
+            log.error("{}: Cannot process manifest filename {} due to corrupt ARM file.", loggingPrefix, manifestFilename);
         }
 
     }
@@ -144,19 +145,19 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
             Integer eodId = eodIdAndAssociatedFilenames.getEodId();
             List<String> associatedFiles = eodIdAndAssociatedFilenames.getAssociatedFiles();
             log.info("{}: There are {} response files for EOD {}, linked to inputUpload filename {}",
-                     manifestFilePrefix, associatedFiles.size(), eodId, inputUploadFilename);
+                     loggingPrefix, associatedFiles.size(), eodId, inputUploadFilename);
 
             for (String associatedFile : associatedFiles) {
                 try {
-                    log.info("{}: About to delete file {} for EOD {}, linked to inputUpload filename {}", manifestFilePrefix, associatedFile, eodId,
+                    log.info("{}: About to delete file {} for EOD {}, linked to inputUpload filename {}", loggingPrefix, associatedFile, eodId,
                              inputUploadFilename);
                     boolean responseFileDeletedSuccessfully = armDataManagementApi.deleteBlobData(associatedFile);
                     if (!responseFileDeletedSuccessfully) {
-                        log.warn("{}: Response file {} failed to delete successfully.", manifestFilePrefix, associatedFile);
+                        log.warn("{}: Response file {} failed to delete successfully.", loggingPrefix, associatedFile);
                         successfullyDeletedAssociatedFiles = false;
                     }
                 } catch (Exception e) {
-                    log.error("{}: Failure to delete response file {} for EOD {} - {}", manifestFilePrefix, associatedFile, eodId, e.getMessage(), e);
+                    log.error("{}: Failure to delete response file {} for EOD {} - {}", loggingPrefix, associatedFile, eodId, e.getMessage(), e);
                     successfullyDeletedAssociatedFiles = false;
                 }
                 if (!successfullyDeletedAssociatedFiles) {
@@ -167,7 +168,7 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
             if (successfullyDeletedAssociatedFiles) {
                 Optional<ExternalObjectDirectoryEntity> eodEntityOpt = externalObjectDirectoryRepository.findById(eodId);
                 if (eodEntityOpt.isEmpty()) {
-                    log.error("{}: EodEntity {} in response file for {} cannot be found.", manifestFilePrefix, eodId, inputUploadFilename);
+                    log.error("{}: EodEntity {} in response file for {} cannot be found.", loggingPrefix, eodId, inputUploadFilename);
                     break;
                 }
                 ExternalObjectDirectoryEntity eodEntityFromRelationId = eodEntityOpt.get();
@@ -183,7 +184,7 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
 
                 if (!matchesEodWithManifestFile) {
                     log.warn("{}: Deleted arm response file is not associated with any eodEntity with manifest file {}, but mentions relationId {}.",
-                             manifestFilePrefix, inputUploadFilename, eodEntityFromRelationId);
+                             loggingPrefix, inputUploadFilename, eodEntityFromRelationId);
                 }
                 setResponseCleaned(userAccount, eodEntityFromRelationId);
             }
@@ -191,21 +192,21 @@ public class BatchCleanupArmResponseFilesServiceCommon implements BatchCleanupAr
 
         if (CollectionUtils.isNotEmpty(eodEntriesWithManifestFilename)) {
             log.warn("{}: All ARM response files related to InputUpload file {} have been deleted, but none referred to the following eodId's - {}.",
-                     manifestFilePrefix, inputUploadFilename, eodEntriesWithManifestFilename.stream().map(ExternalObjectDirectoryEntity::getId).toList());
+                     loggingPrefix, inputUploadFilename, eodEntriesWithManifestFilename.stream().map(ExternalObjectDirectoryEntity::getId).toList());
         }
 
         if (deletedFileStatuses.stream().allMatch(Boolean.TRUE::equals)) {
-            log.info("{}: All associated Eod entries deleted, about to delete InputUpload file {}", manifestFilePrefix, inputUploadFilename);
+            log.info("{}: All associated Eod entries deleted, about to delete InputUpload file {}", loggingPrefix, inputUploadFilename);
             // Make sure to only delete the Input Upload filename after the other response files have been deleted as once this is deleted
             // you cannot find the other response files
             boolean inputUploadFileDeletedSuccessfully = armDataManagementApi.deleteBlobData(inputUploadFilename);
             if (inputUploadFileDeletedSuccessfully) {
-                log.info("{}: Successfully cleaned up response files for InputUpload file {}", manifestFilePrefix, inputUploadFilename);
+                log.info("{}: Successfully cleaned up response files for InputUpload file {}", loggingPrefix, inputUploadFilename);
             } else {
-                log.warn("{}: Unable to delete input upload response file {}", manifestFilePrefix, inputUploadFilename);
+                log.warn("{}: Unable to delete input upload response file {}", loggingPrefix, inputUploadFilename);
             }
         } else {
-            log.warn("{}: Unable to delete all response files for InputUpload file {}", manifestFilePrefix, inputUploadFilename);
+            log.warn("{}: Unable to delete all response files for InputUpload file {}", loggingPrefix, inputUploadFilename);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImpl.java
@@ -24,7 +24,7 @@ public class DartsBatchCleanupArmResponseFilesServiceImpl extends BatchCleanupAr
                                                         ArmResponseFileHelper armResponseFileHelper) {
         super(externalObjectDirectoryRepository, objectRecordStatusRepository, externalLocationTypeRepository, armDataManagementApi, userIdentity,
               batchCleanupConfiguration, armDataManagementConfiguration, currentTimeHelper, armResponseFileHelper,
-              armDataManagementConfiguration.getManifestFilePrefix()
+              armDataManagementConfiguration.getManifestFilePrefix(), armDataManagementConfiguration.getManifestFilePrefix()
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImpl.java
@@ -24,7 +24,7 @@ public class DartsBatchCleanupArmResponseFilesServiceImpl extends BatchCleanupAr
                                                         ArmResponseFileHelper armResponseFileHelper) {
         super(externalObjectDirectoryRepository, objectRecordStatusRepository, externalLocationTypeRepository, armDataManagementApi, userIdentity,
               batchCleanupConfiguration, armDataManagementConfiguration, currentTimeHelper, armResponseFileHelper,
-              armDataManagementConfiguration.getManifestFilePrefix(), armDataManagementConfiguration.getManifestFilePrefix()
+              armDataManagementConfiguration.getManifestFilePrefix()
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImpl.java
@@ -26,7 +26,7 @@ public class DetsBatchCleanupArmResponseFilesServiceImpl extends BatchCleanupArm
                                                        @Value("${darts.storage.dets.dets-manifest-file-prefix}") String manifestFilePrefix) {
         super(externalObjectDirectoryRepository, objectRecordStatusRepository, externalLocationTypeRepository, armDataManagementApi, userIdentity,
               batchCleanupConfiguration, armDataManagementConfiguration, currentTimeHelper, armResponseFileHelper,
-              manifestFilePrefix, manifestFilePrefix
+              manifestFilePrefix
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImpl.java
@@ -17,16 +17,16 @@ public class DetsBatchCleanupArmResponseFilesServiceImpl extends BatchCleanupArm
 
 
     public DetsBatchCleanupArmResponseFilesServiceImpl(ExternalObjectDirectoryRepository externalObjectDirectoryRepository,
-                                                         ObjectRecordStatusRepository objectRecordStatusRepository,
-                                                         ExternalLocationTypeRepository externalLocationTypeRepository,
-                                                         ArmDataManagementApi armDataManagementApi,
-                                                         UserIdentity userIdentity, ArmBatchCleanupConfiguration batchCleanupConfiguration,
-                                                         ArmDataManagementConfiguration armDataManagementConfiguration, CurrentTimeHelper currentTimeHelper,
-                                                         ArmResponseFileHelper armResponseFileHelper,
-                                                         @Value("${darts.storage.dets.dets-manifest-file-prefix}") String manifestFilePrefix) {
+                                                       ObjectRecordStatusRepository objectRecordStatusRepository,
+                                                       ExternalLocationTypeRepository externalLocationTypeRepository,
+                                                       ArmDataManagementApi armDataManagementApi,
+                                                       UserIdentity userIdentity, ArmBatchCleanupConfiguration batchCleanupConfiguration,
+                                                       ArmDataManagementConfiguration armDataManagementConfiguration, CurrentTimeHelper currentTimeHelper,
+                                                       ArmResponseFileHelper armResponseFileHelper,
+                                                       @Value("${darts.storage.dets.dets-manifest-file-prefix}") String manifestFilePrefix) {
         super(externalObjectDirectoryRepository, objectRecordStatusRepository, externalLocationTypeRepository, armDataManagementApi, userIdentity,
               batchCleanupConfiguration, armDataManagementConfiguration, currentTimeHelper, armResponseFileHelper,
-              manifestFilePrefix
+              manifestFilePrefix, manifestFilePrefix
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/AbstractBatchCleanupArmResponseFilesServiceCommonTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/AbstractBatchCleanupArmResponseFilesServiceCommonTest.java
@@ -106,6 +106,7 @@ class AbstractBatchCleanupArmResponseFilesServiceCommonTest {
             armDataManagementConfiguration,
             currentTimeHelper,
             armResponseFileHelper,
+            MANIFEST_FILE_PREFIX,
             MANIFEST_FILE_PREFIX
         );
 

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmMissingResponseCleanupImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmMissingResponseCleanupImplTest.java
@@ -93,7 +93,8 @@ class ArmMissingResponseCleanupImplTest {
             .hasFieldOrPropertyWithValue("armDataManagementConfiguration", armDataManagementConfiguration)
             .hasFieldOrPropertyWithValue("currentTimeHelper", currentTimeHelper)
             .hasFieldOrPropertyWithValue("armResponseFileHelper", armResponseFileHelper)
-            .hasFieldOrPropertyWithValue("manifestFilePrefix", "ArmMissingResponseCleanup")
+            .hasFieldOrPropertyWithValue("loggingPrefix", "ArmMissingResponseCleanup")
+            .hasFieldOrPropertyWithValue("manifestFilePrefix", "")
             .hasFieldOrPropertyWithValue("armRawDataFailed", armRawDataFailedObjectRecordStatus);
         verify(objectRecordStatusRepository).getReferenceById(ARM_RAW_DATA_FAILED.getId());
     }

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImplTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -58,7 +59,7 @@ class DartsBatchCleanupArmResponseFilesServiceImplTest {
             armResponseFileHelper
         );
 
-        verify(armDataManagementConfiguration).getManifestFilePrefix();
+        verify(armDataManagementConfiguration, times(2)).getManifestFilePrefix();
 
         assertThat(cleanupArmResponseFilesService)
             .hasFieldOrPropertyWithValue("externalObjectDirectoryRepository", externalObjectDirectoryRepository)
@@ -70,6 +71,7 @@ class DartsBatchCleanupArmResponseFilesServiceImplTest {
             .hasFieldOrPropertyWithValue("armDataManagementConfiguration", armDataManagementConfiguration)
             .hasFieldOrPropertyWithValue("currentTimeHelper", currentTimeHelper)
             .hasFieldOrPropertyWithValue("armResponseFileHelper", armResponseFileHelper)
+            .hasFieldOrPropertyWithValue("loggingPrefix", MANIFEST_FILE_PREFIX)
             .hasFieldOrPropertyWithValue("manifestFilePrefix", MANIFEST_FILE_PREFIX);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DartsBatchCleanupArmResponseFilesServiceImplTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -59,7 +58,7 @@ class DartsBatchCleanupArmResponseFilesServiceImplTest {
             armResponseFileHelper
         );
 
-        verify(armDataManagementConfiguration, times(2)).getManifestFilePrefix();
+        verify(armDataManagementConfiguration).getManifestFilePrefix();
 
         assertThat(cleanupArmResponseFilesService)
             .hasFieldOrPropertyWithValue("externalObjectDirectoryRepository", externalObjectDirectoryRepository)

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsBatchCleanupArmResponseFilesServiceImplTest.java
@@ -68,6 +68,7 @@ class DetsBatchCleanupArmResponseFilesServiceImplTest {
             .hasFieldOrPropertyWithValue("armDataManagementConfiguration", armDataManagementConfiguration)
             .hasFieldOrPropertyWithValue("currentTimeHelper", currentTimeHelper)
             .hasFieldOrPropertyWithValue("armResponseFileHelper", armResponseFileHelper)
+            .hasFieldOrPropertyWithValue("loggingPrefix", MANIFEST_FILE_PREFIX)
             .hasFieldOrPropertyWithValue("manifestFilePrefix", MANIFEST_FILE_PREFIX);
     }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4461)


### Change description ###

Introduces several updates primarily focused on refining logging practices within the codebase. Key changes include adjustments to the logging prefix, modifications to the constructor parameters, and consistent application of the new logging prefix in various logging statements.

## Highlights

- **Logging Prefix Update**: 
  - A new variable  `loggingPrefix` was added to replace instances where `manifestFilePrefix`  was used for log prefixs.

- **Constructor Modifications**: 
  - Constructors in several classes have been updated to accept an additional `loggingPrefix` parameter, streamlining the logging process.

- **Log Statement Changes**: 
  - Numerous logging statements have been adjusted to utilize the new `loggingPrefix` for consistency and clarity.

- **Test Adjustments**: 
  - Corresponding updates were made in test classes to ensure they align with changes in constructors and logging practices.

- **String Formatting Fix**: 
  - One specific change in `ArmResponseFileHelper.java` corrected the string formatting in a log warning statement.

These modifications aim to enhance the maintainability of the code and improve the clarity of log outputs across the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
