### PR TITLE
DMP-4437: Performance Testing - Automated Tasks - UnstructuredToArmDataStore - Running a batch size of 10,000 doesn't seem to be working

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/arm/helper/DataStoreToArmHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/helper/DataStoreToArmHelper.java
@@ -55,25 +55,25 @@ public class DataStoreToArmHelper {
     private final ArchiveRecordFileGenerator archiveRecordFileGenerator;
 
 
-    public List<ExternalObjectDirectoryEntity> getEodEntitiesToSendToArm(ExternalLocationTypeEntity sourceLocation,
+    public List<Integer> getEodEntitiesToSendToArm(ExternalLocationTypeEntity sourceLocation,
                                                                          ExternalLocationTypeEntity armLocation, int maxResultSize) {
         ObjectRecordStatusEntity armRawStatusFailed = objectRecordStatusRepository.getReferenceById(ARM_RAW_DATA_FAILED.getId());
         ObjectRecordStatusEntity armManifestFailed = objectRecordStatusRepository.getReferenceById(ARM_MANIFEST_FAILED.getId());
 
         List<ObjectRecordStatusEntity> failedArmStatuses = List.of(armRawStatusFailed, armManifestFailed);
 
-        var failedArmExternalObjectDirectoryEntities = externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocation(
+        var failedArmExternalObjectDirectoryEntities = externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocationIds(
             failedArmStatuses,
             armLocation,
             armDataManagementConfiguration.getMaxRetryAttempts(),
             Pageable.ofSize(maxResultSize)
         );
 
-        List<ExternalObjectDirectoryEntity> returnList = new ArrayList<>(failedArmExternalObjectDirectoryEntities);
+        List<Integer> returnList = new ArrayList<>(failedArmExternalObjectDirectoryEntities);
 
         int remainingBatchSizeEods = maxResultSize - failedArmExternalObjectDirectoryEntities.size();
         if (remainingBatchSizeEods > 0) {
-            var pendingUnstructuredExternalObjectDirectoryEntities = externalObjectDirectoryRepository.findEodsNotInOtherStorage(
+            var pendingUnstructuredExternalObjectDirectoryEntities = externalObjectDirectoryRepository.findEodsNotInOtherStorageIds(
                 EodHelper.storedStatus(), sourceLocation,
                 EodHelper.armLocation(),
                 remainingBatchSizeEods);

--- a/src/test/java/uk/gov/hmcts/darts/arm/helper/DataStoreToArmHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/helper/DataStoreToArmHelperTest.java
@@ -104,16 +104,16 @@ class DataStoreToArmHelperTest {
         ObjectRecordStatusEntity armRawStatusFailed = mock(ObjectRecordStatusEntity.class);
         ObjectRecordStatusEntity armManifestFailed = mock(ObjectRecordStatusEntity.class);
         when(objectRecordStatusRepository.getReferenceById(anyInt())).thenReturn(armRawStatusFailed).thenReturn(armManifestFailed);
-        when(externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocation(anyList(), any(), anyInt(), any(Pageable.class)))
-            .thenReturn(List.of(mock(ExternalObjectDirectoryEntity.class)));
+        when(externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocationIds(anyList(), any(), anyInt(), any(Pageable.class)))
+            .thenReturn(List.of(123));
         when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(3);
 
         // when
-        List<ExternalObjectDirectoryEntity> result = dataStoreToArmHelper.getEodEntitiesToSendToArm(sourceLocation, armLocation, 5);
+        List<Integer> result = dataStoreToArmHelper.getEodEntitiesToSendToArm(sourceLocation, armLocation, 5);
 
         // then
         assertNotNull(result);
-        verify(externalObjectDirectoryRepository).findNotFinishedAndNotExceededRetryInStorageLocation(anyList(), any(), anyInt(), any(Pageable.class));
+        verify(externalObjectDirectoryRepository).findNotFinishedAndNotExceededRetryInStorageLocationIds(anyList(), any(), anyInt(), any(Pageable.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmBatchProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmBatchProcessorTest.java
@@ -136,13 +136,15 @@ class UnstructuredToArmBatchProcessorTest {
 
     @Test
     void testDartsArmClientConfigInBatchQuery() {
+
         ExternalObjectDirectoryEntity eod10 = new ExternalObjectDirectoryEntity();
         eod10.setId(10);
         eod10.setExternalLocationType(EodHelper.armLocation());
         eod10.setStatus(EodHelper.failedArmManifestFileStatus());
         //given
-        when(externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocation(any(), any(), any(), any())).thenReturn(List.of(eod10));
-        when(externalObjectDirectoryRepository.findEodsNotInOtherStorage(any(), any(), any(), any())).thenReturn(emptyList());
+        when(externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocationIds(any(), any(), any(), any())).thenReturn(List.of(10));
+        when(externalObjectDirectoryRepository.findAllById(List.of(10))).thenReturn(List.of(eod10));
+        when(externalObjectDirectoryRepository.findEodsNotInOtherStorageIds(any(), any(), any(), any())).thenReturn(emptyList());
         ExternalLocationTypeEntity armLocation = mock(ExternalLocationTypeEntity.class);
         when(armLocation.getId()).thenReturn(ExternalLocationTypeEnum.ARM.getId());
         EOD_HELPER_MOCKS.simulateInitWithMockedData(mock(ObjectRecordStatusEntity.class), armLocation);
@@ -150,11 +152,12 @@ class UnstructuredToArmBatchProcessorTest {
         when(unstructuredToArmProcessorConfiguration.getThreads()).thenReturn(20);
         when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(3);
 
+
         //when
         unstructuredToArmBatchProcessor.processUnstructuredToArm(200);
 
         //then
-        verify(externalObjectDirectoryRepository).findEodsNotInOtherStorage(
+        verify(externalObjectDirectoryRepository).findEodsNotInOtherStorageIds(
             EodHelper.storedStatus(),
             EodHelper.unstructuredLocation(),
             EodHelper.armLocation(), 199
@@ -166,8 +169,8 @@ class UnstructuredToArmBatchProcessorTest {
     @Test
     void testPaginatedBatchQuery() throws IOException {
         //given
-        when(externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocation(any(), any(), any(), any())).thenReturn(List.of(eod1, eod2));
-        when(externalObjectDirectoryRepository.findEodsNotInOtherStorage(any(), any(), any(), any())).thenReturn(emptyList());
+        when(externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocationIds(any(), any(), any(), any())).thenReturn(List.of(12, 34));
+        when(externalObjectDirectoryRepository.findEodsNotInOtherStorageIds(any(), any(), any(), any())).thenReturn(emptyList());
         when(unstructuredToArmProcessorConfiguration.getMaxArmManifestItems()).thenReturn(100);
         when(unstructuredToArmProcessorConfiguration.getThreads()).thenReturn(20);
         when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(3);
@@ -178,13 +181,13 @@ class UnstructuredToArmBatchProcessorTest {
         unstructuredToArmBatchProcessor.processUnstructuredToArm(5000);
 
         //then
-        verify(externalObjectDirectoryRepository).findNotFinishedAndNotExceededRetryInStorageLocation(
+        verify(externalObjectDirectoryRepository).findNotFinishedAndNotExceededRetryInStorageLocationIds(
             any(),
             any(ExternalLocationTypeEntity.class),
             eq(3),
             eq(Pageable.ofSize(5000)));
 
-        verify(externalObjectDirectoryRepository).findEodsNotInOtherStorage(
+        verify(externalObjectDirectoryRepository).findEodsNotInOtherStorageIds(
             EodHelper.storedStatus(),
             EodHelper.unstructuredLocation(),
             EodHelper.armLocation(), 4998
@@ -199,7 +202,7 @@ class UnstructuredToArmBatchProcessorTest {
         when(armDataManagementConfiguration.getManifestFilePrefix()).thenReturn("DARTS");
         when(armDataManagementConfiguration.getFileExtension()).thenReturn("a360");
         when(armDataManagementConfiguration.getTempBlobWorkspace()).thenReturn("/temp_workspace");
-        when(externalObjectDirectoryRepository.findEodsNotInOtherStorage(any(), any(), any(), any())).thenReturn(List.of(eod1));
+        when(externalObjectDirectoryRepository.findEodsNotInOtherStorageIds(any(), any(), any(), any())).thenReturn(List.of(123));
         when(unstructuredToArmProcessorConfiguration.getMaxArmManifestItems()).thenReturn(1000);
         when(unstructuredToArmProcessorConfiguration.getThreads()).thenReturn(20);
         when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(3);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4437)


### Change description ###
# Summary of Git Diff

This Git Diff reflects modifications made to the Java classes involved in the DataStore to ARM (Automated Resource Management) integration. Key changes include updates to method signatures and repository queries to improve data handling efficiency by utilizing IDs instead of full entity objects.

## Highlights

- **Method Signature Changes**:
  - `getEodEntitiesToSendToArm` now returns a `List<Integer>` of IDs instead of a `List<ExternalObjectDirectoryEntity>`.

- **Repository Query Updates**:
  - The repository methods were modified to fetch only IDs:
    - `findNotFinishedAndNotExceededRetryInStorageLocation` is replaced with `findNotFinishedAndNotExceededRetryInStorageLocationIds`.
    - `findEodsNotInOtherStorage` is replaced with `findEodsNotInOtherStorageIds`.

- **Batch Processing Changes**:
  - Adjustments in the `processUnstructuredToArm` method to handle batches of IDs instead of entity objects.

- **Test Adjustments**:
  - Unit tests were updated to reflect changes in method returns and repository calls, ensuring they now work with ID lists.

These updates streamline the data processing and enhance performance by reducing the overhead associated with entity management in the transfer process.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
