### PR TITLE
DMP-4462 ARM RPO createExportBasedOnSearchResultsTable failing

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiGetExtendedSearchesByMatterIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiGetExtendedSearchesByMatterIntTest.java
@@ -38,6 +38,7 @@ class ArmRpoApiGetExtendedSearchesByMatterIntTest extends IntegrationBase {
         extendedSearchesByMatterResponse.setIsError(false);
         ExtendedSearchesByMatterResponse.Search search = new ExtendedSearchesByMatterResponse.Search();
         search.setTotalCount(4);
+        search.setName("searchName");
         ExtendedSearchesByMatterResponse.SearchDetail searchDetail = new ExtendedSearchesByMatterResponse.SearchDetail();
         searchDetail.setSearch(search);
         extendedSearchesByMatterResponse.setSearches(List.of(searchDetail));

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiGetExtendedSearchesByMatterIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiGetExtendedSearchesByMatterIntTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 class ArmRpoApiGetExtendedSearchesByMatterIntTest extends IntegrationBase {
 
+    public static final String PRODUCTION_NAME = "DARTS_RPO_2024-08-13";
     @MockBean
     private ArmRpoClient armRpoClient;
 
@@ -38,7 +39,7 @@ class ArmRpoApiGetExtendedSearchesByMatterIntTest extends IntegrationBase {
         extendedSearchesByMatterResponse.setIsError(false);
         ExtendedSearchesByMatterResponse.Search search = new ExtendedSearchesByMatterResponse.Search();
         search.setTotalCount(4);
-        search.setName("searchName");
+        search.setName(PRODUCTION_NAME);
         ExtendedSearchesByMatterResponse.SearchDetail searchDetail = new ExtendedSearchesByMatterResponse.SearchDetail();
         searchDetail.setSearch(search);
         extendedSearchesByMatterResponse.setSearches(List.of(searchDetail));
@@ -54,9 +55,10 @@ class ArmRpoApiGetExtendedSearchesByMatterIntTest extends IntegrationBase {
         var bearerAuth = "Bearer some-token";
 
         // when
-        armRpoApi.getExtendedSearchesByMatter(bearerAuth, armRpoExecutionDetail.getId(), userAccount);
+        String result = armRpoApi.getExtendedSearchesByMatter(bearerAuth, armRpoExecutionDetail.getId(), userAccount);
 
         // then
+        assertEquals(PRODUCTION_NAME, result);
         var armRpoExecutionDetailEntityUpdated = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetail.getId()).get();
         assertEquals(ArmRpoStateEnum.GET_EXTENDED_SEARCHES_BY_MATTER.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoState().getId());
         assertEquals(ArmRpoStatusEnum.COMPLETED.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoStatus().getId());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
@@ -328,6 +328,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         response.setIsError(false);
         ExtendedSearchesByMatterResponse.Search search = new ExtendedSearchesByMatterResponse.Search();
         search.setTotalCount(4);
+        search.setName("DARTS_RPO_2024-08-13");
         ExtendedSearchesByMatterResponse.SearchDetail searchDetail = new ExtendedSearchesByMatterResponse.SearchDetail();
         searchDetail.setSearch(search);
         response.setSearches(List.of(searchDetail));

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ExtendedSearchesByMatterResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ExtendedSearchesByMatterResponse.java
@@ -29,6 +29,7 @@ public class ExtendedSearchesByMatterResponse extends BaseRpoResponse {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Search {
 
+        private String name;
         private Integer totalCount;
 
     }

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApi.java
@@ -25,10 +25,10 @@ public interface ArmRpoApi {
 
     void saveBackgroundSearch(String bearerToken, Integer executionId, String searchName, UserAccountEntity userAccount);
 
-    void getExtendedSearchesByMatter(String bearerToken, Integer executionId, UserAccountEntity userAccount);
+    String getExtendedSearchesByMatter(String bearerToken, Integer executionId, UserAccountEntity userAccount);
 
     boolean createExportBasedOnSearchResultsTable(String bearerToken, Integer executionId,
-                                                  List<MasterIndexFieldByRecordClassSchema> headerColumns,
+                                                  List<MasterIndexFieldByRecordClassSchema> headerColumns, String productionName,
                                                   UserAccountEntity userAccount);
 
     void getExtendedProductionsByMatter(String bearerToken, Integer executionId, UserAccountEntity userAccount);

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -67,6 +67,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
     private static final int FIELD_TYPE_7 = 7;
     private static final String ADD_ASYNC_SEARCH_RELATED_TASK_NAME = "ProcessE2EArmRpoPending";
     public static final String UNABLE_TO_GET_ARM_RPO_RESPONSE = "Unable to get ARM RPO response from client ";
+    public static final String CREATE_EXPORT_CSV_EXTENSION = "_CSV";
 
     private final ArmRpoClient armRpoClient;
     private final ArmRpoService armRpoService;
@@ -711,7 +712,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
             .searchId(searchId)
             .searchitemsCount(searchItemsCount)
             .headerColumns(createHeaderColumnsFromMasterIndexFieldByRecordClassSchemaResponse(headerColumns))
-            .productionName(productionName)
+            .productionName(productionName + CREATE_EXPORT_CSV_EXTENSION)
             .storageAccountId(storageAccountId)
             .build();
     }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
@@ -69,7 +69,7 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
             var userAccount = userIdentity.getUserAccount();
 
             // step to call ARM RPO API to get the extended searches by matter
-            armRpoApi.getExtendedSearchesByMatter(bearerToken, executionId, userAccount);
+            String productionName = armRpoApi.getExtendedSearchesByMatter(bearerToken, executionId, userAccount);
             // step to call ARM RPO API to get the master index field by record class schema
             List<MasterIndexFieldByRecordClassSchema> headerColumns = armRpoApi.getMasterIndexFieldByRecordClassSchema(
                 bearerToken, executionId,
@@ -77,8 +77,8 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
                 userAccount);
 
             // step to call ARM RPO API to create export based on search results table
-            boolean createExportBasedOnSearchResultsTable = armRpoApi.createExportBasedOnSearchResultsTable(bearerToken, executionId, headerColumns,
-                                                                                                            userAccount);
+            boolean createExportBasedOnSearchResultsTable = armRpoApi.createExportBasedOnSearchResultsTable(
+                bearerToken, executionId, headerColumns, productionName, userAccount);
             if (createExportBasedOnSearchResultsTable) {
                 // step to call ARM RPO API to get the extended productions by matter
                 armRpoApi.getExtendedProductionsByMatter(bearerToken, executionId, userAccount);

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
+    private static final String PRODUCTION_NAME = "DARTS_RPO_2024-08-13";
+
     @Mock
     private ArmRpoClient armRpoClient;
 
@@ -62,7 +64,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     }
 
     @Test
-    void createExportBasedOnSearchResultsTableSuccess() {
+    void createExportBasedOnSearchResultsTable_Success() {
         // given
         CreateExportBasedOnSearchResultsTableResponse response = new CreateExportBasedOnSearchResultsTableResponse();
         response.setStatus(200);
@@ -71,7 +73,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenReturn(response);
 
         // when
-        boolean result = armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), userAccount);
+        boolean result = armRpoApi.createExportBasedOnSearchResultsTable(
+            "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount);
 
         // then
         assertTrue(result);
@@ -83,9 +86,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         verifyNoMoreInteractions(armRpoService);
     }
 
-
     @Test
-    void createExportBasedOnSearchResultsTableReturnsInProgress() {
+    void createExportBasedOnSearchResultsTable_ReturnsInProgress() {
         // given
         CreateExportBasedOnSearchResultsTableResponse response = new CreateExportBasedOnSearchResultsTableResponse();
         response.setStatus(400);
@@ -94,7 +96,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenReturn(response);
 
         // when
-        boolean result = armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), userAccount);
+        boolean result = armRpoApi.createExportBasedOnSearchResultsTable(
+            "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount);
 
         // then
         assertFalse(result);
@@ -106,7 +109,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     }
 
     @Test
-    void createExportBasedOnSearchResultsTableWithStatus200IsErrorTrueResponseStatusZero() {
+    void createExportBasedOnSearchResultsTable_ThrowsException_WithStatus200IsErrorTrueResponseStatusZero() {
         // given
         CreateExportBasedOnSearchResultsTableResponse response = new CreateExportBasedOnSearchResultsTableResponse();
         response.setStatus(200);
@@ -116,7 +119,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -132,7 +136,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     }
 
     @Test
-    void createExportBasedOnSearchResultsTableWithStatus400IsErrorTrueResponseStatusZero() {
+    void createExportBasedOnSearchResultsTable_ThrowsException_WithStatus400IsErrorTrueResponseStatusZero() {
         // given
         CreateExportBasedOnSearchResultsTableResponse response = new CreateExportBasedOnSearchResultsTableResponse();
         response.setStatus(400);
@@ -142,7 +146,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -158,7 +163,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     }
 
     @Test
-    void createExportBasedOnSearchResultsTableWithStatus400IsErrorFalseResponseStatusZero() {
+    void createExportBasedOnSearchResultsTable_ThrowsException_WithStatus400IsErrorFalseResponseStatusZero() {
         // given
         CreateExportBasedOnSearchResultsTableResponse response = new CreateExportBasedOnSearchResultsTableResponse();
         response.setStatus(400);
@@ -168,7 +173,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -184,7 +190,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     }
 
     @Test
-    void createExportBasedOnSearchResultsTableWithStatus500IsErrorFalseResponseStatus500() {
+    void createExportBasedOnSearchResultsTable_ThrowsException_WithStatus500IsErrorFalseResponseStatus500() {
         // given
         CreateExportBasedOnSearchResultsTableResponse response = new CreateExportBasedOnSearchResultsTableResponse();
         response.setStatus(500);
@@ -194,7 +200,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -210,13 +217,14 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     }
 
     @Test
-    void createExportBasedOnSearchResultsTableWithInvalidRequest() {
+    void createExportBasedOnSearchResultsTable_ThrowsException_WithInvalidRequest() {
         // given
         armRpoExecutionDetailEntity.setSearchId(null);
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -232,13 +240,14 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     }
 
     @Test
-    void createExportBasedOnSearchResultsTableThrowsFeignException() {
+    void createExportBasedOnSearchResultsTable_ThrowsException_WhenClientThrowsFeignException() {
         // given
         when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenThrow(FeignException.class);
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
@@ -42,6 +42,8 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("PMD.CloseResource")
 class ArmRpoPollServiceImplTest {
 
+    private static final String PRODUCTION_NAME = "DARTS_RPO_2024-08-13";
+
     @Mock
     private ArmRpoApi armRpoApi;
     @Mock
@@ -92,10 +94,10 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getSaveBackgroundSearchRpoState());
 
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
-        doNothing().when(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
+        when(armRpoApi.getExtendedSearchesByMatter(anyString(), anyInt(), any())).thenReturn(PRODUCTION_NAME);
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any()))
             .thenReturn(createHeaderColumns());
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any())).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
         when(armRpoApi.downloadProduction(anyString(), anyInt(), anyString(), any())).thenReturn(resource);
@@ -111,7 +113,7 @@ class ArmRpoPollServiceImplTest {
         // then
         verify(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any());
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any());
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any());
         verify(armRpoApi).getExtendedProductionsByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getProductionOutputFiles(anyString(), anyInt(), any());
         verify(armRpoApi).downloadProduction(anyString(), anyInt(), any(), any());
@@ -133,10 +135,10 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getSaveBackgroundSearchRpoState());
 
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
-        doNothing().when(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
+        when(armRpoApi.getExtendedSearchesByMatter(anyString(), anyInt(), any())).thenReturn(PRODUCTION_NAME);
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any()))
             .thenReturn(createHeaderColumns());
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any())).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
         when(armRpoApi.downloadProduction(anyString(), anyInt(), anyString(), any())).thenReturn(resource);
@@ -152,7 +154,7 @@ class ArmRpoPollServiceImplTest {
         // then
         verify(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any());
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any());
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any());
         verify(armRpoApi).getExtendedProductionsByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getProductionOutputFiles(anyString(), anyInt(), any());
         verify(armRpoApi).downloadProduction(anyString(), anyInt(), any(), any());
@@ -174,10 +176,10 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState());
 
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
-        doNothing().when(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
+        when(armRpoApi.getExtendedSearchesByMatter(anyString(), anyInt(), any())).thenReturn(PRODUCTION_NAME);
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any()))
             .thenReturn(createHeaderColumns());
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any())).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
         when(armRpoApi.downloadProduction(anyString(), anyInt(), anyString(), any())).thenReturn(resource);
@@ -193,7 +195,7 @@ class ArmRpoPollServiceImplTest {
         // then
         verify(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any());
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any());
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any());
         verify(armRpoApi).getExtendedProductionsByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getProductionOutputFiles(anyString(), anyInt(), any());
         verify(armRpoApi).downloadProduction(anyString(), anyInt(), any(), any());
@@ -215,10 +217,10 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState());
 
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
-        doNothing().when(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
+        when(armRpoApi.getExtendedSearchesByMatter(anyString(), anyInt(), any())).thenReturn(PRODUCTION_NAME);
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any()))
             .thenReturn(createHeaderColumns());
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any())).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
         when(armRpoApi.downloadProduction(anyString(), anyInt(), anyString(), any())).thenReturn(resource);
@@ -234,7 +236,7 @@ class ArmRpoPollServiceImplTest {
         // then
         verify(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any());
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any());
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any());
         verify(armRpoApi).getExtendedProductionsByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getProductionOutputFiles(anyString(), anyInt(), any());
         verify(armRpoApi).downloadProduction(anyString(), anyInt(), any(), any());
@@ -256,10 +258,14 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getDownloadProductionRpoState());
 
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
-        doNothing().when(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
+        when(armRpoApi.getExtendedSearchesByMatter(anyString(), anyInt(), any())).thenReturn(PRODUCTION_NAME);
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any()))
             .thenReturn(createHeaderColumns());
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any())).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenReturn(true);
+        when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
+        when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any()))
+            .thenReturn(createHeaderColumns());
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
         when(armRpoApi.downloadProduction(anyString(), anyInt(), anyString(), any())).thenReturn(resource);
@@ -275,7 +281,7 @@ class ArmRpoPollServiceImplTest {
         // then
         verify(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any());
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any());
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any());
         verify(armRpoApi).getExtendedProductionsByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getProductionOutputFiles(anyString(), anyInt(), any());
         verify(armRpoApi).downloadProduction(anyString(), anyInt(), any(), any());
@@ -360,7 +366,7 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoStatus(ARM_RPO_HELPER_MOCKS.getCompletedRpoStatus());
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getSaveBackgroundSearchRpoState());
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any())).thenReturn(false);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenReturn(false);
 
         // when
         armRpoPollService.pollArmRpo(false);
@@ -370,7 +376,7 @@ class ArmRpoPollServiceImplTest {
         verify(armApiService).getArmBearerToken();
         verify(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any());
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any());
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any());
         verify(userIdentity).getUserAccount();
         verify(logApi).armRpoPollingSuccessful(any());
 
@@ -383,7 +389,7 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoStatus(ARM_RPO_HELPER_MOCKS.getCompletedRpoStatus());
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getSaveBackgroundSearchRpoState());
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any())).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of());
 
         // when
@@ -394,7 +400,7 @@ class ArmRpoPollServiceImplTest {
         verify(armApiService).getArmBearerToken();
         verify(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any());
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any());
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any());
         verify(armRpoApi).getExtendedProductionsByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getProductionOutputFiles(anyString(), anyInt(), any());
         verify(userIdentity).getUserAccount();
@@ -409,7 +415,7 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoStatus(ARM_RPO_HELPER_MOCKS.getCompletedRpoStatus());
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getSaveBackgroundSearchRpoState());
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any())).thenThrow(new ArmRpoException("Test exception"));
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any())).thenThrow(new ArmRpoException("Test exception"));
 
         // when
         armRpoPollService.pollArmRpo(false);
@@ -419,7 +425,7 @@ class ArmRpoPollServiceImplTest {
         verify(armApiService).getArmBearerToken();
         verify(armRpoApi).getExtendedSearchesByMatter(anyString(), anyInt(), any());
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(), any());
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any());
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), any(), any());
         verify(userIdentity).getUserAccount();
         verify(logApi).armRpoPollingFailed(any());
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4462

### Change description ###

Fixed issue where the wrong production value was being passed in. Changed it to get the production name from the getExtendedSearchesByMatter which is then passed to createExportBasedOnSearchResultsTable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
