### PR TITLE
DMP-4351 Do not change is_current status on legacy events

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/CleanupCurrentFlagEventProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/CleanupCurrentFlagEventProcessorImpl.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
@@ -11,18 +11,34 @@ import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.event.service.CleanupCurrentFlagEventProcessor;
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.time.ZoneOffset.UTC;
+
 @Getter
-@RequiredArgsConstructor
 @Slf4j
 @Component
 public class CleanupCurrentFlagEventProcessorImpl implements CleanupCurrentFlagEventProcessor {
     private final EventRepository eventRepository;
     private final HearingRepository hearingRepository;
+    private final OffsetDateTime earliestIsCurrentClearUpDate;
+
+    public CleanupCurrentFlagEventProcessorImpl(
+        @Value("${darts.events.earliest-is-current-clear-up-date}") String earliestIsCurrentClearUpDate,
+            EventRepository eventRepository,
+            HearingRepository hearingRepository
+        ) {
+        this.earliestIsCurrentClearUpDate = LocalDate.parse(earliestIsCurrentClearUpDate)
+            .atStartOfDay()
+            .atOffset(UTC);
+        this.eventRepository = eventRepository;
+        this.hearingRepository = hearingRepository;
+    }
 
     @Override
     @Async("eventTaskExecutor")
@@ -52,6 +68,13 @@ public class CleanupCurrentFlagEventProcessorImpl implements CleanupCurrentFlagE
         if (CollectionUtils.isNotEmpty(eventsToBeSuperseded)) {
             List<Integer> eveIdsThatHaveBeenSuperseded = new ArrayList<>();
             for (EventEntity eventToBeSuperseded : eventsToBeSuperseded) {
+                if (eventToBeSuperseded.getCreatedDateTime().isBefore(earliestIsCurrentClearUpDate)) {
+                    log.info("Event version with event id {} received into modernised DARTS is for a legacy event. Skipping event is_current cleanup " +
+                                 "for eve_id {}",
+                         eventIdAndHearingIds.getEventId(),
+                         eventIdAndHearingIds.getEveId());
+                    continue;
+                }
                 eventToBeSuperseded.setIsCurrent(false);
                 eventToBeSuperseded.setHearingEntities(new ArrayList<>());
                 eveIdsThatHaveBeenSuperseded.add(eventToBeSuperseded.getId());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -201,8 +201,9 @@ darts:
   dar-pc-notification:
     url-format: http://{0}/VIQDARNotifyEvent/DARNotifyEvent.asmx
   events:
+    earliest-is-current-clear-up-date: ${MODERNISED_DARTS_START_DATE:2025-03-01}
     duplicates:
-      earliest-removable-event-date: ${MODERNISED_DARTS_START_DATE:2024-12-01}
+      earliest-removable-event-date: ${MODERNISED_DARTS_START_DATE:2025-03-01}
       clear-up-window: ${DUPLICATE_EVENTS_CLEAR_UP_WINDOW_DAYS:2}
     admin-search:
       max-results: 1000


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-4351


### Change description ###
Legacy events should remain with the is_current flag set to the same status as they were migrated as. This change skips events where the original created date is earlier than the modernised go live date. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
