### PR TITLE
DMP-4269 Skip deleting duplicate events when criteria is null

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
@@ -139,6 +139,58 @@ class EventRepositoryTest extends PostgresIntegrationBase {
         assertThat(duplicates).isEmpty();
     }
 
+    @Test
+    void findDuplicateEventIds_multipleEventIdsWithWithNull_noDuplicatesShouldBeFound() {
+        final EventEntity event1 = EventTestData.someMinimalEvent();
+        final EventEntity event2 = EventTestData.someMinimalEvent();
+        final EventEntity event3 = EventTestData.someMinimalEvent();
+        final EventEntity event4 = EventTestData.someMinimalEvent(); //Not a duplicate
+        event1.setEventText("eventText");
+        event1.setMessageId("msgId");
+        event1.setEventId(null);
+        makeEventsDuplicate(event1, event2);
+        makeEventsDuplicate(event1, event3);
+        event4.setEventText("Some new text");
+        OffsetDateTime createdTime = OffsetDateTime.now().minusDays(3);
+        dartsDatabase.save(event1);
+        dartsDatabase.save(event2);
+        dartsDatabase.save(event3);
+        dartsDatabase.save(event4);
+        updateCreatedBy(event1, createdTime);
+        updateCreatedBy(event2, createdTime.plusMinutes(1));
+        updateCreatedBy(event3, createdTime.plusMinutes(2));
+        updateCreatedBy(event4, createdTime.plusMinutes(3));
+
+        List<EventEntity> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId(), createdTime.minusDays(1));
+        assertThat(duplicates).isEmpty();
+    }
+
+    @Test
+    void findDuplicateEventIds_multipleMessageIdsWithWithNull_noDuplicatesShouldBeFound() {
+        final EventEntity event1 = EventTestData.someMinimalEvent();
+        final EventEntity event2 = EventTestData.someMinimalEvent();
+        final EventEntity event3 = EventTestData.someMinimalEvent();
+        final EventEntity event4 = EventTestData.someMinimalEvent(); //Not a duplicate
+        event1.setEventText("eventText");
+        event1.setMessageId(null);
+        event1.setEventId(1);
+        makeEventsDuplicate(event1, event2);
+        makeEventsDuplicate(event1, event3);
+        event4.setEventText("Some new text");
+        OffsetDateTime createdTime = OffsetDateTime.now().minusDays(3);
+        dartsDatabase.save(event1);
+        dartsDatabase.save(event2);
+        dartsDatabase.save(event3);
+        dartsDatabase.save(event4);
+        updateCreatedBy(event1, createdTime);
+        updateCreatedBy(event2, createdTime.plusMinutes(1));
+        updateCreatedBy(event3, createdTime.plusMinutes(2));
+        updateCreatedBy(event4, createdTime.plusMinutes(3));
+
+        List<EventEntity> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId(), createdTime.minusDays(1));
+        assertThat(duplicates).isEmpty();
+    }
+
     private void updateCreatedBy(EventEntity event, OffsetDateTime offsetDateTime) {
         event.setCreatedDateTime(offsetDateTime);
         dartsDatabase.save(event);

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -156,7 +156,7 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
                         JOIN (                        
                             SELECT e.eventId as eventId, e.messageId as messageId, e.eventText as eventText
                             FROM EventEntity e
-                            WHERE e.eventId = :eventId and e.createdDateTime >= :minDate
+                            WHERE e.eventId IS NOT NULL and e.messageId IS NOT NULL and e.eventId = :eventId and e.createdDateTime >= :minDate 
                             GROUP BY e.eventId, e.messageId, e.eventText
                             HAVING COUNT(e) > 1) e2
                          ON e2.eventId = e3.eventId and e2.messageId = e3.messageId and e2.eventText = e3.eventText

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -156,7 +156,7 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
                         JOIN (                        
                             SELECT e.eventId as eventId, e.messageId as messageId, e.eventText as eventText
                             FROM EventEntity e
-                            WHERE e.eventId IS NOT NULL and e.messageId IS NOT NULL and e.eventId = :eventId and e.createdDateTime >= :minDate 
+                            WHERE e.eventId IS NOT NULL and e.messageId IS NOT NULL and e.eventId = :eventId and e.createdDateTime >= :minDate
                             GROUP BY e.eventId, e.messageId, e.eventText
                             HAVING COUNT(e) > 1) e2
                          ON e2.eventId = e3.eventId and e2.messageId = e3.messageId and e2.eventText = e3.eventText


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-4269


### Change description ###
When message id or event id is null, we want to skip the duplicate tidy up logic, otherwise we could end up incorrectly deleting events.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
