### PR TITLE
DMP-4445 ARM Pull response file - Remove saving response files to Tempworkspace

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/AbstractArmBatchProcessResponseFilesIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/AbstractArmBatchProcessResponseFilesIntTest.java
@@ -2399,12 +2399,6 @@ abstract class AbstractArmBatchProcessResponseFilesIntTest extends IntegrationBa
         return BinaryData.fromString(contents);
     }
 
-    protected String getInputUploadFileContents(String uploadFilename, Integer externalObjectDirectoryId) throws IOException {
-        String expectedResponse = getContentsFromFile(uploadFilename);
-        expectedResponse = expectedResponse.replaceAll("<EODID>", String.valueOf(externalObjectDirectoryId));
-        return expectedResponse;
-    }
-
     protected String getInvalidLineFileContents(String invalidLineFilename, Integer externalObjectDirectoryId) throws IOException {
         String expectedResponse = getContentsFromFile(invalidLineFilename);
         expectedResponse = expectedResponse.replaceAll("<EODID>", String.valueOf(externalObjectDirectoryId));

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
@@ -6,8 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.TestPropertySource;
 import uk.gov.hmcts.darts.arm.client.ArmRpoClient;
 import uk.gov.hmcts.darts.arm.client.model.rpo.CreateExportBasedOnSearchResultsTableResponse;
@@ -17,6 +19,7 @@ import uk.gov.hmcts.darts.arm.client.model.rpo.MasterIndexFieldByRecordClassSche
 import uk.gov.hmcts.darts.arm.client.model.rpo.ProductionOutputFilesResponse;
 import uk.gov.hmcts.darts.arm.client.model.rpo.RemoveProductionResponse;
 import uk.gov.hmcts.darts.arm.component.ArmRpoDownloadProduction;
+import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
 import uk.gov.hmcts.darts.arm.helper.ArmRpoHelper;
 import uk.gov.hmcts.darts.arm.service.impl.ArmApiServiceImpl;
 import uk.gov.hmcts.darts.arm.service.impl.ArmRpoPollServiceImpl;
@@ -63,6 +66,11 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
     @MockBean
     private ArmRpoDownloadProduction armRpoDownloadProduction;
 
+    @SpyBean
+    private ArmDataManagementConfiguration armDataManagementConfiguration;
+    @TempDir
+    protected File tempDirectory;
+
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
 
     @Autowired
@@ -75,6 +83,10 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         lenient().when(userIdentity.getUserAccount()).thenReturn(userAccountEntity);
 
         armRpoExecutionDetailEntity = dartsPersistence.save(getArmRpoExecutionDetailTestData().minimalArmRpoExecutionDetailEntity());
+
+        String fileLocation = tempDirectory.getAbsolutePath();
+        lenient().when(armDataManagementConfiguration.getTempBlobWorkspace()).thenReturn(fileLocation);
+
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchPushProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchPushProcessorIntTest.java
@@ -2,9 +2,12 @@ package uk.gov.hmcts.darts.arm.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
+import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
@@ -15,6 +18,7 @@ import uk.gov.hmcts.darts.common.exception.DartsException;
 import uk.gov.hmcts.darts.common.util.EodHelper;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
+import java.io.File;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -26,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.DETS;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_MANIFEST_FAILED;
@@ -43,6 +48,11 @@ class DetsToArmBatchPushProcessorIntTest extends IntegrationBase {
     private UserIdentity userIdentity;
     @MockBean
     private ArmDataManagementApi armDataManagementApi;
+    @SpyBean
+    private ArmDataManagementConfiguration armDataManagementConfiguration;
+
+    @TempDir
+    private File tempDirectory;
 
     @Autowired
     private DetsToArmBatchPushProcessor detsToArmBatchPushProcessor;
@@ -70,6 +80,9 @@ class DetsToArmBatchPushProcessorIntTest extends IntegrationBase {
             ));
         savedMedia.setFileSize(1000L);
         savedMedia = dartsDatabase.save(savedMedia);
+
+        String fileLocation = tempDirectory.getAbsolutePath();
+        lenient().when(armDataManagementConfiguration.getTempBlobWorkspace()).thenReturn(fileLocation);
 
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
@@ -51,6 +51,7 @@ import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAt
 import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAttributes.ARM_RESPONSE_SUCCESS_STATUS_CODE;
 import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAttributes.ARM_UPLOAD_FILE_FILENAME_KEY;
 import static uk.gov.hmcts.darts.arm.util.ArmResponseFilesUtil.generateSuffix;
+import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_MISSING_RESPONSE;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_CHECKSUM_VERIFICATION_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_MANIFEST_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_PROCESSING_FAILED;

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
@@ -1,13 +1,10 @@
 package uk.gov.hmcts.darts.arm.service.impl;
 
 import com.azure.core.util.BinaryData;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
@@ -39,8 +36,6 @@ import uk.gov.hmcts.darts.common.util.EodHelper;
 import uk.gov.hmcts.darts.log.api.LogApi;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -48,7 +43,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAttributes.ARM_CREATE_RECORD_FILENAME_KEY;
@@ -57,7 +51,6 @@ import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAt
 import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAttributes.ARM_RESPONSE_SUCCESS_STATUS_CODE;
 import static uk.gov.hmcts.darts.arm.util.ArchiveConstants.ArchiveResponseFileAttributes.ARM_UPLOAD_FILE_FILENAME_KEY;
 import static uk.gov.hmcts.darts.arm.util.ArmResponseFilesUtil.generateSuffix;
-import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_MISSING_RESPONSE;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_CHECKSUM_VERIFICATION_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_MANIFEST_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RESPONSE_PROCESSING_FAILED;
@@ -107,7 +100,7 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
                 }
             }
         } catch (Exception e) {
-            log.error("Unable to find response file for prefix: {} - {}", prefix, e.getMessage());
+            log.error("Unable to find response file for prefix: {}", prefix, e);
         }
         if (CollectionUtils.isNotEmpty(inputUploadResponseFiles)) {
             for (String inputUploadBlob : inputUploadResponseFiles) {
@@ -150,6 +143,7 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
                     userAccount,
                     externalObjectDirectoryEntities.stream().map(ExternalObjectDirectoryEntity::getId).toList(),
                     timeHelper.currentOffsetDateTime());
+
             } else {
                 log.warn("No external object directories found with filename: {}", manifestName);
             }
@@ -477,56 +471,41 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
 
     private void readCreateRecordFile(BinaryData createRecordBinary, CreateRecordFilenameProcessor createRecordFilenameProcessor,
                                       ArmBatchResponses armBatchResponses) {
+        String createRecordFilenameAndPath = createRecordFilenameProcessor.getCreateRecordFilenameAndPath();
         if (nonNull(createRecordBinary)) {
-            Path jsonPath = null;
             try {
-                boolean appendUuidToWorkspace = true;
-                jsonPath = fileOperationService.saveBinaryDataToSpecifiedWorkspace(
-                    createRecordBinary,
-                    createRecordFilenameProcessor.getCreateRecordFilename(),
-                    armDataManagementConfiguration.getTempBlobWorkspace(),
-                    appendUuidToWorkspace
-                );
-
-                if (nonNull(jsonPath) && jsonPath.toFile().exists()) {
-                    logResponseFileContents(jsonPath);
-                    ArmResponseCreateRecord armResponseCreateRecord = getResponseCreateRecordOrDelete(jsonPath);
-                    UploadNewFileRecord uploadNewFileRecord = readInputJson(armResponseCreateRecord.getInput());
-                    if (nonNull(uploadNewFileRecord)) {
-                        if (StringUtils.isNotEmpty(uploadNewFileRecord.getRelationId())) {
-                            armBatchResponses.addResponseBatchData(Integer.valueOf(uploadNewFileRecord.getRelationId()),
-                                                                   armResponseCreateRecord, createRecordFilenameProcessor);
-                        } else {
-                            log.warn("Unable to get EOD id (relation id) from uploadNewFileRecord {} create record {}",
-                                     armResponseCreateRecord.getInput(), createRecordFilenameProcessor.getCreateRecordFilenameAndPath());
-                        }
+                log.info("Contents of ARM CR response file: {} - {}", createRecordFilenameAndPath, createRecordBinary);
+                ArmResponseCreateRecord armResponseCreateRecord = getResponseCreateRecordOrDelete(createRecordFilenameAndPath, createRecordBinary);
+                UploadNewFileRecord uploadNewFileRecord = readInputJson(armResponseCreateRecord.getInput());
+                if (nonNull(uploadNewFileRecord)) {
+                    if (StringUtils.isNotEmpty(uploadNewFileRecord.getRelationId())) {
+                        armBatchResponses.addResponseBatchData(Integer.valueOf(uploadNewFileRecord.getRelationId()),
+                                                               armResponseCreateRecord, createRecordFilenameProcessor);
                     } else {
-                        log.warn("Failed to obtain EOD id (relation id) from create record file  {}",
-                                 createRecordFilenameProcessor.getCreateRecordFilenameAndPath());
+                        log.warn("Unable to get EOD id (relation id) from uploadNewFileRecord {} create record {}",
+                                 armResponseCreateRecord.getInput(), createRecordFilenameAndPath);
                     }
                 } else {
-                    log.warn("Failed to write create record file to temp workspace {}", createRecordFilenameProcessor.getCreateRecordFilenameAndPath());
+                    log.warn("Failed to obtain EOD id (relation id) from create record file  {}",
+                             createRecordFilenameAndPath);
                 }
-            } catch (IOException e) {
-                log.error("Unable to write create record file to temporary workspace {} - {}", createRecordFilenameProcessor.getCreateRecordFilenameAndPath(),
-                          e.getMessage());
+
             } catch (Exception e) {
-                log.error("Unable to process arm response create record file {}", createRecordFilenameProcessor.getCreateRecordFilenameAndPath(), e);
-            } finally {
-                cleanupTemporaryJsonFile(jsonPath);
+                log.error("Unable to process arm response create record file {}", createRecordFilenameAndPath, e);
             }
         } else {
-            log.warn("Failed to read create record file {}", createRecordFilenameProcessor.getCreateRecordFilenameAndPath());
+            log.warn("Failed to read create record file {}", createRecordFilenameAndPath);
         }
 
     }
 
-    private ArmResponseCreateRecord getResponseCreateRecordOrDelete(Path jsonPath) throws IOException {
+    private ArmResponseCreateRecord getResponseCreateRecordOrDelete(String createRecordFilenameAndPath,
+                                                                    BinaryData createRecordBinary) throws IOException {
         try {
-            return objectMapper.readValue(jsonPath.toFile(), ArmResponseCreateRecord.class);
+            return objectMapper.readValue(createRecordBinary.toString(), ArmResponseCreateRecord.class);
         } catch (Exception e) {
-            log.error("Unable to read ARM response create record file {} - About to delete ", jsonPath.toFile().getAbsoluteFile(), e);
-            deleteResponseBlobs(List.of(jsonPath.toFile().getAbsolutePath()));
+            log.error("Unable to read ARM response create record file {} - About to delete ", createRecordFilenameAndPath, e);
+            deleteResponseBlobs(List.of(createRecordFilenameAndPath));
             throw e;
         }
     }
@@ -545,80 +524,39 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
     private void readUploadFile(BinaryData uploadFileBinary, UploadFileFilenameProcessor uploadFileFilenameProcessor,
                                 ArmBatchResponses armBatchResponses) {
 
+        String uploadFileFilenameAndPath = uploadFileFilenameProcessor.getUploadFileFilenameAndPath();
         if (nonNull(uploadFileBinary)) {
-            Path jsonPath = null;
             try {
-                boolean appendUuidToWorkspace = true;
-                jsonPath = fileOperationService.saveBinaryDataToSpecifiedWorkspace(
-                    uploadFileBinary,
-                    uploadFileFilenameProcessor.getUploadFileFilename(),
-                    armDataManagementConfiguration.getTempBlobWorkspace(),
-                    appendUuidToWorkspace
-                );
-
-                if (jsonPath.toFile().exists()) {
-                    logResponseFileContents(jsonPath);
-                    ArmResponseUploadFileRecord armResponseUploadFileRecord = getResponseUploadFileRecordOrDelete(jsonPath);
-                    UploadNewFileRecord uploadNewFileRecord = readInputJson(armResponseUploadFileRecord.getInput());
-                    if (nonNull(uploadNewFileRecord)) {
-                        if (StringUtils.isNotEmpty(uploadNewFileRecord.getRelationId())) {
-                            armBatchResponses.addResponseBatchData(Integer.valueOf(uploadNewFileRecord.getRelationId()),
-                                                                   armResponseUploadFileRecord, uploadFileFilenameProcessor);
-                        } else {
-                            log.warn("Unable to get EOD id (relation id) from uploadNewFileRecord {} upload file {}",
-                                     armResponseUploadFileRecord.getInput(), uploadFileFilenameProcessor.getUploadFileFilenameAndPath());
-                        }
-
+                log.info("Contents of ARM UF response file: {} - {}", uploadFileFilenameAndPath, uploadFileBinary);
+                ArmResponseUploadFileRecord armResponseUploadFileRecord = getResponseUploadFileRecordOrDelete(uploadFileFilenameAndPath, uploadFileBinary);
+                UploadNewFileRecord uploadNewFileRecord = readInputJson(armResponseUploadFileRecord.getInput());
+                if (nonNull(uploadNewFileRecord)) {
+                    if (StringUtils.isNotEmpty(uploadNewFileRecord.getRelationId())) {
+                        armBatchResponses.addResponseBatchData(Integer.valueOf(uploadNewFileRecord.getRelationId()),
+                                                               armResponseUploadFileRecord, uploadFileFilenameProcessor);
                     } else {
-                        log.warn("Failed to obtain EOD id (relation id) from upload file  {}",
-                                 uploadFileFilenameProcessor.getUploadFileFilenameAndPath());
+                        log.warn("Unable to get EOD id (relation id) from uploadNewFileRecord {} upload file {}",
+                                 armResponseUploadFileRecord.getInput(), uploadFileFilenameAndPath);
                     }
+
                 } else {
-                    log.warn("Failed to write upload file to temp workspace {}", uploadFileFilenameProcessor.getUploadFileFilenameAndPath());
+                    log.warn("Failed to obtain EOD id (relation id) from upload file  {}", uploadFileFilenameAndPath);
                 }
-            } catch (IOException e) {
-                log.error("Unable to write upload file to temporary workspace {} - {}", uploadFileFilenameProcessor.getUploadFileFilenameAndPath(),
-                          e.getMessage());
             } catch (Exception e) {
-                log.error("Unable to process arm response upload file {}", uploadFileFilenameProcessor.getUploadFileFilenameAndPath(), e);
-            } finally {
-                cleanupTemporaryJsonFile(jsonPath);
+                log.error("Unable to process arm response upload file {}", uploadFileFilenameAndPath, e);
             }
         } else {
-            log.warn("Failed to read upload file {}", uploadFileFilenameProcessor.getUploadFileFilenameAndPath());
+            log.warn("Failed to read upload file {}", uploadFileFilenameAndPath);
         }
     }
 
-    private ArmResponseUploadFileRecord getResponseUploadFileRecordOrDelete(Path jsonPath) throws IOException {
+    private ArmResponseUploadFileRecord getResponseUploadFileRecordOrDelete(String uploadFileFilenameAndPath, BinaryData uploadFileBinary) throws IOException {
         try {
-            return objectMapper.readValue(jsonPath.toFile(), ArmResponseUploadFileRecord.class);
+            return objectMapper.readValue(uploadFileBinary.toString(), ArmResponseUploadFileRecord.class);
         } catch (Exception e) {
-            log.error("Unable to read ARM response upload file {} - About to delete ", jsonPath.toFile().getAbsoluteFile(), e);
-            deleteResponseBlobs(List.of(jsonPath.toFile().getAbsolutePath()));
+            log.error("Unable to read ARM response upload file {} - About to delete ", uploadFileFilenameAndPath, e);
+            deleteResponseBlobs(List.of(uploadFileFilenameAndPath));
             throw e;
-        }
-    }
-
-    private void logResponseFileContents(Path jsonPath) {
-        try {
-            String contents = FileUtils.readFileToString(jsonPath.toFile(), UTF_8);
-            log.info("Contents of ARM response file {} - \n{}",
-                     jsonPath.toFile().getAbsoluteFile(),
-                     contents);
-        } catch (Exception e) {
-            log.error("Unable to read ARM response file {}", jsonPath.toFile().getAbsoluteFile(), e);
-        }
-    }
-
-    private void cleanupTemporaryJsonFile(Path jsonPath) {
-        if (nonNull(jsonPath)) {
-            try {
-                if (!Files.deleteIfExists(jsonPath)) {
-                    log.warn("Deleting temporary file: {} failed", jsonPath.toFile());
-                }
-            } catch (Exception e) {
-                log.error("Unable to delete temporary file: {} - {}", jsonPath.toFile(), e.getMessage());
-            }
         }
     }
 
@@ -717,12 +655,8 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
             String unescapedJson = StringEscapeUtils.unescapeJson(input);
             try {
                 uploadNewFileRecord = objectMapper.readValue(unescapedJson, UploadNewFileRecord.class);
-            } catch (JsonMappingException e) {
-                log.error("Unable to map the input field {}", e.getMessage());
-            } catch (JsonProcessingException e) {
-                log.error("Unable to parse the upload new file record {}", e.getMessage());
             } catch (Exception e) {
-                log.error("Failed to parse the input field {}", e.getMessage());
+                log.error("Failed to parse the input field {}", input, e);
             }
         } else {
             log.warn("Unable to parse the input field as it is null or empty");
@@ -772,60 +706,44 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
 
     private void readInvalidLineFile(BinaryData invalidLineFileBinary, InvalidLineFileFilenameProcessor invalidLineFileFilenameProcessor,
                                      ArmBatchResponses armBatchResponses) {
+        String invalidLineFileFilenameAndPath = invalidLineFileFilenameProcessor.getInvalidLineFileFilenameAndPath();
         if (nonNull(invalidLineFileBinary)) {
-            Path jsonPath = null;
             try {
-                boolean appendUuidToWorkspace = true;
-                jsonPath = fileOperationService.saveBinaryDataToSpecifiedWorkspace(
-                    invalidLineFileBinary,
-                    invalidLineFileFilenameProcessor.getInvalidLineFilename(),
-                    armDataManagementConfiguration.getTempBlobWorkspace(),
-                    appendUuidToWorkspace
-                );
+                log.info("Contents of ARM IL response file: {} - {}", invalidLineFileFilenameAndPath, invalidLineFileBinary);
+                ArmResponseInvalidLineRecord armResponseInvalidLineRecord =
+                    getResponseInvalidLineRecordOrDelete(invalidLineFileFilenameAndPath, invalidLineFileBinary);
+                String input = armResponseInvalidLineRecord.getInput();
+                UploadNewFileRecord uploadNewFileRecord = readInputJson(input);
+                if (nonNull(uploadNewFileRecord)) {
+                    if (StringUtils.isNotEmpty(uploadNewFileRecord.getRelationId())) {
+                        armBatchResponses.addResponseBatchData(Integer.valueOf(uploadNewFileRecord.getRelationId()),
+                                                               armResponseInvalidLineRecord, invalidLineFileFilenameProcessor);
 
-                if (jsonPath.toFile().exists()) {
-                    logResponseFileContents(jsonPath);
-                    ArmResponseInvalidLineRecord armResponseInvalidLineRecord = getResponseInvalidLineRecordOrDelete(jsonPath);
-                    String input = armResponseInvalidLineRecord.getInput();
-                    UploadNewFileRecord uploadNewFileRecord = readInputJson(input);
-                    if (nonNull(uploadNewFileRecord)) {
-                        if (StringUtils.isNotEmpty(uploadNewFileRecord.getRelationId())) {
-                            armBatchResponses.addResponseBatchData(Integer.valueOf(uploadNewFileRecord.getRelationId()),
-                                                                   armResponseInvalidLineRecord, invalidLineFileFilenameProcessor);
-
-                        } else {
-                            log.warn("Unable to get EOD id (relation id) from uploadNewFileRecord {} invalid line file {}",
-                                     armResponseInvalidLineRecord.getInput(), invalidLineFileFilenameProcessor.getInvalidLineFilename());
-                        }
                     } else {
-                        log.warn("Failed to obtain EOD id (relation id) from invalid line record {} from file {}", input,
-                                 invalidLineFileFilenameProcessor.getInvalidLineFilename());
+                        log.warn("Unable to get EOD id (relation id) from uploadNewFileRecord {} invalid line file {}",
+                                 armResponseInvalidLineRecord.getInput(), invalidLineFileFilenameProcessor.getInvalidLineFilename());
                     }
                 } else {
-                    log.warn("Failed to write invalid line file to temp workspace {}", invalidLineFileFilenameProcessor.getInvalidLineFilename());
+                    log.warn("Failed to obtain EOD id (relation id) from invalid line record {} from file {}", input,
+                             invalidLineFileFilenameProcessor.getInvalidLineFilename());
+                    deleteResponseBlobs(List.of(invalidLineFileFilenameAndPath));
                 }
-            } catch (IOException e) {
-                log.error("Unable to write invalid line file to temporary workspace {} - {}",
-                          invalidLineFileFilenameProcessor.getInvalidLineFileFilenameAndPath(), e.getMessage());
 
             } catch (Exception e) {
-                log.error("Unable to process ARM response invalid line file {}",
-                          invalidLineFileFilenameProcessor.getInvalidLineFileFilenameAndPath(), e);
-
-            } finally {
-                cleanupTemporaryJsonFile(jsonPath);
+                log.error("Unable to process ARM response invalid line file {}", invalidLineFileFilenameAndPath, e);
             }
         } else {
-            log.error("Unable to read ARM response invalid line file {}", invalidLineFileFilenameProcessor.getInvalidLineFileFilenameAndPath());
+            log.error("Unable to read ARM response invalid line file {}", invalidLineFileFilenameAndPath);
         }
     }
 
-    private ArmResponseInvalidLineRecord getResponseInvalidLineRecordOrDelete(Path jsonPath) throws IOException {
+    private ArmResponseInvalidLineRecord getResponseInvalidLineRecordOrDelete(String invalidLineFileFilenameAndPath,
+                                                                              BinaryData invalidLineFileBinary) throws IOException {
         try {
-            return objectMapper.readValue(jsonPath.toFile(), ArmResponseInvalidLineRecord.class);
+            return objectMapper.readValue(invalidLineFileBinary.toString(), ArmResponseInvalidLineRecord.class);
         } catch (Exception e) {
-            log.error("Unable to read ARM response invalid line file {} - About to delete ", jsonPath.toFile().getAbsoluteFile(), e);
-            deleteResponseBlobs(List.of(jsonPath.toFile().getAbsolutePath()));
+            log.error("Unable to read ARM response {} - About to delete ", invalidLineFileFilenameAndPath, e);
+            deleteResponseBlobs(List.of(invalidLineFileFilenameAndPath));
             throw e;
         }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4445

### Change description ###

Removed saving the response files to temporary space as its no longer required

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
