### PR TITLE
DMP-4386 Handle zero second audio on preview

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreviewIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreviewIntTest.java
@@ -137,6 +137,19 @@ class AudioControllerPreviewIntTest extends IntegrationBase {
         );
     }
 
+    @Test
+    void previewForZeroSecondMediaShouldReturn422() throws Exception {
+        OffsetDateTime now = OffsetDateTime.now();
+        mediaEntity.setStart(now);
+        mediaEntity.setEnd(now);
+        dartsPersistence.save(mediaEntity);
+
+        MockHttpServletRequestBuilder requestBuilder = get(URI.create(
+            String.format("/audio/preview/%d", mediaEntity.getId()))).header("Range", "bytes=0-");
+
+        mockMvc.perform(requestBuilder).andExpect(status().isUnprocessableEntity());
+    }
+
     private void waitUntilPreviewEncodedAndCached() {
         waitForMaxWithOneSecondPoll(() -> {
             var cachedAudioPreview = binaryDataRedisService.readFromRedis(folder, mediaEntity.getId().toString());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioPreviewTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/service/AudioPreviewTest.java
@@ -18,7 +18,6 @@ import java.time.LocalDate;
 import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.darts.audio.enums.AudioPreviewStatus.ENCODING;
-import static uk.gov.hmcts.darts.audio.enums.AudioPreviewStatus.FAILED;
 import static uk.gov.hmcts.darts.audio.enums.AudioPreviewStatus.READY;
 import static uk.gov.hmcts.darts.test.common.AwaitabilityUtil.waitForMax10SecondsWithOneSecondPoll;
 
@@ -72,17 +71,6 @@ class AudioPreviewTest extends IntegrationBase {
         waitForMax10SecondsWithOneSecondPoll(() -> {
             var cachedAudioPreview = binaryDataRedisService.readFromRedis(folder, mediaEntity.getId().toString());
             return cachedAudioPreview.getStatus().equals(READY);
-        });
-    }
-
-    @Test
-    void audioPreviewEventuallyFailsWhenMediaDoesntExist() {
-        var audioPreview = audioPreviewService.getOrCreateAudioPreview(-1);
-
-        assertThat(audioPreview.getStatus()).isEqualTo(ENCODING).isNotNull();
-        waitForMax10SecondsWithOneSecondPoll(() -> {
-            var cachedAudioPreview = binaryDataRedisService.readFromRedis(folder, "-1");
-            return cachedAudioPreview.getStatus().equals(FAILED);
         });
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -37,7 +37,6 @@ import uk.gov.hmcts.darts.audio.service.MediaRequestService;
 import uk.gov.hmcts.darts.audio.util.StreamingResponseEntityUtil;
 import uk.gov.hmcts.darts.audio.validation.AddAudioFileValidator;
 import uk.gov.hmcts.darts.audio.validation.AddAudioMetaDataValidator;
-import uk.gov.hmcts.darts.audio.validation.MediaIdValidator;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
@@ -78,7 +77,6 @@ public class AudioController implements AudioApi {
     private final MediaRequestService mediaRequestService;
     private final TransformedMediaMapper transformedMediaMapper;
     private final AdminMediaService adminMediaService;
-    private final MediaIdValidator mediaIdValidator;
 
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
@@ -129,8 +127,6 @@ public class AudioController implements AudioApi {
         securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
         globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA, DARTS})
     public ResponseEntity<byte[]> preview(Integer mediaId, String httpRangeList) {
-        // return 404 if the media is hidden
-        mediaIdValidator.validateNotHidden(mediaId);
         AudioPreview audioPreview = audioPreviewService.getOrCreateAudioPreview(mediaId);
         if (audioPreview.getStatus().equals(FAILED)) {
             log.info("Media with ID {} status FAILED", mediaId);

--- a/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioApiError.java
@@ -115,6 +115,11 @@ public enum AudioApiError implements DartsApiError {
         AddAudioErrorCode.FAILED_TO_ADD_AUDIO_META_DATA.getValue(),
         HttpStatus.UNPROCESSABLE_ENTITY,
         AddAudioTitleErrors.FAILED_TO_ADD_AUDIO_META_DATA.getValue()
+    ),
+    START_TIME_END_TIME_NOT_VALID(
+        AddAudioErrorCode.START_TIME_END_TIME_NOT_VALID.getValue(),
+        HttpStatus.UNPROCESSABLE_ENTITY,
+        AddAudioTitleErrors.START_TIME_END_TIME_NOT_VALID.getValue()
     );
 
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioPreviewServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioPreviewServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.audio.model.AudioPreview;
 import uk.gov.hmcts.darts.audio.service.AudioPreviewService;
+import uk.gov.hmcts.darts.audio.validation.MediaIdValidator;
 
 import static uk.gov.hmcts.darts.audio.enums.AudioPreviewStatus.ENCODING;
 
@@ -15,9 +16,13 @@ import static uk.gov.hmcts.darts.audio.enums.AudioPreviewStatus.ENCODING;
 public class AudioPreviewServiceImpl implements AudioPreviewService {
 
     private final CachingAudioPreviewEncoder cachingAudioPreviewEncoder;
+    private final MediaIdValidator mediaIdValidator;
 
     @Override
     public AudioPreview getOrCreateAudioPreview(Integer mediaId) {
+        mediaIdValidator.validateNotHidden(mediaId);
+        mediaIdValidator.validateNotZeroSecondAudio(mediaId);
+
         AudioPreview audioPreview = cachingAudioPreviewEncoder.getPreviewFor(mediaId);
         if (audioPreview == null) {
             audioPreview = new AudioPreview(mediaId, ENCODING, null);
@@ -27,4 +32,5 @@ public class AudioPreviewServiceImpl implements AudioPreviewService {
         }
         return audioPreview;
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/validation/MediaIdValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/validation/MediaIdValidator.java
@@ -4,8 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.common.component.validation.Validator;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
+
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -19,10 +22,21 @@ public class MediaIdValidator implements Validator<Integer> {
         }
     }
 
+    public void validateNotZeroSecondAudio(Integer id) {
+        Optional<MediaEntity> media = mediaRepository.findById(id);
+        media.ifPresent(e -> {
+            if (e.getStart() == null || e.getEnd() == null || e.getStart().isEqual(e.getEnd()) || e.getStart().isAfter(e.getEnd())) {
+                throw new DartsApiException(AudioApiError.START_TIME_END_TIME_NOT_VALID);
+            }
+        });
+    }
+
     @Override
     public void validate(Integer id) {
         if (mediaRepository.findByIdIncludeDeleted(id).isEmpty()) {
             throw new DartsApiException(AudioApiError.MEDIA_NOT_FOUND);
         }
     }
+
+
 }

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -1052,6 +1052,7 @@ components:
         - "AUDIO_119"
         - "AUDIO_120"
         - "AUDIO_121"
+        - "AUDIO_122"
       x-enum-varnames: [ FAILED_TO_PROCESS_AUDIO_REQUEST,
                          REQUESTED_DATA_CANNOT_BE_LOCATED,
                          MEDIA_NOT_FOUND,
@@ -1073,6 +1074,7 @@ components:
                          MARKED_FOR_DELETION_REASON_NOT_FOUND,
                          USER_CANT_APPROVE_THEIR_OWN_DELETION,
                          FAILED_TO_ADD_AUDIO_META_DATA,
+                         START_TIME_END_TIME_NOT_VALID,
       ]
 
     AddAudioTitleErrors:
@@ -1099,6 +1101,7 @@ components:
         - "Media marked for deletion reason not found"
         - "User cannot approve their own deletion"
         - "Failed to add audio meta data"
+        - "Start time or end time of media not valid"
       x-enum-varnames: [ FAILED_TO_PROCESS_AUDIO_REQUEST,
                          REQUESTED_DATA_CANNOT_BE_LOCATED,
                          MEDIA_NOT_FOUND,
@@ -1120,4 +1123,5 @@ components:
                          MARKED_FOR_DELETION_REASON_NOT_FOUND,
                          USER_CANT_APPROVE_THEIR_OWN_DELETION,
                          FAILED_TO_ADD_AUDIO_META_DATA,
+                         START_TIME_END_TIME_NOT_VALID,
       ]

--- a/src/test/java/uk/gov/hmcts/darts/audio/validation/MediaIdValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/validation/MediaIdValidatorTest.java
@@ -5,18 +5,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.MediaRepository;
 
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.audio.exception.AudioApiError.MEDIA_NOT_FOUND;
+import static uk.gov.hmcts.darts.audio.exception.AudioApiError.START_TIME_END_TIME_NOT_VALID;
 
 @ExtendWith(MockitoExtension.class)
 class MediaIdValidatorTest {
 
     @Mock
     MediaRepository mediaRepository;
+    @Mock
+    MediaEntity media1;
 
     private MediaIdValidator mediaIdValidator;
 
@@ -39,5 +47,61 @@ class MediaIdValidatorTest {
         Integer mediaId = 1;
         when(mediaRepository.existsByIdAndIsHiddenFalse(mediaId)).thenReturn(true);
         mediaIdValidator.validateNotHidden(mediaId);
+    }
+
+    @Test
+    void validateNotZeroSecondAudio_shouldThrowException_ifStartAndEndAreEqual() {
+        Integer mediaId = 1;
+        OffsetDateTime now = OffsetDateTime.now();
+        when(media1.getStart()).thenReturn(now);
+        when(media1.getEnd()).thenReturn(now);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media1));
+        assertThatThrownBy(() -> mediaIdValidator.validateNotZeroSecondAudio(mediaId))
+            .isExactlyInstanceOf(DartsApiException.class)
+            .hasFieldOrPropertyWithValue("error", START_TIME_END_TIME_NOT_VALID);
+    }
+
+    @Test
+    void validateNotZeroSecondAudio_shouldThrowException_ifStartDateIsAfterAndEndDate() {
+        Integer mediaId = 1;
+        OffsetDateTime now = OffsetDateTime.now();
+        when(media1.getStart()).thenReturn(now.plusSeconds(1));
+        when(media1.getEnd()).thenReturn(now);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media1));
+        assertThatThrownBy(() -> mediaIdValidator.validateNotZeroSecondAudio(mediaId))
+            .isExactlyInstanceOf(DartsApiException.class)
+            .hasFieldOrPropertyWithValue("error", START_TIME_END_TIME_NOT_VALID);
+    }
+
+    @Test
+    void validateNotZeroSecondAudio_shouldThrowException_ifStartDateIsNull() {
+        Integer mediaId = 1;
+        when(media1.getStart()).thenReturn(null);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media1));
+        assertThatThrownBy(() -> mediaIdValidator.validateNotZeroSecondAudio(mediaId))
+            .isExactlyInstanceOf(DartsApiException.class)
+            .hasFieldOrPropertyWithValue("error", START_TIME_END_TIME_NOT_VALID);
+    }
+
+    @Test
+    void validateNotZeroSecondAudio_shouldThrowException_ifEndDateIsNull() {
+        Integer mediaId = 1;
+        OffsetDateTime now = OffsetDateTime.now();
+        when(media1.getStart()).thenReturn(now);
+        when(media1.getEnd()).thenReturn(null);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media1));
+        assertThatThrownBy(() -> mediaIdValidator.validateNotZeroSecondAudio(mediaId))
+            .isExactlyInstanceOf(DartsApiException.class)
+            .hasFieldOrPropertyWithValue("error", START_TIME_END_TIME_NOT_VALID);
+    }
+
+    @Test
+    void validateNotZeroSecondAudio_shouldNotThrowException_ifStartDateIsBeforeEndDate() {
+        Integer mediaId = 1;
+        OffsetDateTime now = OffsetDateTime.now();
+        when(media1.getStart()).thenReturn(now.minusSeconds(1));
+        when(media1.getEnd()).thenReturn(now);
+        when(mediaRepository.findById(mediaId)).thenReturn(Optional.of(media1));
+        assertThatNoException().isThrownBy(() -> mediaIdValidator.validateNotZeroSecondAudio(mediaId));
     }
 }

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/MediaTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/MediaTestData.java
@@ -44,7 +44,7 @@ public class MediaTestData implements Persistable<TestMediaEntity.TestMediaBuild
         media.setChannel(1);
         media.setTotalChannels(1);
         media.setStart(now());
-        media.setEnd(now());
+        media.setEnd(now().plusMinutes(1));
         media.setMediaFile("a-media-file");
         media.setFileSize(1000L);
         media.setMediaFormat("mp2");


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-4386


### Change description ###
On audio preview, if the audio start and end date is equal (or the start date is after the end date) then throw a 422 error. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
