### PR TITLE
Fix transactional on CaseExpiryDeletionAutomatedTask

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTask.java
@@ -84,6 +84,13 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
         this.eventDateAdjustmentYears = eventDateAdjustmentYears;
     }
 
+
+    @Override
+    @Transactional
+    public void run() {
+        super.run();
+    }
+
     @Override
     public AutomatedTaskName getAutomatedTaskName() {
         return AutomatedTaskName.ASSOCIATED_OBJECT_DATA_EXPIRY_DELETION_TASK_NAME;
@@ -91,7 +98,6 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
 
     @Override
     public void runTask() {
-        log.info("Running AssociatedObjectDataExpiryDeletionAutomatedTask");
         final UserAccountEntity userAccount = userIdentity.getUserAccount();
         OffsetDateTime maxRetentionDate = currentTimeHelper.currentOffsetDateTime()
             .minus(getConfig().getBufferDuration());
@@ -113,6 +119,7 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
             AuditActivity.TRANSCRIPT_EXPIRED
         );
     }
+
 
     void deleteMediaEntity(UserAccountEntity userAccount, OffsetDateTime maxRetentionDate, Limit limit) {
         deleteExternalObjectDirectoryEntity(
@@ -144,8 +151,8 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
         );
     }
 
-    @Transactional
-    public <T extends SoftDelete & HasIntegerId & HasRetention & CanReturnExternalObjectDirectoryEntities> void deleteExternalObjectDirectoryEntity(
+
+    <T extends SoftDelete & HasIntegerId & HasRetention & CanReturnExternalObjectDirectoryEntities> void deleteExternalObjectDirectoryEntity(
         UserAccountEntity userAccount,
         SoftDeleteRepository<T, ?> repository,
         List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities,

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTask.java
@@ -84,13 +84,6 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
         this.eventDateAdjustmentYears = eventDateAdjustmentYears;
     }
 
-
-    @Override
-    @Transactional
-    public void run() {
-        super.run();
-    }
-
     @Override
     public AutomatedTaskName getAutomatedTaskName() {
         return AutomatedTaskName.ASSOCIATED_OBJECT_DATA_EXPIRY_DELETION_TASK_NAME;
@@ -98,6 +91,7 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
 
     @Override
     public void runTask() {
+        log.info("Running AssociatedObjectDataExpiryDeletionAutomatedTask");
         final UserAccountEntity userAccount = userIdentity.getUserAccount();
         OffsetDateTime maxRetentionDate = currentTimeHelper.currentOffsetDateTime()
             .minus(getConfig().getBufferDuration());
@@ -119,7 +113,6 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
             AuditActivity.TRANSCRIPT_EXPIRED
         );
     }
-
 
     void deleteMediaEntity(UserAccountEntity userAccount, OffsetDateTime maxRetentionDate, Limit limit) {
         deleteExternalObjectDirectoryEntity(
@@ -151,8 +144,8 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
         );
     }
 
-
-    <T extends SoftDelete & HasIntegerId & HasRetention & CanReturnExternalObjectDirectoryEntities> void deleteExternalObjectDirectoryEntity(
+    @Transactional
+    public <T extends SoftDelete & HasIntegerId & HasRetention & CanReturnExternalObjectDirectoryEntities> void deleteExternalObjectDirectoryEntity(
         UserAccountEntity userAccount,
         SoftDeleteRepository<T, ?> repository,
         List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities,

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTask.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
@@ -57,6 +58,7 @@ public class CaseExpiryDeletionAutomatedTask
     }
 
     @Override
+    @Transactional
     public void runTask() {
         final UserAccountEntity userAccount = userAccountService.getUserAccount();
         OffsetDateTime maxRetentionDate = currentTimeHelper.currentOffsetDateTime()


### PR DESCRIPTION
### Change description ###
The CaseExpiryDeletionAutomatedTask automated tasks did not have the Transactional annotation in the right place, and could result in data ending up in a stuck state if a pod could exited whilst the task was running. This PR fixes this. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
