### PR TITLE
DMP-4370: Amend case search validation

### DIFF
--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -808,19 +808,18 @@ components:
         courthouse:
           type: string
           example: Swansea
-          maxLength: 255
         courtroom:
           type: string
           example: 2
-          maxLength: 255
+          maxLength: 64
         judge_name:
           type: string
           example: Judge Walker
-          maxLength: 255
+          maxLength: 2000
         defendant_name:
           type: string
           example: 'David Defendant'
-          maxLength: 255
+          maxLength: 2000
         date_from:
           type: string
           format: date
@@ -830,7 +829,7 @@ components:
         event_text_contains:
           type: string
           example: 'Event text'
-          maxLength: 255
+          maxLength: 2000
 
     IsDataAnonymised:
       type: boolean


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4370)


### Change description ###
# Summary of Git Diff

This Git Diff modifies the `cases.yaml` file in the OpenAPI specification. It primarily focuses on adjusting the `maxLength` constraints for several string fields.

## Highlights

- **Removed `maxLength` constraint**:
  - `courthouse`: maxLength removed (was 255).
  
- **Updated `maxLength` constraints**:
  - `courtroom`: changed from 255 to 64.
  - `judge_name`: changed from 255 to 2000.
  - `defendant_name`: changed from 255 to 2000.
  - `event_text_contains`: changed from 255 to 2000. 

These changes allow for more flexible data input for certain fields while removing restrictions on others.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
