### PR TITLE
DMP-4439: Delete audio blob if detected as a duplicate

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
@@ -113,8 +113,10 @@ public class AudioUploadServiceImpl implements AudioUploadService {
                     log.error("Failed to delete blob from inbound container with guid: ", uuid, e);
                 }
             }
-            log.info("Exact duplicate detected based upon media metadata and checksum for media entity ids {}. Returning 200 with no changes.",
-                     duplicatesToBeSuperseded.stream().map(MediaEntity::getId).toList());
+            if (log.isInfoEnabled()) {
+                log.info("Exact duplicate detected based upon media metadata and checksum for media entity ids {}. Returning 200 with no changes.",
+                         duplicatesToBeSuperseded.stream().map(MediaEntity::getId).toList());
+            }
             return;
         }
 
@@ -129,7 +131,14 @@ public class AudioUploadServiceImpl implements AudioUploadService {
         // if we have not found any duplicate audio files to process lets add a new one
         if (isNotEmpty(duplicatesWithDifferentChecksum)) {
             mediaToSupersede.addAll(duplicatesWithDifferentChecksum);
-            log.info("Duplicate audio file has been found with difference in checksum");
+            if (log.isInfoEnabled()) {
+                log.info("Duplicate audio file has been found with difference in checksum for guid {} latest checksum {}. But found {}",
+                         externalLocation, incomingChecksum,
+                         duplicatesWithDifferentChecksum
+                             .stream()
+                             .map(mediaEntity -> "Meida Id " + mediaEntity.getId().toString() + " with checksum " + mediaEntity.getChecksum())
+                             .toList());
+            }
         }
 
         // version the file upload to the database

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.MediaLinkedCaseHelper;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
@@ -237,7 +238,7 @@ class AudioUploadServiceImplTest {
     }
 
     @Test
-    void addAudio_shouldDoNothing_whenMetadataOnlyAndAudioIsADuplicate() {
+    void addAudio_shouldDeleteInboundBlob_whenMetadataOnlyAndAudioIsADuplicate() throws AzureDeleteBlobException {
         UserAccountEntity userAccount = new UserAccountEntity();
         userAccount.setId(10);
         when(userIdentity.getUserAccount()).thenReturn(userAccount);
@@ -274,6 +275,7 @@ class AudioUploadServiceImplTest {
         verifyNoInteractions(logApi);
         verifyNoInteractions(externalObjectDirectoryRepository);
         verify(dataManagementApi, times(1)).getChecksum(DatastoreContainerType.INBOUND, externalLocation);
+        verify(dataManagementApi).deleteBlobDataFromInboundContainer(externalLocation);
         verifyNoMoreInteractions(dataManagementApi);
     }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4439)


### Change description ###
# Summary of Git Diff

This Git diff reflects updates made to the `AudioUploadServiceImpl.java` file, primarily involving changes to the handling of audio file uploads, specifically regarding duplicate audio files. The updates enhance the logic to ensure that duplicates are handled correctly, including the deletion of blobs from the inbound container when duplicates are detected.

## Highlights

- **Import Addition**: 
  - Introduced `AzureDeleteBlobException` to handle exceptions related to Azure blob deletions.

- **Method Signature Changes**:
  - Updated method signatures for `addAudio` methods to include a `boolean deleteGuidOnDuplicate` parameter.

- **Duplicate Handling Logic**:
  - Modified logic to delete the GUID on duplicate detection only if the `deleteGuidOnDuplicate` flag is true.
  - Added error handling for Azure blob deletion failures, logging errors appropriately.

- **Logging Enhancements**:
  - Improved logging statements to provide more context when duplicates are found, including checksums and media entity IDs.

- **Test Method Update**:
  - Renamed the test `addAudio_shouldDoNothing_whenMetadataOnlyAndAudioIsADuplicate` to `addAudio_shouldDeleteInboundBlob_whenMetadataOnlyAndAudioIsADuplicate`, reflecting the updated behavior in the implementation.
  - Included verification in the test to ensure that the blob deletion method is called when duplicates are detected.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
