### PR TITLE
DMP-4385 Filter out 0 second audios from ATS processing

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
@@ -101,10 +101,13 @@ public class OutboundFileProcessorImpl implements OutboundFileProcessor {
         List<AudioFileInfo> concatenatedAndMergedAudioFileInfos = new ArrayList<>();
         if (isNotEmpty(audioFileInfos)) {
             // Used for logging only
-            String audioFilenames = audioFileInfos.stream().map(AudioFileInfo::getMediaFile).collect(Collectors.joining(", "));
+            String audioFilenames = null;
+            if (log.isDebugEnabled()) {
+                audioFileInfos.stream().map(AudioFileInfo::getMediaFile).collect(Collectors.joining(", "));
+            }
 
             List<ChannelAudio> concatenationsList = new ArrayList<>();
-            
+
             if (isWellFormedAudio(audioFileInfos)) {
                 log.debug("Audio files {} are well formed", audioFilenames);
                 List<ChannelAudio> concatenatedAudios = concatenateByChannelWithGaps(audioFileInfos);

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
@@ -103,7 +103,7 @@ public class OutboundFileProcessorImpl implements OutboundFileProcessor {
             // Used for logging only
             String audioFilenames = null;
             if (log.isDebugEnabled()) {
-                audioFileInfos.stream().map(AudioFileInfo::getMediaFile).collect(Collectors.joining(", "));
+                audioFilenames = audioFileInfos.stream().map(AudioFileInfo::getMediaFile).collect(Collectors.joining(", "));
             }
 
             List<ChannelAudio> concatenationsList = new ArrayList<>();

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
@@ -104,7 +104,6 @@ public class OutboundFileProcessorImpl implements OutboundFileProcessor {
             String audioFilenames = audioFileInfos.stream().map(AudioFileInfo::getMediaFile).collect(Collectors.joining(", "));
 
             List<ChannelAudio> concatenationsList = new ArrayList<>();
-
             
             if (isWellFormedAudio(audioFileInfos)) {
                 log.debug("Audio files {} are well formed", audioFilenames);

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
@@ -100,10 +100,12 @@ public class OutboundFileProcessorImpl implements OutboundFileProcessor {
 
         List<AudioFileInfo> concatenatedAndMergedAudioFileInfos = new ArrayList<>();
         if (isNotEmpty(audioFileInfos)) {
+            // Used for logging only
             String audioFilenames = audioFileInfos.stream().map(AudioFileInfo::getMediaFile).collect(Collectors.joining(", "));
 
             List<ChannelAudio> concatenationsList = new ArrayList<>();
 
+            
             if (isWellFormedAudio(audioFileInfos)) {
                 log.debug("Audio files {} are well formed", audioFilenames);
                 List<ChannelAudio> concatenatedAudios = concatenateByChannelWithGaps(audioFileInfos);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -227,13 +227,10 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
         return mediaEntitiesForRequest.stream()
             .filter(media -> nonNull(media.getStart()))
             .filter(media -> nonNull(media.getEnd()))
-            // Filter out media where the media start and media end times are the same and not less than a second apart
+            // Filter out media where the media start and media end times are the same and not less than a second apart as trim works against seconds
             .filter(media -> !media.getStart().truncatedTo(ChronoUnit.SECONDS).isEqual(media.getEnd().truncatedTo(ChronoUnit.SECONDS)))
-            // Filter out media where the media start time is after the media end time
             .filter(media -> media.getStart().isBefore(media.getEnd()))
-            // Filter out media where the media end time is after the media request start time
             .filter(media -> mediaRequestEntity.getStartTime().isBefore(media.getEnd()))
-            // Filter out media where the media start time is before the media request end time
             .filter(media -> media.getStart().isBefore(mediaRequestEntity.getEndTime()))
             .sorted(MEDIA_START_TIME_CHANNEL_COMPARATOR)
             .collect(Collectors.toList());

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImpl.java
@@ -227,7 +227,7 @@ public class AudioTransformationServiceImpl implements AudioTransformationServic
         return mediaEntitiesForRequest.stream()
             .filter(media -> nonNull(media.getStart()))
             .filter(media -> nonNull(media.getEnd()))
-            // Filter out media where the media start and media end times are the same
+            // Filter out media where the media start and media end times are the same and not less than a second apart
             .filter(media -> !media.getStart().truncatedTo(ChronoUnit.SECONDS).isEqual(media.getEnd().truncatedTo(ChronoUnit.SECONDS)))
             // Filter out media where the media start time is after the media end time
             .filter(media -> media.getStart().isBefore(media.getEnd()))

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
@@ -246,7 +246,119 @@ class AudioTransformationServiceImplTest {
     }
 
     @Test
-    void filterMediaByMediaRequestDatesWithStartDateExactRequestAndEndDateExactRequest() {
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithStartDateAndEndDateTheSame() {
+        List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_20, TIME_12_40, TIME_13_00);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        assertEquals(2, mediaEntitiesResult.size());
+        assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
+        assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
+        assertEquals(TIME_12_40, mediaEntitiesResult.get(1).getStart());
+        assertEquals(TIME_13_00, mediaEntitiesResult.get(1).getEnd());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsOnlyMediaWithStartDateAndEndDateTheSame() {
+        List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_00, TIME_12_20, TIME_12_20, TIME_13_00, TIME_13_00);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        assertEquals(0, mediaEntitiesResult.size());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithStartDateAfterEndDate() {
+        List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_40, TIME_12_20, TIME_12_40, TIME_13_00);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        assertEquals(2, mediaEntitiesResult.size());
+        assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
+        assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
+        assertEquals(TIME_12_40, mediaEntitiesResult.get(1).getStart());
+        assertEquals(TIME_13_00, mediaEntitiesResult.get(1).getEnd());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsOnlyMediaWithStartDateAfterEndDate() {
+        List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_20, TIME_12_00, TIME_12_40, TIME_12_20, TIME_13_00, TIME_12_40);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        assertEquals(0, mediaEntitiesResult.size());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithNullStartDate() {
+        List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, null, TIME_12_20, TIME_12_40, TIME_13_00);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        assertEquals(2, mediaEntitiesResult.size());
+        assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
+        assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
+        assertEquals(TIME_12_40, mediaEntitiesResult.get(1).getStart());
+        assertEquals(TIME_13_00, mediaEntitiesResult.get(1).getEnd());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsOnlyMediaWithNullStartDates() {
+        List<MediaEntity> mediaEntities = createMediaEntities(null, TIME_12_00, null, TIME_12_20, null, TIME_12_40);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        assertEquals(0, mediaEntitiesResult.size());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithNullEndDate() {
+        List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_40, null, TIME_12_40, TIME_13_00);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        assertEquals(2, mediaEntitiesResult.size());
+        assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
+        assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
+        assertEquals(TIME_12_40, mediaEntitiesResult.get(1).getStart());
+        assertEquals(TIME_13_00, mediaEntitiesResult.get(1).getEnd());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsOnlyMediaNullEndDates() {
+        List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_20, null, TIME_12_40, null, TIME_13_00, null);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        assertEquals(0, mediaEntitiesResult.size());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateExactRequestAndEndDateExactRequest() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
@@ -260,7 +372,7 @@ class AudioTransformationServiceImplTest {
     }
 
     @Test
-    void filterMediaByMediaRequestDatesWithStartDateAfterRequestAndEndDateBeforeRequest() {
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateAfterRequestAndEndDateBeforeRequest() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_01, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_12_59);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
@@ -273,7 +385,7 @@ class AudioTransformationServiceImplTest {
     }
 
     @Test
-    void filterMediaByMediaRequestDatesWithStartDateBeforeRequestAndEndDateAfterRequest() {
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateBeforeRequestAndEndDateAfterRequest() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_11_59, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_01);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
@@ -286,7 +398,7 @@ class AudioTransformationServiceImplTest {
     }
 
     @Test
-    void filterMediaByMediaRequestDatesWithStartDateAndEndDateExactMiddleMediaMatch() {
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateAndEndDateExactMiddleMediaMatch() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_11_59, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_01);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_20, TIME_12_40);
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
@@ -299,7 +411,7 @@ class AudioTransformationServiceImplTest {
     }
 
     @Test
-    void filterMediaByMediaRequestDatesWithStartDateBetweenRequestAndEndDateBetweenRequest() {
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateBetweenRequestAndEndDateBetweenRequest() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_21, TIME_12_39);
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
@@ -312,7 +424,7 @@ class AudioTransformationServiceImplTest {
     }
 
     @Test
-    void filterMediaByMediaRequestDatesWithRequestStartAndEndDateOutSideMediaRange() {
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithRequestStartAndEndDateOutSideMediaRange() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_12_59);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_13_00, TIME_13_01);
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
@@ -323,7 +435,7 @@ class AudioTransformationServiceImplTest {
     }
 
     @Test
-    void filterMediaByMediaRequestDatesWithRequestStartTimeMatchesAnAudioEndTime() {
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithRequestStartTimeMatchesAnAudioEndTime() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_09_59, TIME_10_00, TIME_10_05, TIME_10_10, TIME_10_15, TIME_10_20);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_10_00, TIME_10_10);
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
@@ -337,7 +449,7 @@ class AudioTransformationServiceImplTest {
     }
 
     @Test
-    void filterMediaByMediaRequestDatesWithRequestEndTimeMatchesAnAudioStartTime() {
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithRequestEndTimeMatchesAnAudioStartTime() {
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_09_59, TIME_10_00, TIME_10_05, TIME_10_10, TIME_10_15, TIME_10_20);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_09_59, TIME_10_15);
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioTransformationServiceImplTest.java
@@ -74,6 +74,7 @@ class AudioTransformationServiceImplTest {
     private static final OffsetDateTime TIME_12_00 = OffsetDateTime.parse("2023-01-01T12:00Z");
     private static final OffsetDateTime TIME_12_01 = OffsetDateTime.parse("2023-01-01T12:01Z");
     private static final OffsetDateTime TIME_12_20 = OffsetDateTime.parse("2023-01-01T12:20Z");
+    private static final OffsetDateTime TIME_12_20_00_900 = OffsetDateTime.parse("2023-01-01T12:20:00.900Z");
     private static final OffsetDateTime TIME_12_21 = OffsetDateTime.parse("2023-01-01T12:21Z");
     private static final OffsetDateTime TIME_12_39 = OffsetDateTime.parse("2023-01-01T12:39Z");
     private static final OffsetDateTime TIME_12_40 = OffsetDateTime.parse("2023-01-01T12:40Z");
@@ -247,13 +248,37 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithStartDateAndEndDateTheSame() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_20, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
+        assertEquals(2, mediaEntitiesResult.size());
+        assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
+        assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
+        assertEquals(TIME_12_40, mediaEntitiesResult.get(1).getStart());
+        assertEquals(TIME_13_00, mediaEntitiesResult.get(1).getEnd());
+    }
+
+    @Test
+    void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithStartDateAndEndDateLessThan1Second() {
+        // given
+        List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_20_00_900, TIME_12_40, TIME_13_00);
+        MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
+        List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
+            mediaEntities,
+            mediaRequestEntity
+        );
+
+        // then
         assertEquals(2, mediaEntitiesResult.size());
         assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
@@ -263,25 +288,34 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsOnlyMediaWithStartDateAndEndDateTheSame() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_00, TIME_12_20, TIME_12_20, TIME_13_00, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
         assertEquals(0, mediaEntitiesResult.size());
     }
 
+
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithStartDateAfterEndDate() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_40, TIME_12_20, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
         assertEquals(2, mediaEntitiesResult.size());
         assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
@@ -291,25 +325,33 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsOnlyMediaWithStartDateAfterEndDate() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_20, TIME_12_00, TIME_12_40, TIME_12_20, TIME_13_00, TIME_12_40);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
         assertEquals(0, mediaEntitiesResult.size());
     }
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithNullStartDate() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, null, TIME_12_20, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
         assertEquals(2, mediaEntitiesResult.size());
         assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
@@ -331,13 +373,17 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WhichContainsMediaWithNullEndDate() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_40, null, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
         assertEquals(2, mediaEntitiesResult.size());
         assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getEnd());
@@ -359,13 +405,17 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateExactRequestAndEndDateExactRequest() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
         assertEquals(3, mediaEntitiesResult.size());
         assertEquals(TIME_12_00, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_13_00, mediaEntitiesResult.get(2).getEnd());
@@ -373,12 +423,17 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateAfterRequestAndEndDateBeforeRequest() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_01, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_12_59);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
+
+        // then
         assertEquals(3, mediaEntitiesResult.size());
         assertEquals(TIME_12_01, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_59, mediaEntitiesResult.get(2).getEnd());
@@ -386,12 +441,17 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateBeforeRequestAndEndDateAfterRequest() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_11_59, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_01);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_00, TIME_13_00);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
+
+        // then
         assertEquals(3, mediaEntitiesResult.size());
         assertEquals(TIME_11_59, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_13_01, mediaEntitiesResult.get(2).getEnd());
@@ -399,12 +459,17 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateAndEndDateExactMiddleMediaMatch() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_11_59, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_01);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_20, TIME_12_40);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
+
+        // then
         assertEquals(1, mediaEntitiesResult.size());
         assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_40, mediaEntitiesResult.get(0).getEnd());
@@ -412,12 +477,17 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithStartDateBetweenRequestAndEndDateBetweenRequest() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_13_00);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_12_21, TIME_12_39);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
+
+        // then
         assertEquals(1, mediaEntitiesResult.size());
         assertEquals(TIME_12_20, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_12_40, mediaEntitiesResult.get(0).getEnd());
@@ -425,24 +495,33 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithRequestStartAndEndDateOutSideMediaRange() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_12_00, TIME_12_20, TIME_12_20, TIME_12_40, TIME_12_40, TIME_12_59);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_13_00, TIME_13_01);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
+
+        // then
         assertEquals(0, mediaEntitiesResult.size());
     }
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithRequestStartTimeMatchesAnAudioEndTime() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_09_59, TIME_10_00, TIME_10_05, TIME_10_10, TIME_10_15, TIME_10_20);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_10_00, TIME_10_10);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
         assertEquals(1, mediaEntitiesResult.size());
         assertEquals(TIME_10_05, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_10_10, mediaEntitiesResult.get(0).getEnd());
@@ -450,13 +529,17 @@ class AudioTransformationServiceImplTest {
 
     @Test
     void filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel_ReturnsFilteredData_WithRequestEndTimeMatchesAnAudioStartTime() {
+        // given
         List<MediaEntity> mediaEntities = createMediaEntities(TIME_09_59, TIME_10_00, TIME_10_05, TIME_10_10, TIME_10_15, TIME_10_20);
         MediaRequestEntity mediaRequestEntity = createMediaRequest(TIME_09_59, TIME_10_15);
+
+        // when
         List<MediaEntity> mediaEntitiesResult = audioTransformationService.filterMediaByMediaRequestTimeframeAndSortByStartTimeAndChannel(
             mediaEntities,
             mediaRequestEntity
         );
 
+        // then
         assertEquals(2, mediaEntitiesResult.size());
         assertEquals(TIME_09_59, mediaEntitiesResult.get(0).getStart());
         assertEquals(TIME_10_10, mediaEntitiesResult.get(1).getEnd());


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4385

### Change description ###

Updated the ATS filtering to filter out audio files that have less than a second start and end time, start or end time is null or start time is after end time

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
