### PR TITLE
DMP-4458: Respond with 404 if courthouse is not found

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/exception/CommonApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/CommonApiError.java
@@ -12,7 +12,7 @@ public enum CommonApiError implements DartsApiError {
 
     COURTHOUSE_PROVIDED_DOES_NOT_EXIST(
         CommonErrorCode.COURTHOUSE_PROVIDED_DOES_NOT_EXIST.getValue(),
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.NOT_FOUND,
         CommonTitleErrors.COURTHOUSE_PROVIDED_DOES_NOT_EXIST.toString()
     ),
     FEATURE_FLAG_NOT_ENABLED(


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4458)


### Change description ###
# Summary of Git Diff

This Git diff shows a modification in the `CommonApiError` enum within the `CommonApiError.java` file. Specifically, the HTTP status code for the `COURTHOUSE_PROVIDED_DOES_NOT_EXIST` error has been changed from `BAD_REQUEST` (400) to `NOT_FOUND` (404).

## Highlights

- **File Changed**: `CommonApiError.java`
- **Enum Affected**: `CommonApiError`
- **Error Modified**: `COURTHOUSE_PROVIDED_DOES_NOT_EXIST`
- **Status Code Change**: 
  - From: `HttpStatus.BAD_REQUEST` (400)
  - To: `HttpStatus.NOT_FOUND` (404)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
