### PR TITLE
DMP-4455: DEV ONLY: Sonar no longer reporting DARTS API code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,7 +330,7 @@ sonarqube {
     property "sonar.projectName", "DARTS :: darts-api"
     property "sonar.projectKey", "uk.gov.hmcts.reform:darts-api"
     property "sonar.exclusions", coverageExclusions.join(', ')
-    property 'sonar.coverage.exclusions', "**/entity/*,**/dto/*,**/AzureCopyUtil.java,**/TestSupportController.java,**/darts/**"
+    property 'sonar.coverage.exclusions', "**/entity/*,**/dto/*,**/AzureCopyUtil.java,**/TestSupportController.java"
     //duplicate code here due to OpenAPI codegen that creates identical
     // objects (Transcript) in different packages
     property "sonar.cpd.exclusions", "**/TranscriptionMapper.java"


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4455)


### Change description ###
# Summary of Git Diff

This Git diff reflects a change in the `build.gradle` file, specifically in the SonarQube configuration section. The modification involves the removal of an exclusion pattern from the `sonar.coverage.exclusions` property.

## Highlights

- **File Changed**: `build.gradle`
- **Modification**: 
  - Removed `**/darts/**` from the `sonar.coverage.exclusions` property.
- **Remaining Exclusions**: 
  - `**/entity/*`
  - `**/dto/*`
  - `**/AzureCopyUtil.java`
  - `**/TestSupportController.java`
- **Other Properties**: No changes were made to other SonarQube properties in the section.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
