### PR TITLE
DMP-4481: Amend get medias marked for deletion endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -22,11 +22,11 @@ import uk.gov.hmcts.darts.audio.model.AdminMediaResponse;
 import uk.gov.hmcts.darts.audio.model.AudioMetadata;
 import uk.gov.hmcts.darts.audio.model.AudioPreview;
 import uk.gov.hmcts.darts.audio.model.GetAdminMediaResponseItem;
+import uk.gov.hmcts.darts.audio.model.GetAdminMediasMarkedForDeletionItem;
 import uk.gov.hmcts.darts.audio.model.GetTransformedMediaResponse;
 import uk.gov.hmcts.darts.audio.model.MediaApproveMarkedForDeletionResponse;
 import uk.gov.hmcts.darts.audio.model.MediaHideRequest;
 import uk.gov.hmcts.darts.audio.model.MediaHideResponse;
-import uk.gov.hmcts.darts.audio.model.PostAdminMediasMarkedForDeletionItem;
 import uk.gov.hmcts.darts.audio.model.PostAdminMediasSearchRequest;
 import uk.gov.hmcts.darts.audio.model.PostAdminMediasSearchResponseItem;
 import uk.gov.hmcts.darts.audio.service.AdminMediaService;
@@ -192,7 +192,7 @@ public class AudioController implements AudioApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = {SUPER_ADMIN})
-    public ResponseEntity<List<PostAdminMediasMarkedForDeletionItem>> adminMediasMarkedForDeletionGet() {
+    public ResponseEntity<List<GetAdminMediasMarkedForDeletionItem>> adminMediasMarkedForDeletionGet() {
         return new ResponseEntity<>(adminMediaService.getMediasMarkedForDeletion(), HttpStatus.OK);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/mapper/AdminMarkedForDeletionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/mapper/AdminMarkedForDeletionMapper.java
@@ -1,17 +1,32 @@
 package uk.gov.hmcts.darts.audio.mapper;
 
+import lombok.RequiredArgsConstructor;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.gov.hmcts.darts.audio.model.GetAdminMediasMarkedForDeletionAdminAction;
+import uk.gov.hmcts.darts.audio.model.GetAdminMediasMarkedForDeletionItem;
+import uk.gov.hmcts.darts.audio.model.GetAdminMediasMarkedForDeletionMediaItem;
 import uk.gov.hmcts.darts.audio.model.PostAdminMediasMarkedForDeletionItem;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
+import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
+import uk.gov.hmcts.darts.common.repository.MediaRepository;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring",
     uses = {ObjectActionMapper.class, CourthouseMapper.class, CourtroomMapper.class},
     unmappedSourcePolicy = ReportingPolicy.IGNORE,
     unmappedTargetPolicy = ReportingPolicy.ERROR)
-public interface AdminMarkedForDeletionMapper {
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
+public abstract class AdminMarkedForDeletionMapper {
+
+    private CourthouseMapper courthouseMapper;
+    private CourtroomMapper courtroomMapper;
+    private ObjectActionMapper objectActionMapper;
+    private MediaRepository mediaRepository;
 
     @Mappings({
         @Mapping(target = "mediaId", source = "id"),
@@ -22,6 +37,32 @@ public interface AdminMarkedForDeletionMapper {
         @Mapping(target = "courtroom", source = "courtroom"),
         @Mapping(target = "adminAction", source = "adminActionReasons")
     })
-    PostAdminMediasMarkedForDeletionItem toApiModel(MediaEntity mediaEntity);
+    public abstract PostAdminMediasMarkedForDeletionItem toApiModel(MediaEntity mediaEntity);
 
+    @Mappings({
+        @Mapping(target = "versionCount", ignore = true)
+    })
+    public abstract GetAdminMediasMarkedForDeletionMediaItem toGetAdminMediasMarkedForDeletionMediaItem(MediaEntity mediaEntity);
+
+    public GetAdminMediasMarkedForDeletionItem toGetAdminMediasMarkedForDeletionItem(List<ObjectAdminActionEntity> actions) {
+        ObjectAdminActionEntity base = actions.get(0);
+        List<GetAdminMediasMarkedForDeletionMediaItem> media = actions.stream()
+            .map(action -> action.getMedia())
+            .map(mediaEntity -> {
+                GetAdminMediasMarkedForDeletionMediaItem item = toGetAdminMediasMarkedForDeletionMediaItem(mediaEntity);
+                item.setVersionCount(mediaRepository.getVersionCount(mediaEntity.getChronicleId()));
+                return item;
+            })
+            .toList();
+        GetAdminMediasMarkedForDeletionItem item = new GetAdminMediasMarkedForDeletionItem();
+        item.setMedia(media);
+        item.setStartAt(base.getMedia().getStart());
+        item.setEndAt(base.getMedia().getEnd());
+        item.setCourthouse(courthouseMapper.toApiModel(base.getMedia().getCourtroom().getCourthouse()));
+        item.setCourtroom(courtroomMapper.toApiModel(base.getMedia().getCourtroom()));
+        GetAdminMediasMarkedForDeletionAdminAction adminAction = objectActionMapper.toGetAdminMediasMarkedForDeletionAdminAction(base);
+        adminAction.setComments(actions.stream().map(ObjectAdminActionEntity::getComments).toList());
+        item.setAdminAction(adminAction);
+        return item;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/mapper/ObjectActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/mapper/ObjectActionMapper.java
@@ -6,6 +6,7 @@ import org.mapstruct.Mappings;
 import org.mapstruct.ReportingPolicy;
 import uk.gov.hmcts.darts.audio.model.AdminActionResponse;
 import uk.gov.hmcts.darts.audio.model.AdminMediaHearingResponseItem;
+import uk.gov.hmcts.darts.audio.model.GetAdminMediasMarkedForDeletionAdminAction;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
 
@@ -48,4 +49,11 @@ public interface ObjectActionMapper {
         return toApiModel(objectAdminActionEntities.get(0));
     }
 
+    @Mappings({
+        @Mapping(target = "ticketReference", source = "ticketReference"),
+        @Mapping(target = "reasonId", source = "objectHiddenReason.id"),
+        @Mapping(target = "hiddenById", source = "hiddenBy.id"),
+        @Mapping(target = "comments", ignore = true)
+    })
+    GetAdminMediasMarkedForDeletionAdminAction toGetAdminMediasMarkedForDeletionAdminAction(ObjectAdminActionEntity objectAdminActionEntity);
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/mapper/PostAdminMediaSearchResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/mapper/PostAdminMediaSearchResponseMapper.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.darts.audio.mapper;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import uk.gov.hmcts.darts.audio.model.CourthouseResponseObject;
-import uk.gov.hmcts.darts.audio.model.CourtroomResponseObject;
+import uk.gov.hmcts.darts.audio.model.AdminMediaCourthouseResponse;
+import uk.gov.hmcts.darts.audio.model.AdminMediaCourtroomResponse;
 import uk.gov.hmcts.darts.audio.model.PostAdminMediasSearchResponseItem;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
@@ -37,15 +37,15 @@ public class PostAdminMediaSearchResponseMapper {
         return responseItem;
     }
 
-    private CourthouseResponseObject createCourthouse(CourthouseEntity courthouse) {
-        CourthouseResponseObject responseCourthouse = new CourthouseResponseObject();
+    private AdminMediaCourthouseResponse createCourthouse(CourthouseEntity courthouse) {
+        AdminMediaCourthouseResponse responseCourthouse = new AdminMediaCourthouseResponse();
         responseCourthouse.setId(courthouse.getId());
         responseCourthouse.setDisplayName(courthouse.getDisplayName());
         return responseCourthouse;
     }
 
-    private CourtroomResponseObject createCourtroom(CourtroomEntity courtroomEntity) {
-        CourtroomResponseObject courtroomResponseObject = new CourtroomResponseObject();
+    private AdminMediaCourtroomResponse createCourtroom(CourtroomEntity courtroomEntity) {
+        AdminMediaCourtroomResponse courtroomResponseObject = new AdminMediaCourtroomResponse();
         courtroomResponseObject.setId(courtroomEntity.getId());
         courtroomResponseObject.setName(courtroomEntity.getName());
         return courtroomResponseObject;

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/AdminMediaService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/AdminMediaService.java
@@ -2,8 +2,8 @@ package uk.gov.hmcts.darts.audio.service;
 
 import uk.gov.hmcts.darts.audio.model.AdminMediaResponse;
 import uk.gov.hmcts.darts.audio.model.GetAdminMediaResponseItem;
+import uk.gov.hmcts.darts.audio.model.GetAdminMediasMarkedForDeletionItem;
 import uk.gov.hmcts.darts.audio.model.MediaApproveMarkedForDeletionResponse;
-import uk.gov.hmcts.darts.audio.model.PostAdminMediasMarkedForDeletionItem;
 import uk.gov.hmcts.darts.audio.model.PostAdminMediasSearchRequest;
 import uk.gov.hmcts.darts.audio.model.PostAdminMediasSearchResponseItem;
 
@@ -23,7 +23,7 @@ public interface AdminMediaService {
 
     List<PostAdminMediasSearchResponseItem> performAdminMediasSearchPost(PostAdminMediasSearchRequest adminMediasSearchRequest);
 
-    List<PostAdminMediasMarkedForDeletionItem> getMediasMarkedForDeletion();
+    List<GetAdminMediasMarkedForDeletionItem> getMediasMarkedForDeletion();
 
     MediaApproveMarkedForDeletionResponse adminApproveMediaMarkedForDeletion(Integer mediaId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
@@ -106,4 +106,11 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Integer>,
     List<MediaEntity> findAllLinkedByMediaLinkedCaseByCaseId(Integer caseId);
 
     boolean existsByIdAndIsHiddenFalse(Integer mediaId);
+
+    @Query("""
+           SELECT COUNT(me)
+           FROM MediaEntity me
+           WHERE me.chronicleId = :chronicleId
+        """)
+    Integer getVersionCount(String chronicleId);
 }

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -454,7 +454,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PostAdminMediasMarkedForDeletionItem'
+                  $ref: '#/components/schemas/GetAdminMediasMarkedForDeletionItem'
 
 ########################################################################################################################
 # COMPONENT DEFINITIONS
@@ -462,6 +462,55 @@ paths:
 
 components:
   schemas:
+    GetAdminMediasMarkedForDeletionItem:
+      type: object
+      properties:
+        media:
+          type: array
+          items:
+              $ref: '#/components/schemas/GetAdminMediasMarkedForDeletionMediaItem'
+        start_at:
+          type: string
+          format: date-time
+          description: start timestamp
+        end_at:
+          type: string
+          format: date-time
+          description: end timestamp
+        courthouse:
+          $ref: '#/components/schemas/AdminMediaCourthouseResponse'
+        courtroom:
+          $ref: '#/components/schemas/AdminMediaCourtroomResponse'
+        admin_action:
+          $ref: '#/components/schemas/GetAdminMediasMarkedForDeletionAdminAction'
+      required:
+        - media
+        - start_at
+        - end_at
+        - courthouse
+        - courtroom
+        - admin_action
+    GetAdminMediasMarkedForDeletionAdminAction:
+      type: object
+      properties:
+        ticket_reference:
+          type: string
+          example: "1234"
+        hidden_by_id:
+          type: integer
+          example: 1
+        reason_id:
+          type: integer
+          example: 1
+        comments:
+          type: array
+          items:
+            type: string
+      required:
+        - ticket_reference
+        - hidden_by_id
+        - reason_id
+        - comments
     PostAdminMediasSearchRequest:
       type: object
       properties:
@@ -482,6 +531,30 @@ components:
         hearing_end_at:
           type: string
           format: date
+    GetAdminMediasMarkedForDeletionMediaItem:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        channel:
+          type: integer
+          example: 1
+        total_channels:
+          type: integer
+          example: 1
+        is_current:
+          type: boolean
+          example: true
+        version_count:
+          type: integer
+          example: 1
+      required:
+        - id
+        - channel
+        - total_channels
+        - is_current
+        - version_count
 
     PostAdminMediasSearchResponseItem:
       type: object
@@ -491,9 +564,9 @@ components:
           example: 1
           description: Unique media identifier, used internally by DARTS.
         courthouse:
-          $ref: '#/components/schemas/CourthouseResponseObject'
+          $ref: '#/components/schemas/AdminMediaCourthouseResponse'
         courtroom:
-          $ref: '#/components/schemas/CourtroomResponseObject'
+          $ref: '#/components/schemas/AdminMediaCourtroomResponse'
         start_at:
           type: string
           format: date-time
@@ -507,7 +580,6 @@ components:
           example: 1
         is_hidden:
           type: boolean
-
     PostAdminMediasMarkedForDeletionItem:
       type: object
       properties:
@@ -525,30 +597,6 @@ components:
           $ref: '#/components/schemas/AdminMediaCourtroomResponse'
         admin_action:
           $ref: '#/components/schemas/AdminActionResponse'
-
-
-    CourthouseResponseObject:
-      type: object
-      properties:
-        id:
-          type: integer
-          example: 1
-          description: the courthouse ID
-        display_name:
-          type: string
-          example: Swansea
-
-    CourtroomResponseObject:
-      type: object
-      properties:
-        id:
-          type: integer
-          example: 1
-          description: the courtroom ID
-        name:
-          type: string
-          example: "1"
-
     AdminMediaResponse:
       type: object
       properties:
@@ -685,7 +733,6 @@ components:
               $ref: '#/components/schemas/CourtroomId'
             name:
               $ref: '#/components/schemas/CourtroomName'
-
     GetAdminMediaResponseItem:
       type: object
       required:


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4481)


### Change description ###
# Summary of Git Diff

This Git diff reflects significant changes in the audio management components of the DARTS application. The primary modifications include the introduction of new data models for handling media marked for deletion and updates to existing services, mappers, and API documentation. These changes enhance the application's handling of media deletion and improve the structure of the relevant data models.

## Highlights

- **New Data Models**: 
  - Introduced `GetAdminMediasMarkedForDeletionItem`, `GetAdminMediasMarkedForDeletionMediaItem`, and `GetAdminMediasMarkedForDeletionAdminAction` to better represent media that is marked for deletion.
  
- **Updated Method Signatures**:
  - Changed the return type of the method `adminMediasMarkedForDeletionGet` from `List<PostAdminMediasMarkedForDeletionItem>` to `List<GetAdminMediasMarkedForDeletionItem>`.
  - Updated the method `getMediasMarkedForDeletion` in `AdminMediaService` to return a list of the new deletion item model.

- **Mapper Enhancements**:
  - `AdminMarkedForDeletionMapper` was converted from an interface to an abstract class, and new mapping methods were added to transform media entities into the new data models.

- **API Documentation Changes**:
  - Updated the OpenAPI specification to reflect the new data models, replacing references to the old `PostAdminMediasMarkedForDeletionItem` with the new `GetAdminMediasMarkedForDeletionItem`.

- **Refactoring**:
  - Various utility methods were introduced or modified for improved functionality and better data handling, including grouping media actions by various identifiers and utilizing the `MediaRepository` for version counting.

These enhancements aim to streamline the media deletion process and ensure a more robust data structure within the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
