### PR TITLE
DMP-4499: Performance Testing - Automated Tasks - DetsToArm - SELECT darts takes 4.5 minutes

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchPushProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchPushProcessorIntTest.java
@@ -300,7 +300,8 @@ class DetsToArmBatchPushProcessorIntTest extends IntegrationBase {
         detsToArmBatchPushProcessor.processDetsToArm(5);
         // when
         //Error is gracefully handled and logged
-        assertThat(output).contains("uk.gov.hmcts.darts.common.exception.DartsException: Unable to find ObjectStateRecordEntity for ARM EOD ID: 2 as OSR UUID is null");
+        assertThat(output)
+            .contains("uk.gov.hmcts.darts.common.exception.DartsException: Unable to find ObjectStateRecordEntity for ARM EOD ID: 2 as OSR UUID is null");
     }
 
     private ObjectStateRecordEntity createObjectStateRecordEntity(Long uuid) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
@@ -109,11 +109,13 @@ public class DetsToArmBatchPushProcessorImpl implements DetsToArmBatchPushProces
                 }
                 return;
             }
+        } else {
+            log.info("No DETS EODs to process");
         }
         log.info("Finished running DETS ARM Batch Push processing at: {}", OffsetDateTime.now());
     }
 
-    private List<Integer> getDetsEodEntitiesToSendToArm(ExternalLocationTypeEntity sourceLocation,
+    List<Integer> getDetsEodEntitiesToSendToArm(ExternalLocationTypeEntity sourceLocation,
                                                         ExternalLocationTypeEntity armLocation, int maxResultSize) {
         ObjectRecordStatusEntity armRawStatusFailed = EodHelper.failedArmRawDataStatus();
         ObjectRecordStatusEntity armManifestFailed = EodHelper.failedArmManifestFileStatus();

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
@@ -28,6 +28,8 @@ import uk.gov.hmcts.darts.common.repository.ObjectStateRecordRepository;
 import uk.gov.hmcts.darts.common.service.FileOperationService;
 import uk.gov.hmcts.darts.common.util.EodHelper;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.config.DetsToArmPushAutomatedTaskConfig;
+import uk.gov.hmcts.darts.util.AsyncUtil;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -35,6 +37,9 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_INGESTION;
@@ -57,6 +62,7 @@ public class DetsToArmBatchPushProcessorImpl implements DetsToArmBatchPushProces
     private final ObjectStateRecordRepository objectStateRecordRepository;
     private final CurrentTimeHelper currentTimeHelper;
     private final ExternalObjectDirectoryService externalObjectDirectoryService;
+    private final DetsToArmPushAutomatedTaskConfig automatedTaskConfigurationProperties;
 
 
     public void processDetsToArm(int taskBatchSize) {
@@ -73,12 +79,35 @@ public class DetsToArmBatchPushProcessorImpl implements DetsToArmBatchPushProces
             //ARM has a max batch size for manifest items, so lets loop through the big list creating lots of individual batches for ARM to process separately
             List<List<Integer>> batchesForArm = ListUtils.partition(eodsForTransfer,
                                                                     detsToArmProcessorConfiguration.getMaxArmManifestItems());
-            int batchCounter = 1;
             UserAccountEntity userAccount = userIdentity.getUserAccount();
-            for (List<Integer> eodsForBatch : batchesForArm) {
-                log.info("Creating DETS batch {} out of {}", batchCounter++, batchesForArm.size());
-                List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities = externalObjectDirectoryRepository.findAllById(eodsForBatch);
-                createAndSendBatchFile(externalObjectDirectoryEntities, userAccount);
+
+            AtomicInteger batchCounter = new AtomicInteger(1);
+            List<Callable<Void>> tasks = batchesForArm
+                .stream()
+                .map(eodsForBatch -> (Callable<Void>) () -> {
+                    int batchNumber = batchCounter.getAndIncrement();
+                    try {
+                        log.info("Creating DETS batch {} out of {}", batchNumber, batchesForArm.size());
+                        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities = externalObjectDirectoryRepository.findAllById(eodsForBatch);
+                        log.info("Starting processing DETS batch {} out of {}", batchNumber, batchesForArm.size());
+                        createAndSendBatchFile(externalObjectDirectoryEntities, userAccount);
+                        log.info("Finished processing DETS batch {} out of {}", batchNumber, batchesForArm.size());
+                    } catch (Exception e) {
+                        log.error("Unexpected exception when processing DETS batch {}", batchNumber, e);
+                    }
+                    return null;
+                })
+                .toList();
+
+
+            try {
+                AsyncUtil.invokeAllAwaitTermination(tasks, automatedTaskConfigurationProperties.getThreads(), 90, TimeUnit.MINUTES);
+            } catch (Exception e) {
+                log.error("Dets to arm batch unexpected exception", e);
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
+                return;
             }
         }
         log.info("Finished running DETS ARM Batch Push processing at: {}", OffsetDateTime.now());

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -364,10 +364,12 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2
             where (eod2.status = :notExistsStatus or eod2.transferAttempts >= :maxTransferAttempts)
             AND eod2.externalLocationType = :notExistsType
-            and (eod.media = eod2.media
-              OR eod.transcriptionDocumentEntity = eod2.transcriptionDocumentEntity
-              OR eod.annotationDocumentEntity = eod2.annotationDocumentEntity
-              OR eod.caseDocument = eod2.caseDocument ))
+            
+                        
+            and ((eod.media is not null and eod.media = eod2.media)
+              OR (eod.transcriptionDocumentEntity is not null and eod.transcriptionDocumentEntity = eod2.transcriptionDocumentEntity)
+              OR (eod.annotationDocumentEntity is not null and eod.annotationDocumentEntity = eod2.annotationDocumentEntity)
+              OR (eod.caseDocument is not null and eod.caseDocument = eod2.caseDocument )))
             order by eod.lastModifiedDateTime
             """
     )
@@ -382,10 +384,10 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             AND eod.externalLocationType = :type
             AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2
             where eod2.externalLocationType = :notExistsLocation
-            and (eod.media = eod2.media
-              OR eod.transcriptionDocumentEntity = eod2.transcriptionDocumentEntity
-              OR eod.annotationDocumentEntity = eod2.annotationDocumentEntity
-              OR eod.caseDocument = eod2.caseDocument ))
+            and ((eod.media is not null and eod.media = eod2.media)
+              OR (eod.transcriptionDocumentEntity is not null and eod.transcriptionDocumentEntity = eod2.transcriptionDocumentEntity)
+              OR (eod.annotationDocumentEntity is not null and eod.annotationDocumentEntity = eod2.annotationDocumentEntity)
+              OR (eod.caseDocument is not null and eod.caseDocument = eod2.caseDocument )))
             order by eod.id
             LIMIT :limitRecords
             """

--- a/src/main/java/uk/gov/hmcts/darts/common/util/EodHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/util/EodHelper.java
@@ -116,10 +116,6 @@ public class EodHelper {
 
     }
 
-    public static boolean isEqual(ObjectRecordStatusEntity ors1, ObjectRecordStatusEntity ors2) {
-        return ors1.getId().equals(ors2.getId());
-    }
-
     public static boolean isEqual(ExternalLocationTypeEntity olt1, ExternalLocationTypeEntity olt2) {
         return olt1.getId().equals(olt2.getId());
     }

--- a/src/main/java/uk/gov/hmcts/darts/task/config/DetsToArmPushAutomatedTaskConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/config/DetsToArmPushAutomatedTaskConfig.java
@@ -10,4 +10,6 @@ import org.springframework.context.annotation.Configuration;
 @Setter
 @Configuration
 public class DetsToArmPushAutomatedTaskConfig extends AbstractAutomatedTaskConfig {
+
+    private int threads;
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -430,6 +430,7 @@ darts:
           at-least-for: PT1M
           at-most-for: PT90M
       dets-to-arm:
+        threads: 20
         system-user-email: system_DetsToArm@hmcts.net
         lock:
           at-least-for: PT1M

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmBatchProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmBatchProcessorTest.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.ExternalLocationTypeEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectRecordStatusEntity;
-import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
@@ -145,12 +144,10 @@ class UnstructuredToArmBatchProcessorTest {
         when(externalObjectDirectoryRepository.findAllById(List.of(10))).thenReturn(List.of(eod10));
         when(externalObjectDirectoryRepository.findEodsNotInOtherStorage(any(), any(), any(), any())).thenReturn(emptyList());
         ExternalLocationTypeEntity armLocation = mock(ExternalLocationTypeEntity.class);
-        when(armLocation.getId()).thenReturn(ExternalLocationTypeEnum.ARM.getId());
-        EOD_HELPER_MOCKS.simulateInitWithMockedData(mock(ObjectRecordStatusEntity.class), armLocation);
+        EOD_HELPER_MOCKS.simulateInitWithMockedData();
         when(unstructuredToArmProcessorConfiguration.getMaxArmManifestItems()).thenReturn(10);
         when(unstructuredToArmProcessorConfiguration.getThreads()).thenReturn(20);
         when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(3);
-
 
         //when
         unstructuredToArmBatchProcessor.processUnstructuredToArm(200);

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmBatchProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/UnstructuredToArmBatchProcessorTest.java
@@ -39,7 +39,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -143,7 +142,6 @@ class UnstructuredToArmBatchProcessorTest {
         when(externalObjectDirectoryRepository.findNotFinishedAndNotExceededRetryInStorageLocation(any(), any(), any(), any())).thenReturn(List.of(10));
         when(externalObjectDirectoryRepository.findAllById(List.of(10))).thenReturn(List.of(eod10));
         when(externalObjectDirectoryRepository.findEodsNotInOtherStorage(any(), any(), any(), any())).thenReturn(emptyList());
-        ExternalLocationTypeEntity armLocation = mock(ExternalLocationTypeEntity.class);
         EOD_HELPER_MOCKS.simulateInitWithMockedData();
         when(unstructuredToArmProcessorConfiguration.getMaxArmManifestItems()).thenReturn(10);
         when(unstructuredToArmProcessorConfiguration.getThreads()).thenReturn(20);

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImplTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.arm.service.impl;
 
 import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +29,7 @@ import uk.gov.hmcts.darts.common.service.FileOperationService;
 import uk.gov.hmcts.darts.common.service.impl.EodHelperMocks;
 import uk.gov.hmcts.darts.common.util.EodHelper;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.config.DetsToArmPushAutomatedTaskConfig;
 import uk.gov.hmcts.darts.test.common.FileStore;
 import uk.gov.hmcts.darts.testutils.ExternalObjectDirectoryTestData;
 
@@ -47,6 +47,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
@@ -84,6 +85,8 @@ class DetsToArmBatchPushProcessorImplTest {
     private CurrentTimeHelper currentTimeHelper;
     @Mock
     private ExternalObjectDirectoryService externalObjectDirectoryService;
+    @Mock
+    private DetsToArmPushAutomatedTaskConfig detsToArmPushAutomatedTaskConfig;
 
     @InjectMocks
     private DataStoreToArmHelper dataStoreToArmHelper;
@@ -95,16 +98,12 @@ class DetsToArmBatchPushProcessorImplTest {
 
     private ObjectStateRecordEntity objectStateRecordEntity;
 
-    private static final EodHelperMocks EOD_HELPER_MOCKS = new EodHelperMocks();
+    private static final EodHelperMocks EOD_HELPER_MOCKS = new EodHelperMocks(false);
 
-    @AfterAll
-    static void close() {
-        EOD_HELPER_MOCKS.close();
-    }
 
     @BeforeEach
     void setUp() throws IOException {
-
+        lenient().when(detsToArmPushAutomatedTaskConfig.getThreads()).thenReturn(2);
         detsToArmBatchPushProcessor = new DetsToArmBatchPushProcessorImpl(
             archiveRecordService,
             dataStoreToArmHelper,
@@ -117,7 +116,8 @@ class DetsToArmBatchPushProcessorImplTest {
             detsToArmProcessorConfiguration,
             objectStateRecordRepository,
             currentTimeHelper,
-            externalObjectDirectoryService
+            externalObjectDirectoryService,
+            detsToArmPushAutomatedTaskConfig
         );
 
         lenient().when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(MAX_RETRY_ATTEMPTS);
@@ -147,7 +147,8 @@ class DetsToArmBatchPushProcessorImplTest {
                                                                    externalObjectDirectoryEntityDets.getId(),
                                                                    externalObjectDirectoryEntityArm.getId());
         externalObjectDirectoryEntityDets.setOsrUuid(objectStateRecordEntity.getUuid());
-        lenient().when(objectStateRecordRepository.findById(objectStateRecordEntity.getUuid())).thenReturn(Optional.of(objectStateRecordEntity));
+        lenient().when(objectStateRecordRepository.findById(objectStateRecordEntity.getUuid()))
+            .thenReturn(Optional.of(objectStateRecordEntity));
 
         String filename = String.format("DETS_%s.a360", DETS_UUID);
         File manifestFile = new File(fileLocation, filename);
@@ -177,19 +178,18 @@ class DetsToArmBatchPushProcessorImplTest {
     void processDetsToArmSetObjectStatusNoMatchingDetsRecordErrorMessage() {
         //given
         when(externalObjectDirectoryRepository.findEodsNotInOtherStorage(any(), any(), any(), any())).thenReturn(emptyList());
-        EOD_HELPER_MOCKS.givenIsEqualLocationReturns(true);
-        EOD_HELPER_MOCKS.givenIsEqualStatusReturns(true);
         when(detsToArmProcessorConfiguration.getMaxArmManifestItems()).thenReturn(10);
         when(armDataManagementConfiguration.getMaxRetryAttempts()).thenReturn(3);
-        when(externalObjectDirectoryRepository.findEodsNotInOtherStorage(
-            EodHelper.storedStatus(),
-            EodHelper.detsLocation(),
-            EodHelper.armLocation(), 200
-        )).thenReturn(List.of(123));
+        when(externalObjectDirectoryRepository.findEodsNotInOtherStorage(any(), any(), any(), eq(200)))
+            .thenReturn(List.of(123));
         when(externalObjectDirectoryRepository.findAllById(List.of(123))).thenReturn(List.of(externalObjectDirectoryEntityDets));
-
+        EOD_HELPER_MOCKS.simulateInitWithMockedData();
+        //Before this method was made async EOD_HELPER_MOCKS.givenIsEqualLocationReturns(true); was used to enforce the ELT to match
+        //This is no longer possible as mockito static mocks don't work well with threads. By setting ELt to ARM it simulates this behavior
+        externalObjectDirectoryEntityDets.setExternalLocationType(EOD_HELPER_MOCKS.getArmLocation());
         //when
         detsToArmBatchPushProcessor.processDetsToArm(200);
+
 
         //then
         assertTrue(

--- a/src/test/java/uk/gov/hmcts/darts/common/service/impl/EodHelperMocks.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/service/impl/EodHelperMocks.java
@@ -194,6 +194,7 @@ public class EodHelperMocks implements Closeable {
     }
 
     @SneakyThrows
+    @Override
     public void close() {
         mockedEodHelper.close();
         closeable.close();
@@ -205,7 +206,7 @@ public class EodHelperMocks implements Closeable {
         ExternalLocationTypeRepository eltRepository = mock(ExternalLocationTypeRepository.class);
         ObjectRecordStatusRepository orsRepository = mock(ObjectRecordStatusRepository.class);
 
-        EodHelper eodHelper = spy(new EodHelper(null, eltRepository, orsRepository));
+        final EodHelper eodHelper = spy(new EodHelper(null, eltRepository, orsRepository));
 
         lenient().when(orsRepository.findById(STORED.getId())).thenReturn(Optional.of(storedStatus));
         lenient().when(orsRepository.findById(FAILURE.getId())).thenReturn(Optional.of(failureStatus));

--- a/src/test/java/uk/gov/hmcts/darts/common/service/impl/EodHelperMocks.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/service/impl/EodHelperMocks.java
@@ -116,12 +116,12 @@ public class EodHelperMocks implements Closeable {
      */
     public final void mockEodHelper() {
         mockedEodHelper = Mockito.mockStatic(EodHelper.class);
-        setupVairables();
+        setupVariables();
         setupLocationTypes();
         setupObjectRecordStatuses();
     }
 
-    private void setupVairables() {
+    private void setupVariables() {
         lenient().when(storedStatus.getId()).thenReturn(STORED.getId());
         lenient().when(storedStatus.getDescription()).thenReturn("Stored");
         lenient().when(failureStatus.getId()).thenReturn(FAILURE.getId());
@@ -202,7 +202,7 @@ public class EodHelperMocks implements Closeable {
 
     //This is needed to bypass static mock limitations with multi threaded operations
     public void simulateInitWithMockedData() {
-        setupVairables();
+        setupVariables();
         ExternalLocationTypeRepository eltRepository = mock(ExternalLocationTypeRepository.class);
         ObjectRecordStatusRepository orsRepository = mock(ObjectRecordStatusRepository.class);
 

--- a/src/test/java/uk/gov/hmcts/darts/common/service/impl/EodHelperMocks.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/service/impl/EodHelperMocks.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.common.service.impl;
 
+import lombok.Getter;
 import lombok.SneakyThrows;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -11,14 +12,13 @@ import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.common.util.EodHelper;
 
+import java.io.Closeable;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.DETS;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
@@ -42,7 +42,8 @@ import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 /**
  * Helper test class that mocks {@link EodHelper} entities and methods so that they can be used in unit tests.
  */
-public class EodHelperMocks {
+@Getter
+public class EodHelperMocks implements Closeable {
 
     @Mock
     private ExternalLocationTypeEntity armLocation;
@@ -92,7 +93,14 @@ public class EodHelperMocks {
     private AutoCloseable closeable;
 
     public EodHelperMocks() {
-        mockEodHelper();
+        this(true);
+    }
+
+    public EodHelperMocks(boolean setupMocks) {
+        closeable = MockitoAnnotations.openMocks(this);
+        if (setupMocks) {
+            mockEodHelper();
+        }
     }
 
     /**
@@ -107,82 +115,81 @@ public class EodHelperMocks {
      * </pre>
      */
     public final void mockEodHelper() {
-        closeable = MockitoAnnotations.openMocks(this);
         mockedEodHelper = Mockito.mockStatic(EodHelper.class);
+        setupVairables();
         setupLocationTypes();
         setupObjectRecordStatuses();
     }
 
-    private void setupObjectRecordStatuses() {
-        mockedEodHelper.when(EodHelper::storedStatus).thenReturn(storedStatus);
+    private void setupVairables() {
         lenient().when(storedStatus.getId()).thenReturn(STORED.getId());
         lenient().when(storedStatus.getDescription()).thenReturn("Stored");
-        mockedEodHelper.when(EodHelper::failureStatus).thenReturn(failureStatus);
         lenient().when(failureStatus.getId()).thenReturn(FAILURE.getId());
         lenient().when(failureStatus.getDescription()).thenReturn("Failure");
-        mockedEodHelper.when(EodHelper::markForDeletionStatus).thenReturn(markForDeletionStatus);
         lenient().when(markForDeletionStatus.getId()).thenReturn(MARKED_FOR_DELETION.getId());
         lenient().when(markForDeletionStatus.getDescription()).thenReturn("marked for Deletion");
-        mockedEodHelper.when(EodHelper::armProcessingResponseFilesStatus).thenReturn(armProcessingResponseFilesStatus);
         lenient().when(armProcessingResponseFilesStatus.getId()).thenReturn(ARM_PROCESSING_RESPONSE_FILES.getId());
         lenient().when(armProcessingResponseFilesStatus.getDescription()).thenReturn("Arm Processing Response Files");
-        mockedEodHelper.when(EodHelper::armIngestionStatus).thenReturn(armIngestionStatus);
         lenient().when(armIngestionStatus.getId()).thenReturn(ARM_INGESTION.getId());
         lenient().when(armIngestionStatus.getDescription()).thenReturn("Arm Ingestion");
-        mockedEodHelper.when(EodHelper::armDropZoneStatus).thenReturn(armDropZoneStatus);
         lenient().when(armDropZoneStatus.getId()).thenReturn(ARM_DROP_ZONE.getId());
         lenient().when(armDropZoneStatus.getDescription()).thenReturn("Arm Drop Zone");
-        mockedEodHelper.when(EodHelper::failedArmRawDataStatus).thenReturn(failedArmRawDataStatus);
         lenient().when(failedArmRawDataStatus.getId()).thenReturn(ARM_RAW_DATA_FAILED.getId());
         lenient().when(failedArmRawDataStatus.getDescription()).thenReturn("Arm Raw Data Failed");
-        mockedEodHelper.when(EodHelper::failedArmManifestFileStatus).thenReturn(failedArmManifestFileStatus);
         lenient().when(failedArmManifestFileStatus.getId()).thenReturn(ARM_MANIFEST_FAILED.getId());
         lenient().when(failedArmManifestFileStatus.getDescription()).thenReturn("Arm Manifest Failed");
-        mockedEodHelper.when(EodHelper::awaitingVerificationStatus).thenReturn(awaitingVerificationStatus);
         lenient().when(awaitingVerificationStatus.getId()).thenReturn(AWAITING_VERIFICATION.getId());
         lenient().when(awaitingVerificationStatus.getDescription()).thenReturn("Awaiting Verification");
-        mockedEodHelper.when(EodHelper::armRpoPendingStatus).thenReturn(armRpoPendingStatus);
         lenient().when(armRpoPendingStatus.getId()).thenReturn(ARM_RPO_PENDING.getId());
         lenient().when(armRpoPendingStatus.getDescription()).thenReturn("Arm RPO Pending");
-        mockedEodHelper.when(EodHelper::armResponseManifestFailedStatus).thenReturn(armResponseManifestFailedStatus);
         lenient().when(armResponseManifestFailedStatus.getId()).thenReturn(ARM_RESPONSE_MANIFEST_FAILED.getId());
         lenient().when(armResponseManifestFailedStatus.getDescription()).thenReturn("Arm Response Manifest Failed");
-        mockedEodHelper.when(EodHelper::armResponseProcessingFailedStatus).thenReturn(armResponseProcessingFailedStatus);
         lenient().when(armResponseProcessingFailedStatus.getId()).thenReturn(ARM_RESPONSE_PROCESSING_FAILED.getId());
         lenient().when(armResponseProcessingFailedStatus.getDescription()).thenReturn("Arm Response Processing Failed");
-        mockedEodHelper.when(EodHelper::armResponseChecksumVerificationFailedStatus).thenReturn(armResponseChecksumVerificationFailedStatus);
         lenient().when(armResponseChecksumVerificationFailedStatus.getId()).thenReturn(ARM_RESPONSE_CHECKSUM_VERIFICATION_FAILED.getId());
         lenient().when(armResponseChecksumVerificationFailedStatus.getDescription()).thenReturn("Arm Response Checksum Verification Failed");
-        mockedEodHelper.when(EodHelper::armReplayStatus).thenReturn(armReplayStatus);
         lenient().when(armReplayStatus.getId()).thenReturn(ARM_REPLAY.getId());
         lenient().when(armReplayStatus.getDescription()).thenReturn("Arm Replay");
-        mockedEodHelper.when(EodHelper::armMissingResponseStatus).thenReturn(armMissingResponseStatus);
         lenient().when(armMissingResponseStatus.getId()).thenReturn(ARM_MISSING_RESPONSE.getId());
         lenient().when(armMissingResponseStatus.getDescription()).thenReturn("Arm Missing Response");
-    }
 
-    private void setupLocationTypes() {
-        mockedEodHelper.when(EodHelper::inboundLocation).thenReturn(inboundLocation);
-        lenient().when(inboundLocation.getId()).thenReturn(INBOUND.getId());
-        lenient().when(inboundLocation.getDescription()).thenReturn("inbound");
-        mockedEodHelper.when(EodHelper::armLocation).thenReturn(armLocation);
-        lenient().when(armLocation.getId()).thenReturn(ARM.getId());
-        lenient().when(armLocation.getDescription()).thenReturn("arm");
-        mockedEodHelper.when(EodHelper::unstructuredLocation).thenReturn(unstructuredLocation);
         lenient().when(unstructuredLocation.getId()).thenReturn(UNSTRUCTURED.getId());
         lenient().when(unstructuredLocation.getDescription()).thenReturn("unstructured");
-        mockedEodHelper.when(EodHelper::detsLocation).thenReturn(detsLocation);
+        lenient().when(inboundLocation.getId()).thenReturn(INBOUND.getId());
+        lenient().when(inboundLocation.getDescription()).thenReturn("inbound");
+        lenient().when(armLocation.getId()).thenReturn(ARM.getId());
+        lenient().when(armLocation.getDescription()).thenReturn("arm");
         lenient().when(detsLocation.getId()).thenReturn(DETS.getId());
         lenient().when(detsLocation.getDescription()).thenReturn("dets");
     }
 
-    public void givenIsEqualLocationReturns(boolean result) {
-        mockedEodHelper.when(() -> EodHelper.isEqual(any(ExternalLocationTypeEntity.class), any(ExternalLocationTypeEntity.class)))
-            .thenReturn(result);
+    private void setupObjectRecordStatuses() {
+        mockedEodHelper.when(EodHelper::storedStatus).thenReturn(storedStatus);
+        mockedEodHelper.when(EodHelper::failureStatus).thenReturn(failureStatus);
+        mockedEodHelper.when(EodHelper::markForDeletionStatus).thenReturn(markForDeletionStatus);
+        mockedEodHelper.when(EodHelper::armProcessingResponseFilesStatus).thenReturn(armProcessingResponseFilesStatus);
+        mockedEodHelper.when(EodHelper::armIngestionStatus).thenReturn(armIngestionStatus);
+        mockedEodHelper.when(EodHelper::armDropZoneStatus).thenReturn(armDropZoneStatus);
+        mockedEodHelper.when(EodHelper::failedArmRawDataStatus).thenReturn(failedArmRawDataStatus);
+        mockedEodHelper.when(EodHelper::failedArmManifestFileStatus).thenReturn(failedArmManifestFileStatus);
+        mockedEodHelper.when(EodHelper::awaitingVerificationStatus).thenReturn(awaitingVerificationStatus);
+        mockedEodHelper.when(EodHelper::armRpoPendingStatus).thenReturn(armRpoPendingStatus);
+        mockedEodHelper.when(EodHelper::armResponseManifestFailedStatus).thenReturn(armResponseManifestFailedStatus);
+        mockedEodHelper.when(EodHelper::armResponseProcessingFailedStatus).thenReturn(armResponseProcessingFailedStatus);
+        mockedEodHelper.when(EodHelper::armResponseChecksumVerificationFailedStatus).thenReturn(armResponseChecksumVerificationFailedStatus);
+        mockedEodHelper.when(EodHelper::armReplayStatus).thenReturn(armReplayStatus);
+        mockedEodHelper.when(EodHelper::armMissingResponseStatus).thenReturn(armMissingResponseStatus);
     }
 
-    public void givenIsEqualStatusReturns(boolean result) {
-        mockedEodHelper.when(() -> EodHelper.isEqual(any(ObjectRecordStatusEntity.class), any(ObjectRecordStatusEntity.class)))
+    private void setupLocationTypes() {
+        mockedEodHelper.when(EodHelper::inboundLocation).thenReturn(inboundLocation);
+        mockedEodHelper.when(EodHelper::armLocation).thenReturn(armLocation);
+        mockedEodHelper.when(EodHelper::unstructuredLocation).thenReturn(unstructuredLocation);
+        mockedEodHelper.when(EodHelper::detsLocation).thenReturn(detsLocation);
+    }
+
+    public void givenIsEqualLocationReturns(boolean result) {
+        mockedEodHelper.when(() -> EodHelper.isEqual(any(ExternalLocationTypeEntity.class), any(ExternalLocationTypeEntity.class)))
             .thenReturn(result);
     }
 
@@ -193,15 +200,35 @@ public class EodHelperMocks {
     }
 
     //This is needed to bypass static mock limitations with multi threaded operations
-    public void simulateInitWithMockedData(ObjectRecordStatusEntity objectRecordStatusEntity,
-                                           ExternalLocationTypeEntity externalLocationTypeEntity) {
+    public void simulateInitWithMockedData() {
+        setupVairables();
         ExternalLocationTypeRepository eltRepository = mock(ExternalLocationTypeRepository.class);
         ObjectRecordStatusRepository orsRepository = mock(ObjectRecordStatusRepository.class);
 
         EodHelper eodHelper = spy(new EodHelper(null, eltRepository, orsRepository));
 
-        when(eltRepository.findById(anyInt())).thenReturn(Optional.of(externalLocationTypeEntity));
-        when(orsRepository.findById(anyInt())).thenReturn(Optional.of(objectRecordStatusEntity));
+        lenient().when(orsRepository.findById(STORED.getId())).thenReturn(Optional.of(storedStatus));
+        lenient().when(orsRepository.findById(FAILURE.getId())).thenReturn(Optional.of(failureStatus));
+        lenient().when(orsRepository.findById(MARKED_FOR_DELETION.getId())).thenReturn(Optional.of(markForDeletionStatus));
+        lenient().when(orsRepository.findById(ARM_PROCESSING_RESPONSE_FILES.getId())).thenReturn(Optional.of(armProcessingResponseFilesStatus));
+        lenient().when(orsRepository.findById(ARM_INGESTION.getId())).thenReturn(Optional.of(armIngestionStatus));
+        lenient().when(orsRepository.findById(ARM_DROP_ZONE.getId())).thenReturn(Optional.of(armDropZoneStatus));
+        lenient().when(orsRepository.findById(ARM_RAW_DATA_FAILED.getId())).thenReturn(Optional.of(failedArmRawDataStatus));
+        lenient().when(orsRepository.findById(ARM_MANIFEST_FAILED.getId())).thenReturn(Optional.of(failedArmManifestFileStatus));
+        lenient().when(orsRepository.findById(AWAITING_VERIFICATION.getId())).thenReturn(Optional.of(awaitingVerificationStatus));
+        lenient().when(orsRepository.findById(ARM_RPO_PENDING.getId())).thenReturn(Optional.of(armRpoPendingStatus));
+        lenient().when(orsRepository.findById(ARM_RESPONSE_MANIFEST_FAILED.getId())).thenReturn(Optional.of(armResponseManifestFailedStatus));
+        lenient().when(orsRepository.findById(ARM_RESPONSE_PROCESSING_FAILED.getId())).thenReturn(Optional.of(armResponseProcessingFailedStatus));
+        lenient().when(orsRepository.findById(ARM_RESPONSE_CHECKSUM_VERIFICATION_FAILED.getId())).thenReturn(
+            Optional.of(armResponseChecksumVerificationFailedStatus));
+        lenient().when(orsRepository.findById(ARM_REPLAY.getId())).thenReturn(Optional.of(armReplayStatus));
+        lenient().when(orsRepository.findById(ARM_MISSING_RESPONSE.getId())).thenReturn(Optional.of(armMissingResponseStatus));
+
+        lenient().when(eltRepository.findById(INBOUND.getId())).thenReturn(Optional.of(inboundLocation));
+        lenient().when(eltRepository.findById(ARM.getId())).thenReturn(Optional.of(armLocation));
+        lenient().when(eltRepository.findById(UNSTRUCTURED.getId())).thenReturn(Optional.of(unstructuredLocation));
+        lenient().when(eltRepository.findById(DETS.getId())).thenReturn(Optional.of(detsLocation));
+
         eodHelper.init();
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/util/LogUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/LogUtil.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.darts.util;
+
+import lombok.SneakyThrows;
+import org.springframework.boot.test.system.CapturedOutput;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public final class LogUtil {
+
+    private LogUtil() {
+
+    }
+
+    @SneakyThrows
+    public static void waitUntilMessag(CapturedOutput capturedOutput, String message,
+                                       int timeoutInSeconds) {
+        long startTime = System.currentTimeMillis();
+        while (!capturedOutput.getAll().contains(message)) {
+            if (System.currentTimeMillis() - startTime > timeoutInSeconds * 1000) {
+                fail("Timeout waiting for message: " + message);
+            }
+            Thread.sleep(100);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/util/LogUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/LogUtil.java
@@ -12,6 +12,7 @@ public final class LogUtil {
     }
 
     @SneakyThrows
+    @SuppressWarnings("PMD.DoNotUseThreads")//Required to prevent busy waiting
     public static void waitUntilMessag(CapturedOutput capturedOutput, String message,
                                        int timeoutInSeconds) {
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4499)


### Change description ###
# Summary of Git Diff

This commit introduces several enhancements to the `DetsToArmBatchPushProcessorImpl` class, particularly focusing on improving the batch processing of DETS records to ARM. Key changes include the introduction of asynchronous processing and the configuration for the number of threads used in batch processing.

## Highlights

- **Asynchronous Processing**: 
  - The `processDetsToArm` method now utilizes `Callable` to process batches asynchronously, improving performance.
  - An `AtomicInteger` is used to track batch counts in a thread-safe manner.

- **Configuration Changes**:
  - A new configuration class `DetsToArmPushAutomatedTaskConfig` has been added to specify the number of threads for processing.
  - The `application.yaml` file has been updated to set the default thread count to 20.

- **Code Cleanup**:
  - Removed a static `isEqual` method from `EodHelper`.
  - General refactoring of existing code to streamline batch processing logic.

- **Test Updates**:
  - Tests for `DetsToArmBatchPushProcessorImpl` have been updated to accommodate the new asynchronous behavior.
  - Mocking improvements in `EodHelperMocks` to facilitate easier testing.

These changes aim to enhance the efficiency and maintainability of the code related to batch processing of DETS records to ARM.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
