### PR TITLE
DMP-4577: Flyway changes to courthouse_region_ae and security_group

### DIFF
--- a/src/main/resources/db/migration/common/V1_426__assign_region_to_burnley_mags.sql
+++ b/src/main/resources/db/migration/common/V1_426__assign_region_to_burnley_mags.sql
@@ -1,0 +1,3 @@
+INSERT INTO courthouse_region_ae (cth_id, reg_id)
+VALUES ((SELECT cth_id FROM courthouse WHERE courthouse_name = 'BURNLEY MAGS TWO'),
+        (SELECT reg_id FROM region WHERE region_name = 'North West'));

--- a/src/main/resources/db/migration/common/V1_427__unset_object_id_for_moj_language_shop.sql
+++ b/src/main/resources/db/migration/common/V1_427__unset_object_id_for_moj_language_shop.sql
@@ -1,0 +1,3 @@
+UPDATE security_group
+SET dm_group_s_object_id = NULL
+WHERE group_name = 'moj_language_shop';


### PR DESCRIPTION
## [DMP-4577](https://tools.hmcts.net/jira/browse/DMP-4577)

Flyway changes to courthouse_region_ae and security_group.

Migrations verified against clean local DB and a locally-cloned staging DB.

Note no changes are required for the following ticket requirement, as the `dm_group_s_object_id` value is already correct:
```
Update the dm_group_s_object_id to "1217075880002900" for the group_name of "moj_appeal_court_users"
```