### PR TITLE
Dmp 4471 ARM IU file cleanup set status

### DIFF
--- a/src/integrationTest/resources/tests/arm/service/ArmBatchResponseFilesProcessorTest/InvalidResponses/InputUploadFile.rsp
+++ b/src/integrationTest/resources/tests/arm/service/ArmBatchResponseFilesProcessorTest/InvalidResponses/InputUploadFile.rsp
@@ -1,0 +1,3 @@
+{
+  "operation": "input_upload",
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/model/record/armresponse/ArmResponseInputUploadFileRecord.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/model/record/armresponse/ArmResponseInputUploadFileRecord.java
@@ -8,13 +8,13 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-@JsonIgnoreProperties(ignoreUnknown = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ArmResponseInputUploadFileRecord {
 
     @JsonProperty("operation")
     private String operation;
 
-    @JsonProperty("timestamp")
+    @JsonProperty(value = "timestamp", required = true)
     private String timestamp;
 
     @JsonProperty("status")

--- a/src/main/java/uk/gov/hmcts/darts/arm/model/record/armresponse/ArmResponseInputUploadFileRecord.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/model/record/armresponse/ArmResponseInputUploadFileRecord.java
@@ -5,9 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
+
 @Data
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class ArmResponseInputUploadFileRecord {
 
     @JsonProperty("operation")


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4471

### Change description ###

When the IU file cannot be parsed, the manifest files status is set to ARM_RESPONSE_PROCESSING_FAILED

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
