### PR TITLE
DMP-4381: Automatically update createdBy and lastModifiedBy when persisting entities to the database

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImplTest.java
@@ -105,7 +105,7 @@ class UserIdentityImplTest extends IntegrationBase {
     }
 
     @Test
-    void getUserAccountOptional_whenNotExists_shouldReturnEmptyUserAccountOptiaonl() {
+    void getUserAccountOptional_whenNotExists_shouldReturnEmptyUserAccountOptional() {
         String email = "unknown.integrationtest.user@example.com";
         Jwt jwt = Jwt.withTokenValue("test")
             .header("alg", "RS256")

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImplTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImplTest.java
@@ -82,6 +82,44 @@ class UserIdentityImplTest extends IntegrationBase {
 
     }
 
+
+    @Test
+    void getUserAccountOptional_whenExists_shouldReturnUserAccount() {
+        String email = "integrationtest.user@example.com";
+        Jwt jwt = Jwt.withTokenValue("test")
+            .header("alg", "RS256")
+            .claim("sub", UUID.randomUUID().toString())
+            .claim("emails", List.of(email))
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
+
+        Optional<UserAccountEntity> userAccountEntity = userIdentity.getUserAccountOptional(jwt);
+
+        assertTrue(userAccountEntity.isPresent());
+        assertEquals(email, userIdentity.getUserAccount().getEmailAddress());
+
+        UserAccountEntity testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+
+        UserAccountEntity currentUser = userIdentity.getUserAccount();
+        assertEquals(testUser.getId(), currentUser.getId());
+    }
+
+    @Test
+    void getUserAccountOptional_whenNotExists_shouldReturnEmptyUserAccountOptiaonl() {
+        String email = "unknown.integrationtest.user@example.com";
+        Jwt jwt = Jwt.withTokenValue("test")
+            .header("alg", "RS256")
+            .claim("sub", UUID.randomUUID().toString())
+            .claim("emails", List.of(email))
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
+
+        Optional<UserAccountEntity> userAccountEntity = userIdentity.getUserAccountOptional(jwt);
+
+        assertTrue(userAccountEntity.isEmpty());
+    }
+
+
     @Test
     void getGuid() {
         String guid = UUID.randomUUID().toString();

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/UserIdentity.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/UserIdentity.java
@@ -20,5 +20,7 @@ public interface UserIdentity {
 
     List<Integer> getListOfCourthouseIdsUserHasAccessTo();
 
+    Optional<UserAccountEntity> getUserAccountOptional(Jwt jwt);
+
     Jwt getJwt();
 }

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
@@ -57,14 +57,18 @@ public class UserIdentityImpl implements UserIdentity {
     public Optional<UserAccountEntity> getUserAccountOptional(Jwt jwt) {
         String guid = getGuidFromToken(jwt);
 
-        return Optional.ofNullable(guid)
+        Optional<UserAccountEntity> userAccount = Optional.ofNullable(guid)
             .map(guidValue -> userAccountRepository.findByAccountGuidAndActive(guidValue, true))
-            .orElseGet(() -> {
-                String emailAddressFromToken = EmailAddressFromTokenUtil.getEmailAddressFromToken(jwt);
-                return userAccountRepository.findByEmailAddressIgnoreCaseAndActive(emailAddressFromToken, true)
-                    .stream()
-                    .findFirst();
-            });
+            .orElse(Optional.empty());
+
+        if (userAccount.isPresent()) {
+            return userAccount;
+        }
+
+        String emailAddressFromToken = EmailAddressFromTokenUtil.getEmailAddressFromToken(jwt);
+        return userAccountRepository.findByEmailAddressIgnoreCaseAndActive(emailAddressFromToken, true)
+            .stream()
+            .findFirst();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/UserIdentityImpl.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.darts.authorisation.exception.AuthorisationError.USER_DETAILS_INVALID;
 
@@ -50,19 +49,22 @@ public class UserIdentityImpl implements UserIdentity {
 
     @Override
     public UserAccountEntity getUserAccount(Jwt jwt) {
-        UserAccountEntity userAccount = null;
+        return getUserAccountOptional(jwt)
+            .orElseThrow(() -> new DartsApiException(USER_DETAILS_INVALID));
+    }
+
+    @Override
+    public Optional<UserAccountEntity> getUserAccountOptional(Jwt jwt) {
         String guid = getGuidFromToken(jwt);
-        if (nonNull(guid)) {
-            // System users will use GUID not email address
-            userAccount = userAccountRepository.findByAccountGuidAndActive(guid, true).orElse(null);
-        }
-        if (isNull(userAccount)) {
-            String emailAddressFromToken = EmailAddressFromTokenUtil.getEmailAddressFromToken(jwt);
-            userAccount = userAccountRepository.findByEmailAddressIgnoreCaseAndActive(emailAddressFromToken, true).stream()
-                .findFirst()
-                .orElseThrow(() -> new DartsApiException(USER_DETAILS_INVALID));
-        }
-        return userAccount;
+
+        return Optional.ofNullable(guid)
+            .map(guidValue -> userAccountRepository.findByAccountGuidAndActive(guidValue, true))
+            .orElseGet(() -> {
+                String emailAddressFromToken = EmailAddressFromTokenUtil.getEmailAddressFromToken(jwt);
+                return userAccountRepository.findByEmailAddressIgnoreCaseAndActive(emailAddressFromToken, true)
+                    .stream()
+                    .findFirst();
+            });
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
@@ -137,14 +137,9 @@ public class SecurityConfig {
             @Override
             public Jwt decode(String token) {
                 Jwt jwt = jwtDecoder.decode(token);
-                Integer userId = null;
-                String email = jwt.getClaimAsString("email");
-
-                if (email != null && !email.isBlank()) {
-                    userId = userAccountRepository.findFirstByEmailAddressIgnoreCase(email)
-                        .map(UserAccountEntity::getId)
-                        .orElse(null);
-                }
+                Integer userId = userIdentity.getUserAccountOptional(jwt)
+                    .map(userAccountEntity -> userAccountEntity.getId())
+                    .orElse(null);
                 return new DartsJwt(jwt, userId);
             }
         };

--- a/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
@@ -39,7 +39,6 @@ import uk.gov.hmcts.darts.authentication.config.internal.InternalAuthProviderCon
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiTrait;
-import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.io.IOException;
 import java.util.Map;
@@ -60,7 +59,6 @@ public class SecurityConfig {
     private final InternalAuthConfigurationProperties internalAuthConfigurationProperties;
     private final InternalAuthProviderConfigurationProperties internalAuthProviderConfigurationProperties;
     private final UserIdentity userIdentity;
-    private final UserAccountRepository userAccountRepository;
     private final JwtDecoder jwtDecoder;
     private static final String TOKEN_BEARER_PREFIX = "Bearer";
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/listener/UserAuditListener.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/listener/UserAuditListener.java
@@ -31,14 +31,12 @@ public class UserAuditListener {
 
     @PrePersist
     void beforeSave(Object object) {
-        log.debug("Before save: {}", object.getClass().getSimpleName());
         updateCreatedBy(object);
         updateModifiedBy(object);
     }
 
     @PreUpdate
     void beforeUpdate(Object object) {
-        log.debug("Before update: {}", object.getClass().getSimpleName());
         updateModifiedBy(object);
     }
 
@@ -68,12 +66,10 @@ public class UserAuditListener {
     void updateCreatedBy(Object object) {
         if (object instanceof CreatedBy entity) {
             if (entity.isSkipUserAudit() || entity.getCreatedBy() != null) {
-                log.debug("Skipping audit as isSkipUserAudit is set or createdBy is already set");
                 return;
             }
             Optional<Integer> userAccountOpt = getUserAccount();
             if (userAccountOpt.isEmpty()) {
-                log.debug("Before save: {} - Skipping audit as user account not found", object.getClass().getSimpleName());
                 return;
             }
             Integer userAccount = userAccountOpt.get();
@@ -86,13 +82,11 @@ public class UserAuditListener {
     void updateModifiedBy(Object object) {
         if (object instanceof LastModifiedBy entity) {
             if (entity.isSkipUserAudit()) {
-                log.debug("Skipping audit as isSkipUserAudit is set");
                 return;
             }
 
             Optional<Integer> userAccountOpt = getUserAccount();
             if (userAccountOpt.isEmpty()) {
-                log.debug("Before update: {} - Skipping audit as user account not found", object.getClass().getSimpleName());
                 return;
             }
             Integer userAccount = userAccountOpt.get();


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4381)


### Change description ###
# Summary of Git Diff

This Git diff introduces new functionality to the `UserIdentity` component to handle user account retrieval more effectively. It adds methods for optional user account retrieval and includes corresponding unit tests to verify their behavior. The changes enhance the existing user identity handling by implementing a more robust approach to querying user accounts based on JWT tokens.

## Highlights

- **New Method in UserIdentity Interface**: 
  - `Optional<UserAccountEntity> getUserAccountOptional(Jwt jwt);` is added to retrieve a user account optionally.

- **Implementation in UserIdentityImpl**:
  - Refactored `getUserAccount` to utilize `getUserAccountOptional`, throwing an exception if no account is found.
  - Added logic to `getUserAccountOptional` to check for user accounts by GUID or email.

- **New Unit Tests**:
  - `getUserAccountOptional_whenExists_shouldReturnUserAccount`: Validates that a user account is returned when the email exists.
  - `getUserAccountOptional_whenNotExists_shouldReturnEmptyUserAccountOptional`: Validates that an empty optional is returned when the email does not exist.

- **Refactoring in SecurityConfig**:
  - Replaced direct email fetching logic with the use of `getUserAccountOptional` for user ID retrieval.

- **Audit Listener Updates**:
  - Removed debug logging statements in `beforeSave` and `beforeUpdate` methods to reduce verbosity.

These changes collectively improve the handling of user identities, enhance the code organization, and ensure more reliable user account retrieval in the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
