### PR TITLE
DMP-4580: Flyway updates: Security Group Courthouse Associations For Burnley Mags Two Courthouse

### DIFF
--- a/src/main/resources/db/migration/common/V1_429__linked_security_groups_to_new_courthouse.sql
+++ b/src/main/resources/db/migration/common/V1_429__linked_security_groups_to_new_courthouse.sql
@@ -1,0 +1,15 @@
+insert into security_group (grp_id, rol_id, global_access, display_state, display_name, dm_group_s_object_id, group_name, use_interpreter,
+                            created_ts, created_by, last_modified_ts, last_modified_by)
+VALUES (nextval('grp_seq'), 3, false, true, 'Burnley Mags Two Approver', '121707588000cd01', 'moj_ch_burnley_mags_two_appr', false,
+        current_timestamp, 0, current_timestamp,0),
+       (nextval('grp_seq'), 2, false, true, 'Burnley Mags Two Requester', '121707588000cd00', 'moj_ch_burnley_mags_two_staff', false,
+        current_timestamp, 0, current_timestamp,0);
+
+
+insert into security_group_courthouse_ae(grp_id, cth_id)
+values ((select grp_id from security_group where group_name = 'moj_ch_burnley_mags_two_appr'),
+        (select cth_id from courthouse where courthouse_name = 'BURNLEY MAGS TWO')),
+       ((select grp_id from security_group where group_name = 'moj_ch_burnley_mags_two_staff'),
+        (select cth_id from courthouse where courthouse_name = 'BURNLEY MAGS TWO')),
+       ((select grp_id from security_group where group_name = 'tc_martinwalshcherer'),
+        (select cth_id from courthouse where courthouse_name = 'BURNLEY MAGS TWO'));


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4580)


### Change description ###
The following security groups (Approver and Requester) need to be created for the newly created Burnley Mags Two courthouse:
||grp_id||rol_id||global_access||display_state||display_name||dm_group_s_object_id||group_name||group_display_name||use_interpreter||
|nnn|3|FALSE|TRUE|Burnley Mags Two Approver|121707588000cd01|moj_ch_burnley_mags_two_appr|0b1707589a44e76a_appr|FALSE|
|nnn|2|FALSE|TRUE|Burnley Mags Two Requester|121707588000cd00|moj_ch_burnley_mags_two_staff|0b1707589a44e76a_staff|FALSE|

 

The following security_group_courthouse_ae entries need to be created:
 # Link each of the above new security groups in the table to the "BURNLEY MAGS TWO" courthouse.
 # Link the transcription company security group (TC Martinwalshcherer) to "BURNLEY MAGS TWO" courthouse - this will be same TC group as "BURNLEY" courthouse.

 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
