### PR TITLE
DMP-4619: Courthouse search results look to default sorting to last updated date

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/CourthouseApiTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/CourthouseApiTest.java
@@ -279,9 +279,9 @@ class CourthouseApiTest extends IntegrationBase {
         MockHttpServletRequestBuilder requestBuilder = get("/courthouses")
             .contentType(MediaType.APPLICATION_JSON_VALUE);
         MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk())
-            .andExpect(jsonPath("$[0].courthouse_name", is(SWANSEA_CROWN_COURT)))
-            .andExpect(jsonPath("$[1].courthouse_name", is(LEEDS_COURT)))
-            .andExpect(jsonPath("$[2].courthouse_name", is(MANCHESTER_COURT)))
+            .andExpect(jsonPath("$[0].courthouse_name", is(LEEDS_COURT)))
+            .andExpect(jsonPath("$[1].courthouse_name", is(MANCHESTER_COURT)))
+            .andExpect(jsonPath("$[2].courthouse_name", is(SWANSEA_CROWN_COURT)))
             .andExpect(jsonPath("$[3].courthouse_name").doesNotExist())
             .andDo(print()).andReturn();
 
@@ -318,8 +318,8 @@ class CourthouseApiTest extends IntegrationBase {
         MockHttpServletRequestBuilder requestBuilder = get("/courthouses")
             .contentType(MediaType.APPLICATION_JSON_VALUE);
         MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk())
-            .andExpect(jsonPath("$[0].courthouse_name", is(SWANSEA_CROWN_COURT)))
-            .andExpect(jsonPath("$[1].courthouse_name", is(MANCHESTER_COURT)))
+            .andExpect(jsonPath("$[0].courthouse_name", is(MANCHESTER_COURT)))
+            .andExpect(jsonPath("$[1].courthouse_name", is(SWANSEA_CROWN_COURT)))
             .andExpect(jsonPath("$[2].courthouse_name").doesNotExist())
             .andDo(print()).andReturn();
 
@@ -352,8 +352,8 @@ class CourthouseApiTest extends IntegrationBase {
             .contentType(MediaType.APPLICATION_JSON_VALUE);
         MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isOk())
             .andExpect(jsonPath("$[0].courthouse_name", is(LEEDS_COURT)))
-            .andExpect(jsonPath("$[1].courthouse_name", is(SWANSEA_CROWN_COURT)))
-            .andExpect(jsonPath("$[2].courthouse_name", is(MANCHESTER_COURT)))
+            .andExpect(jsonPath("$[1].courthouse_name", is(MANCHESTER_COURT)))
+            .andExpect(jsonPath("$[2].courthouse_name", is(SWANSEA_CROWN_COURT)))
             .andDo(print()).andReturn();
 
         assertEquals(200, response.getResponse().getStatus());

--- a/src/main/java/uk/gov/hmcts/darts/courthouse/service/impl/CourthouseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/courthouse/service/impl/CourthouseServiceImpl.java
@@ -120,7 +120,7 @@ public class CourthouseServiceImpl implements CourthouseService {
                 extendedCourthouse.setRegionId(courthouseEntity.getRegion() == null ? null : courthouseEntity.getRegion().getId());
                 extendedCourthouses.add(extendedCourthouse);
             });
-
+        extendedCourthouses.sort((o1, o2) -> o1.getCourthouseName().compareTo(o2.getCourthouseName()));
         return extendedCourthouses;
     }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4619)


### Change description ###
# Summary of Git Diff

This Git diff reflects changes made to the `CourthouseApiTest.java` and `CourthouseServiceImpl.java` files in a Java project. The modifications primarily involve the order of courthouse names in the tests and the addition of sorting logic in the service implementation.

## Highlights

### Changes in `CourthouseServiceImpl.java`
- Added sorting logic to the `mapFromEntitiesToExtendedCourthouses` method to sort the list of `extendedCourthouses` by courthouse name in ascending order:
  ```java
  extendedCourthouses.sort((o1, o2) -> o1.getCourthouseName().compareTo(o2.getCourthouseName()));
  ```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
