### PR TITLE
DMP-4655 ARM RPO Amendments

### DIFF
--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.97
+version: 0.0.98
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -115,7 +115,7 @@ java:
     ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
     ARM_URL: http://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
     FEIGN_LOG_LEVEL: none
-    ARM_RPO_THREAD_SLEEP_DURATION: 5s
+    ARM_RPO_THREAD_SLEEP_DURATION: 60s
 
 function:
   scaleType: Job
@@ -231,7 +231,7 @@ function:
     ARM_URL: http://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
     FEIGN_LOG_LEVEL: none
     IS_MOCK_ARM_RPO_DOWNLOAD_CSV: false
-    ARM_RPO_THREAD_SLEEP_DURATION: 5s
+    ARM_RPO_THREAD_SLEEP_DURATION: 60s
 
   secrets:
     DARTS_API_DB_CONNECTION_STRING:

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
 import uk.gov.hmcts.darts.arm.helper.ArmRpoHelper;
 import uk.gov.hmcts.darts.arm.service.impl.ArmApiServiceImpl;
 import uk.gov.hmcts.darts.arm.service.impl.ArmRpoPollServiceImpl;
+import uk.gov.hmcts.darts.arm.util.ArmRpoUtil;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -74,6 +75,8 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
     private ArmApiServiceImpl armApiService;
     @MockBean
     private ArmRpoDownloadProduction armRpoDownloadProduction;
+    @MockBean
+    private ArmRpoUtil armRpoUtil;
 
     @SpyBean
     private ArmDataManagementConfiguration armDataManagementConfiguration;
@@ -81,6 +84,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
     protected File tempDirectory;
 
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
+    private String uniqueProductionName;
 
     @Autowired
     private ArmRpoPollServiceImpl armRpoPollService;
@@ -96,6 +100,8 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         String fileLocation = tempDirectory.getAbsolutePath();
         lenient().when(armDataManagementConfiguration.getTempBlobWorkspace()).thenReturn(fileLocation);
 
+        uniqueProductionName = PRODUCTION_NAME + "_UUID_CSV";
+        lenient().when(armRpoUtil.generateUniqueProductionName(anyString())).thenReturn(uniqueProductionName);
     }
 
     @Test
@@ -452,7 +458,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         response.setIsError(false);
         ExtendedProductionsByMatterResponse.Productions productions = new ExtendedProductionsByMatterResponse.Productions();
         productions.setProductionId(PRODUCTION_ID);
-        productions.setName(PRODUCTION_NAME);
+        productions.setName(uniqueProductionName);
         productions.setEndProductionTime("2025-01-16T12:30:09.9129726+00:00");
         response.setProductions(List.of(productions));
         return response;

--- a/src/integrationTest/resources/application-intTest.yaml
+++ b/src/integrationTest/resources/application-intTest.yaml
@@ -96,6 +96,8 @@ darts:
         system-user-email: dartssystemuser@hmcts.net
       case-expiry-deletion:
         enabled: true
+      process-e2e-arm-rpo-pending:
+        thread-sleep-duration: ${ARM_RPO_THREAD_SLEEP_DURATION:2s}
 logging:
   level:
     root: DEBUG

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/UpdateMetadataRequest.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/UpdateMetadataRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NonNull;
 import lombok.extern.jackson.Jacksonized;
 
 import java.time.OffsetDateTime;
@@ -21,7 +22,8 @@ public class UpdateMetadataRequest {
     @JsonProperty("manifest")
     private Manifest manifest;
 
-    @JsonProperty("itemId")
+    @JsonProperty(value = "itemId", required = true)
+    @NonNull
     private String itemId;
 
     @Data

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/BaseRpoResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/BaseRpoResponse.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @ToString()
-public abstract class BaseRpoResponse {
+public class BaseRpoResponse {
 
     Integer itemsCount;
     Integer status;

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ResponseStatusMessage.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/ResponseStatusMessage.java
@@ -3,11 +3,14 @@ package uk.gov.hmcts.darts.arm.client.model.rpo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @NoArgsConstructor
+@ToString()
 public class ResponseStatusMessage {
     String message;
     Boolean isError;
+    Boolean canBeShownOnClient;
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/enums/ArmRpoResponseStatusCode.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/enums/ArmRpoResponseStatusCode.java
@@ -12,10 +12,6 @@ public enum ArmRpoResponseStatusCode {
     @Getter
     private final int statusCode;
 
-    ArmRpoResponseStatusCode(int statusCode) {
-        this.statusCode = statusCode;
-    }
-
     private static final Map<Integer, ArmRpoResponseStatusCode> BY_STATUS_CODE = new ConcurrentHashMap<>();
 
     static {
@@ -24,6 +20,10 @@ public enum ArmRpoResponseStatusCode {
         }
     }
 
+    ArmRpoResponseStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+    
     public static ArmRpoResponseStatusCode valueOfId(Integer id) {
         return BY_STATUS_CODE.get(id);
     }

--- a/src/main/java/uk/gov/hmcts/darts/arm/helper/ArmRpoHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/helper/ArmRpoHelper.java
@@ -12,10 +12,14 @@ import uk.gov.hmcts.darts.common.enums.ArmRpoStatusEnum;
 import uk.gov.hmcts.darts.common.repository.ArmRpoStateRepository;
 import uk.gov.hmcts.darts.common.repository.ArmRpoStatusRepository;
 
+import java.util.UUID;
+
 @Component
 @Accessors(fluent = true)
 @RequiredArgsConstructor
 public class ArmRpoHelper {
+
+    private static final String CREATE_EXPORT_CSV_EXTENSION = "_CSV";
 
     private final ArmRpoStateRepository armRpoStateRepository;
     private final ArmRpoStatusRepository armRpoStatusRepository;
@@ -90,4 +94,7 @@ public class ArmRpoHelper {
         return rpoState1.getId().equals(rpoState2.getId());
     }
 
+    public static String generateUniqueProductionName(String productionName) {
+        return productionName + "_" + UUID.randomUUID().toString() + CREATE_EXPORT_CSV_EXTENSION;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/helper/ArmRpoHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/helper/ArmRpoHelper.java
@@ -12,14 +12,10 @@ import uk.gov.hmcts.darts.common.enums.ArmRpoStatusEnum;
 import uk.gov.hmcts.darts.common.repository.ArmRpoStateRepository;
 import uk.gov.hmcts.darts.common.repository.ArmRpoStatusRepository;
 
-import java.util.UUID;
-
 @Component
 @Accessors(fluent = true)
 @RequiredArgsConstructor
 public class ArmRpoHelper {
-
-    private static final String CREATE_EXPORT_CSV_EXTENSION = "_CSV";
 
     private final ArmRpoStateRepository armRpoStateRepository;
     private final ArmRpoStatusRepository armRpoStatusRepository;
@@ -94,7 +90,5 @@ public class ArmRpoHelper {
         return rpoState1.getId().equals(rpoState2.getId());
     }
 
-    public static String generateUniqueProductionName(String productionName) {
-        return productionName + "_" + UUID.randomUUID().toString() + CREATE_EXPORT_CSV_EXTENSION;
-    }
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApi.java
@@ -28,10 +28,10 @@ public interface ArmRpoApi {
     String getExtendedSearchesByMatter(String bearerToken, Integer executionId, UserAccountEntity userAccount);
 
     boolean createExportBasedOnSearchResultsTable(String bearerToken, Integer executionId,
-                                                  List<MasterIndexFieldByRecordClassSchema> headerColumns, String productionName,
+                                                  List<MasterIndexFieldByRecordClassSchema> headerColumns, String uniqueProductionName,
                                                   UserAccountEntity userAccount);
 
-    boolean getExtendedProductionsByMatter(String bearerToken, Integer executionId, String productionName, UserAccountEntity userAccount);
+    boolean getExtendedProductionsByMatter(String bearerToken, Integer executionId, String uniqueProductionName, UserAccountEntity userAccount);
 
     List<String> getProductionOutputFiles(String bearerToken, Integer executionId, UserAccountEntity userAccount);
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -502,18 +502,32 @@ public class ArmRpoApiImpl implements ArmRpoApi {
         try {
             createExportBasedOnSearchResultsTableResponse = armRpoClient.createExportBasedOnSearchResultsTable(bearerToken, request);
         } catch (FeignException e) {
-            String feignResponse = e.contentUTF8();
-            log.debug("Feign response: {}", feignResponse);
-            try {
-                createExportBasedOnSearchResultsTableResponse = objectMapper.readValue(feignResponse, CreateExportBasedOnSearchResultsTableResponse.class);
-            } catch (JsonProcessingException ex) {
-                throw handleFailureAndCreateException(errorMessage.append(UNABLE_TO_GET_ARM_RPO_RESPONSE).append(e).toString(),
-                                                      armRpoExecutionDetailEntity, userAccount);
-            }
+            createExportBasedOnSearchResultsTableResponse = processCreateExportBasedOnSearchResultsTableResponseFeignException(userAccount, e, errorMessage,
+                                                                                                                               armRpoExecutionDetailEntity);
 
         }
         return processCreateExportBasedOnSearchResultsTableResponse(userAccount, createExportBasedOnSearchResultsTableResponse, errorMessage,
                                                                     armRpoExecutionDetailEntity);
+    }
+
+    private CreateExportBasedOnSearchResultsTableResponse processCreateExportBasedOnSearchResultsTableResponseFeignException(UserAccountEntity userAccount,
+                                                                                                                             FeignException e,
+                                                                                                                             StringBuilder errorMessage,
+                                                                                                                             ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity) {
+        CreateExportBasedOnSearchResultsTableResponse createExportBasedOnSearchResultsTableResponse;
+        String feignResponse = e.contentUTF8();
+        if (StringUtils.isBlank(feignResponse)) {
+            throw handleFailureAndCreateException(errorMessage.append(UNABLE_TO_GET_ARM_RPO_RESPONSE).append(e).toString(),
+                                                  armRpoExecutionDetailEntity, userAccount);
+        }
+        log.debug("Feign response: {}", feignResponse);
+        try {
+            createExportBasedOnSearchResultsTableResponse = objectMapper.readValue(feignResponse, CreateExportBasedOnSearchResultsTableResponse.class);
+        } catch (JsonProcessingException ex) {
+            throw handleFailureAndCreateException(errorMessage.append(UNABLE_TO_GET_ARM_RPO_RESPONSE).append(e).toString(),
+                                                  armRpoExecutionDetailEntity, userAccount);
+        }
+        return createExportBasedOnSearchResultsTableResponse;
     }
 
     private boolean processCreateExportBasedOnSearchResultsTableResponse(UserAccountEntity userAccount,

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -78,6 +78,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
 
     private static final String COULD_NOT_CONSTRUCT_API_REQUEST = "Could not construct API request: ";
     private static final String AND_RESPONSE = " and response - ";
+    public static final int CREATE_EXPORT_BASED_ON_SEARCH_RESULTS_IN_PROGRESS_STATUS = 2;
 
     private final ArmRpoClient armRpoClient;
     private final ArmRpoService armRpoService;
@@ -549,7 +550,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
             HttpStatus httpStatus = HttpStatus.valueOf(baseRpoResponse.getStatus());
 
             if (HttpStatus.BAD_REQUEST.value() == httpStatus.value()) {
-                if (baseRpoResponse.getResponseStatus() == 2) {
+                if (baseRpoResponse.getResponseStatus() == CREATE_EXPORT_BASED_ON_SEARCH_RESULTS_IN_PROGRESS_STATUS) {
                     log.error("The search is still running and cannot export as csv - {}", baseRpoResponse);
                     return false;
                 } else {

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -510,10 +510,8 @@ public class ArmRpoApiImpl implements ArmRpoApi {
                                                                     armRpoExecutionDetailEntity);
     }
 
-    private CreateExportBasedOnSearchResultsTableResponse processCreateExportBasedOnSearchResultsTableResponseFeignException(UserAccountEntity userAccount,
-                                                                                                                             FeignException e,
-                                                                                                                             StringBuilder errorMessage,
-                                                                                                                             ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity) {
+    private CreateExportBasedOnSearchResultsTableResponse processCreateExportBasedOnSearchResultsTableResponseFeignException(
+        UserAccountEntity userAccount, FeignException e, StringBuilder errorMessage, ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity) {
         CreateExportBasedOnSearchResultsTableResponse createExportBasedOnSearchResultsTableResponse;
         String feignResponse = e.contentUTF8();
         if (StringUtils.isBlank(feignResponse)) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 
 @Service
 @AllArgsConstructor
@@ -189,7 +188,7 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
 
     private ArmRpoExecutionDetailEntity getArmRpoExecutionDetailEntity(boolean isManualRun) {
         var armRpoExecutionDetailEntity = armRpoService.getLatestArmRpoExecutionDetailEntity();
-        if (isNull(armRpoExecutionDetailEntity)) {
+        if (isNull(armRpoExecutionDetailEntity) || isNull(armRpoExecutionDetailEntity.getArmRpoState())) {
             return null;
         }
 
@@ -210,20 +209,17 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
     }
 
     private boolean pollServiceFailed(ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity) {
-        return nonNull(armRpoExecutionDetailEntity.getArmRpoState())
-            && ArmRpoHelper.failedRpoStatus().getId().equals(armRpoExecutionDetailEntity.getArmRpoStatus().getId())
+        return ArmRpoHelper.failedRpoStatus().getId().equals(armRpoExecutionDetailEntity.getArmRpoStatus().getId())
             && allowableFailedStates.contains(armRpoExecutionDetailEntity.getArmRpoState().getId());
     }
 
     private boolean pollServiceInProgress(ArmRpoExecutionDetailEntity armRpoExecutionDetail) {
-        return nonNull(armRpoExecutionDetail.getArmRpoState())
-            && ArmRpoHelper.inProgressRpoStatus().getId().equals(armRpoExecutionDetail.getArmRpoStatus().getId())
+        return ArmRpoHelper.inProgressRpoStatus().getId().equals(armRpoExecutionDetail.getArmRpoStatus().getId())
             && allowableInProgressStates.contains(armRpoExecutionDetail.getArmRpoState().getId());
     }
 
     private boolean saveBackgroundSearchCompleted(ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity) {
-        return nonNull(armRpoExecutionDetailEntity.getArmRpoState())
-            && ArmRpoHelper.saveBackgroundSearchRpoState().getId().equals(armRpoExecutionDetailEntity.getArmRpoState().getId())
+        return ArmRpoHelper.saveBackgroundSearchRpoState().getId().equals(armRpoExecutionDetailEntity.getArmRpoState().getId())
             && ArmRpoHelper.completedRpoStatus().getId().equals(armRpoExecutionDetailEntity.getArmRpoStatus().getId());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
@@ -130,15 +130,17 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
                                         UserAccountEntity userAccount) throws IOException {
         String productionExportFilename = generateTempProductionExportFilename(productionExportFileId);
         // step to call ARM RPO API to download the production export file
-        var inputStream = armRpoApi.downloadProduction(bearerToken, executionId, productionExportFileId, userAccount);
-        log.info("About to save production export file to temp workspace {}", productionExportFilename);
-        Path tempProductionFile = fileOperationService.saveFileToTempWorkspace(
-            inputStream,
-            productionExportFilename,
-            armDataManagementConfiguration,
-            true
-        );
-        tempProductionFiles.add(tempProductionFile.toFile());
+
+        try (var inputStream = armRpoApi.downloadProduction(bearerToken, executionId, productionExportFileId, userAccount)) {
+            log.info("About to save production export file to temp workspace {}", productionExportFilename);
+            Path tempProductionFile = fileOperationService.saveFileToTempWorkspace(
+                inputStream,
+                productionExportFilename,
+                armDataManagementConfiguration,
+                true
+            );
+            tempProductionFiles.add(tempProductionFile.toFile());
+        }
     }
 
     private void setupFailedStatuses() {

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -32,8 +31,6 @@ import static java.util.Objects.nonNull;
 @AllArgsConstructor
 @Slf4j
 public class ArmRpoPollServiceImpl implements ArmRpoPollService {
-
-    private static final String CREATE_EXPORT_CSV_EXTENSION = "_CSV";
 
     private final ArmRpoApi armRpoApi;
     private final ArmApiService armApiService;
@@ -75,7 +72,7 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
             // step to call ARM RPO API to get the extended searches by matter
             String productionName = armRpoApi.getExtendedSearchesByMatter(bearerToken, executionId, userAccount);
 
-            String uniqueProductionName = productionName + "_" + UUID.randomUUID().toString() + CREATE_EXPORT_CSV_EXTENSION;
+            String uniqueProductionName = ArmRpoHelper.generateUniqueProductionName(productionName);
 
             // step to call ARM RPO API to get the master index field by record class schema
             List<MasterIndexFieldByRecordClassSchema> headerColumns = armRpoApi.getMasterIndexFieldByRecordClassSchema(
@@ -101,6 +98,7 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
             cleanUpTempFiles();
         }
     }
+
 
     private void processProductions(String bearerToken, Integer executionId, String uniqueProductionName, UserAccountEntity userAccount,
                                     ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity) throws IOException {

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImpl.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.arm.rpo.ArmRpoApi;
 import uk.gov.hmcts.darts.arm.service.ArmApiService;
 import uk.gov.hmcts.darts.arm.service.ArmRpoPollService;
 import uk.gov.hmcts.darts.arm.service.ArmRpoService;
+import uk.gov.hmcts.darts.arm.util.ArmRpoUtil;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -39,6 +40,7 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
     private final FileOperationService fileOperationService;
     private final ArmDataManagementConfiguration armDataManagementConfiguration;
     private final LogApi logApi;
+    private final ArmRpoUtil armRpoUtil;
 
     private List<File> tempProductionFiles;
 
@@ -72,7 +74,7 @@ public class ArmRpoPollServiceImpl implements ArmRpoPollService {
             // step to call ARM RPO API to get the extended searches by matter
             String productionName = armRpoApi.getExtendedSearchesByMatter(bearerToken, executionId, userAccount);
 
-            String uniqueProductionName = ArmRpoHelper.generateUniqueProductionName(productionName);
+            String uniqueProductionName = armRpoUtil.generateUniqueProductionName(productionName);
 
             // step to call ARM RPO API to get the master index field by record class schema
             List<MasterIndexFieldByRecordClassSchema> headerColumns = armRpoApi.getMasterIndexFieldByRecordClassSchema(

--- a/src/main/java/uk/gov/hmcts/darts/arm/util/ArmRpoUtil.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/util/ArmRpoUtil.java
@@ -2,12 +2,14 @@ package uk.gov.hmcts.darts.arm.util;
 
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Component
 public class ArmRpoUtil {
 
     private static final String CREATE_EXPORT_CSV_EXTENSION = "_CSV";
 
     public String generateUniqueProductionName(String productionName) {
-        return productionName + "_" + CREATE_EXPORT_CSV_EXTENSION;
+        return productionName + "_" + UUID.randomUUID().toString() + CREATE_EXPORT_CSV_EXTENSION;
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/util/ArmRpoUtil.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/util/ArmRpoUtil.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.darts.arm.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ArmRpoUtil {
+
+    private static final String CREATE_EXPORT_CSV_EXTENSION = "_CSV";
+
+    public String generateUniqueProductionName(String productionName) {
+        return productionName + "_" + CREATE_EXPORT_CSV_EXTENSION;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -495,7 +495,7 @@ darts:
         system-user-email: system_ProcessE2EArmRpoPending@hmcts.net
         process-e2e-arm-rpo: ${PROCESS_E2E_ARM_RPO:true}
         arm-rpo-duration: ${ARM_RPO_DURATION:1h}
-        thread-sleep-duration: ${ARM_RPO_THREAD_SLEEP_DURATION:5s}
+        thread-sleep-duration: ${ARM_RPO_THREAD_SLEEP_DURATION:60s}
         lock:
           at-least-for: PT1M
           at-most-for: PT60M

--- a/src/test/java/uk/gov/hmcts/darts/arm/helper/ArmRpoHelperMocks.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/helper/ArmRpoHelperMocks.java
@@ -188,10 +188,6 @@ public class ArmRpoHelperMocks {
         }
     }
 
-    public void mockArmRpoGenerateUniqueProductionName(String productionName) {
-        lenient().when(ArmRpoHelper.generateUniqueProductionName(productionName)).thenReturn(productionName + "_uuid_CSV");
-    }
-
     @SneakyThrows
     public void close() {
         armRpoHelperMockedStatic.close();

--- a/src/test/java/uk/gov/hmcts/darts/arm/helper/ArmRpoHelperMocks.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/helper/ArmRpoHelperMocks.java
@@ -188,6 +188,10 @@ public class ArmRpoHelperMocks {
         }
     }
 
+    public void mockArmRpoGenerateUniqueProductionName(String productionName) {
+        lenient().when(ArmRpoHelper.generateUniqueProductionName(productionName)).thenReturn(productionName + "_uuid_CSV");
+    }
+
     @SneakyThrows
     public void close() {
         armRpoHelperMockedStatic.close();

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiAddAsyncSearchTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiAddAsyncSearchTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.arm.rpo.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.darts.arm.config.ArmApiConfigurationProperties;
 import uk.gov.hmcts.darts.arm.exception.ArmRpoException;
 import uk.gov.hmcts.darts.arm.helper.ArmRpoHelperMocks;
 import uk.gov.hmcts.darts.arm.service.ArmRpoService;
+import uk.gov.hmcts.darts.common.config.ObjectMapperConfig;
 import uk.gov.hmcts.darts.common.entity.ArmAutomatedTaskEntity;
 import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -73,9 +75,12 @@ class ArmRpoApiAddAsyncSearchTest {
         requestCaptor = ArgumentCaptor.forClass(String.class);
 
         ArmApiConfigurationProperties armApiConfigurationProperties = new ArmApiConfigurationProperties();
+        ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig();
+        ObjectMapper objectMapper = objectMapperConfig.objectMapper();
 
         armRpoApi = new ArmRpoApiImpl(armRpoClient, armRpoService, armApiConfigurationProperties,
-                                      armAutomatedTaskRepository, currentTimeHelper, armRpoDownloadProduction);
+                                      armAutomatedTaskRepository, currentTimeHelper, armRpoDownloadProduction,
+                                      objectMapper);
 
         armRpoHelperMocks = new ArmRpoHelperMocks(); // Mocks are set via the default constructor call
 

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -503,7 +503,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
-            "Failure during ARM createExportBasedOnSearchResultsTable: ARM RPO API baseRpoResponse is invalid"));
+            "Failure during ARM createExportBasedOnSearchResultsTable: ARM RPO API createExportBasedOnSearchResultsTable is invalid"));
 
         verify(armRpoService).updateArmRpoStateAndStatus(any(),
                                                          eq(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState()),

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -155,8 +155,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -232,8 +231,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -259,8 +257,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -284,8 +281,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -311,8 +307,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -336,8 +331,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -407,8 +401,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -432,8 +425,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -457,8 +449,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -399,7 +399,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     }
 
     @Test
-    void createExportBasedOnSearchResultsTable_ThrowsException_WhenFeignExceptionThrown() {
+    void createExportBasedOnSearchResultsTable_ThrowsException_WhenFeignExceptionThrownWithStatus500IsErrorFalseResponseStatus500() {
         // given
         FeignException feignException = mock(FeignException.class);
         when(feignException.contentUTF8()).thenReturn(getFeignResponseAsString("500", true, "500"));
@@ -413,6 +413,106 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // then
         assertThat(armRpoException.getMessage(), containsString(
             "Failure during ARM createExportBasedOnSearchResultsTable: ARM RPO API failed with status - 500 INTERNAL_SERVER_ERROR"));
+
+        verify(armRpoService).updateArmRpoStateAndStatus(any(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), any());
+        verifyNoMoreInteractions(armRpoService);
+
+    }
+
+    @Test
+    void createExportBasedOnSearchResultsTable_ThrowsException_WhenFeignExceptionThrownWithNullResponse() {
+        // given
+        FeignException feignException = mock(FeignException.class);
+        when(feignException.contentUTF8()).thenReturn(null);
+        when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenThrow(feignException);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM createExportBasedOnSearchResultsTable: Unable to get ARM RPO response from client"));
+
+        verify(armRpoService).updateArmRpoStateAndStatus(any(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), any());
+        verifyNoMoreInteractions(armRpoService);
+
+    }
+
+    @Test
+    void createExportBasedOnSearchResultsTable_ThrowsException_WhenFeignExceptionThrownWithEmptyResponse() {
+        // given
+        FeignException feignException = mock(FeignException.class);
+        when(feignException.contentUTF8()).thenReturn("");
+        when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenThrow(feignException);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM createExportBasedOnSearchResultsTable: Unable to get ARM RPO response from client"));
+
+        verify(armRpoService).updateArmRpoStateAndStatus(any(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), any());
+        verifyNoMoreInteractions(armRpoService);
+
+    }
+
+    @Test
+    void createExportBasedOnSearchResultsTable_ThrowsException_WhenFeignExceptionThrownWithInvalidJsonResponse() {
+        // given
+        FeignException feignException = mock(FeignException.class);
+        when(feignException.contentUTF8()).thenReturn("{");
+        when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenThrow(feignException);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM createExportBasedOnSearchResultsTable: Unable to get ARM RPO response from client"));
+
+        verify(armRpoService).updateArmRpoStateAndStatus(any(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), any());
+        verifyNoMoreInteractions(armRpoService);
+
+    }
+
+    @Test
+    void createExportBasedOnSearchResultsTable_ThrowsException_WhenFeignExceptionThrownWithEmptyResponseObject() {
+        // given
+        FeignException feignException = mock(FeignException.class);
+        when(feignException.contentUTF8()).thenReturn("{}");
+        when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenThrow(feignException);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.createExportBasedOnSearchResultsTable(
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM createExportBasedOnSearchResultsTable: ARM RPO API baseRpoResponse is invalid"));
 
         verify(armRpoService).updateArmRpoStateAndStatus(any(),
                                                          eq(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState()),

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetExtendedSearchesByMatterTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetExtendedSearchesByMatterTest.java
@@ -276,11 +276,13 @@ class ArmRpoApiGetExtendedSearchesByMatterTest {
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
-            "RPO endpoint extendedSearchesByMatterResponse is already in progress for execution id 1"));
+            "Failure during ARM RPO getExtendedSearchesByMatter: extendedSearchesByMatterResponse search data is missing for searchId"));
         verify(armRpoService).updateArmRpoStateAndStatus(any(ArmRpoExecutionDetailEntity.class),
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetExtendedSearchesByMatterRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          any(UserAccountEntity.class));
+        verify(armRpoService).updateArmRpoStatus(any(ArmRpoExecutionDetailEntity.class), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()),
+                                                 any(UserAccountEntity.class));
         verifyNoMoreInteractions(armRpoService);
 
     }

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetExtendedSearchesByMatterTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetExtendedSearchesByMatterTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.darts.arm.service.ArmRpoService;
 import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -128,6 +129,42 @@ class ArmRpoApiGetExtendedSearchesByMatterTest {
     }
 
     @Test
+    void getExtendedSearchesByMatter_ThrowsException_WhenIsSavedNull() {
+        // given
+        ExtendedSearchesByMatterResponse extendedSearchesByMatterResponse = new ExtendedSearchesByMatterResponse();
+        extendedSearchesByMatterResponse.setStatus(200);
+        extendedSearchesByMatterResponse.setIsError(false);
+        ExtendedSearchesByMatterResponse.Search search = new ExtendedSearchesByMatterResponse.Search();
+        search.setSearchId(SEARCH_ID);
+        search.setTotalCount(4);
+        search.setName(PRODUCTION_NAME);
+        search.setIsSaved(null);
+        ExtendedSearchesByMatterResponse.SearchDetail searchDetail = new ExtendedSearchesByMatterResponse.SearchDetail();
+        searchDetail.setSearch(search);
+        extendedSearchesByMatterResponse.setSearches(List.of(searchDetail));
+
+        armRpoExecutionDetailEntity.setMatterId("1");
+
+        when(armRpoClient.getExtendedSearchesByMatter(anyString(), any())).thenReturn(extendedSearchesByMatterResponse);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(
+            ArmRpoException.class, () -> armRpoApi.getExtendedSearchesByMatter("token", 1, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO getExtendedSearchesByMatter: extendedSearchesByMatterResponse search data is missing for searchId"));
+        verify(armRpoService).updateArmRpoStateAndStatus(any(ArmRpoExecutionDetailEntity.class),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetExtendedSearchesByMatterRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any(UserAccountEntity.class));
+        verify(armRpoService).updateArmRpoStatus(any(ArmRpoExecutionDetailEntity.class), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()),
+                                                 any(UserAccountEntity.class));
+        verifyNoMoreInteractions(armRpoService);
+
+    }
+
+    @Test
     void getExtendedSearchesByMatter_ThrowsException_WhenClientThrowsFeignException() {
         // given
         when(armRpoClient.getExtendedSearchesByMatter(anyString(), anyString())).thenThrow(FeignException.class);
@@ -233,6 +270,7 @@ class ArmRpoApiGetExtendedSearchesByMatterTest {
         ExtendedSearchesByMatterResponse.Search search = new ExtendedSearchesByMatterResponse.Search();
         search.setSearchId(SEARCH_ID);
         search.setTotalCount(4);
+        search.setIsSaved(true);
         ExtendedSearchesByMatterResponse.SearchDetail searchDetail = new ExtendedSearchesByMatterResponse.SearchDetail();
         searchDetail.setSearch(search);
         extendedSearchesByMatterResponse.setSearches(List.of(searchDetail));
@@ -246,6 +284,91 @@ class ArmRpoApiGetExtendedSearchesByMatterTest {
         // then
         assertThat(armRpoException.getMessage(), containsString(
             "Failure during ARM RPO getExtendedSearchesByMatter: extendedSearchesByMatterResponse search data is missing for searchId"));
+        verify(armRpoService).updateArmRpoStateAndStatus(any(ArmRpoExecutionDetailEntity.class),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetExtendedSearchesByMatterRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(ArmRpoExecutionDetailEntity.class), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()),
+                                                 any(UserAccountEntity.class));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getExtendedSearchesByMatter_ThrowsException_WithMissingSearchId() {
+        // given
+        ExtendedSearchesByMatterResponse extendedSearchesByMatterResponse = new ExtendedSearchesByMatterResponse();
+        extendedSearchesByMatterResponse.setStatus(200);
+        extendedSearchesByMatterResponse.setIsError(false);
+        ExtendedSearchesByMatterResponse.Search search = new ExtendedSearchesByMatterResponse.Search();
+        search.setTotalCount(4);
+        search.setName(PRODUCTION_NAME);
+        search.setIsSaved(true);
+        ExtendedSearchesByMatterResponse.SearchDetail searchDetail = new ExtendedSearchesByMatterResponse.SearchDetail();
+        searchDetail.setSearch(search);
+        extendedSearchesByMatterResponse.setSearches(List.of(searchDetail));
+        when(armRpoClient.getExtendedSearchesByMatter(anyString(), anyString())).thenReturn(extendedSearchesByMatterResponse);
+        armRpoExecutionDetailEntity.setMatterId("1");
+
+        // when
+        ArmRpoException armRpoException = assertThrows(
+            ArmRpoException.class, () -> armRpoApi.getExtendedSearchesByMatter("token", 1, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO getExtendedSearchesByMatter: extendedSearchesByMatterResponse search data is missing for searchId"));
+        verify(armRpoService).updateArmRpoStateAndStatus(any(ArmRpoExecutionDetailEntity.class),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetExtendedSearchesByMatterRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(ArmRpoExecutionDetailEntity.class), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()),
+                                                 any(UserAccountEntity.class));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getExtendedSearchesByMatter_ThrowsException_WithMissingSearch() {
+        // given
+        ExtendedSearchesByMatterResponse extendedSearchesByMatterResponse = new ExtendedSearchesByMatterResponse();
+        extendedSearchesByMatterResponse.setStatus(200);
+        extendedSearchesByMatterResponse.setIsError(false);
+        ExtendedSearchesByMatterResponse.SearchDetail searchDetail = new ExtendedSearchesByMatterResponse.SearchDetail();
+        extendedSearchesByMatterResponse.setSearches(List.of(searchDetail));
+        when(armRpoClient.getExtendedSearchesByMatter(anyString(), anyString())).thenReturn(extendedSearchesByMatterResponse);
+        armRpoExecutionDetailEntity.setMatterId("1");
+
+        // when
+        ArmRpoException armRpoException = assertThrows(
+            ArmRpoException.class, () -> armRpoApi.getExtendedSearchesByMatter("token", 1, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO getExtendedSearchesByMatter: extendedSearchesByMatterResponse search data is missing for searchId"));
+        verify(armRpoService).updateArmRpoStateAndStatus(any(ArmRpoExecutionDetailEntity.class),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetExtendedSearchesByMatterRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any());
+        verify(armRpoService).updateArmRpoStatus(any(ArmRpoExecutionDetailEntity.class), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()),
+                                                 any(UserAccountEntity.class));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getExtendedSearchesByMatter_ThrowsException_WithMissingSearches() {
+        // given
+        ExtendedSearchesByMatterResponse extendedSearchesByMatterResponse = new ExtendedSearchesByMatterResponse();
+        extendedSearchesByMatterResponse.setStatus(200);
+        extendedSearchesByMatterResponse.setIsError(false);
+        extendedSearchesByMatterResponse.setSearches(Collections.emptyList());
+        when(armRpoClient.getExtendedSearchesByMatter(anyString(), anyString())).thenReturn(extendedSearchesByMatterResponse);
+        armRpoExecutionDetailEntity.setMatterId("1");
+
+        // when
+        ArmRpoException armRpoException = assertThrows(
+            ArmRpoException.class, () -> armRpoApi.getExtendedSearchesByMatter("token", 1, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO getExtendedSearchesByMatter: Search data is missing"));
         verify(armRpoService).updateArmRpoStateAndStatus(any(ArmRpoExecutionDetailEntity.class),
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetExtendedSearchesByMatterRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetExtendedSearchesByMatterTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetExtendedSearchesByMatterTest.java
@@ -187,6 +187,27 @@ class ArmRpoApiGetExtendedSearchesByMatterTest {
     }
 
     @Test
+    void getExtendedSearchesByMatter_ThrowsException_WhenMatterIdIsNull() {
+        // given
+        armRpoExecutionDetailEntity.setMatterId(null);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(
+            ArmRpoException.class, () -> armRpoApi.getExtendedSearchesByMatter("token", 1, userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO getExtendedSearchesByMatter: Could not construct API request"));
+        verify(armRpoService).updateArmRpoStateAndStatus(any(ArmRpoExecutionDetailEntity.class),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetExtendedSearchesByMatterRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         any(UserAccountEntity.class));
+        verify(armRpoService).updateArmRpoStatus(any(ArmRpoExecutionDetailEntity.class), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()),
+                                                 any(UserAccountEntity.class));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
     void getExtendedSearchesByMatter_ThrowsException_WithNullResponse() {
         // given
         when(armRpoClient.getExtendedSearchesByMatter(anyString(), anyString())).thenReturn(null);

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetIndexesByMatterIdTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetIndexesByMatterIdTest.java
@@ -111,7 +111,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 
@@ -128,7 +128,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 
@@ -150,7 +150,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 
@@ -174,7 +174,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 
@@ -240,7 +240,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 
@@ -269,7 +269,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 
@@ -295,7 +295,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 
@@ -321,7 +321,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetIndexesByMatterIdTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetIndexesByMatterIdTest.java
@@ -67,7 +67,7 @@ class ArmRpoApiGetIndexesByMatterIdTest {
     }
 
     @Test
-    void getIndexesByMatterIdSuccess() {
+    void getIndexesByMatterId_Success() {
         // given
         IndexesByMatterIdResponse response = new IndexesByMatterIdResponse();
         response.setStatus(200);
@@ -175,6 +175,41 @@ class ArmRpoApiGetIndexesByMatterIdTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
         verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getIndexesByMatterId_Success_WithMultipleIndexes() {
+        // given
+        IndexesByMatterIdResponse response = new IndexesByMatterIdResponse();
+        response.setStatus(200);
+        response.setIsError(false);
+
+        IndexesByMatterIdResponse.Index index1 = new IndexesByMatterIdResponse.Index();
+        IndexesByMatterIdResponse.IndexDetails indexDetails1 = new IndexesByMatterIdResponse.IndexDetails();
+        indexDetails1.setIndexId("indexId");
+        index1.setIndex(indexDetails1);
+
+        IndexesByMatterIdResponse.Index index2 = new IndexesByMatterIdResponse.Index();
+        IndexesByMatterIdResponse.IndexDetails indexDetails2 = new IndexesByMatterIdResponse.IndexDetails();
+        indexDetails2.setIndexId("indexId 2");
+        index2.setIndex(indexDetails2);
+
+        response.setIndexes(List.of(index1, index2));
+
+        when(armRpoService.getArmRpoExecutionDetailEntity(anyInt())).thenReturn(armRpoExecutionDetailEntity);
+        when(armRpoClient.getIndexesByMatterId(anyString(), any(IndexesByMatterIdRequest.class))).thenReturn(response);
+
+        // when
+        armRpoApi.getIndexesByMatterId(BEARER_TOKEN, EXECUTION_ID, "matterId", userAccount);
+
+        // then
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntityArgumentCaptor.capture(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         eq(userAccount));
+        assertEquals("indexId", armRpoExecutionDetailEntityArgumentCaptor.getValue().getIndexId());
+        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getCompletedRpoStatus()), eq(userAccount));
         verifyNoMoreInteractions(armRpoService);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetIndexesByMatterIdTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetIndexesByMatterIdTest.java
@@ -213,6 +213,118 @@ class ArmRpoApiGetIndexesByMatterIdTest {
         verifyNoMoreInteractions(armRpoService);
     }
 
+    @Test
+    void getIndexesByMatterId_ThrowsException_WithNullIndexId() {
+        // given
+        IndexesByMatterIdResponse response = new IndexesByMatterIdResponse();
+        response.setStatus(200);
+        response.setIsError(false);
+
+        IndexesByMatterIdResponse.Index index = new IndexesByMatterIdResponse.Index();
+        IndexesByMatterIdResponse.IndexDetails indexDetails = new IndexesByMatterIdResponse.IndexDetails();
+        indexDetails.setIndexId(null);
+        index.setIndex(indexDetails);
+        response.setIndexes(List.of(index));
+
+        when(armRpoService.getArmRpoExecutionDetailEntity(anyInt())).thenReturn(armRpoExecutionDetailEntity);
+        when(armRpoClient.getIndexesByMatterId(anyString(), any(IndexesByMatterIdRequest.class))).thenReturn(response);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getIndexesByMatterId(BEARER_TOKEN, EXECUTION_ID, "matterId", userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO get indexes by matter ID: Unable to find any indexes by matter ID in response"));
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntityArgumentCaptor.capture(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getIndexesByMatterId_ThrowsException_WithNullIndexDetails() {
+        // given
+        IndexesByMatterIdResponse response = new IndexesByMatterIdResponse();
+        response.setStatus(200);
+        response.setIsError(false);
+
+        IndexesByMatterIdResponse.Index index = new IndexesByMatterIdResponse.Index();
+        index.setIndex(null);
+        response.setIndexes(List.of(index));
+
+        when(armRpoService.getArmRpoExecutionDetailEntity(anyInt())).thenReturn(armRpoExecutionDetailEntity);
+        when(armRpoClient.getIndexesByMatterId(anyString(), any(IndexesByMatterIdRequest.class))).thenReturn(response);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getIndexesByMatterId(BEARER_TOKEN, EXECUTION_ID, "matterId", userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO get indexes by matter ID: Unable to find any indexes by matter ID in response"));
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntityArgumentCaptor.capture(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getIndexesByMatterId_ThrowsException_WithEmptyIndexes() {
+        // given
+        IndexesByMatterIdResponse response = new IndexesByMatterIdResponse();
+        response.setStatus(200);
+        response.setIsError(false);
+        response.setIndexes(Collections.emptyList());
+
+        when(armRpoService.getArmRpoExecutionDetailEntity(anyInt())).thenReturn(armRpoExecutionDetailEntity);
+        when(armRpoClient.getIndexesByMatterId(anyString(), any(IndexesByMatterIdRequest.class))).thenReturn(response);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getIndexesByMatterId(BEARER_TOKEN, EXECUTION_ID, "matterId", userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO get indexes by matter ID: Unable to find any indexes by matter ID in response"));
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntityArgumentCaptor.capture(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
+    @Test
+    void getIndexesByMatterId_ThrowsException_WithNullIndexes() {
+        // given
+        IndexesByMatterIdResponse response = new IndexesByMatterIdResponse();
+        response.setStatus(200);
+        response.setIsError(false);
+        response.setIndexes(null);
+
+        when(armRpoService.getArmRpoExecutionDetailEntity(anyInt())).thenReturn(armRpoExecutionDetailEntity);
+        when(armRpoClient.getIndexesByMatterId(anyString(), any(IndexesByMatterIdRequest.class))).thenReturn(response);
+
+        // when
+        ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
+            armRpoApi.getIndexesByMatterId(BEARER_TOKEN, EXECUTION_ID, "matterId", userAccount));
+
+        // then
+        assertThat(armRpoException.getMessage(), containsString(
+            "Failure during ARM RPO get indexes by matter ID: Unable to find any indexes by matter ID in response"));
+        verify(armRpoService).updateArmRpoStateAndStatus(armRpoExecutionDetailEntityArgumentCaptor.capture(),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getGetIndexesByMatterIdRpoState()),
+                                                         eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
+                                                         eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verifyNoMoreInteractions(armRpoService);
+    }
+
     @AfterAll
     static void close() {
         ARM_RPO_HELPER_MOCKS.close();

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetProductionOutputFilesTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetProductionOutputFilesTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.arm.rpo.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ import uk.gov.hmcts.darts.arm.exception.ArmRpoException;
 import uk.gov.hmcts.darts.arm.exception.ArmRpoInProgressException;
 import uk.gov.hmcts.darts.arm.helper.ArmRpoHelperMocks;
 import uk.gov.hmcts.darts.arm.service.ArmRpoService;
+import uk.gov.hmcts.darts.common.config.ObjectMapperConfig;
 import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
@@ -69,9 +71,12 @@ class ArmRpoApiGetProductionOutputFilesTest {
         var armRpoDownloadProduction = mock(ArmRpoDownloadProduction.class);
 
         ArmApiConfigurationProperties armApiConfigurationProperties = new ArmApiConfigurationProperties();
+        ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig();
+        ObjectMapper objectMapper = objectMapperConfig.objectMapper();
 
         armRpoApi = new ArmRpoApiImpl(armRpoClient, armRpoService, armApiConfigurationProperties,
-                                      armAutomatedTaskRepository, currentTimeHelper, armRpoDownloadProduction);
+                                      armAutomatedTaskRepository, currentTimeHelper, armRpoDownloadProduction,
+                                      objectMapper);
 
         armRpoHelperMocks = new ArmRpoHelperMocks(); // Mocks are set via the default constructor call
     }

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetProfileEntitlementsTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiGetProfileEntitlementsTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.arm.rpo.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import feign.FeignException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +18,7 @@ import uk.gov.hmcts.darts.arm.config.ArmApiConfigurationProperties;
 import uk.gov.hmcts.darts.arm.exception.ArmRpoException;
 import uk.gov.hmcts.darts.arm.helper.ArmRpoHelperMocks;
 import uk.gov.hmcts.darts.arm.service.ArmRpoService;
+import uk.gov.hmcts.darts.common.config.ObjectMapperConfig;
 import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
@@ -64,9 +66,12 @@ class ArmRpoApiGetProfileEntitlementsTest {
 
         ArmApiConfigurationProperties armApiConfigurationProperties = new ArmApiConfigurationProperties();
         armApiConfigurationProperties.setArmServiceEntitlement(ENTITLEMENT_NAME);
+        ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig();
+        ObjectMapper objectMapper = objectMapperConfig.objectMapper();
 
         armRpoApi = new ArmRpoApiImpl(armRpoClient, armRpoService, armApiConfigurationProperties,
-                                      armAutomatedTaskRepository, currentTimeHelper, armRpoDownloadProduction);
+                                      armAutomatedTaskRepository, currentTimeHelper, armRpoDownloadProduction,
+                                      objectMapper);
     }
 
     @AfterEach

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiRemoveProductionTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiRemoveProductionTest.java
@@ -100,7 +100,7 @@ class ArmRpoApiRemoveProductionTest {
                                                          eq(ARM_RPO_HELPER_MOCKS.getRemoveProductionRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),
                                                          eq(userAccount));
-        verify(armRpoService).updateArmRpoStatus(eq(armRpoExecutionDetailEntity), eq(ARM_RPO_HELPER_MOCKS.getFailedRpoStatus()), eq(userAccount));
+        verify(armRpoService).updateArmRpoStatus(armRpoExecutionDetailEntity, ARM_RPO_HELPER_MOCKS.getFailedRpoStatus(), userAccount);
         verifyNoMoreInteractions(armRpoService);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
@@ -80,8 +80,7 @@ class ArmRpoPollServiceImplTest {
     private static final Integer EXECUTION_ID = 1;
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
     private static final ArmRpoHelperMocks ARM_RPO_HELPER_MOCKS = new ArmRpoHelperMocks();
-    private String uniqueProductionName;
-    
+
     private ArmRpoPollServiceImpl armRpoPollService;
 
     @BeforeEach
@@ -95,8 +94,8 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
         armRpoExecutionDetailEntity.setId(EXECUTION_ID);
         when(armRpoService.getLatestArmRpoExecutionDetailEntity()).thenReturn(armRpoExecutionDetailEntity);
-        uniqueProductionName = PRODUCTION_NAME + "_UUID_CSV";
-        lenient().when(armRpoUtil.generateUniqueProductionName(anyString())).thenReturn(uniqueProductionName);
+
+        lenient().when(armRpoUtil.generateUniqueProductionName(anyString())).thenReturn(PRODUCTION_NAME + "_UUID_CSV");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.darts.arm.model.rpo.MasterIndexFieldByRecordClassSchema;
 import uk.gov.hmcts.darts.arm.rpo.ArmRpoApi;
 import uk.gov.hmcts.darts.arm.service.ArmApiService;
 import uk.gov.hmcts.darts.arm.service.ArmRpoService;
+import uk.gov.hmcts.darts.arm.util.ArmRpoUtil;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
 import uk.gov.hmcts.darts.common.entity.ArmRpoStateEntity;
@@ -63,6 +64,8 @@ class ArmRpoPollServiceImplTest {
     private ArmDataManagementConfiguration armDataManagementConfiguration;
     @Mock
     private LogApi logApi;
+    @Mock
+    private ArmRpoUtil armRpoUtil;
 
     @Mock
     private UserAccountEntity userAccountEntity;
@@ -77,14 +80,14 @@ class ArmRpoPollServiceImplTest {
     private static final Integer EXECUTION_ID = 1;
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
     private static final ArmRpoHelperMocks ARM_RPO_HELPER_MOCKS = new ArmRpoHelperMocks();
-
+    private String uniqueProductionName;
+    
     private ArmRpoPollServiceImpl armRpoPollService;
-
 
     @BeforeEach
     void setUp() {
         armRpoPollService = new ArmRpoPollServiceImpl(armRpoApi, armApiService, armRpoService, userIdentity, fileOperationService,
-                                                      armDataManagementConfiguration, logApi, tempProductionFiles, allowableFailedStates,
+                                                      armDataManagementConfiguration, logApi, armRpoUtil, tempProductionFiles, allowableFailedStates,
                                                       inProgressStates);
 
         lenient().when(userIdentity.getUserAccount()).thenReturn(userAccountEntity);
@@ -92,9 +95,8 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
         armRpoExecutionDetailEntity.setId(EXECUTION_ID);
         when(armRpoService.getLatestArmRpoExecutionDetailEntity()).thenReturn(armRpoExecutionDetailEntity);
-
-        ARM_RPO_HELPER_MOCKS.mockArmRpoGenerateUniqueProductionName(PRODUCTION_NAME);
-
+        uniqueProductionName = PRODUCTION_NAME + "_UUID_CSV";
+        lenient().when(armRpoUtil.generateUniqueProductionName(anyString())).thenReturn(uniqueProductionName);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
@@ -92,6 +92,9 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
         armRpoExecutionDetailEntity.setId(EXECUTION_ID);
         when(armRpoService.getLatestArmRpoExecutionDetailEntity()).thenReturn(armRpoExecutionDetailEntity);
+
+        ARM_RPO_HELPER_MOCKS.mockArmRpoGenerateUniqueProductionName(PRODUCTION_NAME);
+
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
@@ -35,6 +35,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
@@ -122,8 +124,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
-        verify(armRpoApi).getExtendedProductionsByMatter("bearerToken", 1, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
         verify(armRpoApi).removeProduction("bearerToken", 1, userAccountEntity);
@@ -166,8 +168,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1,
                                                                  ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(), userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
-        verify(armRpoApi).getExtendedProductionsByMatter("bearerToken", 1, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
         verify(armRpoApi).removeProduction("bearerToken", 1, userAccountEntity);
@@ -210,8 +212,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
-        verify(armRpoApi).getExtendedProductionsByMatter("bearerToken", 1, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
         verify(armRpoApi).removeProduction("bearerToken", 1, userAccountEntity);
@@ -254,8 +256,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
-        verify(armRpoApi).getExtendedProductionsByMatter("bearerToken", 1, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
         verify(armRpoApi).removeProduction("bearerToken", 1, userAccountEntity);
@@ -298,8 +300,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
-        verify(armRpoApi).getExtendedProductionsByMatter("bearerToken", 1, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
         verify(armRpoApi).removeProduction("bearerToken", 1, userAccountEntity);
@@ -342,8 +344,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
-        verify(armRpoApi).getExtendedProductionsByMatter("bearerToken", 1, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
         verify(armRpoApi).removeProduction("bearerToken", 1, userAccountEntity);
@@ -440,7 +442,7 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(userIdentity).getUserAccount();
 
         verifyNoMoreInteractions(armRpoApi, userIdentity, fileOperationService, logApi);
@@ -490,8 +492,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
-        verify(armRpoApi).getExtendedProductionsByMatter("bearerToken", 1, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(userIdentity).getUserAccount();
         verify(logApi).armRpoPollingSuccessful(EXECUTION_ID);
@@ -521,7 +523,7 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable("bearerToken", 1, headerColumns, PRODUCTION_NAME, userAccountEntity);
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(userIdentity).getUserAccount();
         verify(logApi).armRpoPollingFailed(EXECUTION_ID);
 

--- a/src/test/java/uk/gov/hmcts/darts/arm/util/ArmRpoUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/util/ArmRpoUtilTest.java
@@ -17,7 +17,7 @@ class ArmRpoUtilTest {
         String result = armRpoUtil.generateUniqueProductionName(productionName);
 
         // then
-        assertEquals("testProduction__CSV", result);
+        assertEquals("testProduction_" + result.substring(15, 51) + "_CSV", result);
     }
 
     @Test
@@ -29,7 +29,7 @@ class ArmRpoUtilTest {
         String result = armRpoUtil.generateUniqueProductionName(productionName);
 
         // then
-        assertEquals("_CSV", result);
+        assertEquals("_" + result.substring(1, 37) + "_CSV", result);
     }
 
     @Test
@@ -41,6 +41,6 @@ class ArmRpoUtilTest {
         String result = armRpoUtil.generateUniqueProductionName(productionName);
 
         // then
-        assertEquals("null_CSV", result);
+        assertEquals("null_" + result.substring(5, 41) + "_CSV", result);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/arm/util/ArmRpoUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/util/ArmRpoUtilTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.darts.arm.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArmRpoUtilTest {
+
+    private final ArmRpoUtil armRpoUtil = new ArmRpoUtil();
+
+    @Test
+    void generateUniqueProductionName_shouldAppendCsvExtension() {
+        // given
+        String productionName = "testProduction";
+
+        // when
+        String result = armRpoUtil.generateUniqueProductionName(productionName);
+
+        // then
+        assertEquals("testProduction__CSV", result);
+    }
+
+    @Test
+    void generateUniqueProductionName_shouldHandleEmptyString() {
+        // given
+        String productionName = "";
+
+        // when
+        String result = armRpoUtil.generateUniqueProductionName(productionName);
+
+        // then
+        assertEquals("_CSV", result);
+    }
+
+    @Test
+    void generateUniqueProductionName_shouldHandleNull() {
+        // given
+        String productionName = null;
+
+        // when
+        String result = armRpoUtil.generateUniqueProductionName(productionName);
+
+        // then
+        assertEquals("null_CSV", result);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4655

### Change description ###

1) Added UUID and _CSV to production name so that it is always unique each time its polled and pass to  createExportBasedOnSearchResultsTable and  getExtendedProductionsByMatter

2) Changed createExportBasedOnSearchResultsTable catch feign response to handle bad request by using e.contentUTF8(), convert to BaseRpoRresponse and then pass to processCreateExportBasedOnSearchResultsTableResponse

3) Set thread sleep to 60 seconds
4) Added NonNull check to updateMetadata

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
