### PR TITLE
DMP-4550: Performance Testing - Automated Tasks - UnstructuredToArmDataStore - 28K Batch Size - SELECT darts taking 12.5 minutes

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -373,36 +373,38 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     }
 
     @Query(
-        """
-            SELECT eod FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status = :status
-            AND eod.externalLocationType = :type
-            AND eod.media is not null            
-            AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2
-            where (eod2.status = :notExistsStatus or eod2.transferAttempts >= :maxTransferAttempts)
-            AND eod2.externalLocationType = :notExistsType
-            and (eod.media is not null and eod.media = eod2.media))
-            order by eod.lastModifiedDateTime
-            """
+        value = """
+            select eode1_0.elt_id from darts.external_object_directory eode1_0
+            where eode1_0.ors_id=:status
+            and eode1_0.elt_id=:type
+            and eode1_0.med_id is not null 
+            and not exists(select 1 from darts.external_object_directory eode2_0 
+                where (eode2_0.elt_id=:notExistsStatus or eode2_0.transfer_attempts >= :maxTransferAttempts) 
+                and eode1_0.elt_id=:notExistsType
+                and eode1_0.med_id is not null and eode1_0.med_id=eode2_0.med_id)
+            fetch first :limitRecords rows only                 
+            """,
+        nativeQuery = true
     )
     List<ExternalObjectDirectoryEntity> findEodsForTransferOnlyMedia(ObjectRecordStatusEntity status, ExternalLocationTypeEntity type,
                                                                      ObjectRecordStatusEntity notExistsStatus, ExternalLocationTypeEntity notExistsType,
                                                                      Integer maxTransferAttempts, Limit limit);
 
     @Query(
-        """
-            SELECT eod FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status = :status
-            AND eod.externalLocationType = :type
-            AND eod.media is null            
-            AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2
-            where (eod2.status = :notExistsStatus or eod2.transferAttempts >= :maxTransferAttempts)
-            AND eod2.externalLocationType = :notExistsType
-            and ((eod.transcriptionDocumentEntity is not null and eod.transcriptionDocumentEntity = eod2.transcriptionDocumentEntity)
-              OR (eod.annotationDocumentEntity is not null and eod.annotationDocumentEntity = eod2.annotationDocumentEntity)
-              OR (eod.caseDocument is not null and eod.caseDocument = eod2.caseDocument )))
-            order by eod.lastModifiedDateTime
-            """
+        value = """
+            select eode1_0.elt_id from darts.external_object_directory eode1_0
+            where eode1_0.ors_id=:status
+            and eode1_0.elt_id=:type
+            and eode1_0.med_id is null 
+            and not exists(select 1 from darts.external_object_directory eode2_0 
+                where (eode2_0.elt_id=:notExistsStatus or eode2_0.transfer_attempts >= :maxTransferAttempts) 
+                and eode1_0.elt_id=:notExistsType
+                and ((eode1_0.trd_id is not null and eode1_0.trd_id = eode2_0.trd_id)
+                    or (eode1_0.ado_id is not null and eode1_0.ado_id = eode2_0.ado_id)
+                    or (eode1_0.cad_id is not null and eode1_0.cad_id = eode2_0.cad_id)))
+            fetch first :limitRecords rows only                 
+            """,
+        nativeQuery = true
     )
     List<ExternalObjectDirectoryEntity> findEodsForTransferExcludingMedia(ObjectRecordStatusEntity status, ExternalLocationTypeEntity type,
                                                                           ObjectRecordStatusEntity notExistsStatus, ExternalLocationTypeEntity notExistsType,
@@ -420,36 +422,35 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     }
 
     @Query(
-        """
-            SELECT eod.id FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status = :status
-            AND eod.externalLocationType = :type
-            AND eod.media is not null          
-            AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2
-            WHERE eod2.externalLocationType = :notExistsLocation
-            AND eod.media = eod2.media)
-            ORDER BY eod.id
-            LIMIT :limitRecords
-            """
+        value = """
+            select eode1_0.elt_id from darts.external_object_directory eode1_0
+            where eode1_0.ors_id=:status
+            and eode1_0.elt_id=:type
+            and eode1_0.med_id is not null 
+            and not exists(select 1 from darts.external_object_directory eode2_0 
+                where eode2_0.elt_id=:notExistsLocation 
+                and eode1_0.med_id=eode2_0.med_id)
+            fetch first :limitRecords rows only                 
+            """,
+        nativeQuery = true
     )
     List<Integer> findEodsNotInOtherStorageOnlyMedia(ObjectRecordStatusEntity status, ExternalLocationTypeEntity type,
                                                      ExternalLocationTypeEntity notExistsLocation, Integer limitRecords);
 
-
     @Query(
-        """
-            SELECT eod.id FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status = :status
-            AND eod.externalLocationType = :type
-            AND eod.media is null          
-            AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2
-            where eod2.externalLocationType = :notExistsLocation
-            and ((eod.transcriptionDocumentEntity is not null and eod.transcriptionDocumentEntity = eod2.transcriptionDocumentEntity)
-              OR (eod.annotationDocumentEntity is not null and eod.annotationDocumentEntity = eod2.annotationDocumentEntity)
-              OR (eod.caseDocument is not null and eod.caseDocument = eod2.caseDocument )))
-            order by eod.id
-            LIMIT :limitRecords
-            """
+        value = """
+            select eode1_0.elt_id from darts.external_object_directory eode1_0
+            where eode1_0.ors_id=:status
+            and eode1_0.elt_id=:type
+            and eode1_0.med_id is null 
+            and not exists(select 1 from darts.external_object_directory eode2_0 
+                where eode2_0.elt_id=:notExistsLocation 
+                and ((eode1_0.trd_id is not null and eode1_0.trd_id = eode2_0.trd_id)
+                    or (eode1_0.ado_id is not null and eode1_0.ado_id = eode2_0.ado_id)
+                    or (eode1_0.cad_id is not null and eode1_0.cad_id = eode2_0.cad_id)))
+            fetch first :limitRecords rows only                 
+            """,
+        nativeQuery = true
     )
     List<Integer> findEodsNotInOtherStorageExcludingMedia(ObjectRecordStatusEntity status, ExternalLocationTypeEntity type,
                                                           ExternalLocationTypeEntity notExistsLocation, Integer limitRecords);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4550)


### Change description ###
# Summary of Git Diff

This Git diff reflects changes made to the `ExternalObjectDirectoryRepository.java` file, focusing on the query definitions for retrieving external object directory entities and their IDs. The queries have been optimized and converted from JPQL to native SQL syntax, enhancing performance and readability.

## Highlights

- **Query Optimization**: 
  - Original JPQL queries were replaced with native SQL queries, which can result in better performance and efficiency.
  
- **Media Handling**:
  - Queries now specifically handle media checks with `med_id` instead of `media`, improving clarity on what is being checked.
  
- **Removed Redundant Code**:
  - The updated queries eliminate the use of the `ORDER BY` clause in favor of using `fetch first :limitRecords rows only`, streamlining the logic.
  
- **Consistent Naming**:
  - Entity fields have been renamed for better readability, aligning with the database schema (e.g., `elt_id`, `med_id`, `trd_id`, `ado_id`, `cad_id`).

- **Overall Structure**:
  - The overall structure of method signatures remains consistent, ensuring that functionality is preserved while improving underlying code quality.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
