### PR TITLE
Dmp 4667 armrpo get extended productions by matter change polling logic

### DIFF
--- a/charts/darts-api/Chart.yaml
+++ b/charts/darts-api/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: "1.0"
 description: A Helm chart for darts-api App
 name: darts-api
 home: https://github.com/hmcts/darts-api
-version: 0.0.98
+version: 0.0.99
 maintainers:
   - name: HMCTS darts team
 dependencies:

--- a/charts/darts-api/values.yaml
+++ b/charts/darts-api/values.yaml
@@ -116,6 +116,7 @@ java:
     ARM_URL: http://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
     FEIGN_LOG_LEVEL: none
     ARM_RPO_THREAD_SLEEP_DURATION: 60s
+    ARM_RPO_POLL_DURATION: 4h
 
 function:
   scaleType: Job
@@ -232,6 +233,7 @@ function:
     FEIGN_LOG_LEVEL: none
     IS_MOCK_ARM_RPO_DOWNLOAD_CSV: false
     ARM_RPO_THREAD_SLEEP_DURATION: 60s
+    ARM_RPO_POLL_DURATION: 4h
 
   secrets:
     DARTS_API_DB_CONNECTION_STRING:

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
@@ -63,7 +63,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
         armRpoExecutionDetailEntity.setStorageAccountId("storageAccountId");
         var armRpoExecutionDetail = dartsPersistence.save(armRpoExecutionDetailEntity);
         assertNull(armRpoExecutionDetail.getProductionName());
-        assertNull(armRpoExecutionDetail.getPollingCreatedTs());
+        assertNull(armRpoExecutionDetail.getPollingCreatedAt());
 
         var bearerAuth = "Bearer some-token";
 
@@ -76,8 +76,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
 
         var armRpoExecutionDetailEntityUpdated = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetail.getId()).orElseThrow();
         assertEquals(PRODUCTION_NAME, armRpoExecutionDetailEntityUpdated.getProductionName());
-        assertEquals(pollCreatedTs, armRpoExecutionDetailEntityUpdated.getPollingCreatedTs());
-        assertThat(armRpoExecutionDetailEntityUpdated.getPollingCreatedTs()).isNotNull();
+        assertEquals(pollCreatedTs, armRpoExecutionDetailEntityUpdated.getPollingCreatedAt());
+        assertThat(armRpoExecutionDetailEntityUpdated.getPollingCreatedAt()).isNotNull();
         assertEquals(ArmRpoStateEnum.CREATE_EXPORT_BASED_ON_SEARCH_RESULTS_TABLE.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoState().getId());
         assertEquals(ArmRpoStatusEnum.COMPLETED.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoStatus().getId());
 
@@ -115,7 +115,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
 
         var armRpoExecutionDetailEntityUpdated = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetail.getId()).orElseThrow();
         assertNull(armRpoExecutionDetailEntityUpdated.getProductionName());
-        assertEquals(pollCreatedTs, armRpoExecutionDetailEntityUpdated.getPollingCreatedTs());
+        assertEquals(pollCreatedTs, armRpoExecutionDetailEntityUpdated.getPollingCreatedAt());
         assertEquals(ArmRpoStateEnum.CREATE_EXPORT_BASED_ON_SEARCH_RESULTS_TABLE.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoState().getId());
         assertEquals(ArmRpoStatusEnum.IN_PROGRESS.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoStatus().getId());
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
@@ -34,7 +34,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
     @MockitoBean
     private ArmRpoClient armRpoClient;
 
-    @MockBean
+    @MockitoBean
     private CurrentTimeHelper currentTimeHelper;
 
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,7 +77,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
 
         var armRpoExecutionDetailEntityUpdated = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetail.getId()).orElseThrow();
         assertEquals(PRODUCTION_NAME, armRpoExecutionDetailEntityUpdated.getProductionName());
-        assertEquals(pollCreatedTs, armRpoExecutionDetailEntityUpdated.getPollingCreatedAt());
+        assertEquals(pollCreatedTs.truncatedTo(ChronoUnit.SECONDS), armRpoExecutionDetailEntityUpdated.getPollingCreatedAt().truncatedTo(ChronoUnit.SECONDS));
         assertThat(armRpoExecutionDetailEntityUpdated.getPollingCreatedAt()).isNotNull();
         assertEquals(ArmRpoStateEnum.CREATE_EXPORT_BASED_ON_SEARCH_RESULTS_TABLE.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoState().getId());
         assertEquals(ArmRpoStatusEnum.COMPLETED.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoStatus().getId());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
@@ -116,7 +116,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
 
         var armRpoExecutionDetailEntityUpdated = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetail.getId()).orElseThrow();
         assertNull(armRpoExecutionDetailEntityUpdated.getProductionName());
-        assertEquals(pollCreatedTs, armRpoExecutionDetailEntityUpdated.getPollingCreatedAt());
+        assertEquals(pollCreatedTs.truncatedTo(ChronoUnit.SECONDS), armRpoExecutionDetailEntityUpdated.getPollingCreatedAt().truncatedTo(ChronoUnit.SECONDS));
         assertEquals(ArmRpoStateEnum.CREATE_EXPORT_BASED_ON_SEARCH_RESULTS_TABLE.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoState().getId());
         assertEquals(ArmRpoStatusEnum.IN_PROGRESS.getId(), armRpoExecutionDetailEntityUpdated.getArmRpoStatus().getId());
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.darts.common.enums.ArmRpoStateEnum;
 import uk.gov.hmcts.darts.common.enums.ArmRpoStatusEnum;
 import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,6 +31,9 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
 
     @Autowired
     private ArmRpoApi armRpoApi;
+
+    private final Duration pollDuration = Duration.ofHours(4);
+
 
     @Test
     void createExportBasedOnSearchResultsTable_ReturnsTrue() {
@@ -53,7 +57,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
 
         // when
         boolean result = armRpoApi.createExportBasedOnSearchResultsTable(
-            bearerAuth, armRpoExecutionDetail.getId(), createHeaderColumns(), PRODUCTION_NAME, userAccount);
+            bearerAuth, armRpoExecutionDetail.getId(), createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount);
 
         // then
         assertTrue(result);
@@ -86,7 +90,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableIntTest extends PostgresInte
 
         // when
         boolean result = armRpoApi.createExportBasedOnSearchResultsTable(
-            bearerAuth, armRpoExecutionDetail.getId(), createHeaderColumns(), PRODUCTION_NAME, userAccount);
+            bearerAuth, armRpoExecutionDetail.getId(), createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount);
 
         // then
         assertFalse(result);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArpRpoApiGetMasterIndexFieldByRecordClassSchemaIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/rpo/ArpRpoApiGetMasterIndexFieldByRecordClassSchemaIntTest.java
@@ -33,8 +33,7 @@ class ArpRpoApiGetMasterIndexFieldByRecordClassSchemaIntTest extends Integration
 
     @Autowired
     private ArmRpoApi armRpoApi;
-
-
+    
     @Test
     void getMasterIndexFieldByRecordClassSchemaSuccess() {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
@@ -37,9 +37,11 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -249,6 +251,9 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         armRpoExecutionDetailEntity.setSearchId(SEARCH_ID);
         armRpoExecutionDetailEntity.setStorageAccountId(STORAGE_ACCOUNT_ID);
         armRpoExecutionDetailEntity.setProductionId(PRODUCTION_ID);
+        OffsetDateTime pollCreatedTs = OffsetDateTime.now().minusMinutes(10);
+        armRpoExecutionDetailEntity.setPollingCreatedTs(pollCreatedTs);
+        armRpoExecutionDetailEntity.setProductionName(PRODUCTION_NAME);
         armRpoExecutionDetailEntity = dartsPersistence.save(armRpoExecutionDetailEntity);
 
         when(armApiService.getArmBearerToken()).thenReturn(BEARER_TOKEN);
@@ -277,7 +282,9 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         assertNotNull(updatedArmRpoExecutionDetailEntity);
         assertEquals(ArmRpoHelper.removeProductionRpoState().getId(), updatedArmRpoExecutionDetailEntity.get().getArmRpoState().getId());
         assertEquals(ArmRpoHelper.completedRpoStatus().getId(), updatedArmRpoExecutionDetailEntity.get().getArmRpoStatus().getId());
-
+        assertEquals(pollCreatedTs, updatedArmRpoExecutionDetailEntity.get().getPollingCreatedTs());
+        assertThat(updatedArmRpoExecutionDetailEntity.get().getProductionName()).contains(PRODUCTION_NAME);
+        
         verify(armRpoClient).getExtendedSearchesByMatter(any(), any());
         verify(armRpoClient).getMasterIndexFieldByRecordClassSchema(any(), any());
         verify(armRpoClient).createExportBasedOnSearchResultsTable(anyString(), any());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
@@ -38,6 +38,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 
@@ -282,7 +283,8 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         assertNotNull(updatedArmRpoExecutionDetailEntity);
         assertEquals(ArmRpoHelper.removeProductionRpoState().getId(), updatedArmRpoExecutionDetailEntity.get().getArmRpoState().getId());
         assertEquals(ArmRpoHelper.completedRpoStatus().getId(), updatedArmRpoExecutionDetailEntity.get().getArmRpoStatus().getId());
-        assertEquals(pollCreatedTs, updatedArmRpoExecutionDetailEntity.get().getPollingCreatedAt());
+        assertEquals(pollCreatedTs.truncatedTo(ChronoUnit.SECONDS),
+                     updatedArmRpoExecutionDetailEntity.get().getPollingCreatedAt().truncatedTo(ChronoUnit.SECONDS));
         assertThat(updatedArmRpoExecutionDetailEntity.get().getProductionName()).contains(PRODUCTION_NAME);
 
         verify(armRpoClient).getExtendedSearchesByMatter(any(), any());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
@@ -86,7 +86,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
 
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
     private String uniqueProductionName;
-    private Duration pollDuration = Duration.ofHours(4);
+    private final Duration pollDuration = Duration.ofHours(4);
 
     @Autowired
     private ArmRpoPollServiceImpl armRpoPollService;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
@@ -252,7 +252,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         armRpoExecutionDetailEntity.setStorageAccountId(STORAGE_ACCOUNT_ID);
         armRpoExecutionDetailEntity.setProductionId(PRODUCTION_ID);
         OffsetDateTime pollCreatedTs = OffsetDateTime.now().minusMinutes(10);
-        armRpoExecutionDetailEntity.setPollingCreatedTs(pollCreatedTs);
+        armRpoExecutionDetailEntity.setPollingCreatedAt(pollCreatedTs);
         armRpoExecutionDetailEntity.setProductionName(PRODUCTION_NAME);
         armRpoExecutionDetailEntity = dartsPersistence.save(armRpoExecutionDetailEntity);
 
@@ -282,9 +282,9 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
         assertNotNull(updatedArmRpoExecutionDetailEntity);
         assertEquals(ArmRpoHelper.removeProductionRpoState().getId(), updatedArmRpoExecutionDetailEntity.get().getArmRpoState().getId());
         assertEquals(ArmRpoHelper.completedRpoStatus().getId(), updatedArmRpoExecutionDetailEntity.get().getArmRpoStatus().getId());
-        assertEquals(pollCreatedTs, updatedArmRpoExecutionDetailEntity.get().getPollingCreatedTs());
+        assertEquals(pollCreatedTs, updatedArmRpoExecutionDetailEntity.get().getPollingCreatedAt());
         assertThat(updatedArmRpoExecutionDetailEntity.get().getProductionName()).contains(PRODUCTION_NAME);
-        
+
         verify(armRpoClient).getExtendedSearchesByMatter(any(), any());
         verify(armRpoClient).getMasterIndexFieldByRecordClassSchema(any(), any());
         verify(armRpoClient).createExportBasedOnSearchResultsTable(anyString(), any());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollServiceIntTest.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -85,6 +86,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
 
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
     private String uniqueProductionName;
+    private Duration pollDuration = Duration.ofHours(4);
 
     @Autowired
     private ArmRpoPollServiceImpl armRpoPollService;
@@ -134,7 +136,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
             .thenReturn(getRemoveProductionResponse());
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         var updatedArmRpoExecutionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetailEntity.getId());
@@ -183,7 +185,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
             .thenReturn(getRemoveProductionResponse());
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         var updatedArmRpoExecutionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetailEntity.getId());
@@ -223,7 +225,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
             .thenReturn(getCreateExportBasedOnSearchResultsTableResponseInProgress());
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         var updatedArmRpoExecutionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetailEntity.getId());
@@ -268,7 +270,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
             .thenReturn(getRemoveProductionResponse());
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         var updatedArmRpoExecutionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetailEntity.getId());
@@ -318,7 +320,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
             .thenReturn(getRemoveProductionResponse());
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         var updatedArmRpoExecutionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetailEntity.getId());
@@ -368,7 +370,7 @@ class ArmRpoPollServiceIntTest extends PostgresIntegrationBase {
             .thenReturn(getRemoveProductionResponse());
 
         // when
-        armRpoPollService.pollArmRpo(true);
+        armRpoPollService.pollArmRpo(true, pollDuration);
 
         // then
         var updatedArmRpoExecutionDetailEntity = dartsPersistence.getArmRpoExecutionDetailRepository().findById(armRpoExecutionDetailEntity.getId());

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/ArmRpoApi.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.List;
 
 public interface ArmRpoApi {
@@ -29,9 +30,9 @@ public interface ArmRpoApi {
 
     boolean createExportBasedOnSearchResultsTable(String bearerToken, Integer executionId,
                                                   List<MasterIndexFieldByRecordClassSchema> headerColumns, String uniqueProductionName,
-                                                  UserAccountEntity userAccount);
+                                                  Duration pollDuration, UserAccountEntity userAccount);
 
-    boolean getExtendedProductionsByMatter(String bearerToken, Integer executionId, String uniqueProductionName, UserAccountEntity userAccount);
+    boolean getExtendedProductionsByMatter(String bearerToken, Integer executionId, String productionName, UserAccountEntity userAccount);
 
     List<String> getProductionOutputFiles(String bearerToken, Integer executionId, UserAccountEntity userAccount);
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -582,18 +582,10 @@ public class ArmRpoApiImpl implements ArmRpoApi {
         return true;
     }
 
-    private void setPollingCreatedTimestamp(UserAccountEntity userAccount, ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity) {
-        if (isNull(armRpoExecutionDetailEntity.getPollingCreatedTs())) {
-            armRpoExecutionDetailEntity.setPollingCreatedTs(currentTimeHelper.currentOffsetDateTime());
-            armRpoService.updateArmRpoStateAndStatus(armRpoExecutionDetailEntity, ArmRpoHelper.createExportBasedOnSearchResultsTableRpoState(),
-                                                     ArmRpoHelper.inProgressRpoStatus(), userAccount);
-        }
-    }
-
-    private boolean checkCreateExportBasedOnSearchResultsInProgress(UserAccountEntity userAccount,
-                                                                    BaseRpoResponse baseRpoResponse,
-                                                                    StringBuilder errorMessage, ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity,
-                                                                    Duration pollDuration) {
+    boolean checkCreateExportBasedOnSearchResultsInProgress(UserAccountEntity userAccount,
+                                                            BaseRpoResponse baseRpoResponse,
+                                                            StringBuilder errorMessage, ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity,
+                                                            Duration pollDuration) {
         if (isNull(armRpoExecutionDetailEntity.getPollingCreatedTs())) {
             log.error("checkCreateExportBasedOnSearchResults is still In-Progress - {}", baseRpoResponse);
             return false;

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -486,7 +486,9 @@ public class ArmRpoApiImpl implements ArmRpoApi {
 
         log.debug("createExportBasedOnSearchResultsTable called with executionId: {}, uniqueProductionName: {}", executionId, uniqueProductionName);
         var armRpoExecutionDetailEntity = armRpoService.getArmRpoExecutionDetailEntity(executionId);
-        armRpoExecutionDetailEntity.setPollingCreatedTs(currentTimeHelper.currentOffsetDateTime());
+        if (isNull(armRpoExecutionDetailEntity.getPollingCreatedTs())) {
+            armRpoExecutionDetailEntity.setPollingCreatedTs(currentTimeHelper.currentOffsetDateTime());
+        }
         armRpoService.updateArmRpoStateAndStatus(armRpoExecutionDetailEntity, ArmRpoHelper.createExportBasedOnSearchResultsTableRpoState(),
                                                  ArmRpoHelper.inProgressRpoStatus(), userAccount);
 
@@ -589,7 +591,8 @@ public class ArmRpoApiImpl implements ArmRpoApi {
         if (isNull(armRpoExecutionDetailEntity.getPollingCreatedTs())) {
             log.error("checkCreateExportBasedOnSearchResults is still In-Progress - {}", baseRpoResponse);
             return false;
-        } else if (Duration.between(armRpoExecutionDetailEntity.getPollingCreatedTs(), currentTimeHelper.currentOffsetDateTime())
+        } else if (Duration.between(armRpoExecutionDetailEntity.getPollingCreatedTs(),
+                                    currentTimeHelper.currentOffsetDateTime())
             .compareTo(pollDuration) <= 0) {
             log.error("The search is still running and cannot export as csv - {}", baseRpoResponse);
             return false;

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -486,8 +486,8 @@ public class ArmRpoApiImpl implements ArmRpoApi {
 
         log.debug("createExportBasedOnSearchResultsTable called with executionId: {}, uniqueProductionName: {}", executionId, uniqueProductionName);
         var armRpoExecutionDetailEntity = armRpoService.getArmRpoExecutionDetailEntity(executionId);
-        if (isNull(armRpoExecutionDetailEntity.getPollingCreatedTs())) {
-            armRpoExecutionDetailEntity.setPollingCreatedTs(currentTimeHelper.currentOffsetDateTime());
+        if (isNull(armRpoExecutionDetailEntity.getPollingCreatedAt())) {
+            armRpoExecutionDetailEntity.setPollingCreatedAt(currentTimeHelper.currentOffsetDateTime());
         }
         armRpoService.updateArmRpoStateAndStatus(armRpoExecutionDetailEntity, ArmRpoHelper.createExportBasedOnSearchResultsTableRpoState(),
                                                  ArmRpoHelper.inProgressRpoStatus(), userAccount);
@@ -589,10 +589,10 @@ public class ArmRpoApiImpl implements ArmRpoApi {
                                                             BaseRpoResponse baseRpoResponse,
                                                             StringBuilder errorMessage, ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity,
                                                             Duration pollDuration) {
-        if (isNull(armRpoExecutionDetailEntity.getPollingCreatedTs())) {
+        if (isNull(armRpoExecutionDetailEntity.getPollingCreatedAt())) {
             log.error("checkCreateExportBasedOnSearchResults is still In-Progress - {}", baseRpoResponse);
             return false;
-        } else if (Duration.between(armRpoExecutionDetailEntity.getPollingCreatedTs(),
+        } else if (Duration.between(armRpoExecutionDetailEntity.getPollingCreatedAt(),
                                     currentTimeHelper.currentOffsetDateTime())
             .compareTo(pollDuration) <= 0) {
             log.error("The search is still running and cannot export as csv - {}", baseRpoResponse);

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -403,7 +403,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
             log.error(errorMessage.append("Unable to save background search").append(e).toString(), e);
             throw handleFailureAndCreateException(errorMessage.toString(), armRpoExecutionDetailEntity, userAccount);
         }
-        log.debug("ARM RPO Response - SaveBackgroundSearchResponse: {}", saveBackgroundSearchResponse);
+
         handleResponseStatus(userAccount, saveBackgroundSearchResponse, errorMessage, armRpoExecutionDetailEntity);
 
         armRpoService.updateArmRpoStatus(armRpoExecutionDetailEntity, ArmRpoHelper.completedRpoStatus(), userAccount);

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -132,7 +132,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
             log.error(errorMessage.append(UNABLE_TO_GET_ARM_RPO_RESPONSE).append(e).toString(), e);
             throw handleFailureAndCreateException(errorMessage.toString(), armRpoExecutionDetailEntity, userAccount);
         }
-
+        log.debug("ARM RPO Response - IndexesByMatterIdResponse: {}", indexesByMatterIdResponse);
         processIndexesByMatterIdResponse(matterId, userAccount, indexesByMatterIdResponse, errorMessage, armRpoExecutionDetailEntity);
     }
 
@@ -176,7 +176,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
             log.error(errorMessage.append(UNABLE_TO_GET_ARM_RPO_RESPONSE).append(e).toString(), e);
             throw handleFailureAndCreateException(errorMessage.toString(), armRpoExecutionDetailEntity, userAccount);
         }
-
+        log.debug("ARM RPO Response - StorageAccountResponse: {}", storageAccountResponse);
         processGetStorageAccountsResponse(userAccount, storageAccountResponse, errorMessage, armRpoExecutionDetailEntity);
     }
 
@@ -403,7 +403,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
             log.error(errorMessage.append("Unable to save background search").append(e).toString(), e);
             throw handleFailureAndCreateException(errorMessage.toString(), armRpoExecutionDetailEntity, userAccount);
         }
-
+        log.debug("ARM RPO Response - SaveBackgroundSearchResponse: {}", saveBackgroundSearchResponse);
         handleResponseStatus(userAccount, saveBackgroundSearchResponse, errorMessage, armRpoExecutionDetailEntity);
 
         armRpoService.updateArmRpoStatus(armRpoExecutionDetailEntity, ArmRpoHelper.completedRpoStatus(), userAccount);

--- a/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiImpl.java
@@ -514,7 +514,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
         }
         log.debug("ARM RPO Response - CreateExportBasedOnSearchResultsTable response: {}", baseRpoResponse);
         return processCreateExportBasedOnSearchResultsTableResponse(userAccount, baseRpoResponse, errorMessage,
-                                                                    armRpoExecutionDetailEntity, pollDuration);
+                                                                    armRpoExecutionDetailEntity, pollDuration, uniqueProductionName);
     }
 
 
@@ -548,7 +548,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
                                                                          BaseRpoResponse baseRpoResponse,
                                                                          StringBuilder errorMessage,
                                                                          ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity,
-                                                                         Duration pollDuration) {
+                                                                         Duration pollDuration, String uniqueProductionName) {
 
         if (isNull(baseRpoResponse) || isNull(baseRpoResponse.getStatus()) || isNull(baseRpoResponse.getIsError())
             || (!baseRpoResponse.getIsError() && isNull(baseRpoResponse.getResponseStatus()))
@@ -580,6 +580,7 @@ public class ArmRpoApiImpl implements ArmRpoApi {
                                                       .append(baseRpoResponse).toString(),
                                                   armRpoExecutionDetailEntity, userAccount);
         }
+        armRpoExecutionDetailEntity.setProductionName(uniqueProductionName);
         armRpoService.updateArmRpoStatus(armRpoExecutionDetailEntity, ArmRpoHelper.completedRpoStatus(), userAccount);
         return true;
     }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollService.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/ArmRpoPollService.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.darts.arm.service;
 
+import java.time.Duration;
+
 public interface ArmRpoPollService {
 
-    void pollArmRpo(boolean isManualRun);
+    void pollArmRpo(boolean isManualRun, Duration pollDuration);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImpl.java
@@ -54,7 +54,7 @@ public class ArmRpoServiceImpl implements ArmRpoService {
 
         UserAccountEntity mergedUserAccountEntity = entityManager.merge(userAccount);
         armRpoExecutionDetailEntity.setCreatedBy(mergedUserAccountEntity);
-        // armRpoExecutionDetailEntity.setLastModifiedBy(mergedUserAccountEntity);
+        armRpoExecutionDetailEntity.setLastModifiedBy(mergedUserAccountEntity);
 
         return saveArmRpoExecutionDetailEntity(armRpoExecutionDetailEntity);
     }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImpl.java
@@ -54,7 +54,7 @@ public class ArmRpoServiceImpl implements ArmRpoService {
 
         UserAccountEntity mergedUserAccountEntity = entityManager.merge(userAccount);
         armRpoExecutionDetailEntity.setCreatedBy(mergedUserAccountEntity);
-        armRpoExecutionDetailEntity.setLastModifiedBy(mergedUserAccountEntity);
+        // armRpoExecutionDetailEntity.setLastModifiedBy(mergedUserAccountEntity);
 
         return saveArmRpoExecutionDetailEntity(armRpoExecutionDetailEntity);
     }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImpl.java
@@ -133,7 +133,7 @@ public class ArmRpoServiceImpl implements ArmRpoService {
                 }
                 log.info("Finished reading CSV file: {}. Read {} rows", csvFile.getName(), counter);
             } catch (FileNotFoundException e) {
-                log.info("Only read {} rows for file {}", counter, csvFile.getName());
+                log.info("Files not found only read {} rows for file {}", counter, csvFile.getName());
                 log.error(errorMessage.append("Unable to find CSV file for Reconciliation ").toString(), e);
                 throw new ArmRpoException(errorMessage.toString());
             } catch (Exception e) {

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoExecutionDetailEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoExecutionDetailEntity.java
@@ -67,4 +67,7 @@ public class ArmRpoExecutionDetailEntity extends MandatoryCreatedModifiedBaseEnt
     @Column(name = "production_name")
     private String productionName;
 
+    @Column(name = "production_name")
+    private String productionName;
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoExecutionDetailEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoExecutionDetailEntity.java
@@ -67,7 +67,4 @@ public class ArmRpoExecutionDetailEntity extends MandatoryCreatedModifiedBaseEnt
     @Column(name = "production_name")
     private String productionName;
 
-    @Column(name = "production_name")
-    private String productionName;
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/config/ArmRpoPollAutomatedTaskConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/config/ArmRpoPollAutomatedTaskConfig.java
@@ -5,10 +5,13 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+
 @ConfigurationProperties("darts.automated.task.arm-rpo-poll")
 @Getter
 @Setter
 @Configuration
 public class ArmRpoPollAutomatedTaskConfig extends AbstractAutomatedTaskConfig {
 
+    private Duration pollDuration;
 }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ArmRpoPollingAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/ArmRpoPollingAutomatedTask.java
@@ -37,6 +37,6 @@ public class ArmRpoPollingAutomatedTask
 
     @Override
     protected void runTask() {
-        armRpoPollService.pollArmRpo(isManualRun());
+        armRpoPollService.pollArmRpo(isManualRun(), getConfig().getPollDuration());
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -378,6 +378,7 @@ darts:
           at-most-for: PT120M
       arm-rpo-poll:
         system-user-email: system_ArmRpoPolling@hmcts.net
+        poll-duration: ${ARM_RPO_POLL_DURATION:4h}
         lock:
           at-least-for: PT1M
           at-most-for: PT30M

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableCheckTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableCheckTest.java
@@ -77,8 +77,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableCheckTest {
 
     @Test
     void checkCreateExportBasedOnSearchResultsInProgress_PollingStillInProgress() {
-        //
-        armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now().minusMinutes(10));
+        // given
+        armRpoExecutionDetailEntity.setPollingCreatedAt(OffsetDateTime.now().minusMinutes(10));
         CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
 
         // when
@@ -93,7 +93,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableCheckTest {
     @Test
     void checkCreateExportBasedOnSearchResultsInProgress_PollingExceeded() {
         //given
-        armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now().minusHours(5));
+        armRpoExecutionDetailEntity.setPollingCreatedAt(OffsetDateTime.now().minusHours(5));
         CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
 
         // when

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableCheckTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableCheckTest.java
@@ -1,0 +1,119 @@
+package uk.gov.hmcts.darts.arm.rpo.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.arm.client.ArmRpoClient;
+import uk.gov.hmcts.darts.arm.client.model.rpo.CreateExportBasedOnSearchResultsTableResponse;
+import uk.gov.hmcts.darts.arm.component.ArmRpoDownloadProduction;
+import uk.gov.hmcts.darts.arm.config.ArmApiConfigurationProperties;
+import uk.gov.hmcts.darts.arm.exception.ArmRpoException;
+import uk.gov.hmcts.darts.arm.helper.ArmRpoHelperMocks;
+import uk.gov.hmcts.darts.arm.service.ArmRpoService;
+import uk.gov.hmcts.darts.common.config.ObjectMapperConfig;
+import uk.gov.hmcts.darts.common.entity.ArmRpoExecutionDetailEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.ArmAutomatedTaskRepository;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ArmRpoApiCreateExportBasedOnSearchResultsTableCheckTest {
+
+    @Mock
+    private ArmRpoClient armRpoClient;
+
+    @Mock
+    private ArmRpoService armRpoService;
+
+    private ArmRpoApiImpl armRpoApi;
+
+    @Mock
+    private UserAccountEntity userAccount;
+    @Mock
+    private CurrentTimeHelper currentTimeHelper;
+
+    private static final Integer EXECUTION_ID = 1;
+    private static final ArmRpoHelperMocks ARM_RPO_HELPER_MOCKS = new ArmRpoHelperMocks();
+    private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
+    private final Duration pollDuration = Duration.ofHours(4);
+
+    @BeforeEach
+    void setUp() {
+        var armAutomatedTaskRepository = mock(ArmAutomatedTaskRepository.class);
+        var armRpoDownloadProduction = mock(ArmRpoDownloadProduction.class);
+
+        ArmApiConfigurationProperties armApiConfigurationProperties = new ArmApiConfigurationProperties();
+        ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig();
+        ObjectMapper objectMapper = objectMapperConfig.objectMapper();
+
+        armRpoApi = new ArmRpoApiImpl(armRpoClient, armRpoService, armApiConfigurationProperties,
+                                      armAutomatedTaskRepository, currentTimeHelper, armRpoDownloadProduction,
+                                      objectMapper);
+
+        armRpoExecutionDetailEntity = new ArmRpoExecutionDetailEntity();
+        armRpoExecutionDetailEntity.setId(EXECUTION_ID);
+        armRpoExecutionDetailEntity.setSearchId("searchId");
+        armRpoExecutionDetailEntity.setSearchItemCount(7);
+        armRpoExecutionDetailEntity.setProductionId("productionId");
+        armRpoExecutionDetailEntity.setStorageAccountId("storageAccountId");
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.now());
+
+    }
+
+    @Test
+    void checkCreateExportBasedOnSearchResultsInProgress_PollingStillInProgress() {
+        //
+        armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now().minusMinutes(10));
+        CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
+
+        // when
+        boolean result = armRpoApi.checkCreateExportBasedOnSearchResultsInProgress(userAccount, response, new StringBuilder(),
+                                                                                   armRpoExecutionDetailEntity, pollDuration);
+
+        // then
+        assertFalse(result);
+        verify(armRpoService, never()).updateArmRpoStatus(any(), any(), any());
+    }
+
+    @Test
+    void checkCreateExportBasedOnSearchResultsInProgress_PollingExceeded() {
+        //given
+        armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now().minusHours(5));
+        CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
+
+        // when
+        assertThrows(ArmRpoException.class, () ->
+            armRpoApi.checkCreateExportBasedOnSearchResultsInProgress(userAccount, response, new StringBuilder(), armRpoExecutionDetailEntity, pollDuration));
+
+        // then
+        verify(armRpoService).updateArmRpoStatus(any(), any(), any());
+    }
+
+    private CreateExportBasedOnSearchResultsTableResponse createResponse(int status, boolean isError, int responseStatus) {
+        CreateExportBasedOnSearchResultsTableResponse response = new CreateExportBasedOnSearchResultsTableResponse();
+        response.setStatus(status);
+        response.setIsError(isError);
+        response.setResponseStatus(responseStatus);
+        return response;
+    }
+
+    @AfterAll
+    static void close() {
+        ARM_RPO_HELPER_MOCKS.close();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -132,7 +132,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // given
         CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
         when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenReturn(response);
-        armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now());
+        armRpoExecutionDetailEntity.setPollingCreatedAt(OffsetDateTime.now());
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.now());
 
         // when
@@ -153,7 +153,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // given
         CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
         when(armRpoClient.createExportBasedOnSearchResultsTable(anyString(), any())).thenReturn(response);
-        armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now().minusHours(5));
+        armRpoExecutionDetailEntity.setPollingCreatedAt(OffsetDateTime.now().minusHours(5));
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.now());
 
         // when

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -52,11 +52,13 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
     private ArmRpoApiImpl armRpoApi;
 
+    @Mock
     private UserAccountEntity userAccount;
+
     private static final Integer EXECUTION_ID = 1;
     private static final ArmRpoHelperMocks ARM_RPO_HELPER_MOCKS = new ArmRpoHelperMocks();
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
-    private Duration pollDuration = Duration.ofHours(4);
+    private final Duration pollDuration = Duration.ofHours(4);
 
     @BeforeEach
     void setUp() {
@@ -135,7 +137,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         boolean result = armRpoApi.createExportBasedOnSearchResultsTable(
-            "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount);
+            BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount);
 
         // then
         assertFalse(result);
@@ -158,7 +160,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -234,7 +236,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -260,7 +262,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -284,7 +286,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -310,7 +312,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -334,7 +336,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME,  pollDuration, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -357,7 +359,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
             armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
+                BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -380,7 +382,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
             armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
+                BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -404,7 +406,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -428,7 +430,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -452,7 +454,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable(BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -477,7 +479,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
             armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+                BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -502,7 +504,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
             armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+                BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -67,7 +68,6 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     @BeforeEach
     void setUp() {
         var armAutomatedTaskRepository = mock(ArmAutomatedTaskRepository.class);
-        var currentTimeHelper = mock(CurrentTimeHelper.class);
         var armRpoDownloadProduction = mock(ArmRpoDownloadProduction.class);
 
         ArmApiConfigurationProperties armApiConfigurationProperties = new ArmApiConfigurationProperties();
@@ -84,7 +84,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         armRpoExecutionDetailEntity.setSearchItemCount(7);
         armRpoExecutionDetailEntity.setProductionId("productionId");
         armRpoExecutionDetailEntity.setStorageAccountId("storageAccountId");
-        when(armRpoService.getArmRpoExecutionDetailEntity(EXECUTION_ID)).thenReturn(armRpoExecutionDetailEntity);
+        lenient().when(armRpoService.getArmRpoExecutionDetailEntity(EXECUTION_ID)).thenReturn(armRpoExecutionDetailEntity);
     }
 
     @Test
@@ -507,38 +507,33 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
     @Test
     void checkCreateExportBasedOnSearchResultsInProgress_PollingStillInProgress() {
+        //
         armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now().minusMinutes(10));
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.now());
         CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
+
+        // when
         boolean result = armRpoApi.checkCreateExportBasedOnSearchResultsInProgress(userAccount, response, new StringBuilder(),
                                                                                    armRpoExecutionDetailEntity, pollDuration);
 
+        // then
         assertFalse(result);
         verify(armRpoService, never()).updateArmRpoStatus(any(), any(), any());
     }
 
     @Test
     void checkCreateExportBasedOnSearchResultsInProgress_PollingExceeded() {
+        //given
         armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now().minusHours(5));
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(OffsetDateTime.now());
         CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
 
+        // when
         assertThrows(ArmRpoException.class, () ->
             armRpoApi.checkCreateExportBasedOnSearchResultsInProgress(userAccount, response, new StringBuilder(), armRpoExecutionDetailEntity, pollDuration));
 
+        // then
         verify(armRpoService).updateArmRpoStatus(any(), any(), any());
-    }
-
-    @Test
-    void checkCreateExportBasedOnSearchResultsInProgress_PollingCreatedTsNull() {
-        armRpoExecutionDetailEntity.setPollingCreatedTs(null);
-        CreateExportBasedOnSearchResultsTableResponse response = createResponse(400, false, 2);
-
-        boolean result = armRpoApi.checkCreateExportBasedOnSearchResultsInProgress(userAccount, response, new StringBuilder(),
-                                                                                   armRpoExecutionDetailEntity, pollDuration);
-
-        assertFalse(result);
-        verify(armRpoService, never()).updateArmRpoStatus(any(), any(), any());
     }
 
     private String getFeignResponseAsString(String status, boolean isError, String responseStatus) {

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.ArmAutomatedTaskRepository;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,6 +42,7 @@ import static org.mockito.Mockito.when;
 class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
     private static final String PRODUCTION_NAME = "DARTS_RPO_2024-08-13";
+    private static final String BEARER_TOKEN = "token";
 
     @Mock
     private ArmRpoClient armRpoClient;
@@ -54,6 +56,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
     private static final Integer EXECUTION_ID = 1;
     private static final ArmRpoHelperMocks ARM_RPO_HELPER_MOCKS = new ArmRpoHelperMocks();
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
+    private Duration pollDuration = Duration.ofHours(4);
 
     @BeforeEach
     void setUp() {
@@ -89,7 +92,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         boolean result = armRpoApi.createExportBasedOnSearchResultsTable(
-            "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount);
+            BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount);
 
         // then
         assertTrue(result);
@@ -112,7 +115,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         boolean result = armRpoApi.createExportBasedOnSearchResultsTable(
-            "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount);
+            BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount);
 
         // then
         assertFalse(result);
@@ -180,7 +183,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
             armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+                BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -207,7 +210,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
             armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+                BEARER_TOKEN, 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -257,7 +260,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -307,7 +310,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -331,7 +334,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME,  pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -354,7 +357,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
             armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -377,7 +380,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
             armRpoApi.createExportBasedOnSearchResultsTable(
-                "token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+                "token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -401,7 +404,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -425,7 +428,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(
@@ -449,7 +452,7 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // when
         ArmRpoException armRpoException = assertThrows(ArmRpoException.class, () ->
-            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, userAccount));
+            armRpoApi.createExportBasedOnSearchResultsTable("token", 1, createHeaderColumns(), PRODUCTION_NAME, pollDuration, userAccount));
 
         // then
         assertThat(armRpoException.getMessage(), containsString(

--- a/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/rpo/impl/ArmRpoApiCreateExportBasedOnSearchResultsTableTest.java
@@ -98,6 +98,8 @@ class ArmRpoApiCreateExportBasedOnSearchResultsTableTest {
 
         // then
         assertTrue(result);
+        // assert that the productionName of armRpoExecutionDetailEntity contains the production name
+        assertThat(armRpoExecutionDetailEntity.getProductionName(), containsString(PRODUCTION_NAME));
         verify(armRpoService).updateArmRpoStateAndStatus(any(),
                                                          eq(ARM_RPO_HELPER_MOCKS.getCreateExportBasedOnSearchResultsTableRpoState()),
                                                          eq(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus()),

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
@@ -112,7 +112,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class)))
             .thenReturn(headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getExtendedProductionsByMatter(anyString(), anyInt(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any(UserAccountEntity.class))).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
@@ -130,7 +130,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
@@ -156,7 +157,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class))).thenReturn(
             headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getExtendedProductionsByMatter(anyString(), anyInt(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
@@ -174,7 +175,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1,
                                                                  ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(), userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
@@ -200,7 +202,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class))).thenReturn(
             headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getExtendedProductionsByMatter(anyString(), anyInt(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
@@ -218,7 +220,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
@@ -244,7 +247,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class))).thenReturn(
             headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getExtendedProductionsByMatter(anyString(), anyInt(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
@@ -262,7 +265,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
@@ -288,7 +292,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class))).thenReturn(
             headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getExtendedProductionsByMatter(anyString(), anyInt(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
@@ -306,7 +310,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
@@ -332,7 +337,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class))).thenReturn(
             headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getExtendedProductionsByMatter(anyString(), anyInt(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any())).thenReturn(List.of("fileId"));
         InputStream resource = IOUtils.toInputStream("dummy input stream", "UTF-8");
@@ -350,7 +355,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).downloadProduction("bearerToken", 1, "fileId", userAccountEntity);
@@ -437,7 +443,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class)))
             .thenReturn(headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(false);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenReturn(false);
 
         // when
         armRpoPollService.pollArmRpo(false, pollDuration);
@@ -448,7 +454,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(userIdentity).getUserAccount();
 
         verifyNoMoreInteractions(armRpoApi, userIdentity, fileOperationService, logApi);
@@ -485,7 +492,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class))).thenReturn(
             headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getExtendedProductionsByMatter(anyString(), anyInt(), anyString(), any(UserAccountEntity.class))).thenReturn(true);
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any(UserAccountEntity.class))).thenReturn(List.of());
 
@@ -498,7 +505,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(armRpoApi).getExtendedProductionsByMatter(eq("bearerToken"), eq(1), contains(PRODUCTION_NAME), eq(userAccountEntity));
         verify(armRpoApi).getProductionOutputFiles("bearerToken", 1, userAccountEntity);
         verify(userIdentity).getUserAccount();
@@ -517,7 +525,7 @@ class ArmRpoPollServiceImplTest {
         List<MasterIndexFieldByRecordClassSchema> headerColumns = createHeaderColumns();
         when(armRpoApi.getMasterIndexFieldByRecordClassSchema(anyString(), anyInt(), any(ArmRpoStateEntity.class), any(UserAccountEntity.class))).thenReturn(
             headerColumns);
-        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenThrow(
+        when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(), any(UserAccountEntity.class))).thenThrow(
             new ArmRpoException("Test exception"));
 
         // when
@@ -529,7 +537,8 @@ class ArmRpoPollServiceImplTest {
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
         verify(armRpoApi).getMasterIndexFieldByRecordClassSchema("bearerToken", 1, ArmRpoHelper.getMasterIndexFieldByRecordClassSchemaSecondaryRpoState(),
                                                                  userAccountEntity);
-        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(userAccountEntity));
+        verify(armRpoApi).createExportBasedOnSearchResultsTable(eq("bearerToken"), eq(1), eq(headerColumns), contains(PRODUCTION_NAME), eq(pollDuration),
+                                                                eq(userAccountEntity));
         verify(userIdentity).getUserAccount();
         verify(logApi).armRpoPollingFailed(EXECUTION_ID);
 

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
@@ -288,7 +288,7 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoStatus(ARM_RPO_HELPER_MOCKS.getInProgressRpoStatus());
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getGetExtendedProductionsByMatterRpoState());
         armRpoExecutionDetailEntity.setProductionName(PRODUCTION_NAME);
-        armRpoExecutionDetailEntity.setPollingCreatedTs(OffsetDateTime.now().minusMinutes(10));
+        armRpoExecutionDetailEntity.setPollingCreatedAt(OffsetDateTime.now().minusMinutes(10));
 
         when(armApiService.getArmBearerToken()).thenReturn("bearerToken");
         when(armRpoApi.getExtendedProductionsByMatter(anyString(), anyInt(), anyString(), any(UserAccountEntity.class))).thenReturn(true);

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoPollServiceImplTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -80,6 +81,7 @@ class ArmRpoPollServiceImplTest {
     private static final Integer EXECUTION_ID = 1;
     private ArmRpoExecutionDetailEntity armRpoExecutionDetailEntity;
     private static final ArmRpoHelperMocks ARM_RPO_HELPER_MOCKS = new ArmRpoHelperMocks();
+    private final Duration pollDuration = Duration.ofHours(4);
 
     private ArmRpoPollServiceImpl armRpoPollService;
 
@@ -122,7 +124,7 @@ class ArmRpoPollServiceImplTest {
         when(fileOperationService.saveFileToTempWorkspace(any(InputStream.class), anyString(), any(), anyBoolean())).thenReturn(filePath);
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
@@ -166,7 +168,7 @@ class ArmRpoPollServiceImplTest {
         when(fileOperationService.saveFileToTempWorkspace(any(InputStream.class), anyString(), any(), anyBoolean())).thenReturn(filePath);
 
         // when
-        armRpoPollService.pollArmRpo(true);
+        armRpoPollService.pollArmRpo(true, pollDuration);
 
         // then
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
@@ -210,7 +212,7 @@ class ArmRpoPollServiceImplTest {
         when(fileOperationService.saveFileToTempWorkspace(any(InputStream.class), anyString(), any(), anyBoolean())).thenReturn(filePath);
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
@@ -254,7 +256,7 @@ class ArmRpoPollServiceImplTest {
         when(fileOperationService.saveFileToTempWorkspace(any(InputStream.class), anyString(), any(), anyBoolean())).thenReturn(filePath);
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
@@ -298,7 +300,7 @@ class ArmRpoPollServiceImplTest {
         when(fileOperationService.saveFileToTempWorkspace(any(InputStream.class), anyString(), any(), anyBoolean())).thenReturn(filePath);
 
         // when
-        armRpoPollService.pollArmRpo(true);
+        armRpoPollService.pollArmRpo(true, pollDuration);
 
         // then
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
@@ -342,7 +344,7 @@ class ArmRpoPollServiceImplTest {
         when(fileOperationService.saveFileToTempWorkspace(any(InputStream.class), anyString(), any(), anyBoolean())).thenReturn(filePath);
 
         // when
-        armRpoPollService.pollArmRpo(true);
+        armRpoPollService.pollArmRpo(true, pollDuration);
 
         // then
         verify(armRpoApi).getExtendedSearchesByMatter("bearerToken", 1, userAccountEntity);
@@ -370,7 +372,7 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getDownloadProductionRpoState());
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoService).getLatestArmRpoExecutionDetailEntity();
@@ -385,7 +387,7 @@ class ArmRpoPollServiceImplTest {
         armRpoExecutionDetailEntity.setArmRpoState(ARM_RPO_HELPER_MOCKS.getDownloadProductionRpoState());
 
         // when
-        armRpoPollService.pollArmRpo(true);
+        armRpoPollService.pollArmRpo(true, pollDuration);
 
         // then
         verify(armRpoService).getLatestArmRpoExecutionDetailEntity();
@@ -399,7 +401,7 @@ class ArmRpoPollServiceImplTest {
         when(armRpoService.getLatestArmRpoExecutionDetailEntity()).thenReturn(null);
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoService).getLatestArmRpoExecutionDetailEntity();
@@ -416,7 +418,7 @@ class ArmRpoPollServiceImplTest {
         when(armApiService.getArmBearerToken()).thenReturn(null);
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoService).getLatestArmRpoExecutionDetailEntity();
@@ -438,7 +440,7 @@ class ArmRpoPollServiceImplTest {
         when(armRpoApi.createExportBasedOnSearchResultsTable(anyString(), anyInt(), any(), anyString(), any(UserAccountEntity.class))).thenReturn(false);
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoService).getLatestArmRpoExecutionDetailEntity();
@@ -462,7 +464,7 @@ class ArmRpoPollServiceImplTest {
             ArmRpoInProgressException.class);
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoService).getLatestArmRpoExecutionDetailEntity();
@@ -488,7 +490,7 @@ class ArmRpoPollServiceImplTest {
         when(armRpoApi.getProductionOutputFiles(anyString(), anyInt(), any(UserAccountEntity.class))).thenReturn(List.of());
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoService).getLatestArmRpoExecutionDetailEntity();
@@ -519,7 +521,7 @@ class ArmRpoPollServiceImplTest {
             new ArmRpoException("Test exception"));
 
         // when
-        armRpoPollService.pollArmRpo(false);
+        armRpoPollService.pollArmRpo(false, pollDuration);
 
         // then
         verify(armRpoService).getLatestArmRpoExecutionDetailEntity();

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImplTest.java
@@ -95,8 +95,7 @@ class ArmRpoServiceImplTest {
 
         var armRpoExecutionDetail = detailEntityCaptor.getValue();
         assertEquals(userAccountEntity, armRpoExecutionDetail.getCreatedBy());
-        assertEquals(userAccountEntity, armRpoExecutionDetail.getLastModifiedBy());
-
+        
         verifyNoMoreInteractions(entityManager, armRpoExecutionDetailRepository);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ArmRpoPollAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ArmRpoPollAutomatedTaskTest.java
@@ -8,7 +8,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.arm.service.ArmRpoPollService;
 import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.config.ArmRpoPollAutomatedTaskConfig;
 import uk.gov.hmcts.darts.task.service.LockService;
+
+import java.time.Duration;
 
 @ExtendWith(MockitoExtension.class)
 class ArmRpoPollAutomatedTaskTest {
@@ -24,11 +27,12 @@ class ArmRpoPollAutomatedTaskTest {
 
     @Test
     void runTask() {
-
+        ArmRpoPollAutomatedTaskConfig armRpoPollAutomatedTaskConfig = new ArmRpoPollAutomatedTaskConfig();
+        armRpoPollAutomatedTaskConfig.setPollDuration(Duration.ofSeconds(5));
         // given
         ArmRpoPollingAutomatedTask armRpoPollAutomatedTask = new ArmRpoPollingAutomatedTask(
             null,
-            null,
+            armRpoPollAutomatedTaskConfig,
             armRpoPollService,
             logApi,
             lockService
@@ -38,6 +42,6 @@ class ArmRpoPollAutomatedTaskTest {
         armRpoPollAutomatedTask.runTask();
 
         // then
-        Mockito.verify(armRpoPollService, Mockito.times(1)).pollArmRpo(false);
+        Mockito.verify(armRpoPollService, Mockito.times(1)).pollArmRpo(false, Duration.ofSeconds(5));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4667
https://tools.hmcts.net/jira/browse/DMP-4658

### Change description ###

1. Add a new field 'production_name' to arm_rpo_execution_details entity.
 
2. When the 'CreateExportBasedOnSearchResultsTable' is called and the result is 200, updates the production_name in arm_rpo_execution_detail table.
 
3. Before calling 'getExtendedProductionsByMatter', uses 'production_name' from arm_rpo_execution_detail. 

4. In the beginning of ARMPolling job, add a check if the current execution state is 11 (getExtendedProductionsByMatter)  then skip the following endpoints and call getExtendedProductionsByMatter:

getExtendedSearchesByMatter
getMasterIndexFieldByRecordClassSchema
createExportBasedOnSearchResultsTable

5. When the 'CreateExportBasedOnSearchResultsTable' called for the first time against the execution Id, update the polling_created_ts. Please make sure the field is not updated again for the same execution Id.
 
6. After calling 'CreateExportBasedOnSearchResultsTable',if it fails i.e. status =400 and responseStatus= 2,  fetch the 'polling_created_ts' and check if its more than 4 hrs. If so, update the execution status as FAILED (arm_rpo_status table). If its not more than 4 hrs, continue with the current logic.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
