### PR TITLE
DMP-4682: Associated object automated task should add 100 years when comparing event date with retain until date

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTaskITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTaskITest.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
-@DisplayName("UnstructuredDataExpiryDeletionAutomatedTask test")
+@DisplayName("AssociatedObjectDataExpiryDeletionAutomatedTask test")
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 class AssociatedObjectDataExpiryDeletionAutomatedTaskITest extends PostgresIntegrationBase {
     private final AssociatedObjectDataExpiryDeletionAutomatedTask associatedObjectDataExpiryDeletionAutomatedTask;
@@ -542,12 +542,12 @@ class AssociatedObjectDataExpiryDeletionAutomatedTaskITest extends PostgresInteg
         boolean assignArm, boolean storeArm) {
 
         ExternalObjectDirectoryEntity inbound = externalLocationTypeEnumConsumer.apply(entity, ObjectRecordStatusEnum.STORED, ExternalLocationTypeEnum.INBOUND);
-        inbound.setEventDateTs(OffsetDateTime.now().minusDays(1).plusYears(100));
+        inbound.setEventDateTs(OffsetDateTime.now().minusDays(1).minusYears(100));
         dartsDatabase.save(inbound);
 
         ExternalObjectDirectoryEntity unstructured = externalLocationTypeEnumConsumer
             .apply(entity, ObjectRecordStatusEnum.STORED, ExternalLocationTypeEnum.UNSTRUCTURED);
-        unstructured.setEventDateTs(OffsetDateTime.now().minusDays(1).plusYears(100));
+        unstructured.setEventDateTs(OffsetDateTime.now().minusDays(1).minusYears(100));
         dartsDatabase.save(unstructured);
 
         if (assignArm) {
@@ -555,7 +555,7 @@ class AssociatedObjectDataExpiryDeletionAutomatedTaskITest extends PostgresInteg
                 entity,
                 storeArm ? ObjectRecordStatusEnum.STORED : ObjectRecordStatusEnum.FAILURE,
                 ExternalLocationTypeEnum.ARM);
-            arm.setEventDateTs(OffsetDateTime.now().minusDays(1).plusYears(100));
+            arm.setEventDateTs(OffsetDateTime.now().minusDays(1).minusYears(100));
             dartsDatabase.save(arm);
 
         }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTask.java
@@ -34,6 +34,7 @@ import uk.gov.hmcts.darts.task.service.LockService;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 @Component
@@ -199,12 +200,17 @@ public class AssociatedObjectDataExpiryDeletionAutomatedTask
         }
 
         if (armExternalObjectDirectoryEntity.getEventDateTs() == null
-            || !armExternalObjectDirectoryEntity.getEventDateTs().toLocalDate().minusYears(eventDateAdjustmentYears)
+            || !armExternalObjectDirectoryEntity.getEventDateTs().toLocalDate().plusYears(eventDateAdjustmentYears)
             .isEqual(entity.getRetainUntilTs().toLocalDate())) {
-            log.info("Skipping deletion of {} with id {} as the event date minus {} years is not the same as the retention date",
+            log.info("Skipping deletion of {} with id '{}' as the event date ({}) plus '{}' years is not the same as the retention date ({})",
                      entity.getClass().getSimpleName(),
                      entity.getId(),
-                     eventDateAdjustmentYears);
+                     Optional.ofNullable(armExternalObjectDirectoryEntity.getEventDateTs())
+                         .map(offsetDateTime -> offsetDateTime.toLocalDate())
+                         .orElse(null),
+                     eventDateAdjustmentYears,
+                     entity.getRetainUntilTs().toLocalDate()
+            );
             return false;
         }
         return true;

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTaskTest.java
@@ -486,7 +486,7 @@ class AssociatedObjectDataExpiryDeletionAutomatedTaskTest {
         ExternalObjectDirectoryEntity armEod = createEodWithExternalLocationType(ExternalLocationTypeEnum.ARM);
 
         TranscriptionDocumentEntity transcriptionDocumentEntity = new TranscriptionDocumentEntity();
-        transcriptionDocumentEntity.setRetainUntilTs(OffsetDateTime.now().minusYears(100));
+        transcriptionDocumentEntity.setRetainUntilTs(OffsetDateTime.now().plusYears(100));
         transcriptionDocumentEntity.setExternalObjectDirectoryEntities(List.of(inboundEod, unstructuredEod, armEod));
 
 

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/AssociatedObjectDataExpiryDeletionAutomatedTaskTest.java
@@ -515,7 +515,7 @@ class AssociatedObjectDataExpiryDeletionAutomatedTaskTest {
         armEod.setEventDateTs(null);
 
         TranscriptionDocumentEntity transcriptionDocumentEntity = new TranscriptionDocumentEntity();
-        transcriptionDocumentEntity.setRetainUntilTs(OffsetDateTime.now().minusYears(100));
+        transcriptionDocumentEntity.setRetainUntilTs(OffsetDateTime.now().plusYears(100));
         transcriptionDocumentEntity.setExternalObjectDirectoryEntities(List.of(inboundEod, unstructuredEod, armEod));
 
 
@@ -531,7 +531,7 @@ class AssociatedObjectDataExpiryDeletionAutomatedTaskTest {
         ExternalObjectDirectoryEntity armEod = createEodWithExternalLocationType(ExternalLocationTypeEnum.ARM);
 
         TranscriptionDocumentEntity transcriptionDocumentEntity = new TranscriptionDocumentEntity();
-        transcriptionDocumentEntity.setRetainUntilTs(OffsetDateTime.now().minusYears(100).minusDays(1));
+        transcriptionDocumentEntity.setRetainUntilTs(OffsetDateTime.now().plusYears(100).minusDays(1));
         transcriptionDocumentEntity.setExternalObjectDirectoryEntities(List.of(inboundEod, unstructuredEod, armEod));
 
         assertThat(associatedObjectDataExpiryDeletionAutomatedTask.shouldDeleteFilter(transcriptionDocumentEntity))


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4682)


### Change description ###
The logic spec'd out in DMP-4358 had a slight error. This is what it said: 
 * add a check if the object's retain_until_ts matches the object's event_dt {color:#FF0000}minus{color} 100 years (event-date-adjustment-years from application.yaml) in external_object_directory table for ARM record i.e. the event_date for the object is calculated and its same as object's retain_until_ts before DELETING the object.

When it should have said:
 * add a check if the object's retain_until_ts matches the object's event_dt {color:#FF0000}plus{color} 100 years (event-date-adjustment-years from application.yaml) in external_object_directory table for ARM record i.e. the event_date for the object is calculated and its same as object's retain_until_ts before DELETING the object.

Please also update the log message be updated to include the 2 event dates that are being compared

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
