### PR TITLE
DMP-4168 Fixing logic for archived audio email

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryImplIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryImplIntTest.java
@@ -92,11 +92,6 @@ class AudioRequestBeingProcessedFromArchiveQueryImplIntTest extends IntegrationB
                 (2544, 183, NULL, NULL, 2, 1, 'c15137df-1a2b-4c0d-b309-bc9238330efb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:58:18.120536+00', '2024-01-04 15:58:18.120547+00', -45, -45, NULL, NULL, NULL, NULL, NULL, false),
                 (2546, 184, NULL, NULL, 2, 1, '8f37e682-633c-465b-b1e3-75cdf4a04d85', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:59:16.538801+00', '2024-01-04 15:59:16.538821+00', -45, -45, NULL, NULL, NULL, NULL, NULL, false),
 
-                (2547, 184, NULL, NULL, 11, 2, 'e9dce141-5f58-4bfd-8660-bce8e0759acb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:59:30.057281+00', '2024-01-04 15:59:30.291683+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
-                (2561, 181, NULL, NULL, 11, 2, 'e4a003a0-2184-4f2b-a4e2-4ed85a36f734', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:53:30.132639+00', '2024-01-04 15:53:30.486242+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
-                (2562, 182, NULL, NULL, 11, 2, 'a3c10ea0-01c2-43f1-bfe7-3b25b7902dfb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:55:30.075869+00', '2024-01-04 15:55:30.334252+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
-                (2545, 183, NULL, NULL, 11, 2, '0e5d566a-00d9-4d02-bcaf-f01f7c582f99', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:58:30.071231+00', '2024-01-04 15:58:30.345809+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
-
                 (2750, 184, NULL, NULL, 2, 3, '8b7dff0f-a2e7-4210-8a5e-f216d8c874eb', 'wysXTgRikGN6nMB8AJ0JrQ==', 1, '2024-01-22 16:10:17.427415+00', '2024-01-22 16:10:17.681265+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
                 (2759, 181, NULL, NULL, 2, 3, '71c3e02b-b7d2-4603-be74-e8c39faaf285', 'wysXTgRikGN6nMB8AJ0JrQ==', 1, '2024-01-22 16:10:19.834748+00', '2024-01-22 16:10:20.093688+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
                 (2763, 182, NULL, NULL, 2, 3, '0dde5ec4-d16d-4940-a923-a73bacd969bb', 'wysXTgRikGN6nMB8AJ0JrQ==', 1, '2024-01-22 16:10:20.882012+00', '2024-01-22 16:10:21.144768+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
@@ -115,11 +110,69 @@ class AudioRequestBeingProcessedFromArchiveQueryImplIntTest extends IntegrationB
             mediaRequestId);
 
         List expected = List.of(
-            new AudioRequestBeingProcessedFromArchiveQueryResult(181, 2561, 2759),
-            new AudioRequestBeingProcessedFromArchiveQueryResult(182, 2562, 2763),
-            new AudioRequestBeingProcessedFromArchiveQueryResult(183, 2545, 2766),
-            new AudioRequestBeingProcessedFromArchiveQueryResult(184, 2547, 2750)
+            new AudioRequestBeingProcessedFromArchiveQueryResult(181),
+            new AudioRequestBeingProcessedFromArchiveQueryResult(182),
+            new AudioRequestBeingProcessedFromArchiveQueryResult(183),
+            new AudioRequestBeingProcessedFromArchiveQueryResult(184)
         );
+        assertEquals(expected.size(), results.size());
+        assertEquals(expected, results);
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:linelength")
+    void givenAudioRequestBeingProcessedFromUnstructured_thenReturnNoResults() {
+        jdbcTemplate.update("""
+                INSERT INTO darts.external_object_directory (eod_id, med_id, trd_id, ado_id, ors_id, elt_id, external_location, checksum, transfer_attempts, created_ts, last_modified_ts, last_modified_by, created_by, cad_id, manifest_file, event_date_ts, external_file_id, external_record_id, update_retention)
+                VALUES
+                (2547, 184, NULL, NULL, 2, 2, 'e9dce141-5f58-4bfd-8660-bce8e0759acb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:59:30.057281+00', '2024-01-04 15:59:30.291683+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
+                (2561, 181, NULL, NULL, 2, 2, 'e4a003a0-2184-4f2b-a4e2-4ed85a36f734', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:53:30.132639+00', '2024-01-04 15:53:30.486242+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
+                (2562, 182, NULL, NULL, 2, 2, 'a3c10ea0-01c2-43f1-bfe7-3b25b7902dfb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:55:30.075869+00', '2024-01-04 15:55:30.334252+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
+                (2545, 183, NULL, NULL, 2, 2, '0e5d566a-00d9-4d02-bcaf-f01f7c582f99', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:58:30.071231+00', '2024-01-04 15:58:30.345809+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false)
+                """);
+        Integer mediaRequestId = 421;
+        final List<AudioRequestBeingProcessedFromArchiveQueryResult> results = audioRequestBeingProcessedFromArchiveQuery.getResults(
+            mediaRequestId);
+
+        assertEquals(0, results.size());
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:linelength")
+    void givenAudioRequestBeingProcessedFromDets_thenReturnNoResults() {
+        jdbcTemplate.update("""
+                INSERT INTO darts.external_object_directory (eod_id, med_id, trd_id, ado_id, ors_id, elt_id, external_location, checksum, transfer_attempts, created_ts, last_modified_ts, last_modified_by, created_by, cad_id, manifest_file, event_date_ts, external_file_id, external_record_id, update_retention)
+                VALUES
+                (2547, 184, NULL, NULL, 4, 2, 'e9dce141-5f58-4bfd-8660-bce8e0759acb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:59:30.057281+00', '2024-01-04 15:59:30.291683+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
+                (2561, 181, NULL, NULL, 4, 2, 'e4a003a0-2184-4f2b-a4e2-4ed85a36f734', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:53:30.132639+00', '2024-01-04 15:53:30.486242+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
+                (2562, 182, NULL, NULL, 4, 2, 'a3c10ea0-01c2-43f1-bfe7-3b25b7902dfb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:55:30.075869+00', '2024-01-04 15:55:30.334252+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
+                (2545, 183, NULL, NULL, 4, 2, '0e5d566a-00d9-4d02-bcaf-f01f7c582f99', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:58:30.071231+00', '2024-01-04 15:58:30.345809+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false)
+                """);
+        Integer mediaRequestId = 421;
+        final List<AudioRequestBeingProcessedFromArchiveQueryResult> results = audioRequestBeingProcessedFromArchiveQuery.getResults(
+            mediaRequestId);
+
+        assertEquals(0, results.size());
+    }
+
+    @Test
+    @SuppressWarnings("checkstyle:linelength")
+    void givenAudioRequestBeingProcessedPartlyFromArchive_thenReturnResultsWhereInArchiveOnly() {
+        jdbcTemplate.update("""
+                INSERT INTO darts.external_object_directory (eod_id, med_id, trd_id, ado_id, ors_id, elt_id, external_location, checksum, transfer_attempts, created_ts, last_modified_ts, last_modified_by, created_by, cad_id, manifest_file, event_date_ts, external_file_id, external_record_id, update_retention)
+                VALUES
+                (2547, 184, NULL, NULL, 2, 2, 'e9dce141-5f58-4bfd-8660-bce8e0759acb', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:59:30.057281+00', '2024-01-04 15:59:30.291683+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false),
+                (2561, 181, NULL, NULL, 4, 2, 'e4a003a0-2184-4f2b-a4e2-4ed85a36f734', 'wysXTgRikGN6nMB8AJ0JrQ==', NULL, '2024-01-04 15:53:30.132639+00', '2024-01-04 15:53:30.486242+00', 0, 0, NULL, NULL, NULL, NULL, NULL, false)
+                """);
+        Integer mediaRequestId = 421;
+        final List<AudioRequestBeingProcessedFromArchiveQueryResult> results = audioRequestBeingProcessedFromArchiveQuery.getResults(
+            mediaRequestId);
+
+        List expected = List.of(
+            new AudioRequestBeingProcessedFromArchiveQueryResult(182),
+            new AudioRequestBeingProcessedFromArchiveQueryResult(183)
+        );
+
         assertEquals(expected.size(), results.size());
         assertEquals(expected, results);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EodRepositoryHasMediaNotBeenCopiedFromInboundStorageIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EodRepositoryHasMediaNotBeenCopiedFromInboundStorageIntTest.java
@@ -16,7 +16,6 @@ import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_INGESTION;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.AWAITING_VERIFICATION;
-import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.DELETED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.FAILURE;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.NEW;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
@@ -96,7 +95,7 @@ class EodRepositoryHasMediaNotBeenCopiedFromInboundStorageIntTest extends Integr
 
     @Test
     void testMediaInInboundNotStoredAndArm() {
-        eodStub.createAndSaveEod(media, DELETED, INBOUND);
+        eodStub.createAndSaveEod(media, NEW, INBOUND);
         eodStub.createAndSaveEod(media, ARM_INGESTION, ARM);
 
         var result = eodRepo.hasMediaNotBeenCopiedFromInboundStorage(media,

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryImpl.java
@@ -10,8 +10,8 @@ import uk.gov.hmcts.darts.audio.model.AudioRequestBeingProcessedFromArchiveQuery
 import java.util.List;
 
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
+import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.DETS;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.UNSTRUCTURED;
-import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.DELETED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
 
 @Component
@@ -24,48 +24,29 @@ public class AudioRequestBeingProcessedFromArchiveQueryImpl implements AudioRequ
     public List<AudioRequestBeingProcessedFromArchiveQueryResult> getResults(Integer mediaRequestId) {
         return jdbcTemplate.query(
             """
-                SELECT
-                    med.med_id,
-                    eod_unstructured.eod_id AS unstructured_eod_id,
-                    eod_arm.eod_id          AS arm_eod_id
-                FROM
-                    darts.media_request mer
-                JOIN
-                    darts.hearing hea
-                ON
-                    mer.hea_id = hea.hea_id
-                JOIN
-                    darts.hearing_media_ae hem
-                ON
-                    hea.hea_id = hem.hea_id
-                JOIN
-                    darts.media med
-                ON
-                    med.med_id = hem.med_id
-                AND
-                    (mer.start_ts >= med.start_ts
-                    AND med.end_ts <= mer.end_ts)
-                JOIN
-                    darts.external_object_directory eod_unstructured
-                ON
-                    med.med_id = eod_unstructured.med_id
-                AND eod_unstructured.elt_id = :unstructured_elt_id
-                AND eod_unstructured.ors_id = :unstructured_ors_id
-                JOIN
-                    darts.external_object_directory eod_arm
-                ON
-                    med.med_id = eod_arm.med_id
-                AND eod_arm.elt_id = :arm_elt_id
-                AND eod_arm.ors_id = :arm_ors_id
-                WHERE
-                    mer.mer_id = :mer_id
-                ORDER BY
-                    med.med_id ASC
+                SELECT med.med_id
+                FROM darts.media_request mer
+                JOIN darts.hearing hea ON mer.hea_id = hea.hea_id
+                JOIN darts.hearing_media_ae hem ON hea.hea_id = hem.hea_id
+                JOIN darts.media med
+                  ON med.med_id = hem.med_id
+                 AND (mer.start_ts >= med.start_ts AND med.end_ts <= mer.end_ts)
+                JOIN darts.external_object_directory eod_arm
+                  ON med.med_id = eod_arm.med_id
+                 AND eod_arm.elt_id = :arm_elt_id
+                 AND eod_arm.ors_id = :arm_ors_id
+                WHERE mer.mer_id = :mer_id
+                AND NOT EXISTS (
+                  SELECT eod_other.eod_id
+                  FROM darts.external_object_directory eod_other
+                  WHERE eod_arm.med_id = eod_other.med_id
+                  AND eod_other.elt_id IN (:other_elt_id)
+                )
+                ORDER BY med.med_id ASC
                 """,
             new MapSqlParameterSource()
                 .addValue("mer_id", mediaRequestId)
-                .addValue("unstructured_elt_id", UNSTRUCTURED.getId())
-                .addValue("unstructured_ors_id", DELETED.getId())
+                .addValue("other_elt_id", List.of(UNSTRUCTURED.getId(), DETS.getId()))
                 .addValue("arm_elt_id", ARM.getId())
                 .addValue("arm_ors_id", STORED.getId()),
             rowMapper

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryResultRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AudioRequestBeingProcessedFromArchiveQueryResultRowMapper.java
@@ -12,11 +12,7 @@ public class AudioRequestBeingProcessedFromArchiveQueryResultRowMapper implement
 
     @Override
     public AudioRequestBeingProcessedFromArchiveQueryResult mapRow(ResultSet rs, int rowNum) throws SQLException {
-        return new AudioRequestBeingProcessedFromArchiveQueryResult(
-            rs.getInt("med_id"),
-            rs.getInt("unstructured_eod_id"),
-            rs.getInt("arm_eod_id")
-        );
+        return new AudioRequestBeingProcessedFromArchiveQueryResult(rs.getInt("med_id"));
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/model/AudioRequestBeingProcessedFromArchiveQueryResult.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/model/AudioRequestBeingProcessedFromArchiveQueryResult.java
@@ -1,6 +1,4 @@
 package uk.gov.hmcts.darts.audio.model;
 
-public record AudioRequestBeingProcessedFromArchiveQueryResult(Integer mediaId,
-                                                               Integer unstructuredExternalObjectDirectoryId,
-                                                               Integer armExternalObjectDirectoryId) {
+public record AudioRequestBeingProcessedFromArchiveQueryResult(Integer mediaId) {
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/enums/ObjectRecordStatusEnum.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/enums/ObjectRecordStatusEnum.java
@@ -20,6 +20,7 @@ public enum ObjectRecordStatusEnum {
     FAILURE_ARM_INGESTION_FAILED(8),
     AWAITING_VERIFICATION(9),
     MARKED_FOR_DELETION(10),
+    @Deprecated
     DELETED(11),
     ARM_INGESTION(12),
     ARM_DROP_ZONE(13),

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
@@ -347,10 +347,10 @@ class MediaRequestServiceImplTest {
 
         when(audioRequestBeingProcessedFromArchiveQuery.getResults(mediaRequestId))
             .thenReturn(List.of(
-                new AudioRequestBeingProcessedFromArchiveQueryResult(181, 2561, 2759),
-                new AudioRequestBeingProcessedFromArchiveQueryResult(182, 2562, 2763),
-                new AudioRequestBeingProcessedFromArchiveQueryResult(183, 2545, 2766),
-                new AudioRequestBeingProcessedFromArchiveQueryResult(184, 2547, 2750)
+                new AudioRequestBeingProcessedFromArchiveQueryResult(181),
+                new AudioRequestBeingProcessedFromArchiveQueryResult(182),
+                new AudioRequestBeingProcessedFromArchiveQueryResult(183),
+                new AudioRequestBeingProcessedFromArchiveQueryResult(184)
             ));
 
         mediaRequestService.scheduleMediaRequestPendingNotification(mockMediaRequestEntity);


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DMP-4168](https://tools.hmcts.net/jira/browse/DMP-4168)

### Change description ###

- using the same logic as checking archived audio for the DARTS portal
- EOD record for stored in ARM, and no record for unstructured or DETS
- deprecating `DISABLED` status as it's not used

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
