### PR TITLE
Dmp 4705 fix issue with manifest file getting set when push failed

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchPushProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchPushProcessorIntTest.java
@@ -92,7 +92,7 @@ class DetsToArmBatchPushProcessorIntTest extends IntegrationBase {
     }
 
     @Test
-    void processDetsToArmWithDetsEodReturnsSuccess() {
+    void processDetsToArm_Success_WithDetsEod() {
         // given
         ObjectStateRecordEntity objectStateRecordEntity = dartsDatabase.getObjectStateRecordRepository()
             .save(createObjectStateRecordEntity(111L));
@@ -143,7 +143,7 @@ class DetsToArmBatchPushProcessorIntTest extends IntegrationBase {
     }
 
     @Test
-    void processDetsToArmWithFailedRawDataStatusArmEodSuccess() {
+    void processDetsToArm_Success_WithFailedRawDataStatusArmEod() {
         // given
         ObjectStateRecordEntity objectStateRecordEntity = dartsDatabase.getObjectStateRecordRepository()
             .save(createObjectStateRecordEntity(111L));
@@ -290,7 +290,7 @@ class DetsToArmBatchPushProcessorIntTest extends IntegrationBase {
     }
 
     @Test
-    void processDetsToArm_WithDetsEodReturnsSuccess() {
+    void processDetsToArm_ThrowsException_WhenSaveManifestFails() {
         // given
         ObjectStateRecordEntity objectStateRecordEntity = dartsDatabase.getObjectStateRecordRepository()
             .save(createObjectStateRecordEntity(111L));
@@ -372,7 +372,7 @@ class DetsToArmBatchPushProcessorIntTest extends IntegrationBase {
         assertNotNull(objectStateRecordEntityModified.getDateFileMfstCreated());
         assertNotNull(objectStateRecordEntityModified.getIdManifestFile());
     }
-    
+
     private ObjectStateRecordEntity createObjectStateRecordEntity(Long uuid) {
         ObjectStateRecordEntity objectStateRecordEntity = new ObjectStateRecordEntity();
         objectStateRecordEntity.setUuid(uuid);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchPushProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/DetsToArmBatchPushProcessorIntTest.java
@@ -367,7 +367,6 @@ class DetsToArmBatchPushProcessorIntTest extends IntegrationBase {
         objectStateRecordEntity.setEodId(String.valueOf(detsEod.getId()));
         dartsDatabase.getObjectStateRecordRepository().save(objectStateRecordEntity);
 
-        String rawFilename = String.format("%s_%s_%s", detsEod.getId(), savedMedia.getId(), detsEod.getTransferAttempts());
         doThrow(new DartsException("")).when(armDataManagementApi).copyDetsBlobDataToArm(any(), any());
 
         // when

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -495,7 +496,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertThat(ingestedArmEods).hasSize(1);
         var failedEod = failedArmEods.get(0);
         assertThat(failedEod.getTransferAttempts()).isEqualTo(3);
-        assertThat(failedEod.getManifestFile()).isEqualTo("existingManifestFile");
+        assertNull(failedEod.getManifestFile());
     }
 
     @Test
@@ -525,7 +526,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertThat(failedArmEodsMedia1).hasSize(1);
         var failedEod = failedArmEodsMedia0.get(0);
         assertThat(failedEod.getTransferAttempts()).isEqualTo(2);
-        assertThat(failedEod.getManifestFile()).isEqualTo("existingManifestFile");
+        assertNull(failedEod.getManifestFile());
 
         verify(armDataManagementApi, never()).saveBlobDataToArm(matches("DARTS_.+\\.a360"), any());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
@@ -32,7 +32,6 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.AuthorisationStub;
 import uk.gov.hmcts.darts.testutils.stubs.ExternalObjectDirectoryStub;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,9 +40,9 @@ import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -129,7 +128,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
 
         // skipped
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
 
         // processed
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
@@ -148,7 +147,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //then
         var foundMediaList = eodRepository.findMediaIdsByInMediaIdStatusAndType(
-            List.of(medias.get(0).getId(),
+            List.of(medias.getFirst().getId(),
                     medias.get(1).getId(),
                     medias.get(2).getId(),
                     medias.get(3).getId(),
@@ -159,7 +158,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         );
         assertThat(foundMediaList.size()).isEqualTo(BATCH_SIZE);
         assertThat(
-            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.get(0).getId()), EodHelper.storedStatus(), EodHelper.unstructuredLocation())
+            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.getFirst().getId()), EodHelper.storedStatus(), EodHelper.unstructuredLocation())
         )
             .hasSize(1);
     }
@@ -174,7 +173,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
 
         // skipped
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
 
         // processed
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
@@ -193,7 +192,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //then
         var foundMediaList = eodRepository.findMediaIdsByInMediaIdStatusAndType(
-            List.of(medias.get(0).getId(),
+            List.of(medias.getFirst().getId(),
                     medias.get(1).getId(),
                     medias.get(2).getId(),
                     medias.get(3).getId(),
@@ -204,7 +203,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         );
         assertThat(foundMediaList.size()).isEqualTo(5);
         assertThat(
-            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.get(0).getId()), EodHelper.storedStatus(), EodHelper.unstructuredLocation())
+            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.getFirst().getId()), EodHelper.storedStatus(), EodHelper.unstructuredLocation())
         )
             .hasSize(1);
     }
@@ -219,7 +218,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
 
         // skipped
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
 
         // processed
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
@@ -238,7 +237,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //then
         var foundMediaList = eodRepository.findMediaIdsByInMediaIdStatusAndType(
-            List.of(medias.get(0).getId(),
+            List.of(medias.getFirst().getId(),
                     medias.get(1).getId(),
                     medias.get(2).getId(),
                     medias.get(3).getId(),
@@ -249,19 +248,19 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         );
         assertThat(foundMediaList.size()).isEqualTo(3);
         assertThat(
-            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.get(0).getId()), EodHelper.storedStatus(), EodHelper.unstructuredLocation())
+            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.getFirst().getId()), EodHelper.storedStatus(), EodHelper.unstructuredLocation())
         )
             .hasSize(1);
     }
 
     @Test
-    void testBatchedQueryWhereSomeFailedToPush() throws IOException {
+    void testBatchedQueryWhereSomeFailedToPush() {
 
         //given
         //batch size is 5
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
 
-        var eod1 = externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
+        var eod1 = externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
         var eod3 = externalObjectDirectoryStub.createAndSaveEod(medias.get(2), STORED, UNSTRUCTURED);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(3), STORED, UNSTRUCTURED);
@@ -270,10 +269,10 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
 
         DartsException dartsException = new DartsException("Exception copying file");
-        String failedFilename1 = format("^%s.*", 7, eod1.getMedia().getId(), eod1.getTransferAttempts());
+        String failedFilename1 = format("^%s_%s_%s.*", 7, eod1.getMedia().getId(), eod1.getTransferAttempts());
         doThrow(dartsException).when(armDataManagementApi).copyBlobDataToArm(any(), matches(failedFilename1));
 
-        String failedFilename3 = format("^%s.*", 9, eod3.getMedia().getId(), eod3.getTransferAttempts());
+        String failedFilename3 = format("^%s_%s_%s.*", 9, eod3.getMedia().getId(), eod3.getTransferAttempts());
         doThrow(dartsException).when(armDataManagementApi).copyBlobDataToArm(any(), matches(failedFilename3));
 
         //when
@@ -281,7 +280,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //then
         List<Integer> foundMediaList = eodRepository.findMediaIdsByInMediaIdStatusAndType(
-            List.of(medias.get(0).getId(),
+            List.of(medias.getFirst().getId(),
                     medias.get(1).getId(),
                     medias.get(2).getId(),
                     medias.get(3).getId(),
@@ -292,12 +291,12 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         );
         assertThat(foundMediaList.size()).isEqualTo(3);
         assertThat(
-            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.get(0).getId()), EodHelper.storedStatus(), EodHelper.unstructuredLocation())
+            eodRepository.findMediaIdsByInMediaIdStatusAndType(List.of(medias.getFirst().getId()), EodHelper.storedStatus(), EodHelper.unstructuredLocation())
         ).hasSize(1);
 
 
         List<Integer> failedMediaList = eodRepository.findMediaIdsByInMediaIdStatusAndType(
-            List.of(medias.get(0).getId(),
+            List.of(medias.getFirst().getId(),
                     medias.get(1).getId(),
                     medias.get(2).getId(),
                     medias.get(3).getId(),
@@ -335,33 +334,33 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertTrue(successEods.stream().allMatch(eodEntity -> manifestFileContents.contains(
             format("\"relation_id\":\"%d\"", eodEntity.getId())
         )));
-        assertTrue(failedEods.stream().allMatch(eodEntity -> !manifestFileContents.contains(
+        assertTrue(failedEods.stream().noneMatch(eodEntity -> manifestFileContents.contains(
             format("\"relation_id\":\"%d\"", eodEntity.getId())
         )));
 
     }
 
     @Test
-    void movePendingMediaDataFromUnstructuredToArmStorage() throws IOException {
+    void movePendingMediaDataFromUnstructuredToArmStorage() {
 
         //given
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
 
         //when
         unstructuredToArmProcessor.processUnstructuredToArm(5);
 
         //then
-        List<ExternalObjectDirectoryEntity> armDropZoneEodsMedia0 = eodRepository.findByMediaStatusAndType(medias.get(0), EodHelper.armDropZoneStatus(),
+        List<ExternalObjectDirectoryEntity> armDropZoneEodsMedia0 = eodRepository.findByMediaStatusAndType(medias.getFirst(), EodHelper.armDropZoneStatus(),
                                                                                                            EodHelper.armLocation());
         assertThat(armDropZoneEodsMedia0).hasSize(1);
         List<ExternalObjectDirectoryEntity> armDropZoneEodsMedia1 = eodRepository.findByMediaStatusAndType(medias.get(1), EodHelper.armDropZoneStatus(),
                                                                                                            EodHelper.armLocation());
         assertThat(armDropZoneEodsMedia1).hasSize(1);
 
-        var rawFile0Name = format("%d_%d_1", armDropZoneEodsMedia0.get(0).getId(), medias.get(0).getId());
-        var rawFile1Name = format("%d_%d_1", armDropZoneEodsMedia1.get(0).getId(), medias.get(1).getId());
+        var rawFile0Name = format("%d_%d_1", armDropZoneEodsMedia0.getFirst().getId(), medias.getFirst().getId());
+        var rawFile1Name = format("%d_%d_1", armDropZoneEodsMedia1.getFirst().getId(), medias.get(1).getId());
 
         verify(armDataManagementApi, times(1)).copyBlobDataToArm(any(), eq(rawFile0Name));
         verify(armDataManagementApi, times(1)).copyBlobDataToArm(any(), eq(rawFile0Name));
@@ -382,21 +381,21 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
                       "\"dz_file_name\":\"" + rawFile1Name);
 
         String manifestFileName = manifestFileNameCaptor.getValue();
-        assertThat(armDropZoneEodsMedia0.get(0).getManifestFile()).isEqualTo(manifestFileName);
-        assertThat(armDropZoneEodsMedia0.get(0).getLastModifiedBy().getId()).isEqualTo(testUser.getId());
-        assertThat(armDropZoneEodsMedia0.get(0).getLastModifiedDateTime()).isCloseToUtcNow(within(1, SECONDS));
-        assertThat(armDropZoneEodsMedia1.get(0).getManifestFile()).isEqualTo(manifestFileName);
+        assertThat(armDropZoneEodsMedia0.getFirst().getManifestFile()).isEqualTo(manifestFileName);
+        assertThat(armDropZoneEodsMedia0.getFirst().getLastModifiedBy().getId()).isEqualTo(testUser.getId());
+        assertThat(armDropZoneEodsMedia0.getFirst().getLastModifiedDateTime()).isCloseToUtcNow(within(1, SECONDS));
+        assertThat(armDropZoneEodsMedia1.getFirst().getManifestFile()).isEqualTo(manifestFileName);
     }
 
     @Test
-    void movePreviousArmFailedFromUnstructuredToArmStorage() throws IOException {
+    void movePreviousArmFailedFromUnstructuredToArmStorage() {
 
         //given
         when(unstructuredToArmProcessorConfiguration.getMaxArmManifestItems()).thenReturn(5);
 
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), ARM_RAW_DATA_FAILED, ARM, eod -> eod.setTransferAttempts(2));
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), ARM_RAW_DATA_FAILED, ARM, eod -> eod.setTransferAttempts(2));
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), ARM_MANIFEST_FAILED, ARM);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(2), STORED, UNSTRUCTURED);
@@ -412,7 +411,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         verify(armDataManagementApi, times(1)).saveBlobDataToArm(matches("DARTS_.+\\.a360"), any());
         verify(armDataManagementApi, times(1)).saveBlobDataToArm(any(), any());
 
-        var armDropzoneEodsMedia0 = eodRepository.findByMediaStatusAndType(medias.get(0), EodHelper.armDropZoneStatus(), EodHelper.armLocation());
+        var armDropzoneEodsMedia0 = eodRepository.findByMediaStatusAndType(medias.getFirst(), EodHelper.armDropZoneStatus(), EodHelper.armLocation());
         assertThat(armDropzoneEodsMedia0).hasSize(1);
         var armDropzoneEodsMedia1 = eodRepository.findByMediaStatusAndType(medias.get(1), EodHelper.armDropZoneStatus(), EodHelper.armLocation());
         assertThat(armDropzoneEodsMedia1).hasSize(1);
@@ -422,28 +421,28 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         verify(archiveRecordFileGenerator).generateArchiveRecords(manifestFileNameCaptor.capture(), any());
         String manifestFileName = manifestFileNameCaptor.getValue();
-        assertThat(armDropzoneEodsMedia0.get(0).getManifestFile()).isEqualTo(manifestFileName);
-        assertThat(armDropzoneEodsMedia0.get(0).getLastModifiedBy().getId()).isEqualTo(testUser.getId());
-        assertThat(armDropzoneEodsMedia0.get(0).getLastModifiedDateTime()).isCloseToUtcNow(within(1, SECONDS));
-        assertThat(armDropzoneEodsMedia1.get(0).getManifestFile()).isEqualTo(manifestFileName);
+        assertThat(armDropzoneEodsMedia0.getFirst().getManifestFile()).isEqualTo(manifestFileName);
+        assertThat(armDropzoneEodsMedia0.getFirst().getLastModifiedBy().getId()).isEqualTo(testUser.getId());
+        assertThat(armDropzoneEodsMedia0.getFirst().getLastModifiedDateTime()).isCloseToUtcNow(within(1, SECONDS));
+        assertThat(armDropzoneEodsMedia1.getFirst().getManifestFile()).isEqualTo(manifestFileName);
 
         ArgumentCaptor<String> manifestFileContentCaptor = ArgumentCaptor.forClass(String.class);
         verify(dataStoreToArmHelper).convertStringToBinaryData(manifestFileContentCaptor.capture());
         String manifestFileContent = manifestFileContentCaptor.getValue();
         assertThat(manifestFileContent.lines().count()).isEqualTo(4);
         assertThat(manifestFileContent).contains(
-            format("_%d_", medias.get(0).getId()),
+            format("_%d_", medias.getFirst().getId()),
             format("_%d_", medias.get(1).getId())
         );
         assertThat(manifestFileContent).doesNotContain(format("_%d_", medias.get(2).getId()));
     }
 
     @Test
-    void movePreviousArmFailedWithNoCorrespondingUnstructuredFailsAndProcessingContinues() throws IOException {
+    void movePreviousArmFailedWithNoCorrespondingUnstructuredFailsAndProcessingContinues() {
 
         //given
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), ARM_MANIFEST_FAILED, ARM, eod -> eod.setManifestFile("existingManifestFile"));
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), ARM_MANIFEST_FAILED, ARM, eod -> eod.setManifestFile("existingManifestFile"));
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), ARM_RAW_DATA_FAILED, ARM);
 
@@ -452,10 +451,10 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //then
         List<ExternalObjectDirectoryEntity> failedArmEods = eodRepository.findByMediaStatusAndType(
-            medias.get(0), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
+            medias.getFirst(), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
         assertThat(failedArmEods).hasSize(1);
-        assertThat(failedArmEods.get(0).getManifestFile()).isEqualTo("existingManifestFile");
-        assertThat(failedArmEods.get(0).getTransferAttempts()).isEqualTo(2);
+        assertThat(failedArmEods.getFirst().getManifestFile()).isEqualTo("existingManifestFile");
+        assertThat(failedArmEods.getFirst().getTransferAttempts()).isEqualTo(2);
         assertThat(eodRepository.findByMediaStatusAndType(medias.get(1), EodHelper.armDropZoneStatus(), EodHelper.armLocation())).hasSize(1);
 
         verify(archiveRecordFileGenerator).generateArchiveRecords(manifestFileNameCaptor.capture(), any());
@@ -466,7 +465,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         assertThat(manifestFileContent.lines().count()).isEqualTo(2);
         assertThat(manifestFileContent).contains(format("_%d_", medias.get(1).getId()));
-        assertThat(manifestFileContent).doesNotContain(format("_%d_", medias.get(0).getId()));
+        assertThat(manifestFileContent).doesNotContain(format("_%d_", medias.getFirst().getId()));
     }
 
     @Test
@@ -474,8 +473,8 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //given
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), ARM_RAW_DATA_FAILED, ARM, eod -> {
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), ARM_RAW_DATA_FAILED, ARM, eod -> {
             eod.setManifestFile("existingManifestFile");
             eod.setTransferAttempts(2);
         });
@@ -488,13 +487,13 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         unstructuredToArmProcessor.processUnstructuredToArm(5);
 
         //then
-        List<ExternalObjectDirectoryEntity> failedArmEods = eodRepository.findByMediaStatusAndType(medias.get(0), EodHelper.failedArmRawDataStatus(),
+        List<ExternalObjectDirectoryEntity> failedArmEods = eodRepository.findByMediaStatusAndType(medias.getFirst(), EodHelper.failedArmRawDataStatus(),
                                                                                                    EodHelper.armLocation());
         assertThat(failedArmEods).hasSize(1);
         List<ExternalObjectDirectoryEntity> ingestedArmEods = eodRepository.findByMediaStatusAndType(medias.get(1), EodHelper.armDropZoneStatus(),
                                                                                                      EodHelper.armLocation());
         assertThat(ingestedArmEods).hasSize(1);
-        var failedEod = failedArmEods.get(0);
+        var failedEod = failedArmEods.getFirst();
         assertThat(failedEod.getTransferAttempts()).isEqualTo(3);
         assertNull(failedEod.getManifestFile());
     }
@@ -507,8 +506,8 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //given
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), ARM_RAW_DATA_FAILED, ARM, eod -> eod.setManifestFile("existingManifestFile"));
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), ARM_RAW_DATA_FAILED, ARM, eod -> eod.setManifestFile("existingManifestFile"));
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), ARM_MANIFEST_FAILED, ARM);
 
@@ -519,12 +518,12 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //then
         List<ExternalObjectDirectoryEntity> failedArmEodsMedia0 = eodRepository.findByMediaStatusAndType(
-            medias.get(0), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
+            medias.getFirst(), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
         assertThat(failedArmEodsMedia0).hasSize(1);
         List<ExternalObjectDirectoryEntity> failedArmEodsMedia1 = eodRepository.findByMediaStatusAndType(
             medias.get(1), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
         assertThat(failedArmEodsMedia1).hasSize(1);
-        var failedEod = failedArmEodsMedia0.get(0);
+        var failedEod = failedArmEodsMedia0.getFirst();
         assertThat(failedEod.getTransferAttempts()).isEqualTo(2);
         assertNull(failedEod.getManifestFile());
 
@@ -536,8 +535,8 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //given
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), ARM_RAW_DATA_FAILED, ARM, eod -> eod.setManifestFile("existingManifestFile"));
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), ARM_RAW_DATA_FAILED, ARM, eod -> eod.setManifestFile("existingManifestFile"));
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), ARM_MANIFEST_FAILED, ARM);
 
@@ -548,12 +547,12 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //then
         List<ExternalObjectDirectoryEntity> failedArmEodsMedia0 = eodRepository.findByMediaStatusAndType(
-            medias.get(0), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
+            medias.getFirst(), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
         assertThat(failedArmEodsMedia0).hasSize(1);
         List<ExternalObjectDirectoryEntity> failedArmEodsMedia1 = eodRepository.findByMediaStatusAndType(
             medias.get(1), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
         assertThat(failedArmEodsMedia1).hasSize(1);
-        var failedEod = failedArmEodsMedia0.get(0);
+        var failedEod = failedArmEodsMedia0.getFirst();
         assertThat(failedEod.getTransferAttempts()).isEqualTo(2);
         assertThat(failedEod.getManifestFile()).isEqualTo("existingManifestFile");
 
@@ -565,8 +564,8 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //given
         List<MediaEntity> medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), STORED, UNSTRUCTURED);
-        externalObjectDirectoryStub.createAndSaveEod(medias.get(0), ARM_RAW_DATA_FAILED, ARM, eod -> eod.setManifestFile("existingManifestFile"));
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), STORED, UNSTRUCTURED);
+        externalObjectDirectoryStub.createAndSaveEod(medias.getFirst(), ARM_RAW_DATA_FAILED, ARM, eod -> eod.setManifestFile("existingManifestFile"));
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), STORED, UNSTRUCTURED);
         externalObjectDirectoryStub.createAndSaveEod(medias.get(1), ARM_MANIFEST_FAILED, ARM);
 
@@ -577,12 +576,12 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
 
         //then
         List<ExternalObjectDirectoryEntity> failedArmEodsMedia0 = eodRepository.findByMediaStatusAndType(
-            medias.get(0), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
+            medias.getFirst(), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
         assertThat(failedArmEodsMedia0).hasSize(1);
         List<ExternalObjectDirectoryEntity> failedArmEodsMedia1 = eodRepository.findByMediaStatusAndType(
             medias.get(1), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
         assertThat(failedArmEodsMedia1).hasSize(1);
-        var failedEod = failedArmEodsMedia0.get(0);
+        var failedEod = failedArmEodsMedia0.getFirst();
         assertThat(failedEod.getTransferAttempts()).isEqualTo(2);
         assertThat(failedEod.getManifestFile()).isEqualTo("existingManifestFile");
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/UnstructuredToArmBatchProcessorIntTest.java
@@ -453,7 +453,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         List<ExternalObjectDirectoryEntity> failedArmEods = eodRepository.findByMediaStatusAndType(
             medias.getFirst(), EodHelper.failedArmManifestFileStatus(), EodHelper.armLocation());
         assertThat(failedArmEods).hasSize(1);
-        assertThat(failedArmEods.getFirst().getManifestFile()).isEqualTo("existingManifestFile");
+        assertNull(failedArmEods.getFirst().getManifestFile());
         assertThat(failedArmEods.getFirst().getTransferAttempts()).isEqualTo(2);
         assertThat(eodRepository.findByMediaStatusAndType(medias.get(1), EodHelper.armDropZoneStatus(), EodHelper.armLocation())).hasSize(1);
 
@@ -554,7 +554,7 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertThat(failedArmEodsMedia1).hasSize(1);
         var failedEod = failedArmEodsMedia0.getFirst();
         assertThat(failedEod.getTransferAttempts()).isEqualTo(2);
-        assertThat(failedEod.getManifestFile()).isEqualTo("existingManifestFile");
+        assertNull(failedEod.getManifestFile());
 
         verify(armDataManagementApi, never()).saveBlobDataToArm(matches("DARTS_.+\\.a360"), any());
     }
@@ -583,6 +583,6 @@ class UnstructuredToArmBatchProcessorIntTest extends IntegrationBase {
         assertThat(failedArmEodsMedia1).hasSize(1);
         var failedEod = failedArmEodsMedia0.getFirst();
         assertThat(failedEod.getTransferAttempts()).isEqualTo(2);
-        assertThat(failedEod.getManifestFile()).isEqualTo("existingManifestFile");
+        assertNull(failedEod.getManifestFile());
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImpl.java
@@ -3,10 +3,12 @@ package uk.gov.hmcts.darts.arm.component.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.arm.component.ArchiveRecordFileGenerator;
 import uk.gov.hmcts.darts.arm.enums.ArchiveRecordType;
 import uk.gov.hmcts.darts.arm.model.ArchiveRecord;
+import uk.gov.hmcts.darts.arm.model.ArchiveRecordOperation;
 import uk.gov.hmcts.darts.common.exception.DartsException;
 
 import java.io.BufferedWriter;
@@ -15,6 +17,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.Objects.isNull;
 
@@ -65,10 +68,21 @@ public class ArchiveRecordFileGeneratorImpl implements ArchiveRecordFileGenerato
                 }
             }
             archiveRecordsString = archiveRecordsStringBuilder.toString();
-            log.info("Contents of manifest file {} \n{}",
+            List<String> relationIds = getRelationIds(archiveRecords);
+            log.info("Contents of manifest file {} for EOD's {}\n{}",
                      archiveFileName,
+                     StringUtils.join(relationIds, ", "),
                      archiveRecordsString);
         }
         return archiveRecordsString;
+    }
+
+    private static List<String> getRelationIds(List<ArchiveRecord> archiveRecords) {
+        return archiveRecords.stream()
+            .map(ArchiveRecord::getArchiveRecordOperation)
+            .filter(Objects::nonNull)
+            .map(ArchiveRecordOperation::getRelationId)
+            .filter(Objects::nonNull)
+            .toList();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImpl.java
@@ -65,9 +65,8 @@ public class ArchiveRecordFileGeneratorImpl implements ArchiveRecordFileGenerato
                 }
             }
             archiveRecordsString = archiveRecordsStringBuilder.toString();
-            log.info("Contents of manifest file {} for EOD {}\n{}",
+            log.info("Contents of manifest file {} \n{}",
                      archiveFileName,
-                     archiveRecords.get(0).getArchiveRecordOperation().getRelationId(),
                      archiveRecordsString);
         }
         return archiveRecordsString;

--- a/src/main/java/uk/gov/hmcts/darts/arm/helper/DataStoreToArmHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/helper/DataStoreToArmHelper.java
@@ -240,7 +240,7 @@ public class DataStoreToArmHelper {
             incrementTransferAttempts(armEod);
             updateExternalObjectDirectoryStatus(armEod, EodHelper.armIngestionStatus(), userAccount);
         } else {
-            log.error("Unable to find matching external object directory for {}", armEod.getId());
+            log.error("Unable to find matching external object directory for {} - manifest {}", armEod.getId(), archiveRecordsFileName);
             updateExternalObjectDirectoryFailedTransferAttempts(armEod, userAccount);
             throw new DartsException(MessageFormat.format("Unable to find matching external object directory for {0}", armEod.getId()));
         }

--- a/src/main/java/uk/gov/hmcts/darts/arm/model/batch/ArmBatchItem.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/model/batch/ArmBatchItem.java
@@ -21,7 +21,7 @@ public class ArmBatchItem {
     }
 
     public void undoManifestFileChange() {
-        this.armEod.setManifestFile(this.previousManifestFile);
+        this.armEod.setManifestFile(null);
     }
 
     public boolean isRawFilePushNotNeededOrSuccessfulWhenNeeded() {

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.arm.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.data.domain.Limit;
@@ -101,7 +100,7 @@ public class DetsToArmBatchPushProcessorImpl implements DetsToArmBatchPushProces
             try {
                 AsyncUtil.invokeAllAwaitTermination(tasks, automatedTaskConfigurationProperties);
             } catch (Exception e) {
-                log.error("Dets to arm batch unexpected exception", e);
+                log.error("DETS to ARM batch unexpected exception", e);
                 if (e instanceof InterruptedException) {
                     Thread.currentThread().interrupt();
                 }
@@ -203,13 +202,7 @@ public class DetsToArmBatchPushProcessorImpl implements DetsToArmBatchPushProces
 
     private boolean writeManifestAndCopyToArm(UserAccountEntity userAccount, ArmBatchItems batchItems, String archiveRecordsFileName) {
         try {
-            if (CollectionUtils.isNotEmpty(batchItems.getFailed())) {
-                batchItems.getFailed().forEach(batchItem -> {
-                    var eod = batchItem.getArmEod();
-                    eod.setManifestFile(null);
-                    externalObjectDirectoryRepository.save(eod);
-                });
-            }
+
             if (!batchItems.getSuccessful().isEmpty()) {
                 String archiveRecordsContents = dataStoreToArmHelper.generateManifestFileContents(batchItems, archiveRecordsFileName);
 

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
@@ -161,7 +161,6 @@ public class DetsToArmBatchPushProcessorImpl implements DetsToArmBatchPushProces
                     objectStateRecord.setObjectStatus(null);
                     objectStateRecordRepository.save(objectStateRecord);
                 } else {
-
                     armEod = dataStoreToArmHelper.createArmEodWithArmIngestionStatus(
                         currentEod, batchItem, batchItems, archiveRecordsFileName, userAccount);
                     objectStateRecord = getObjectStateRecordEntity(currentEod);

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImpl.java
@@ -189,6 +189,10 @@ public class DetsToArmBatchPushProcessorImpl implements DetsToArmBatchPushProces
             return;
         }
 
+        updateBatchedItemsStatuses(userAccount, batchItems);
+    }
+
+    private void updateBatchedItemsStatuses(UserAccountEntity userAccount, ArmBatchItems batchItems) {
         for (var batchItem : batchItems.getItems()) {
             if (batchItem.isRawFilePushNotNeededOrSuccessfulWhenNeeded() && batchItem.getArchiveRecord() != null) {
                 dataStoreToArmHelper.updateExternalObjectDirectoryStatus(batchItem.getArmEod(), EodHelper.armDropZoneStatus(), userAccount);

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/UnstructuredToArmBatchProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/UnstructuredToArmBatchProcessorImpl.java
@@ -137,6 +137,7 @@ public class UnstructuredToArmBatchProcessorImpl implements UnstructuredToArmBat
                 unstructuredToArmHelper.updateExternalObjectDirectoryStatus(batchItem.getArmEod(), EodHelper.armDropZoneStatus(), userAccount);
                 logApi.armPushSuccessful(batchItem.getArmEod().getId());
             } else {
+                batchItem.getArmEod().setManifestFile(null);
                 recoverByUpdatingEodToFailedArmStatus(batchItem, userAccount);
             }
         }

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/UnstructuredToArmBatchProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/UnstructuredToArmBatchProcessorImpl.java
@@ -137,7 +137,6 @@ public class UnstructuredToArmBatchProcessorImpl implements UnstructuredToArmBat
                 unstructuredToArmHelper.updateExternalObjectDirectoryStatus(batchItem.getArmEod(), EodHelper.armDropZoneStatus(), userAccount);
                 logApi.armPushSuccessful(batchItem.getArmEod().getId());
             } else {
-                batchItem.getArmEod().setManifestFile(null);
                 recoverByUpdatingEodToFailedArmStatus(batchItem, userAccount);
             }
         }

--- a/src/test/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/component/impl/ArchiveRecordFileGeneratorImplTest.java
@@ -54,6 +54,9 @@ import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 class ArchiveRecordFileGeneratorImplTest {
 
     public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssX";
+    public static final String READING_FILE = "Reading file {}";
+    public static final String ACTUAL_RESPONSE = "actual Response {}";
+    public static final String EXPECT_RESPONSE = "expect Response {}";
     @TempDir
     private File tempDirectory;
 
@@ -70,7 +73,9 @@ class ArchiveRecordFileGeneratorImplTest {
     @SuppressWarnings("PMD.SignatureDeclareThrowsException")
     public void clean() throws Exception {
         FileStore.getFileStore().remove();
-        Assertions.assertEquals(0, Files.list(tempDirectory.toPath()).count());
+        try (var filesStream = Files.list(tempDirectory.toPath())) {
+            Assertions.assertEquals(0, filesStream.count());
+        }
     }
 
     @Test
@@ -81,12 +86,12 @@ class ArchiveRecordFileGeneratorImplTest {
 
         archiveRecordFileGenerator.generateArchiveRecord(createMediaArchiveRecord(relationId), archiveFile, ArchiveRecordType.MEDIA_ARCHIVE_TYPE);
 
-        log.info("Reading file {}", archiveFile.getAbsolutePath());
+        log.info(READING_FILE, archiveFile.getAbsolutePath());
 
         String actualResponse = getFileContents(archiveFile);
         String expectedResponse = getContentsFromFile("Tests/arm/component/ArchiveMediaMetadata/expectedResponse.a360");
-        log.info("actual Response {}", actualResponse);
-        log.info("expect Response {}", expectedResponse);
+        log.info(ACTUAL_RESPONSE, actualResponse);
+        log.info(EXPECT_RESPONSE, expectedResponse);
         assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -99,12 +104,12 @@ class ArchiveRecordFileGeneratorImplTest {
         archiveRecordFileGenerator.generateArchiveRecord(createTranscriptionArchiveRecord(relationId), archiveFile,
                                                          ArchiveRecordType.TRANSCRIPTION_ARCHIVE_TYPE);
 
-        log.info("Reading file {}", archiveFile.getAbsolutePath());
+        log.info(READING_FILE, archiveFile.getAbsolutePath());
 
         String actualResponse = getFileContents(archiveFile);
         String expectedResponse = getContentsFromFile("Tests/arm/component/ArchiveTranscriptionMetadata/expectedResponse.a360");
-        log.info("actual Response {}", actualResponse);
-        log.info("expect Response {}", expectedResponse);
+        log.info(ACTUAL_RESPONSE, actualResponse);
+        log.info(EXPECT_RESPONSE, expectedResponse);
         assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -116,12 +121,12 @@ class ArchiveRecordFileGeneratorImplTest {
 
         archiveRecordFileGenerator.generateArchiveRecord(createAnnotationArchiveRecord(relationId), archiveFile, ArchiveRecordType.ANNOTATION_ARCHIVE_TYPE);
 
-        log.info("Reading file {}", archiveFile.getAbsolutePath());
+        log.info(READING_FILE, archiveFile.getAbsolutePath());
 
         String actualResponse = getFileContents(archiveFile);
         String expectedResponse = getContentsFromFile("Tests/arm/component/ArchiveAnnotationMetadata/expectedResponse.a360");
-        log.info("actual Response {}", actualResponse);
-        log.info("expect Response {}", expectedResponse);
+        log.info(ACTUAL_RESPONSE, actualResponse);
+        log.info(EXPECT_RESPONSE, expectedResponse);
         assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -134,12 +139,12 @@ class ArchiveRecordFileGeneratorImplTest {
 
         archiveRecordFileGenerator.generateArchiveRecord(createCaseArchiveRecord(relationId), archiveFile, ArchiveRecordType.CASE_ARCHIVE_TYPE);
 
-        log.info("Reading file {}", archiveFile.getAbsolutePath());
+        log.info(READING_FILE, archiveFile.getAbsolutePath());
 
         String actualResponse = getFileContents(archiveFile);
         String expectedResponse = getContentsFromFile("Tests/arm/component/ArchiveCaseMetadata/expectedResponse.a360");
-        log.info("actual Response {}", actualResponse);
-        log.info("expect Response {}", expectedResponse);
+        log.info(ACTUAL_RESPONSE, actualResponse);
+        log.info(EXPECT_RESPONSE, expectedResponse);
         assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -148,8 +153,7 @@ class ArchiveRecordFileGeneratorImplTest {
         String fileLocation = tempDirectory.getAbsolutePath();
         File archiveFile = FileStore.getFileStore().create(Path.of(fileLocation), Path.of("test-media-arm.a360"));
 
-        ArchiveRecord archiveRecord = null;
-        boolean result = archiveRecordFileGenerator.generateArchiveRecord(archiveRecord, archiveFile, ArchiveRecordType.MEDIA_ARCHIVE_TYPE);
+        boolean result = archiveRecordFileGenerator.generateArchiveRecord(null, archiveFile, ArchiveRecordType.MEDIA_ARCHIVE_TYPE);
         assertFalse(result);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/ArchiveRecordServiceImplTest.java
@@ -5,20 +5,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.darts.arm.component.ArchiveRecordFileGenerator;
-import uk.gov.hmcts.darts.arm.component.impl.ArchiveRecordFileGeneratorImpl;
 import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
 import uk.gov.hmcts.darts.arm.mapper.AnnotationArchiveRecordMapper;
 import uk.gov.hmcts.darts.arm.mapper.CaseArchiveRecordMapper;
 import uk.gov.hmcts.darts.arm.mapper.MediaArchiveRecordMapper;
 import uk.gov.hmcts.darts.arm.mapper.TranscriptionArchiveRecordMapper;
-import uk.gov.hmcts.darts.arm.mapper.impl.AnnotationArchiveRecordMapperImpl;
-import uk.gov.hmcts.darts.arm.mapper.impl.CaseArchiveRecordMapperImpl;
-import uk.gov.hmcts.darts.arm.mapper.impl.MediaArchiveRecordMapperImpl;
-import uk.gov.hmcts.darts.arm.mapper.impl.TranscriptionArchiveRecordMapperImpl;
 import uk.gov.hmcts.darts.arm.model.ArchiveRecord;
 import uk.gov.hmcts.darts.arm.model.record.AnnotationArchiveRecord;
 import uk.gov.hmcts.darts.arm.model.record.CaseArchiveRecord;
@@ -26,28 +19,14 @@ import uk.gov.hmcts.darts.arm.model.record.MediaArchiveRecord;
 import uk.gov.hmcts.darts.arm.model.record.TranscriptionArchiveRecord;
 import uk.gov.hmcts.darts.arm.service.impl.ArchiveRecordServiceImpl;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
-import uk.gov.hmcts.darts.common.entity.AnnotationEntity;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
-import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
-import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
-import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
-import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionCommentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionStatusEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionTypeEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionUrgencyEntity;
-import uk.gov.hmcts.darts.common.entity.TranscriptionWorkflowEntity;
-import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsException;
-import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 
 import java.io.File;
-import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,25 +35,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.darts.test.common.TestUtils.getObjectMapper;
 
 @SuppressWarnings("PMD.AssignmentInOperand")
 @ExtendWith(MockitoExtension.class)
 @Slf4j
 class ArchiveRecordServiceImplTest {
-    public static final String TEST_ARCHIVE_FILENAME = "1234-1-1.a360";
-    public static final String MP_2 = "mp2";
-    public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssX";
-    public static final String DARTS = "DARTS";
-    public static final String REGION = "GBR";
-    public static final int EODID = 1234;
-    public static final String FILE_EXTENSION = "a360";
-    public static final String DATE_FORMAT = "yyyy-MM-dd";
-    public static final int RETENTION_CONFIDENCE_SCORE = 2;
-    public static final String RETENTION_CONFIDENCE_REASON = "RetentionConfidenceReason";
 
-    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT);
-
+    private static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssX";
+    private static final String DARTS = "DARTS";
+    private static final String REGION = "GBR";
+    private static final int EODID = 1234;
+    private static final String FILE_EXTENSION = "a360";
 
     @Mock(lenient = true)
     private ArmDataManagementConfiguration armDataManagementConfiguration;
@@ -83,46 +54,11 @@ class ArchiveRecordServiceImplTest {
     @Mock
     private MediaEntity mediaEntity;
     @Mock
-    private TranscriptionEntity transcriptionEntity;
-    @Mock
     private TranscriptionDocumentEntity transcriptionDocumentEntity;
     @Mock
     private AnnotationDocumentEntity annotationDocumentEntity;
     @Mock
     private CaseDocumentEntity caseDocumentEntity;
-    @Mock
-    private CourtroomEntity courtroomEntity;
-    @Mock
-    private CourthouseEntity courthouseEntity;
-    @Mock
-    private TranscriptionCommentEntity transcriptionCommentEntity;
-    @Mock
-    private TranscriptionUrgencyEntity transcriptionUrgencyEntity;
-    @Mock
-    private TranscriptionTypeEntity transcriptionTypeEntity;
-    @Mock
-    private TranscriptionWorkflowEntity transcriptionWorkflowEntity;
-    @Mock
-    private TranscriptionStatusEntity transcriptionStatusEntity;
-    @Mock
-    private AnnotationEntity annotationEntity;
-    @Mock
-    private HearingEntity hearingEntity1;
-    @Mock
-    private HearingEntity hearingEntity2;
-    @Mock
-    private HearingEntity hearingEntity3;
-    @Mock
-    private CourtCaseEntity courtCaseEntity1;
-    @Mock
-    private CourtCaseEntity courtCaseEntity2;
-    @Mock
-    private CourtCaseEntity courtCaseEntity3;
-    @Mock
-    private UserAccountEntity userAccountEntity;
-
-    @Mock
-    private CurrentTimeHelper currentTimeHelper;
 
     @Mock
     private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
@@ -136,33 +72,13 @@ class ArchiveRecordServiceImplTest {
     @Mock
     private CaseArchiveRecordMapper caseArchiveRecordMapperMock;
 
-    private ArchiveRecordFileGenerator archiveRecordFileGenerator;
-
     @TempDir
     private File tempDirectory;
 
-    @InjectMocks
     private ArchiveRecordServiceImpl archiveRecordService;
 
     @BeforeEach
     void setUp() {
-        archiveRecordFileGenerator = new ArchiveRecordFileGeneratorImpl(getObjectMapper());
-
-        MediaArchiveRecordMapper mediaArchiveRecordMapper = new MediaArchiveRecordMapperImpl(armDataManagementConfiguration, currentTimeHelper);
-        TranscriptionArchiveRecordMapper transcriptionArchiveRecordMapper = new TranscriptionArchiveRecordMapperImpl(
-            armDataManagementConfiguration,
-            currentTimeHelper
-        );
-        AnnotationArchiveRecordMapper annotationArchiveRecordMapper = new AnnotationArchiveRecordMapperImpl(armDataManagementConfiguration, currentTimeHelper);
-        CaseArchiveRecordMapper caseArchiveRecordMapper = new CaseArchiveRecordMapperImpl(armDataManagementConfiguration, currentTimeHelper);
-
-        archiveRecordService = new ArchiveRecordServiceImpl(
-            mediaArchiveRecordMapper,
-            transcriptionArchiveRecordMapper,
-            annotationArchiveRecordMapper,
-            caseArchiveRecordMapper,
-            externalObjectDirectoryRepository
-        );
 
         String fileLocation = tempDirectory.getAbsolutePath();
         when(armDataManagementConfiguration.getTempBlobWorkspace()).thenReturn(fileLocation);
@@ -171,6 +87,13 @@ class ArchiveRecordServiceImplTest {
         when(armDataManagementConfiguration.getRegion()).thenReturn(REGION);
         when(armDataManagementConfiguration.getFileExtension()).thenReturn(FILE_EXTENSION);
 
+        archiveRecordService = new ArchiveRecordServiceImpl(
+            mediaArchiveRecordMapperMock,
+            transcriptionArchiveRecordMapperMock,
+            annotationArchiveRecordMapperMock,
+            caseArchiveRecordMapperMock,
+            externalObjectDirectoryRepository
+        );
     }
 
     @Test
@@ -179,14 +102,6 @@ class ArchiveRecordServiceImplTest {
         when(externalObjectDirectoryRepository.findById(any())).thenReturn(Optional.of(externalObjectDirectoryEntity));
         when(externalObjectDirectoryEntity.getMedia()).thenReturn(mediaEntity);
         when(mediaArchiveRecordMapperMock.mapToMediaArchiveRecord(any(), any())).thenReturn(MediaArchiveRecord.builder().build());
-
-        ArchiveRecordServiceImpl archiveRecordService = new ArchiveRecordServiceImpl(
-            mediaArchiveRecordMapperMock,
-            transcriptionArchiveRecordMapperMock,
-            annotationArchiveRecordMapperMock,
-            caseArchiveRecordMapperMock,
-            externalObjectDirectoryRepository
-        );
 
         // when
         ArchiveRecord archiveRecord = archiveRecordService.generateArchiveRecordInfo(EODID, "1234_1_1");
@@ -206,14 +121,6 @@ class ArchiveRecordServiceImplTest {
         when(externalObjectDirectoryEntity.getTranscriptionDocumentEntity()).thenReturn(transcriptionDocumentEntity);
         when(transcriptionArchiveRecordMapperMock.mapToTranscriptionArchiveRecord(any(), any())).thenReturn(TranscriptionArchiveRecord.builder().build());
 
-        ArchiveRecordServiceImpl archiveRecordService = new ArchiveRecordServiceImpl(
-            mediaArchiveRecordMapperMock,
-            transcriptionArchiveRecordMapperMock,
-            annotationArchiveRecordMapperMock,
-            caseArchiveRecordMapperMock,
-            externalObjectDirectoryRepository
-        );
-
         // when
         ArchiveRecord archiveRecord = archiveRecordService.generateArchiveRecordInfo(EODID, "1234_1_1");
 
@@ -231,14 +138,6 @@ class ArchiveRecordServiceImplTest {
         when(externalObjectDirectoryRepository.findById(any())).thenReturn(Optional.of(externalObjectDirectoryEntity));
         when(externalObjectDirectoryEntity.getAnnotationDocumentEntity()).thenReturn(annotationDocumentEntity);
         when(annotationArchiveRecordMapperMock.mapToAnnotationArchiveRecord(any(), any())).thenReturn(AnnotationArchiveRecord.builder().build());
-
-        ArchiveRecordServiceImpl archiveRecordService = new ArchiveRecordServiceImpl(
-            mediaArchiveRecordMapperMock,
-            transcriptionArchiveRecordMapperMock,
-            annotationArchiveRecordMapperMock,
-            caseArchiveRecordMapperMock,
-            externalObjectDirectoryRepository
-        );
 
         // when
         ArchiveRecord archiveRecord = archiveRecordService.generateArchiveRecordInfo(EODID, "1234_1_1");
@@ -258,14 +157,6 @@ class ArchiveRecordServiceImplTest {
         when(externalObjectDirectoryEntity.getCaseDocument()).thenReturn(caseDocumentEntity);
         when(caseArchiveRecordMapperMock.mapToCaseArchiveRecord(any(), any())).thenReturn(CaseArchiveRecord.builder().build());
 
-        ArchiveRecordServiceImpl archiveRecordService = new ArchiveRecordServiceImpl(
-            mediaArchiveRecordMapperMock,
-            transcriptionArchiveRecordMapperMock,
-            annotationArchiveRecordMapperMock,
-            caseArchiveRecordMapperMock,
-            externalObjectDirectoryRepository
-        );
-
         // when
         ArchiveRecord archiveRecord = archiveRecordService.generateArchiveRecordInfo(EODID, "1234_1_1");
 
@@ -283,14 +174,6 @@ class ArchiveRecordServiceImplTest {
         when(externalObjectDirectoryRepository.findById(any())).thenReturn(Optional.of(externalObjectDirectoryEntity));
         when(externalObjectDirectoryEntity.getTranscriptionDocumentEntity()).thenReturn(transcriptionDocumentEntity);
 
-        ArchiveRecordServiceImpl archiveRecordService = new ArchiveRecordServiceImpl(
-            mediaArchiveRecordMapperMock,
-            transcriptionArchiveRecordMapperMock,
-            annotationArchiveRecordMapperMock,
-            caseArchiveRecordMapperMock,
-            externalObjectDirectoryRepository
-        );
-
         // then
         assertThrows(DartsException.class, () -> archiveRecordService.generateArchiveRecordInfo(EODID, "1234_1_1"));
     }
@@ -300,14 +183,6 @@ class ArchiveRecordServiceImplTest {
         // given
         when(externalObjectDirectoryRepository.findById(any())).thenReturn(Optional.empty());
 
-        ArchiveRecordServiceImpl archiveRecordService = new ArchiveRecordServiceImpl(
-            mediaArchiveRecordMapperMock,
-            transcriptionArchiveRecordMapperMock,
-            annotationArchiveRecordMapperMock,
-            caseArchiveRecordMapperMock,
-            externalObjectDirectoryRepository
-        );
-
         // then
         assertThrows(DartsException.class, () -> archiveRecordService.generateArchiveRecordInfo(EODID, "1234_1_1"));
     }
@@ -316,14 +191,6 @@ class ArchiveRecordServiceImplTest {
     void generateArchiveRecordInfo_throwsError_whenUnknownArchiveRecordType() {
         // given
         when(externalObjectDirectoryRepository.findById(any())).thenReturn(Optional.of(externalObjectDirectoryEntity));
-
-        ArchiveRecordServiceImpl archiveRecordService = new ArchiveRecordServiceImpl(
-            mediaArchiveRecordMapperMock,
-            transcriptionArchiveRecordMapperMock,
-            annotationArchiveRecordMapperMock,
-            caseArchiveRecordMapperMock,
-            externalObjectDirectoryRepository
-        );
 
         // then
         assertThrows(DartsException.class, () -> archiveRecordService.generateArchiveRecordInfo(EODID, "1234_1_1"));

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImplTest.java
@@ -178,8 +178,7 @@ class DetsToArmBatchPushProcessorImplTest {
             log.info("Files left: {}", filesStream.count());
         }
     }
-
-
+    
     @Test
     void processDetsToArmSetObjectStatusNoMatchingDetsRecordErrorMessage() {
         //given

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImplTest.java
@@ -28,7 +28,6 @@ import uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum;
 import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectStateRecordRepository;
-import uk.gov.hmcts.darts.common.service.FileOperationService;
 import uk.gov.hmcts.darts.common.service.impl.EodHelperMocks;
 import uk.gov.hmcts.darts.common.util.EodHelper;
 import uk.gov.hmcts.darts.log.api.LogApi;
@@ -54,7 +53,6 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -81,8 +79,6 @@ class DetsToArmBatchPushProcessorImplTest {
 
     private ExternalObjectDirectoryEntity externalObjectDirectoryEntityDets;
 
-    @Mock
-    private FileOperationService fileOperationService;
     @Mock
     private ArchiveRecordService archiveRecordService;
     @Mock
@@ -123,7 +119,6 @@ class DetsToArmBatchPushProcessorImplTest {
             logApi,
             armDataManagementConfiguration,
             externalObjectDirectoryRepository,
-            fileOperationService,
             armDataManagementApi,
             detsToArmProcessorConfiguration,
             objectStateRecordRepository,
@@ -171,7 +166,6 @@ class DetsToArmBatchPushProcessorImplTest {
         }
         externalObjectDirectoryEntityArm.setManifestFile(manifestFile.getName());
 
-        lenient().when(fileOperationService.createFile(any(), any(), anyBoolean())).thenReturn(manifestFile.toPath());
         lenient().when(detsToArmProcessorConfiguration.getManifestFilePrefix()).thenReturn("DETS");
     }
 
@@ -256,7 +250,7 @@ class DetsToArmBatchPushProcessorImplTest {
     }
 
     @Test
-    void processDetsToArm_asyncException(CapturedOutput output) throws Exception {
+    void processDetsToArm_asyncException(CapturedOutput output) {
         EOD_HELPER_MOCKS.simulateInitWithMockedData();
         detsToArmBatchPushProcessor = spy(detsToArmBatchPushProcessor);
         doReturn(List.of(1)).when(detsToArmBatchPushProcessor).getDetsEodEntitiesToSendToArm(any(), any(), anyInt());
@@ -265,11 +259,11 @@ class DetsToArmBatchPushProcessorImplTest {
             asyncUtilMockedStatic.when(() -> AsyncUtil.invokeAllAwaitTermination(any(), any()))
                 .thenThrow(new RuntimeException("Test exception"));
             detsToArmBatchPushProcessor.processDetsToArm(5);
-            LogUtil.waitUntilMessage(output, "Dets to arm batch unexpected exception", 5);
+            LogUtil.waitUntilMessage(output, "DETS to ARM batch unexpected exception", 5);
 
             assertThat(output)
-                .contains("Dets to arm batch unexpected exception")
-                .contains("DetsToArmBatchPushProcessorImpljava.lang.RuntimeException: Test exception");
+                .contains("DETS to ARM batch unexpected exception")
+                .contains("DETSToArmBatchPushProcessorImpljava.lang.RuntimeException: Test exception");
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchPushProcessorImplTest.java
@@ -178,7 +178,7 @@ class DetsToArmBatchPushProcessorImplTest {
             log.info("Files left: {}", filesStream.count());
         }
     }
-    
+
     @Test
     void processDetsToArmSetObjectStatusNoMatchingDetsRecordErrorMessage() {
         //given
@@ -249,7 +249,7 @@ class DetsToArmBatchPushProcessorImplTest {
     }
 
     @Test
-    void processDetsToArm_asyncException(CapturedOutput output) {
+    void processDetsToArm_asyncException(CapturedOutput output) throws Exception {
         EOD_HELPER_MOCKS.simulateInitWithMockedData();
         detsToArmBatchPushProcessor = spy(detsToArmBatchPushProcessor);
         doReturn(List.of(1)).when(detsToArmBatchPushProcessor).getDetsEodEntitiesToSendToArm(any(), any(), anyInt());
@@ -262,7 +262,7 @@ class DetsToArmBatchPushProcessorImplTest {
 
             assertThat(output)
                 .contains("DETS to ARM batch unexpected exception")
-                .contains("DETSToArmBatchPushProcessorImpljava.lang.RuntimeException: Test exception");
+                .contains("DetsToArmBatchPushProcessorImpljava.lang.RuntimeException: Test exception");
         }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4705

### Change description ###

Added code to set the eod manifest file to null if the push fails

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
