### PR TITLE
DMP-4707: Flyway changes - Adding storage_id for 5 tables for Data Migration

### DIFF
--- a/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1OkJsonAndXml/expectedResponse.json
+++ b/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1OkJsonAndXml/expectedResponse.json
@@ -25,5 +25,6 @@
   "externalLocationTypeEntity": null,
   "subcontentObjectId": null,
   "subcontentPosition": null,
-  "dataTicket": null
+  "dataTicket": null,
+  "storageId": null
 }

--- a/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1OkJsonAndXml/expectedResponse2.json
+++ b/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1OkJsonAndXml/expectedResponse2.json
@@ -25,5 +25,6 @@
   "externalLocationTypeEntity": null,
   "subcontentObjectId": null,
   "subcontentPosition": null,
-  "dataTicket": null
+  "dataTicket": null,
+  "storageId": null
 }

--- a/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1_duplicate_ok/expectedResponse.json
+++ b/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1_duplicate_ok/expectedResponse.json
@@ -25,5 +25,6 @@
   "externalLocationTypeEntity": null,
   "subcontentObjectId": null,
   "subcontentPosition": null,
-  "dataTicket": null
+  "dataTicket": null,
+  "storageId": null
 }

--- a/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1_ok/expectedResponse.json
+++ b/src/integrationTest/resources/tests/dailylist/DailyListServiceTest/insert1_ok/expectedResponse.json
@@ -25,5 +25,6 @@
   "externalLocationTypeEntity": null,
   "subcontentObjectId": null,
   "subcontentPosition": null,
-  "dataTicket": null
+  "dataTicket": null,
+  "storageId": null
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationDocumentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationDocumentEntity.java
@@ -101,6 +101,9 @@ public class AnnotationDocumentEntity extends ModifiedBaseEntity
     @Column(name = "data_ticket")
     private Integer dataTicket;
 
+    @Column(name = "storage_id")
+    private String storageId;
+
     @OneToMany(mappedBy = ExternalObjectDirectoryEntity_.ANNOTATION_DOCUMENT_ENTITY)
     private List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities = new ArrayList<>();
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DailyListEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DailyListEntity.java
@@ -114,4 +114,7 @@ public class DailyListEntity extends CreatedModifiedBaseEntity {
     @Column(name = "data_ticket")
     private Integer dataTicket;
 
+    @Column(name = "storage_id")
+    private String storageId;
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
@@ -143,6 +143,9 @@ public class MediaEntity extends CreatedModifiedBaseEntity
     @Column(name = "data_ticket")
     private Integer dataTicket;
 
+    @Column(name = "storage_id")
+    private String storageId;
+
     public List<CourtCaseEntity> associatedCourtCases() {
         var cases = hearingList.stream().map(HearingEntity::getCourtCase);
         return io.vavr.collection.List.ofAll(cases).distinctBy(CourtCaseEntity::getId).toJavaList();

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectRetrievalQueueEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectRetrievalQueueEntity.java
@@ -58,4 +58,7 @@ public class ObjectRetrievalQueueEntity extends CreatedModifiedBaseEntity {
     @Column(name = "data_ticket")
     private Integer dataTicket;
 
+    @Column(name = "storage_id")
+    private String storageId;
+
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionDocumentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionDocumentEntity.java
@@ -108,4 +108,7 @@ public class TranscriptionDocumentEntity extends ModifiedBaseEntity
     @Column(name = "data_ticket")
     private Integer dataTicket;
 
+    @Column(name = "storage_id")
+    private String storageId;
+
 }

--- a/src/main/resources/db/migration/common/V1_443__adding_storage_id_to_some_tables.sql
+++ b/src/main/resources/db/migration/common/V1_443__adding_storage_id_to_some_tables.sql
@@ -1,0 +1,10 @@
+alter table media
+    add column storage_id varchar;
+alter table transcription_document
+    add column storage_id varchar;
+alter table daily_list
+    add column storage_id varchar;
+alter table annotation_document
+    add column storage_id varchar;
+alter table object_retrieval_queue
+    add column storage_id varchar;


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4707)


### Change description ###
Add *storage_id* attribute as char varying to the following 5 tables:
 #  media
 # transcription_document
 # daily_list
 # annotation_document
 # object_retrieval_queue

 

This is similar change as data_ticket attribute.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
