### PR TITLE
DMP-4696: Empty admin portal events search timeout

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.common.repository;
 import jakarta.persistence.Column;
 import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -82,7 +81,7 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
         String courtroomName,
         LocalDate hearingStartDate,
         LocalDate hearingEndDate,
-        Pageable pageable);
+        Limit limit);
 
     @Query(value = """
         SELECT distinct e2.event_id

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventSearchServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventSearchServiceImpl.java
@@ -3,8 +3,8 @@ package uk.gov.hmcts.darts.event.service.impl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
@@ -37,10 +37,10 @@ public class EventSearchServiceImpl implements EventSearchService {
             adminEventSearch.getCourtroomName(),
             adminEventSearch.getHearingStartAt(),
             adminEventSearch.getHearingEndAt(),
-            PageRequest.of(0, maxResults)
+            Limit.of(maxResults + 1)
         );
 
-        if (eventSearchResults.hasNext()) {
+        if (eventSearchResults.getSize() > maxResults) {
             throw new DartsApiException(
                 TOO_MANY_SEARCH_RESULTS,
                 "Number of results exceeded " + maxResults + " please narrow your search."
@@ -54,7 +54,7 @@ public class EventSearchServiceImpl implements EventSearchService {
 
     private static List<Integer> getNonEmptyOrNull(List<Integer> integerList) {
         if (integerList != null && integerList.isEmpty()) {
-           return null;
+            return null;
         }
         return integerList;
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4696)


### Change description ###
# Summary of Git Diff

This diff introduces changes to the `EventRepository.java` and `EventSearchServiceImpl.java` files, primarily focusing on the replacement of the `Pageable` parameter with a `Limit` parameter for event search functionalities. These modifications aim to streamline the pagination of search results.

## Highlights

- **Removal of `Pageable`**:
  - The `Pageable` parameter was removed from the `searchEventsFilteringOn` method in `EventRepository.java`.
  - Replaced with a `Limit` parameter to control the number of results returned.

- **Update in `EventSearchServiceImpl`**:
  - The `PageRequest` import was removed, and the `Limit` class was imported instead.
  - Updated the call to `searchEventsFilteringOn` to use `Limit.of(maxResults + 1)` instead of `PageRequest.of(0, maxResults)`.
  
- **Exception Handling**:
  - The condition to check for excessive results was updated from `eventSearchResults.hasNext()` to `eventSearchResults.getSize() > maxResults`.

- **Code Clean-up**:
  - Minor formatting changes, including adjustment of whitespace in the `getNonEmptyOrNull` method.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
