### PR TITLE
DMP-4653 Fixing courtroom name unique constraint violation

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/noderegistration/controller/NodeRegistrationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/noderegistration/controller/NodeRegistrationControllerTest.java
@@ -1,7 +1,9 @@
 package uk.gov.hmcts.darts.noderegistration.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -10,7 +12,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
@@ -34,7 +35,6 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.MID_TIER;
 
 @Slf4j
 @AutoConfigureMockMvc
-@Transactional
 class NodeRegistrationControllerTest extends IntegrationBase {
 
     @Autowired
@@ -43,6 +43,15 @@ class NodeRegistrationControllerTest extends IntegrationBase {
     @MockitoBean
     private UserIdentity mockUserIdentity;
 
+    @BeforeEach
+    void startHibernateSession() {
+        openInViewUtil.openEntityManager();
+    }
+
+    @AfterEach
+    void closeHibernateSession() {
+        openInViewUtil.closeEntityManager();
+    }
 
     @Test
     void testPostRegisterDevices() throws Exception {

--- a/src/main/java/uk/gov/hmcts/darts/common/service/RetrieveCoreObjectService.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/RetrieveCoreObjectService.java
@@ -43,7 +43,7 @@ public interface RetrieveCoreObjectService {
      * Retrieve or create a case and link to media.
      * @deprecated This method is only used by tests. Tests should be refactored and this method should be removed.
      */
-    @Deprecated
+    @Deprecated(since = "04/02/2025")
     HearingEntity retrieveOrCreateHearingWithMedia(String courthouseName, String courtroomName, String caseNumber, LocalDateTime hearingDate,
                                                    UserAccountEntity userAccount, MediaEntity mediaEntity);
 
@@ -52,7 +52,7 @@ public interface RetrieveCoreObjectService {
      * @deprecated This method is only used by tests.
      *     Tests should be refactored to use the other `retrieveOrCreateCourtroom` method, and this method should be removed.
      */
-    @Deprecated
+    @Deprecated(since = "04/02/2025")
     CourtroomEntity retrieveOrCreateCourtroom(CourthouseEntity courthouse, String courtroomName, UserAccountEntity userAccount);
 
     /**
@@ -87,7 +87,7 @@ public interface RetrieveCoreObjectService {
      * @deprecated This method is only used by tests.
      *     Tests should be refactored to use the other `retrieveOrCreateCase` method, and this method should be removed.
      */
-    @Deprecated
+    @Deprecated(since = "04/02/2025")
     CourtCaseEntity retrieveOrCreateCase(String courthouseName, String caseNumber, UserAccountEntity userAccount);
 
     /**

--- a/src/main/java/uk/gov/hmcts/darts/common/service/RetrieveCoreObjectService.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/RetrieveCoreObjectService.java
@@ -43,6 +43,7 @@ public interface RetrieveCoreObjectService {
      * Retrieve or create a case and link to media.
      * @deprecated This method is only used by tests. Tests should be refactored and this method should be removed.
      */
+    @SuppressWarnings("java:S1133") // suppress sonar warning about deprecated methods
     @Deprecated(since = "04/02/2025")
     HearingEntity retrieveOrCreateHearingWithMedia(String courthouseName, String courtroomName, String caseNumber, LocalDateTime hearingDate,
                                                    UserAccountEntity userAccount, MediaEntity mediaEntity);
@@ -52,6 +53,7 @@ public interface RetrieveCoreObjectService {
      * @deprecated This method is only used by tests.
      *     Tests should be refactored to use the other `retrieveOrCreateCourtroom` method, and this method should be removed.
      */
+    @SuppressWarnings("java:S1133") // suppress sonar warning about deprecated methods
     @Deprecated(since = "04/02/2025")
     CourtroomEntity retrieveOrCreateCourtroom(CourthouseEntity courthouse, String courtroomName, UserAccountEntity userAccount);
 
@@ -87,6 +89,7 @@ public interface RetrieveCoreObjectService {
      * @deprecated This method is only used by tests.
      *     Tests should be refactored to use the other `retrieveOrCreateCase` method, and this method should be removed.
      */
+    @SuppressWarnings("java:S1133") // suppress sonar warning about deprecated methods
     @Deprecated(since = "04/02/2025")
     CourtCaseEntity retrieveOrCreateCase(String courthouseName, String caseNumber, UserAccountEntity userAccount);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-4653

### Change description ###

Primarily fixing courtroom name unique constraint violations.

- plus hearing, case and judge constraint violations
- increasing the attempts made by the Retryable annotation, up to 10 attempts retying every 50ms, spending a total of 500ms before failing
- most of these are used by requests via the SOAP service and if a failure did happen it would be retried by the external system
- creating a new transaction so that the retried method has the latest data, before it was stuck with a stable view when retrying and never doing anything
- adding javadoc for all methods in `RetrieveCoreObjectService` to help explain how they are used
- deprecating some methods as they are only used in tests
- removing the Retryable annotation from some methods because it's not necessary

The impact of this change, specifically the new transactions, is that it's possible that courtrooms, cases, hearings and judges could be persisted in the database when the whole request fails. I don't see this as an issue, since it's likely the request would be retried and the likelihood of this happening and the request failing is tiny, therefore any data persisted would be minimal.

These items are central to many of the requests DARTS receives and need to persisted quickly to allow other transactions to be aware of them.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
