### PR TITLE
DMP-4701: Performance Testing - Add Audio - Test Harness - Post /audios/metadata -   could not execute statement [ERROR: duplicate key value violates unique constraint "hearing_media_ae_pk"

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
@@ -153,6 +153,7 @@ public class MediaEntity extends CreatedModifiedBaseEntity
 
     public void removeHearing(HearingEntity hearing) {
         hearing.getMediaList().remove(this);
+        getHearingList().remove(this);
     }
 
     @Override


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4701)


### Change description ###
# Summary of Git Diff

This Git diff shows a modification in the `MediaEntity.java` file, specifically the addition of a line in the `removeHearing` method to remove the current instance from the hearing list.

## Highlights
- **File Changed**: `src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java`
- **Modification**: 
  - Added the line `getHearingList().remove(this);` within the `removeHearing` method to ensure the current `MediaEntity` instance is also removed from the hearing list when a hearing is removed.
- **Purpose**: This change enhances the integrity of the relationships between `MediaEntity` and `HearingEntity` by ensuring that the `MediaEntity` is properly disassociated from its related hearings.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
