### PR TITLE
DMP-4712 Remove redundant audio config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ pmd {
 pmdMain {
   ruleSetFiles = files("config/pmd/main-ruleset.xml")
   //Ensures we don't passively increase pmd errors but we should aim to reduce this
-  maxFailures = 603
+  maxFailures = 574
 }
 
 pmdTestCommon {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioMetaDataNoSessionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioMetaDataNoSessionIntTest.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -46,10 +45,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = {
-    "spring.servlet.multipart.max-file-size=4MB",
-    "spring.servlet.multipart.max-request-size=4MB",
-})
 @SuppressWarnings({"PMD.DoNotUseThreads", "PMD.AvoidInstantiatingObjectsInLoops", "PMD.AvoidThrowingRawExceptionTypes"})
 class AudioControllerAddAudioMetaDataNoSessionIntTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioMetadataMediaLinkIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioMetadataMediaLinkIntTest.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -47,10 +46,6 @@ import static uk.gov.hmcts.darts.test.common.AwaitabilityUtil.waitForMax10Second
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = {
-    "spring.servlet.multipart.max-file-size=4MB",
-    "spring.servlet.multipart.max-request-size=4MB",
-})
 class AudioControllerAddAudioMetadataMediaLinkIntTest extends IntegrationBase {
 
     private static final URI ENDPOINT = URI.create("/audios");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioNoSessionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerAddAudioNoSessionIntTest.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.util.unit.DataSize;
@@ -44,10 +43,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = {
-    "spring.servlet.multipart.max-file-size=4MB",
-    "spring.servlet.multipart.max-request-size=4MB",
-})
 @SuppressWarnings({"PMD.DoNotUseThreads", "PMD.AvoidInstantiatingObjectsInLoops", "PMD.AvoidThrowingRawExceptionTypes"})
 class AudioControllerAddAudioNoSessionIntTest extends IntegrationBase {
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAttachTranscriptIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAttachTranscriptIntTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.util.unit.DataSize.ofMegabytes;
 import static uk.gov.hmcts.darts.audit.api.AuditActivity.COMPLETE_TRANSCRIPTION;
 import static uk.gov.hmcts.darts.audit.api.AuditActivity.IMPORT_TRANSCRIPTION;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
@@ -117,9 +116,6 @@ class TranscriptionControllerAttachTranscriptIntTest extends IntegrationBase {
         UserAccountEntity testUser = authorisationStub.getSeparateIntegrationUser();
         when(mockUserIdentity.getUserAccount()).thenReturn(testUser);
         testUserId = testUser.getId();
-
-        when(mockMultipartProperties.getMaxFileSize()).thenReturn(ofMegabytes(10));
-        when(mockMultipartProperties.getMaxRequestSize()).thenReturn(ofMegabytes(10));
 
         doNothing().when(mockAuditApi)
             .record(IMPORT_TRANSCRIPTION, testUser, transcriptionEntity.getCourtCase());

--- a/src/integrationTest/resources/application-intTest.yaml
+++ b/src/integrationTest/resources/application-intTest.yaml
@@ -41,10 +41,6 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration
-  servlet:
-    multipart:
-      max-file-size: 1KB
-      max-request-size: 10KB #this affects addAudio as well, so needs to handle a 350mb mp2 file
   datasource:
     hikari:
       maximum-pool-size: 10 # Overrides the value in `application.yaml` to a smaller value more appropriate for integration tests, sized below the `max_connections` limit specified in PostgresIntegrationBase.
@@ -61,16 +57,11 @@ darts:
   gateway:
     url: ${DARTS_GATEWAY_URL:http://localhost:${wiremock.server.port}}
   audio:
-    max-file-duration-minutes: 1440
     concat-workspace: ${java.io.tmpdir}/audiotransform/concatenate
     merge-workspace: ${java.io.tmpdir}/audiotransform/merge
     trim-workspace: ${java.io.tmpdir}/audiotransform/trim
     re-encode-workspace: ${java.io.tmpdir}/audiotransform/encode
     temp-blob-workspace: ${java.io.tmpdir}/audiotransform/tempworkspace
-    allowed-media-formats:
-      - "mpeg2"
-      - "mp2"
-      - "audio/mpeg"
   transformation:
     service:
       audio:

--- a/src/main/java/uk/gov/hmcts/darts/audio/config/AudioConfigurationProperties.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/config/AudioConfigurationProperties.java
@@ -8,7 +8,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 
 @ConfigurationProperties("darts.audio")
@@ -31,12 +30,6 @@ public class AudioConfigurationProperties {
     @NotEmpty
     private String tempBlobWorkspace;
 
-    private List<String> allowedMediaExtensions = new ArrayList<>();
-    private List<String> allowedMediaMimeTypes = new ArrayList<>();
-    private List<String> allowedMediaFormats = new ArrayList<>();
-    private List<String> allowedContentTypes = new ArrayList<>();
-
-    private Integer maxFileSize;
     private Duration allowableAudioGapDuration;
     private Integer preAmbleDuration;
     private Integer postAmbleDuration;

--- a/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/exception/AudioApiError.java
@@ -41,21 +41,6 @@ public enum AudioApiError implements DartsApiError {
         HttpStatus.BAD_REQUEST,
         AddAudioTitleErrors.AUDIO_NOT_PROVIDED.toString()
     ),
-    UNEXPECTED_FILE_TYPE(
-        AddAudioErrorCode.UNEXPECTED_FILE_TYPE.getValue(),
-        HttpStatus.BAD_REQUEST,
-        AddAudioTitleErrors.UNEXPECTED_FILE_TYPE.toString()
-    ),
-    FILE_DURATION_OUT_OF_BOUNDS(
-        AddAudioErrorCode.FILE_DURATION_OUT_OF_BOUNDS.getValue(),
-        HttpStatus.BAD_REQUEST,
-        AddAudioTitleErrors.FILE_DURATION_OUT_OF_BOUNDS.toString()
-    ),
-    FILE_SIZE_OUT_OF_BOUNDS(
-        AddAudioErrorCode.FILE_SIZE_OUT_OF_BOUNDS.getValue(),
-        HttpStatus.BAD_REQUEST,
-        AddAudioTitleErrors.FILE_SIZE_OUT_OF_BOUNDS.toString()
-    ),
     ADMIN_SEARCH_CRITERIA_NOT_PROVIDED(
         AddAudioErrorCode.ADMIN_SEARCH_CRITERIA_NOT_PROVIDED.getValue(),
         HttpStatus.BAD_REQUEST,

--- a/src/main/java/uk/gov/hmcts/darts/audio/validation/AddAudioFileValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/validation/AddAudioFileValidator.java
@@ -2,55 +2,21 @@ package uk.gov.hmcts.darts.audio.validation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.tika.Tika;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
 import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.common.component.validation.Validator;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
-
-import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class AddAudioFileValidator implements Validator<MultipartFile> {
 
-    private final AudioConfigurationProperties properties;
-
     @Override
-    @SuppressWarnings({"PMD.CyclomaticComplexity"})
     public void validate(MultipartFile addAudioFileRequest) {
         if (addAudioFileRequest.getSize() <= 0) {
             throw new DartsApiException(AudioApiError.AUDIO_NOT_PROVIDED);
-        }
-
-        String contentType = addAudioFileRequest.getContentType();
-        if (contentType != null && !properties.getAllowedContentTypes().contains(contentType)) {
-            log.warn("A file with contentType {} has been rejected.", contentType);
-            throw new DartsApiException(AudioApiError.UNEXPECTED_FILE_TYPE);
-        }
-
-        String extension = FilenameUtils.getExtension(addAudioFileRequest.getOriginalFilename());
-        if (!properties.getAllowedMediaExtensions().contains(extension)) {
-            log.warn("A file with extension {} has been rejected.", extension);
-            throw new DartsApiException(AudioApiError.UNEXPECTED_FILE_TYPE);
-        }
-
-        // check the file signature is suitable
-        try {
-            Tika tika = new Tika();
-            String mimeType
-                = tika.detect(addAudioFileRequest.getInputStream());
-
-            if (!properties.getAllowedMediaMimeTypes().contains(mimeType)) {
-                log.warn("A file with mimeType {} has been rejected.", mimeType);
-                throw new DartsApiException(AudioApiError.UNEXPECTED_FILE_TYPE);
-            }
-        } catch (IOException ioException) {
-            throw new DartsApiException(AudioApiError.UNEXPECTED_FILE_TYPE, ioException);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/validation/AddAudioMetaDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/validation/AddAudioMetaDataValidator.java
@@ -2,21 +2,14 @@ package uk.gov.hmcts.darts.audio.validation;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.util.unit.DataSize;
 import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
-import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.common.component.validation.Validator;
 import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.log.service.AudioLoggerService;
-import uk.gov.hmcts.darts.util.DurationUtil;
-
-import java.time.Duration;
-import java.time.OffsetDateTime;
 
 @Component
 @RequiredArgsConstructor
@@ -27,16 +20,10 @@ public class AddAudioMetaDataValidator implements Validator<AddAudioMetadataRequ
     private final AudioConfigurationProperties properties;
     private final AudioLoggerService audioLoggerService;
 
-    @Value("${darts.audio.max-file-duration}")
-    private Duration maxAllowableAudioDuration;
-
-    @Value("${spring.servlet.multipart.max-file-size}")
-    private DataSize fileSizeThreshold;
-
     @Override
     public void validate(AddAudioMetadataRequest addAudioMetadataRequest) {
 
-        // attempt to resolve the court house
+        // attempt to resolve the courthouse
         try {
             retrieveCoreObjectService.retrieveCourthouse(addAudioMetadataRequest.getCourthouse());
         } catch (DartsApiException e) {
@@ -44,28 +31,6 @@ public class AddAudioMetaDataValidator implements Validator<AddAudioMetadataRequ
                 audioLoggerService.missingCourthouse(addAudioMetadataRequest.getCourthouse(), addAudioMetadataRequest.getCourtroom());
             }
             throw e;
-        }
-        log.debug("Validated the court house {} exists", addAudioMetadataRequest.getCourthouse());
-
-        boolean isMediaFormatValid = properties.getAllowedMediaFormats().contains(addAudioMetadataRequest.getFormat());
-
-        if (!isMediaFormatValid) {
-            throw new DartsApiException(AudioApiError.UNEXPECTED_FILE_TYPE);
-        }
-
-        // if the metadata file size exceeds the upload threshold then error
-        if (addAudioMetadataRequest.getFileSize() > fileSizeThreshold.toBytes()) {
-            throw new DartsApiException(AudioApiError.FILE_SIZE_OUT_OF_BOUNDS);
-        }
-
-        // check the duration
-        OffsetDateTime startDate = addAudioMetadataRequest.getStartedAt();
-        OffsetDateTime finishDate = addAudioMetadataRequest.getEndedAt();
-
-        Duration difference = Duration.between(startDate, finishDate);
-
-        if (DurationUtil.greaterThan(difference, maxAllowableAudioDuration)) {
-            throw new DartsApiException(AudioApiError.FILE_DURATION_OUT_OF_BOUNDS);
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -67,11 +67,6 @@ spring:
             logout-uri: ${darts.azure.active-directory-justice-auth-uri}/${AAD_TENANT_ID_JUSTICE:00000000-0000-0000-0000-000000000000}/oauth2/v2.0/logout
             reset-password-uri: ${darts.azure.active-directory-justice-auth-uri}/${AAD_TENANT_ID_JUSTICE:00000000-0000-0000-0000-000000000000}/oauth2/v2.0/authorize
 
-  servlet:
-    multipart:
-      max-file-size: ${MAX_FILE_UPLOAD_SIZE_MEGABYTES:350}MB #this affects addAudio as well, so needs to handle a 350mb mp2 file
-      max-request-size: ${MAX_FILE_UPLOAD_REQUEST_SIZE_MEGABYTES:360}MB #this affects addAudio as well, so needs to handle a 350mb mp2 file
-
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://${DARTS_API_DB_HOST:localhost}:5432/${DARTS_API_DB_NAME:darts}${DARTS_API_DB_OPTIONS:}
@@ -123,34 +118,6 @@ darts:
   audio:
     small-file-size: ${SMALL_FILE_SIZE:1024}
     small-file-max-length: ${SMALL_FILE_SIZE_MAX_LENGTH:2S}
-    allowed-media-mime-types:
-      - "audio/mpeg"
-      - "application/octet-stream"
-    allowed-media-formats:
-      - "mpeg2"
-      - "mp2"
-    allowed-content-types:
-      - "audio/mpeg"
-      - "application/octet-stream"
-    allowed-media-extensions:
-      - "mp2"
-      - "a00"
-      - "a01"
-      - "a02"
-      - "a03"
-      - "a04"
-      - "a05"
-      - "a06"
-      - "a07"
-      - "b00"
-      - "b01"
-      - "b02"
-      - "b03"
-      - "b04"
-      - "b05"
-      - "b06"
-      - "b07"
-      - "b08"
     admin-search:
       max-results: 1000
     allowable-audio-gap-duration: 1s
@@ -158,8 +125,6 @@ darts:
     ffmpeg-executable: ffmpeg
     handheld-audio-courtroom-numbers:
       - 199
-    max-file-duration: 1440m
-    max-file-size: 524288000
     merge-workspace: ${user.home}/audiotransform/merge
     outbounddeleter:
       last-accessed-deletion-day: 2

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -1132,9 +1132,6 @@ components:
         - "AUDIO_103"
         - "AUDIO_104"
         - "AUDIO_105"
-        - "AUDIO_106"
-        - "AUDIO_107"
-        - "AUDIO_108"
         - "AUDIO_109"
         - "AUDIO_110"
         - "AUDIO_111"
@@ -1154,9 +1151,6 @@ components:
                          FAILED_TO_UPLOAD_AUDIO_FILE,
                          MISSING_SYSTEM_USER,
                          AUDIO_NOT_PROVIDED,
-                         UNEXPECTED_FILE_TYPE,
-                         FILE_DURATION_OUT_OF_BOUNDS,
-                         FILE_SIZE_OUT_OF_BOUNDS,
                          ADMIN_SEARCH_CRITERIA_NOT_PROVIDED,
                          MEDIA_ALREADY_HIDDEN,
                          MEDIA_HIDE_ACTION_PAYLOAD_INCORRECT_USAGE,
@@ -1181,9 +1175,6 @@ components:
         - "Failed to store uploaded audio file"
         - "Failed to mark audio(s) for deletion as system user was not found"
         - "Audio not found"
-        - "The file type is not acceptable"
-        - "The duration of the audio exceeds maximum threshold"
-        - "The audio metadata size exceeds maximum threshold"
         - "Required request parameter 'transformed_media_id' for method parameter type Integer is not present"
         - "Media is already hidden"
         - "Hide media action payload not correct"
@@ -1203,9 +1194,6 @@ components:
                          FAILED_TO_UPLOAD_AUDIO_FILE,
                          MISSING_SYSTEM_USER,
                          AUDIO_NOT_PROVIDED,
-                         UNEXPECTED_FILE_TYPE,
-                         FILE_DURATION_OUT_OF_BOUNDS,
-                         FILE_SIZE_OUT_OF_BOUNDS,
                          ADMIN_SEARCH_CRITERIA_NOT_PROVIDED,
                          MEDIA_ALREADY_HIDDEN,
                          MEDIA_HIDE_ACTION_PAYLOAD_INCORRECT_USAGE,

--- a/src/test/java/uk/gov/hmcts/darts/audio/validation/AddAudioMetaDataValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/validation/AddAudioMetaDataValidatorTest.java
@@ -5,9 +5,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.util.unit.DataSize;
-import org.springframework.util.unit.DataUnit;
 import uk.gov.hmcts.darts.audio.config.AudioConfigurationProperties;
 import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.common.exception.CommonApiError;
@@ -15,9 +12,7 @@ import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.log.service.AudioLoggerService;
 
-import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -56,9 +51,6 @@ class AddAudioMetaDataValidatorTest {
 
     @Test
     void validate_hasCourtHouse_shouldNotErrorOrLog() {
-        ReflectionTestUtils.setField(addAudioMetaDataValidator, "fileSizeThreshold", DataSize.of(10, DataUnit.GIGABYTES));
-        ReflectionTestUtils.setField(addAudioMetaDataValidator, "maxAllowableAudioDuration", Duration.ofDays(1));
-
         AddAudioMetadataRequest request = new AddAudioMetadataRequest();
         request.setCourthouse("INVALID");
         request.setCourtroom("COURTROOM_123");
@@ -66,7 +58,6 @@ class AddAudioMetaDataValidatorTest {
         request.setFileSize(123L);
         request.setStartedAt(OffsetDateTime.now());
         request.setEndedAt(OffsetDateTime.now().plusHours(1));
-        when(properties.getAllowedMediaFormats()).thenReturn(List.of("mp3"));
 
         addAudioMetaDataValidator.validate(request);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-4712


### Change description ###
Remove audio config from DARTS API that is no longer required. This is handled in DARTS Gateway instead. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
