### PR TITLE
Align RevisionInfo entity to schema, such that ddl validation passes

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audit/model/RevisionInfo.java
+++ b/src/main/java/uk/gov/hmcts/darts/audit/model/RevisionInfo.java
@@ -31,11 +31,10 @@ public class RevisionInfo implements Serializable {
 
     @Id
     @GeneratedValue(generator = GENERATOR_NAME, strategy = GenerationType.SEQUENCE)
-    @SequenceGenerator(name = GENERATOR_NAME, sequenceName = "revinfo_seq",
-        allocationSize = 1)
+    @SequenceGenerator(name = GENERATOR_NAME, sequenceName = "revinfo_seq")
     @RevisionNumber
     @Column(name = "rev")
-    private Long revision;
+    private Integer revision;
 
     @RevisionTimestamp
     @Column(name = "revtstmp")


### PR DESCRIPTION
Starting the application locally (with the `local` spring profile) performs a DDL validation check on startup. This ensures the modelled Entities are aligned with the underlying schema.

Some misalignment in the `RevisionInfo` entity causes validataion to fail. This PR addresses this.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
