### PR TITLE
DMP-4640: Make all RestControllers conditional on property

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/controller/HiddenReasonsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/controller/HiddenReasonsController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.common.controller;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.darts.authorisation.annotation.Authorisation;
@@ -17,6 +18,7 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
 
 @RestController
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "darts", name = "api-pod", havingValue = "true")
 public class HiddenReasonsController implements HiddenReasonApi {
 
     private final HiddenReasonsService hiddenReasonsService;

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityGroupController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityGroupController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.usermanagement.controller;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +23,7 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
 
 @RestController
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "darts", name = "api-pod", havingValue = "true")
 public class SecurityGroupController implements SecurityGroupApi {
 
     private final SecurityGroupService securityGroupService;

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityRoleController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/SecurityRoleController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.usermanagement.controller;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,6 +20,7 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
 
 @RestController
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "darts", name = "api-pod", havingValue = "true")
 public class SecurityRoleController implements SecurityRoleApi {
 
     private final SecurityRoleService securityRoleService;


### PR DESCRIPTION
### [DMP-4640](https://tools.hmcts.net/jira/browse/DMP-4640)

Some of our `@RestControllers` are not conditional on the `api-pod` property, meaning their associated endpoints will be active when the darts-api-function pods are running, which is undesirable.

This PR address this issue, see comments on the Jira ticket for analysis performed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
