### PR TITLE
DMP-4701: Performance Testing - Add Audio - Test Harness - Post /audios/metadata -   could not execute statement [ERROR: duplicate key value violates unique constraint "hearing_media_ae_pk"

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
@@ -178,7 +178,7 @@ public class AudioUploadServiceImpl implements AudioUploadService {
             log.info("Revised version of media added with filename {} and antecedent media id {}", newMediaEntity.getMediaFile(),
                      newMediaEntity.getId().toString());
         }
-        mediaRepository.save(newMediaEntity);
+        newMediaEntity = mediaRepository.saveAndFlush(newMediaEntity);
         log.info("Saved media id {}", newMediaEntity.getId());
 
         OffsetDateTime startDate = addAudioMetadataRequest.getStartedAt();
@@ -268,9 +268,9 @@ public class AudioUploadServiceImpl implements AudioUploadService {
     }
 
     void saveExternalObjectDirectory(UUID externalLocation,
-                                             String checksum,
-                                             UserAccountEntity userAccountEntity,
-                                             MediaEntity mediaEntity) {
+                                     String checksum,
+                                     UserAccountEntity userAccountEntity,
+                                     MediaEntity mediaEntity) {
         var externalObjectDirectoryEntity = new ExternalObjectDirectoryEntity();
         externalObjectDirectoryEntity.setMedia(mediaEntity);
         externalObjectDirectoryEntity.setStatus(EodHelper.storedStatus());

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -127,6 +127,6 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     }
 
     public boolean containsMedia(MediaEntity mediaEntity) {
-        return mediaList.stream().anyMatch(media -> media.getId().equals(mediaEntity.getId()));
+        return mediaEntity.getId() != null && mediaList.stream().anyMatch(media -> mediaEntity.getId().equals(media.getId()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -93,9 +93,11 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     private List<AnnotationEntity> annotations = new ArrayList<>();
 
     public void addMedia(MediaEntity mediaEntity) {
-        if (!mediaList.contains(mediaEntity)) {
+        if (!containsMedia(mediaEntity)) {
             mediaList.add(mediaEntity);
-            mediaEntity.getHearingList().add(this);
+            if (!mediaEntity.getHearingList().stream().noneMatch(hearing -> hearing.getId().equals(this.id))) {
+                mediaEntity.getHearingList().add(this);
+            }
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -95,7 +95,7 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     public void addMedia(MediaEntity mediaEntity) {
         if (!containsMedia(mediaEntity)) {
             mediaList.add(mediaEntity);
-            if (!mediaEntity.getHearingList().stream().noneMatch(hearing -> hearing.getId().equals(this.id))) {
+            if (mediaEntity.getHearingList().stream().noneMatch(hearing -> hearing.getId().equals(this.id))) {
                 mediaEntity.getHearingList().add(this);
             }
         }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -95,7 +95,7 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     public void addMedia(MediaEntity mediaEntity) {
         if (!containsMedia(mediaEntity)) {
             mediaList.add(mediaEntity);
-            if (mediaEntity.getHearingList().stream().noneMatch(hearing -> hearing.getId().equals(this.id))) {
+            if (this.id == null || mediaEntity.getHearingList().stream().noneMatch(hearing -> this.id.equals(hearing.getId()))) {
                 mediaEntity.getHearingList().add(this);
             }
         }

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
@@ -123,6 +123,8 @@ class AudioUploadServiceImplTest {
             audioAsyncService));
         ReflectionTestUtils.setField(audioService, "smallFileSizeMaxLength", Duration.ofSeconds(2));
         ReflectionTestUtils.setField(audioService, "smallFileSize", 1024);
+
+        lenient().doAnswer(invocation -> invocation.getArgument(0)).when(mediaRepository).saveAndFlush(any());
     }
 
     @Test
@@ -154,7 +156,7 @@ class AudioUploadServiceImplTest {
 
         MediaEntity mediaEntity = createMediaEntity(startedAt, endedAt);
         mediaEntity.setId(10);
-        when(mediaRepository.save(any(MediaEntity.class))).thenReturn(mediaEntity);
+        when(mediaRepository.saveAndFlush(any(MediaEntity.class))).thenReturn(mediaEntity);
 
         MockMultipartFile audioFile = new MockMultipartFile(
             "addAudio",
@@ -171,7 +173,7 @@ class AudioUploadServiceImplTest {
 
         // Then
         verify(dataManagementApi).saveBlobDataToInboundContainer(inboundBlobStorageArgumentCaptor.capture());
-        verify(mediaRepository, times(2)).save(mediaEntityArgumentCaptor.capture());
+        verify(mediaRepository, times(1)).save(mediaEntityArgumentCaptor.capture());
         verify(hearingRepository, times(3)).saveAndFlush(any());
         verify(logApi, times(1)).audioUploaded(addAudioMetadataRequest);
         verify(externalObjectDirectoryRepository).save(externalObjectDirectoryEntityArgumentCaptor.capture());
@@ -217,7 +219,7 @@ class AudioUploadServiceImplTest {
 
         MediaEntity mediaEntity = createMediaEntity(startedAt, endedAt);
         mediaEntity.setId(10);
-        when(mediaRepository.save(any(MediaEntity.class))).thenReturn(mediaEntity);
+        when(mediaRepository.saveAndFlush(any(MediaEntity.class))).thenReturn(mediaEntity);
 
         AddAudioMetadataRequest addAudioMetadataRequest = createAddAudioRequest(startedAt, endedAt);
         when(dataManagementApi.getChecksum(any(), any()))
@@ -228,7 +230,7 @@ class AudioUploadServiceImplTest {
         audioService.addAudio(externalLocation, addAudioMetadataRequest);
 
         // Then
-        verify(mediaRepository, times(2)).save(mediaEntityArgumentCaptor.capture());
+        verify(mediaRepository, times(1)).save(mediaEntityArgumentCaptor.capture());
         verify(hearingRepository, times(3)).saveAndFlush(any());
         verify(logApi, times(1)).audioUploaded(addAudioMetadataRequest);
         verify(externalObjectDirectoryRepository).save(externalObjectDirectoryEntityArgumentCaptor.capture());


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4701)


### Change description ###
# Summary of Git Diff

This Git diff shows modifications made to the `AudioUploadServiceImpl.java` and `HearingEntity.java` files in the HMCTS DARTS project. The changes primarily involve method updates to improve functionality and clarity regarding media handling and hearing associations.

## Highlights

### AudioUploadServiceImpl.java
- **Change in media saving method**: 
  - The method `mediaRepository.save(newMediaEntity);` has been replaced with `newMediaEntity = mediaRepository.saveAndFlush(newMediaEntity);` to ensure that changes are immediately flushed to the database.
  
### HearingEntity.java
- **Enhanced media addition logic**:
  - The method `addMedia(MediaEntity mediaEntity)` was updated to improve the check for existing media in the list. It now uses the `containsMedia(mediaEntity)` method for better clarity.
  - The check for adding the hearing to the `mediaEntity`'s hearing list has been refined with a more readable conditional structure.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
