### PR TITLE
DMP-4710: DMP225 - Courthouse Regions do not align to expectation

### DIFF
--- a/src/main/resources/db/migration/common/V1_448__update_courthouse_regions.sql
+++ b/src/main/resources/db/migration/common/V1_448__update_courthouse_regions.sql
@@ -1,0 +1,8 @@
+update courthouse_region_ae set reg_id = (select reg_id from region where region_name = 'London') where cth_id = (select cth_id from courthouse where courthouse_name = 'CROWN COURT SITTING AT BARCLAY ROAD');
+update courthouse_region_ae set reg_id = (select reg_id from region where region_name = 'London') where cth_id = (select cth_id from courthouse where courthouse_name = 'CROYDON');
+update courthouse_region_ae set reg_id = (select reg_id from region where region_name = 'London') where cth_id = (select cth_id from courthouse where courthouse_name = 'FIELD HOUSE');
+update courthouse_region_ae set reg_id = (select reg_id from region where region_name = 'South East') where cth_id = (select cth_id from courthouse where courthouse_name = 'GUILDFORD');
+update courthouse_region_ae set reg_id = (select reg_id from region where region_name = 'South East') where cth_id = (select cth_id from courthouse where courthouse_name = 'GUILDFORD CROWN COURT SITE B');
+update courthouse_region_ae set reg_id = (select reg_id from region where region_name = 'London') where cth_id = (select cth_id from courthouse where courthouse_name = 'HATTON CROSS');
+update courthouse_region_ae set reg_id = (select reg_id from region where region_name = 'North West') where cth_id = (select cth_id from courthouse where courthouse_name = 'KNUTSFORD');
+update courthouse_region_ae set reg_id = (select reg_id from region where region_name = 'London') where cth_id = (select cth_id from courthouse where courthouse_name = 'TAYLOR HOUSE');


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4710)


### Change description ###
_Replace this text with your description_
h4. Prerequisites:
 # _ Access to Admin Portal in Prod

h4. Steps to reproduce:
 # _ Search for Courthouses

h4. Expected results:
 # _ Correct Regions against each courthouse

h4. Actual results:
 # _
Croydon Crown Court sitting at Barclay Road  - Region is showing as Southeast, it should be London.
Croydon -  Region is showing as Southeast, it should be London
note: Croydon Jurys Inn - Region marked as London, despite 2 other Croydon sites being marked as Southeast.
 
FIELD HOUSE - Region is Midlands when it should be London.
 
GUILDFORD - Region is London when it should be Southeast
 
Guildford Crown Court Site B - Region is London when it should be Southeast 
 
HATTON CROSS - Region is Midlands when it should be London.
 
KNUTSFORD - Region is London but looks like it should be in the Northwest. Need to confirm the correct region for this as it was missing from HD spreadsheet. 
 
TAYLOR HOUSE - Region is Midlands when it should be London. 

h4. Impact:
 # _ Access/permission issues in live

h4. Workarounds:
 # _ N/A

UPDATES TO BE MADE
|courthouse_object_id|courthouse_name|display_name|region_name|*Updates to be made*|
|0b170758817c142a|CROWN COURT SITTING AT BARCLAY ROAD|Croydon Crown Court sitting at Barclay Road|South East|*London*|
|0b170758817c1429|CROYDON|Croydon|South East|*London*|
|0b17075881908263|FIELD HOUSE|Field House|Midlands|*London*|
|0b17075881425171|GUILDFORD|Guildford|London| *South East*|
|0b17075881425172|GUILDFORD CROWN COURT SITE B|Guildford Crown Court Site B|London| *South East*|
|0b1707589856654b|HATTON CROSS|Hatton Cross|Midlands|*London*|
|0b17075880f5ead4|KNUTSFORD|Knutsford|London|*North West*|
|0b170758981f894c|TAYLOR HOUSE|Taylor House|Midlands|*London*|

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
