### PR TITLE
DMP-4723: Disable global_access for rasso_users security group

### DIFF
--- a/src/main/resources/db/migration/common/V1_453__rasso_disable_global_access.sql
+++ b/src/main/resources/db/migration/common/V1_453__rasso_disable_global_access.sql
@@ -1,0 +1,1 @@
+UPDATE security_group SET global_access = 'false' WHERE group_name = 'rasso_users';


### PR DESCRIPTION
### [DMP-4723](https://tools.hmcts.net/jira/browse/DMP-4723)

This PR covers Part 1 of DMP-4723, which is limited to disabling global_access for the `rasso_users` security group.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
