### PR TITLE
Safety improvements to migrate-dets.sh

### DIFF
--- a/bin/migrate-dets.sh
+++ b/bin/migrate-dets.sh
@@ -22,14 +22,28 @@ if [ -z "$DATABASE_NAME" ]; then
   exit 1
 fi
 
+if [ "$(git symbolic-ref --short -q HEAD)" != "master" ]; then
+  echo "This script is only permitted to run on the master branch."
+  exit 1
+fi
+
+cd ..
+
+MIGRATION_SRC_DIR="src/main/resources/db/migration/"
+if [ -n "$(git status --porcelain ${MIGRATION_SRC_DIR})" ]; then
+  echo "Uncommitted changes exist in ${MIGRATION_SRC_DIR}, which is probably not intentional. Please check the state of your branch."
+  exit 1
+fi
+
+./gradlew clean assemble
+
 # Port 5433 is the local port that is mapped to the DB on the production bastion, per
 # https://tools.hmcts.net/confluence/display/DMP/Applying+Flyway+changes+to+Migration
 export FLYWAY_URL="jdbc:postgresql://localhost:5433/$DATABASE_NAME"
 
-cd ..
 ./gradlew flywayInfo
 
-read -p 'Execute flywayMigrate? (y/n): ' continue
+read -p "Execute flywayMigrate as user ${FLYWAY_USER}? (y/n): " continue
 if [ "$continue" != "y" ]
 then
   exit 1


### PR DESCRIPTION
Improving the safety of the dets migration script by adding guardrails to:
* Ensure master branch is locally checked out, as we shouldn't be performing migrations from any other branch
* Ensure master branch is in a clean working state with no pending changes, as we should only be applying migrations that have gone through the review process and have been merged to master

The script now also includes the mandatory `./gradlew clean assemble` step, whereas before the onus was on the user to run that as a prereq.

This prevents some issues that almost bit me when performing DETS migrations.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
