### PR TITLE
DMP-3409 Build admin get event versions endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
@@ -166,6 +166,32 @@ class EventRepositoryTest extends PostgresIntegrationBase {
         assertThat(duplicates).isEmpty();
     }
 
+    @Test
+    void findAllByEventIdExcludingEventIdZero_whenEventIdIsSetAboveZero_willReturnVersions() {
+        final EventEntity event1 = EventTestData.someMinimalEvent();
+        final EventEntity event2 = EventTestData.someMinimalEvent();
+        event1.setEventText("eventText");
+        event2.setEventText("eventText");
+        event1.setEventId(1);
+        event2.setEventId(1);
+        dartsDatabase.save(event1);
+        dartsDatabase.save(event2);
+
+        List<EventEntity> eventVersions = eventRepository.findAllByEventIdExcludingEventIdZero(event1.getEventId());
+        assertThat(eventVersions).hasSize(2);
+    }
+
+    @Test
+    void findAllByEventIdExcludingEventIdZero_whenEventIdIsSetToZero_willNotReturnVersions() {
+        final EventEntity event1 = EventTestData.someMinimalEvent();
+        event1.setEventText("eventText");
+        event1.setEventId(0);
+        dartsDatabase.save(event1);
+
+        List<EventEntity> eventVersions = eventRepository.findAllByEventIdExcludingEventIdZero(event1.getEventId());
+        assertThat(eventVersions).isEmpty();
+    }
+
     private void updateCreatedBy(EventEntity event, OffsetDateTime offsetDateTime) {
         event.setCreatedDateTime(offsetDateTime);
         dartsDatabase.save(event);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerAdminGetVersionsByEventIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerAdminGetVersionsByEventIdTest.java
@@ -23,6 +23,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
@@ -63,56 +64,56 @@ class EventsControllerAdminGetVersionsByEventIdTest extends IntegrationBase {
                                                                                  AdminGetVersionsByEventIdResponseResult.class);
 
         // Then
-        Assertions.assertEquals(currentEventEntity.getId(), responseResult.getCurrentVersion().getId());
-        Assertions.assertEquals(currentEventEntity.getLegacyObjectId(), responseResult.getCurrentVersion().getDocumentumId());
-        Assertions.assertEquals(currentEventEntity.getEventId(), responseResult.getCurrentVersion().getSourceId());
-        Assertions.assertEquals(currentEventEntity.getMessageId(), responseResult.getCurrentVersion().getMessageId());
-        Assertions.assertEquals(currentEventEntity.getEventText(), responseResult.getCurrentVersion().getText());
-        Assertions.assertEquals(currentEventEntity.getEventType().getId(), responseResult.getCurrentVersion().getEventMapping().getId());
-        Assertions.assertEquals(currentEventEntity.getEventType().getEventName(), responseResult.getCurrentVersion().getEventMapping().getName());
-        Assertions.assertEquals(currentEventEntity.isLogEntry(), responseResult.getCurrentVersion().getIsLogEntry());
-        Assertions.assertEquals(currentEventEntity.getCourtroom().getId(), responseResult.getCurrentVersion().getCourtroom().getId());
-        Assertions.assertEquals(currentEventEntity.getCourtroom().getName(), responseResult.getCurrentVersion().getCourtroom().getName());
-        Assertions.assertEquals(currentEventEntity.getCourtroom().getCourthouse().getId(), responseResult.getCurrentVersion().getCourthouse().getId());
-        Assertions.assertEquals(currentEventEntity.getCourtroom().getCourthouse().getDisplayName(),
+        assertEquals(currentEventEntity.getId(), responseResult.getCurrentVersion().getId());
+        assertEquals(currentEventEntity.getLegacyObjectId(), responseResult.getCurrentVersion().getDocumentumId());
+        assertEquals(currentEventEntity.getEventId(), responseResult.getCurrentVersion().getSourceId());
+        assertEquals(currentEventEntity.getMessageId(), responseResult.getCurrentVersion().getMessageId());
+        assertEquals(currentEventEntity.getEventText(), responseResult.getCurrentVersion().getText());
+        assertEquals(currentEventEntity.getEventType().getId(), responseResult.getCurrentVersion().getEventMapping().getId());
+        assertEquals(currentEventEntity.getEventType().getEventName(), responseResult.getCurrentVersion().getEventMapping().getName());
+        assertEquals(currentEventEntity.isLogEntry(), responseResult.getCurrentVersion().getIsLogEntry());
+        assertEquals(currentEventEntity.getCourtroom().getId(), responseResult.getCurrentVersion().getCourtroom().getId());
+        assertEquals(currentEventEntity.getCourtroom().getName(), responseResult.getCurrentVersion().getCourtroom().getName());
+        assertEquals(currentEventEntity.getCourtroom().getCourthouse().getId(), responseResult.getCurrentVersion().getCourthouse().getId());
+        assertEquals(currentEventEntity.getCourtroom().getCourthouse().getDisplayName(),
                                 responseResult.getCurrentVersion().getCourthouse().getDisplayName());
-        Assertions.assertEquals(currentEventEntity.getLegacyVersionLabel(), responseResult.getCurrentVersion().getVersion());
-        Assertions.assertEquals(currentEventEntity.getTimestamp(), responseResult.getCurrentVersion().getEventTs());
-        Assertions.assertEquals(currentEventEntity.getIsCurrent(), responseResult.getCurrentVersion().getIsCurrent());
-        Assertions.assertEquals(currentEventEntity.getCreatedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+        assertEquals(currentEventEntity.getLegacyVersionLabel(), responseResult.getCurrentVersion().getVersion());
+        assertEquals(currentEventEntity.getTimestamp(), responseResult.getCurrentVersion().getEventTs());
+        assertEquals(currentEventEntity.getIsCurrent(), responseResult.getCurrentVersion().getIsCurrent());
+        assertEquals(currentEventEntity.getCreatedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
                                 responseResult.getCurrentVersion().getCreatedAt());
-        Assertions.assertEquals(currentEventEntity.getCreatedBy().getId(), responseResult.getCurrentVersion().getCreatedBy());
-        Assertions.assertEquals(currentEventEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+        assertEquals(currentEventEntity.getCreatedBy().getId(), responseResult.getCurrentVersion().getCreatedBy());
+        assertEquals(currentEventEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
                                 responseResult.getCurrentVersion().getLastModifiedAt());
-        Assertions.assertEquals(currentEventEntity.getLastModifiedBy().getId(), responseResult.getCurrentVersion().getLastModifiedBy());
+        assertEquals(currentEventEntity.getLastModifiedBy().getId(), responseResult.getCurrentVersion().getLastModifiedBy());
 
         // Previous version
         EventEntity previousEventEntity = eventEntityVersions.get(1).get(1);
-        Assertions.assertEquals(1, responseResult.getPreviousVersions().size());
-        Assertions.assertEquals(previousEventEntity.getId(), responseResult.getPreviousVersions().getFirst().getId());
-        Assertions.assertEquals(previousEventEntity.getLegacyObjectId(), responseResult.getPreviousVersions().getFirst().getDocumentumId());
-        Assertions.assertEquals(previousEventEntity.getEventId(), responseResult.getPreviousVersions().getFirst().getSourceId());
-        Assertions.assertEquals(previousEventEntity.getMessageId(), responseResult.getPreviousVersions().getFirst().getMessageId());
-        Assertions.assertEquals(previousEventEntity.getEventText(), responseResult.getPreviousVersions().getFirst().getText());
-        Assertions.assertEquals(previousEventEntity.getEventType().getId(), responseResult.getPreviousVersions().getFirst().getEventMapping().getId());
-        Assertions.assertEquals(previousEventEntity.getEventType().getEventName(),
+        assertEquals(1, responseResult.getPreviousVersions().size());
+        assertEquals(previousEventEntity.getId(), responseResult.getPreviousVersions().getFirst().getId());
+        assertEquals(previousEventEntity.getLegacyObjectId(), responseResult.getPreviousVersions().getFirst().getDocumentumId());
+        assertEquals(previousEventEntity.getEventId(), responseResult.getPreviousVersions().getFirst().getSourceId());
+        assertEquals(previousEventEntity.getMessageId(), responseResult.getPreviousVersions().getFirst().getMessageId());
+        assertEquals(previousEventEntity.getEventText(), responseResult.getPreviousVersions().getFirst().getText());
+        assertEquals(previousEventEntity.getEventType().getId(), responseResult.getPreviousVersions().getFirst().getEventMapping().getId());
+        assertEquals(previousEventEntity.getEventType().getEventName(),
                                 responseResult.getPreviousVersions().getFirst().getEventMapping().getName());
-        Assertions.assertEquals(previousEventEntity.isLogEntry(), responseResult.getPreviousVersions().getFirst().getIsLogEntry());
-        Assertions.assertEquals(previousEventEntity.getCourtroom().getId(), responseResult.getPreviousVersions().getFirst().getCourtroom().getId());
-        Assertions.assertEquals(previousEventEntity.getCourtroom().getName(), responseResult.getPreviousVersions().getFirst().getCourtroom().getName());
-        Assertions.assertEquals(previousEventEntity.getCourtroom().getCourthouse().getId(),
+        assertEquals(previousEventEntity.isLogEntry(), responseResult.getPreviousVersions().getFirst().getIsLogEntry());
+        assertEquals(previousEventEntity.getCourtroom().getId(), responseResult.getPreviousVersions().getFirst().getCourtroom().getId());
+        assertEquals(previousEventEntity.getCourtroom().getName(), responseResult.getPreviousVersions().getFirst().getCourtroom().getName());
+        assertEquals(previousEventEntity.getCourtroom().getCourthouse().getId(),
                                 responseResult.getPreviousVersions().getFirst().getCourthouse().getId());
-        Assertions.assertEquals(previousEventEntity.getCourtroom().getCourthouse().getDisplayName(),
+        assertEquals(previousEventEntity.getCourtroom().getCourthouse().getDisplayName(),
                                 responseResult.getPreviousVersions().getFirst().getCourthouse().getDisplayName());
-        Assertions.assertEquals(previousEventEntity.getLegacyVersionLabel(), responseResult.getPreviousVersions().getFirst().getVersion());
-        Assertions.assertEquals(previousEventEntity.getTimestamp(), responseResult.getPreviousVersions().getFirst().getEventTs());
-        Assertions.assertEquals(previousEventEntity.getIsCurrent(), responseResult.getPreviousVersions().getFirst().getIsCurrent());
-        Assertions.assertEquals(previousEventEntity.getCreatedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+        assertEquals(previousEventEntity.getLegacyVersionLabel(), responseResult.getPreviousVersions().getFirst().getVersion());
+        assertEquals(previousEventEntity.getTimestamp(), responseResult.getPreviousVersions().getFirst().getEventTs());
+        assertEquals(previousEventEntity.getIsCurrent(), responseResult.getPreviousVersions().getFirst().getIsCurrent());
+        assertEquals(previousEventEntity.getCreatedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
                                 responseResult.getPreviousVersions().getFirst().getCreatedAt());
-        Assertions.assertEquals(previousEventEntity.getCreatedBy().getId(), responseResult.getPreviousVersions().getFirst().getCreatedBy());
-        Assertions.assertEquals(previousEventEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+        assertEquals(previousEventEntity.getCreatedBy().getId(), responseResult.getPreviousVersions().getFirst().getCreatedBy());
+        assertEquals(previousEventEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
                                 responseResult.getPreviousVersions().getFirst().getLastModifiedAt());
-        Assertions.assertEquals(previousEventEntity.getLastModifiedBy().getId(), responseResult.getPreviousVersions().getFirst().getLastModifiedBy());
+        assertEquals(previousEventEntity.getLastModifiedBy().getId(), responseResult.getPreviousVersions().getFirst().getLastModifiedBy());
 
         // When
         EventEntity eventIdZeroEventEntity = eventEntityVersions.get(0).getFirst();
@@ -126,7 +127,7 @@ class EventsControllerAdminGetVersionsByEventIdTest extends IntegrationBase {
 
         // Then
         Assertions.assertNull(responseResult2.getPreviousVersions());
-        Assertions.assertEquals(eventIdZeroEventEntity.getId(), responseResult2.getCurrentVersion().getId());
+        assertEquals(eventIdZeroEventEntity.getId(), responseResult2.getCurrentVersion().getId());
     }
 
     @Test
@@ -142,7 +143,7 @@ class EventsControllerAdminGetVersionsByEventIdTest extends IntegrationBase {
                                                         Problem.class);
 
         // Then
-        Assertions.assertEquals(CommonApiError.NOT_FOUND.getType(), responseResult.getType());
+        assertEquals(CommonApiError.NOT_FOUND.getType(), responseResult.getType());
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerAdminGetVersionsByEventIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerAdminGetVersionsByEventIdTest.java
@@ -23,6 +23,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -136,7 +137,7 @@ class EventsControllerAdminGetVersionsByEventIdTest extends IntegrationBase {
                                                                                          AdminGetVersionsByEventIdResponseResult.class);
 
         // Then
-        Assertions.assertNull(responseResult.getPreviousVersions());
+        assertThat(responseResult.getPreviousVersions()).hasSize(0);
 
         assertEquals(currentEventEntity.getId(), responseResult.getCurrentVersion().getId());
         assertEquals(currentEventEntity.getLegacyObjectId(), responseResult.getCurrentVersion().getDocumentumId());

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerAdminGetVersionsByEventIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerAdminGetVersionsByEventIdTest.java
@@ -1,0 +1,148 @@
+package uk.gov.hmcts.darts.event.controller;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.darts.common.entity.EventEntity;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
+import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
+import uk.gov.hmcts.darts.event.model.Problem;
+import uk.gov.hmcts.darts.event.service.EventDispatcher;
+import uk.gov.hmcts.darts.testutils.GivenBuilder;
+import uk.gov.hmcts.darts.testutils.IntegrationBase;
+import uk.gov.hmcts.darts.testutils.stubs.EventStub;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
+
+@AutoConfigureMockMvc
+class EventsControllerAdminGetVersionsByEventIdTest extends IntegrationBase {
+
+    @Autowired
+    private transient MockMvc mockMvc;
+
+    @MockitoBean
+    private EventDispatcher eventDispatcher;
+
+    @Autowired
+    private GivenBuilder given;
+
+    @Autowired
+    private EventStub eventStub;
+
+    private static final OffsetDateTime EVENT_TS = OffsetDateTime.of(2024, 10, 10, 10, 0, 0, 0, ZoneOffset.UTC);
+
+    @Test
+    void adminEventsApiGetVersionsByEventIdEndpointSuccess() throws Exception {
+
+        // Given
+        Map<Integer, List<EventEntity>> eventEntityVersions = eventStub.generateEventIdEventsIncludingZeroEventId(2, 2, false, EVENT_TS);
+        EventEntity currentEventEntity = eventEntityVersions.get(1).get(0);
+
+        given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = get("/admin/events/" + currentEventEntity.getId() + "/versions")
+            .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().is2xxSuccessful()).andReturn();
+
+        AdminGetVersionsByEventIdResponseResult responseResult = objectMapper.readValue(response.getResponse().getContentAsString(),
+                                                                                 AdminGetVersionsByEventIdResponseResult.class);
+
+        // Then
+        Assertions.assertEquals(currentEventEntity.getId(), responseResult.getCurrentVersion().getId());
+        Assertions.assertEquals(currentEventEntity.getLegacyObjectId(), responseResult.getCurrentVersion().getDocumentumId());
+        Assertions.assertEquals(currentEventEntity.getEventId(), responseResult.getCurrentVersion().getSourceId());
+        Assertions.assertEquals(currentEventEntity.getMessageId(), responseResult.getCurrentVersion().getMessageId());
+        Assertions.assertEquals(currentEventEntity.getEventText(), responseResult.getCurrentVersion().getText());
+        Assertions.assertEquals(currentEventEntity.getEventType().getId(), responseResult.getCurrentVersion().getEventMapping().getId());
+        Assertions.assertEquals(currentEventEntity.getEventType().getEventName(), responseResult.getCurrentVersion().getEventMapping().getName());
+        Assertions.assertEquals(currentEventEntity.isLogEntry(), responseResult.getCurrentVersion().getIsLogEntry());
+        Assertions.assertEquals(currentEventEntity.getCourtroom().getId(), responseResult.getCurrentVersion().getCourtroom().getId());
+        Assertions.assertEquals(currentEventEntity.getCourtroom().getName(), responseResult.getCurrentVersion().getCourtroom().getName());
+        Assertions.assertEquals(currentEventEntity.getCourtroom().getCourthouse().getId(), responseResult.getCurrentVersion().getCourthouse().getId());
+        Assertions.assertEquals(currentEventEntity.getCourtroom().getCourthouse().getDisplayName(),
+                                responseResult.getCurrentVersion().getCourthouse().getDisplayName());
+        Assertions.assertEquals(currentEventEntity.getLegacyVersionLabel(), responseResult.getCurrentVersion().getVersion());
+        Assertions.assertEquals(currentEventEntity.getTimestamp(), responseResult.getCurrentVersion().getEventTs());
+        Assertions.assertEquals(currentEventEntity.getIsCurrent(), responseResult.getCurrentVersion().getIsCurrent());
+        Assertions.assertEquals(currentEventEntity.getCreatedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+                                responseResult.getCurrentVersion().getCreatedAt());
+        Assertions.assertEquals(currentEventEntity.getCreatedBy().getId(), responseResult.getCurrentVersion().getCreatedBy());
+        Assertions.assertEquals(currentEventEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+                                responseResult.getCurrentVersion().getLastModifiedAt());
+        Assertions.assertEquals(currentEventEntity.getLastModifiedBy().getId(), responseResult.getCurrentVersion().getLastModifiedBy());
+
+        // Previous version
+        EventEntity previousEventEntity = eventEntityVersions.get(1).get(1);
+        Assertions.assertEquals(1, responseResult.getPreviousVersions().size());
+        Assertions.assertEquals(previousEventEntity.getId(), responseResult.getPreviousVersions().getFirst().getId());
+        Assertions.assertEquals(previousEventEntity.getLegacyObjectId(), responseResult.getPreviousVersions().getFirst().getDocumentumId());
+        Assertions.assertEquals(previousEventEntity.getEventId(), responseResult.getPreviousVersions().getFirst().getSourceId());
+        Assertions.assertEquals(previousEventEntity.getMessageId(), responseResult.getPreviousVersions().getFirst().getMessageId());
+        Assertions.assertEquals(previousEventEntity.getEventText(), responseResult.getPreviousVersions().getFirst().getText());
+        Assertions.assertEquals(previousEventEntity.getEventType().getId(), responseResult.getPreviousVersions().getFirst().getEventMapping().getId());
+        Assertions.assertEquals(previousEventEntity.getEventType().getEventName(),
+                                responseResult.getPreviousVersions().getFirst().getEventMapping().getName());
+        Assertions.assertEquals(previousEventEntity.isLogEntry(), responseResult.getPreviousVersions().getFirst().getIsLogEntry());
+        Assertions.assertEquals(previousEventEntity.getCourtroom().getId(), responseResult.getPreviousVersions().getFirst().getCourtroom().getId());
+        Assertions.assertEquals(previousEventEntity.getCourtroom().getName(), responseResult.getPreviousVersions().getFirst().getCourtroom().getName());
+        Assertions.assertEquals(previousEventEntity.getCourtroom().getCourthouse().getId(),
+                                responseResult.getPreviousVersions().getFirst().getCourthouse().getId());
+        Assertions.assertEquals(previousEventEntity.getCourtroom().getCourthouse().getDisplayName(),
+                                responseResult.getPreviousVersions().getFirst().getCourthouse().getDisplayName());
+        Assertions.assertEquals(previousEventEntity.getLegacyVersionLabel(), responseResult.getPreviousVersions().getFirst().getVersion());
+        Assertions.assertEquals(previousEventEntity.getTimestamp(), responseResult.getPreviousVersions().getFirst().getEventTs());
+        Assertions.assertEquals(previousEventEntity.getIsCurrent(), responseResult.getPreviousVersions().getFirst().getIsCurrent());
+        Assertions.assertEquals(previousEventEntity.getCreatedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+                                responseResult.getPreviousVersions().getFirst().getCreatedAt());
+        Assertions.assertEquals(previousEventEntity.getCreatedBy().getId(), responseResult.getPreviousVersions().getFirst().getCreatedBy());
+        Assertions.assertEquals(previousEventEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(),
+                                responseResult.getPreviousVersions().getFirst().getLastModifiedAt());
+        Assertions.assertEquals(previousEventEntity.getLastModifiedBy().getId(), responseResult.getPreviousVersions().getFirst().getLastModifiedBy());
+
+        // When
+        EventEntity eventIdZeroEventEntity = eventEntityVersions.get(0).getFirst();
+        MockHttpServletRequestBuilder requestBuilder2 = get("/admin/events/" + eventIdZeroEventEntity.getId() + "/versions")
+            .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+        MvcResult response2 = mockMvc.perform(requestBuilder2).andExpect(status().is2xxSuccessful()).andReturn();
+
+        AdminGetVersionsByEventIdResponseResult responseResult2 = objectMapper.readValue(response2.getResponse().getContentAsString(),
+                                                                                        AdminGetVersionsByEventIdResponseResult.class);
+
+        // Then
+        Assertions.assertNull(responseResult2.getPreviousVersions());
+        Assertions.assertEquals(eventIdZeroEventEntity.getId(), responseResult2.getCurrentVersion().getId());
+    }
+
+    @Test
+    void adminEventsApiGetVersionsByEventIdEndpointFailureNoEventFound() throws Exception {
+        given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
+
+        // When
+        MockHttpServletRequestBuilder requestBuilder = get("/admin/events/-1/versions")
+            .contentType(MediaType.APPLICATION_JSON_VALUE);
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isNotFound()).andReturn();
+
+        Problem responseResult = objectMapper.readValue(response.getResponse().getContentAsString(),
+                                                        Problem.class);
+
+        // Then
+        Assertions.assertEquals(CommonApiError.NOT_FOUND.getType(), responseResult.getType());
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerAdminGetVersionsByEventIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerAdminGetVersionsByEventIdTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.event.controller;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
@@ -28,7 +28,7 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.event.component.DartsEventMapper;
-import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.model.Problem;
 import uk.gov.hmcts.darts.event.service.EventDispatcher;
@@ -130,8 +130,8 @@ class EventsControllerTest extends IntegrationBase {
 
         MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().is2xxSuccessful()).andReturn();
 
-        AdminGetEventForIdResponseResult responseResult = objectMapper.readValue(response.getResponse().getContentAsString(),
-                                                                                 AdminGetEventForIdResponseResult.class);
+        AdminGetEventResponseDetails responseResult = objectMapper.readValue(response.getResponse().getContentAsString(),
+                                                                                 AdminGetEventResponseDetails.class);
 
         // Then
         Assertions.assertEquals(eventEntity.getId(), responseResult.getId());

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -148,6 +148,14 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
         """)
     List<EventEntity> findAllBetweenDateTimesInclusive(OffsetDateTime startDateTime, OffsetDateTime endDateTime);
 
+    @Query("""
+        SELECT ee
+        FROM EventEntity ee
+        WHERE ee.eventId = :eventId
+        AND ee.eventId <> 0
+        """)
+    List<EventEntity> findAllByEventIdExcludingEventIdZero(Integer eventId);
+
     @Query("select e.id from EventEntity e where e.eventStatus = :statusNumber")
     List<Integer> findAllByEventStatus(Integer statusNumber, Limit limit);
 

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -22,7 +22,8 @@ import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
 import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.http.api.EventApi;
 import uk.gov.hmcts.darts.event.model.AdminEventSearch;
-import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
 import uk.gov.hmcts.darts.event.model.AdminObfuscateEveByIdsRequest;
 import uk.gov.hmcts.darts.event.model.AdminSearchEventResponseResult;
 import uk.gov.hmcts.darts.event.model.CourtLog;
@@ -54,7 +55,7 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.XHIBIT;
 @RequiredArgsConstructor
 @RestController
 @ConditionalOnProperty(prefix = "darts", name = "api-pod", havingValue = "true")
-@SuppressWarnings({"checkstyle.LineLengthCheck"})
+@SuppressWarnings({"checkstyle.LineLengthCheck", "PMD.TooManyMethods"})
 public class EventsController implements EventApi {
 
     private final CourtLogsService courtLogsService;
@@ -180,8 +181,16 @@ public class EventsController implements EventApi {
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
-    public ResponseEntity<AdminGetEventForIdResponseResult> adminGetEventById(Integer eventId) {
+    public ResponseEntity<AdminGetEventResponseDetails> adminGetEventById(Integer eventId) {
         return new ResponseEntity<>(eventService.adminGetEventById(eventId), HttpStatus.OK);
+    }
+
+    @Override
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = ANY_ENTITY_ID,
+        globalAccessSecurityRoles = {SUPER_ADMIN})
+    public ResponseEntity<AdminGetVersionsByEventIdResponseResult> adminGetVersionsByEventId(Integer eventId) {
+        return new ResponseEntity<>(eventService.adminGetVersionsByEventId(eventId), HttpStatus.OK);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
@@ -71,9 +71,7 @@ public class EventMapper {
             previousVersions.add(mapToAdminGetEventsResponseForId(eventEntity));
         }
 
-        if (!previousVersions.isEmpty()) {
-            adminGetEventsForIdResponse.setPreviousVersions(previousVersions);
-        }
+        adminGetEventsForIdResponse.setPreviousVersions(previousVersions);
 
         return adminGetEventsForIdResponse;
     }

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
@@ -3,49 +3,86 @@ package uk.gov.hmcts.darts.event.mapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
-import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
 import uk.gov.hmcts.darts.event.model.CourthouseResponseDetails;
 import uk.gov.hmcts.darts.event.model.CourtroomResponseDetails;
-import uk.gov.hmcts.darts.event.model.EventMappingDetails;
+import uk.gov.hmcts.darts.event.model.EventMapping;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class EventMapper {
 
-    public AdminGetEventForIdResponseResult mapToAdminGetEventsResponseForId(EventEntity eventEntity) {
-        AdminGetEventForIdResponseResult adminGetEventsForIdResponse = new AdminGetEventForIdResponseResult();
+    public AdminGetEventResponseDetails mapToAdminGetEventsResponseForId(EventEntity eventEntity) {
+        AdminGetEventResponseDetails adminGetEventResponseDetail = new AdminGetEventResponseDetails();
 
-        adminGetEventsForIdResponse.setId(eventEntity.getId());
-        adminGetEventsForIdResponse.setDocumentumId(eventEntity.getLegacyObjectId());
-        adminGetEventsForIdResponse.setSourceId(eventEntity.getEventId());
-        adminGetEventsForIdResponse.setMessageId(eventEntity.getMessageId());
-        adminGetEventsForIdResponse.setText(eventEntity.getEventText());
-        adminGetEventsForIdResponse.setIsLogEntry(eventEntity.isLogEntry());
+        adminGetEventResponseDetail.setId(eventEntity.getId());
+        adminGetEventResponseDetail.setDocumentumId(eventEntity.getLegacyObjectId());
+        adminGetEventResponseDetail.setSourceId(eventEntity.getEventId());
+        adminGetEventResponseDetail.setMessageId(eventEntity.getMessageId());
+        adminGetEventResponseDetail.setText(eventEntity.getEventText());
+        adminGetEventResponseDetail.setIsLogEntry(eventEntity.isLogEntry());
 
-        EventMappingDetails eventMappingDetails = new EventMappingDetails();
+        EventMapping eventMappingDetails = new EventMapping();
         eventMappingDetails.setId(eventEntity.getEventType().getId());
-        adminGetEventsForIdResponse.setEventMapping(eventMappingDetails);
+        eventMappingDetails.setName(eventEntity.getEventType().getEventName());
+        adminGetEventResponseDetail.setEventMapping(eventMappingDetails);
 
         CourthouseResponseDetails courthouseResponseDetails = new CourthouseResponseDetails();
         courthouseResponseDetails.setId(eventEntity.getCourtroom().getCourthouse().getId());
         courthouseResponseDetails.setDisplayName(eventEntity.getCourtroom().getCourthouse().getDisplayName());
-        adminGetEventsForIdResponse.setCourthouse(courthouseResponseDetails);
+        adminGetEventResponseDetail.setCourthouse(courthouseResponseDetails);
 
         CourtroomResponseDetails courtroomResponseDetails = new CourtroomResponseDetails();
         courtroomResponseDetails.setId(eventEntity.getCourtroom().getId());
         courtroomResponseDetails.setName(eventEntity.getCourtroom().getName());
-        adminGetEventsForIdResponse.setCourtroom(courtroomResponseDetails);
+        adminGetEventResponseDetail.setCourtroom(courtroomResponseDetails);
 
-        adminGetEventsForIdResponse.setVersion(eventEntity.getLegacyVersionLabel());
-        adminGetEventsForIdResponse.setChronicleId(eventEntity.getChronicleId());
-        adminGetEventsForIdResponse.setAntecedentId(eventEntity.getAntecedentId());
-        adminGetEventsForIdResponse.setEventTs(eventEntity.getTimestamp());
-        adminGetEventsForIdResponse.isCurrent(eventEntity.getIsCurrent());
-        adminGetEventsForIdResponse.setCreatedAt(eventEntity.getCreatedDateTime());
-        adminGetEventsForIdResponse.setCreatedBy(eventEntity.getCreatedBy().getId());
-        adminGetEventsForIdResponse.setLastModifiedAt(eventEntity.getLastModifiedDateTime());
-        adminGetEventsForIdResponse.setLastModifiedBy(eventEntity.getLastModifiedBy().getId());
-        adminGetEventsForIdResponse.setIsDataAnonymised(eventEntity.isDataAnonymised());
+        adminGetEventResponseDetail.setVersion(eventEntity.getLegacyVersionLabel());
+        adminGetEventResponseDetail.setChronicleId(eventEntity.getChronicleId());
+        adminGetEventResponseDetail.setAntecedentId(eventEntity.getAntecedentId());
+        adminGetEventResponseDetail.setEventTs(eventEntity.getTimestamp());
+        adminGetEventResponseDetail.isCurrent(eventEntity.getIsCurrent());
+        adminGetEventResponseDetail.setCreatedAt(eventEntity.getCreatedDateTime());
+        adminGetEventResponseDetail.setCreatedBy(eventEntity.getCreatedBy().getId());
+        adminGetEventResponseDetail.setLastModifiedAt(eventEntity.getLastModifiedDateTime());
+        adminGetEventResponseDetail.setLastModifiedBy(eventEntity.getLastModifiedBy().getId());
+        adminGetEventResponseDetail.setIsDataAnonymised(eventEntity.isDataAnonymised());
+        return adminGetEventResponseDetail;
+    }
+
+    public AdminGetVersionsByEventIdResponseResult mapToAdminGetEventVersionsResponseForId(List<EventEntity> eventEntities) {
+        AdminGetVersionsByEventIdResponseResult adminGetEventsForIdResponse = new AdminGetVersionsByEventIdResponseResult();
+
+        List<AdminGetEventResponseDetails> previousVersions = new ArrayList<>();
+
+        Optional<EventEntity> currentEventEntity = findLatestIsCurrentEvent(eventEntities);
+
+        for (EventEntity eventEntity : eventEntities.stream().sorted(Comparator.comparing(EventEntity::getCreatedDateTime).reversed()).toList()) {
+            if (currentEventEntity.isPresent() && eventEntity.equals(currentEventEntity.get())) {
+                adminGetEventsForIdResponse.setCurrentVersion(mapToAdminGetEventsResponseForId(eventEntity));
+                continue;
+            }
+            previousVersions.add(mapToAdminGetEventsResponseForId(eventEntity));
+        }
+
+        if (!previousVersions.isEmpty()) {
+            adminGetEventsForIdResponse.setPreviousVersions(previousVersions);
+        }
+
         return adminGetEventsForIdResponse;
+    }
+
+    private Optional<EventEntity> findLatestIsCurrentEvent(List<EventEntity> eventEntities) {
+
+        // There could be multiple events with isCurrent = true, so only return the latest one
+        return eventEntities.stream()
+            .filter(EventEntity::getIsCurrent)
+            .max(Comparator.comparing(EventEntity::getCreatedDateTime));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
@@ -2,14 +2,20 @@ package uk.gov.hmcts.darts.event.service;
 
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
-import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
 
+import java.util.List;
 import java.util.Set;
 
 public interface EventService {
-    AdminGetEventForIdResponseResult adminGetEventById(Integer eventId);
+    AdminGetEventResponseDetails adminGetEventById(Integer eventId);
+
+    AdminGetVersionsByEventIdResponseResult adminGetVersionsByEventId(Integer eventId);
 
     EventEntity getEventByEveId(Integer eveId);
+
+    List<EventEntity> getEventVersionsForEveIdExcludingEventIdZero(Integer eveId);
 
     EventEntity saveEvent(EventEntity eventEntity);
 

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -528,7 +528,35 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AdminGetEventForIdResponseResult'
+                $ref: '#/components/schemas/AdminGetEventResponseDetails'
+        '404':
+          description: Not Found - Event id
+          content:
+            application/json+problem:
+              schema:
+                $ref: './problem.yaml'
+  /admin/events/{event_id}/versions:
+    get:
+      tags:
+        - Event
+      summary: Gets versions of an event
+      description: |-
+        Retrieves a version of an event for a given event_id
+      operationId: adminGetVersionsByEventId
+      parameters:
+        - in: path
+          name: event_id
+          schema:
+            type: integer
+          description: "event_id is the internal event_id of the event."
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminGetVersionsByEventIdResponseResult'
         '404':
           description: Not Found - Event id
           content:
@@ -798,13 +826,7 @@ components:
         name:
           type: string
 
-    EventMappingDetails:
-      type: object
-      properties:
-        id:
-          type: integer
-
-    AdminGetEventForIdResponseResult:
+    AdminGetEventResponseDetails:
       type: object
       properties:
         id:
@@ -818,7 +840,7 @@ components:
         text:
           type: string
         event_mapping:
-          $ref: '#/components/schemas/EventMappingDetails'
+          $ref: '#/components/schemas/EventMapping'
         is_log_entry:
           type: boolean
         courthouse:
@@ -848,6 +870,16 @@ components:
           format: date-time
         last_modified_by:
           type: integer
+
+    AdminGetVersionsByEventIdResponseResult:
+      type: object
+      properties:
+        current_version:
+          $ref: '#/components/schemas/AdminGetEventResponseDetails'
+        previous_versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminGetEventResponseDetails'
 
     GetCourtLogsErrorCode:
       type: string

--- a/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.event.mapper;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,9 +9,14 @@ import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.event.model.AdminGetEventForIdResponseResult;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
 
 import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @ExtendWith(MockitoExtension.class)
 class EventMapperTest {
@@ -27,8 +31,206 @@ class EventMapperTest {
     @Test
     void mapsEventToAdminSearchEventResponseResult() {
         // When
+        EventEntity eventEntity = setGenericEventDataForTest();
+        eventEntity.setId(2);
+        eventEntity.setCreatedDateTime(OffsetDateTime.now());
+        eventEntity.setIsCurrent(true);
+
+        // Given
+        AdminGetEventResponseDetails responseResult = eventMapper.mapToAdminGetEventsResponseForId(eventEntity);
+
+        // Then
+        assertEquals(eventEntity.getId(), responseResult.getId());
+        assertEquals(eventEntity.getLegacyObjectId(), responseResult.getDocumentumId());
+        assertEquals(eventEntity.getEventId(), responseResult.getSourceId());
+        assertEquals(eventEntity.getMessageId(), responseResult.getMessageId());
+        assertEquals(eventEntity.getEventText(), responseResult.getText());
+        assertEquals(eventEntity.getEventType().getId(), responseResult.getEventMapping().getId());
+        assertEquals(eventEntity.isLogEntry(), responseResult.getIsLogEntry());
+        assertEquals(eventEntity.getCourtroom().getId(), responseResult.getCourtroom().getId());
+        assertEquals(eventEntity.getCourtroom().getName(), responseResult.getCourtroom().getName());
+        assertEquals(eventEntity.getCourtroom().getCourthouse().getId(), responseResult.getCourthouse().getId());
+        assertEquals(eventEntity.getCourtroom().getCourthouse().getDisplayName(), responseResult.getCourthouse().getDisplayName());
+        assertEquals(eventEntity.getLegacyVersionLabel(), responseResult.getVersion());
+        assertEquals(eventEntity.getChronicleId(), responseResult.getChronicleId());
+        assertEquals(eventEntity.getAntecedentId(), responseResult.getAntecedentId());
+        assertEquals(eventEntity.getTimestamp(), responseResult.getEventTs());
+        assertEquals(eventEntity.getIsCurrent(), responseResult.getIsCurrent());
+        assertEquals(eventEntity.getCreatedDateTime(), responseResult.getCreatedAt());
+        assertEquals(eventEntity.getCreatedBy().getId(), responseResult.getCreatedBy());
+        assertEquals(eventEntity.getLastModifiedDateTime(), responseResult.getLastModifiedAt());
+        assertEquals(eventEntity.getLastModifiedBy().getId(), responseResult.getLastModifiedBy());
+        assertEquals(eventEntity.isDataAnonymised(), responseResult.getIsDataAnonymised());
+    }
+
+    @Test
+    void whenSingleVersionForAnEvent_mapsEventVersionToAdminGetEventVersionsResponseResult() {
+        // When
+        OffsetDateTime now = OffsetDateTime.now();
+        EventEntity eventEntity1 = setGenericEventDataForTest();
+        eventEntity1.setId(1);
+        eventEntity1.setCreatedDateTime(now.minusDays(1));
+        eventEntity1.setIsCurrent(true);
+
+        List<EventEntity> eventEntities = List.of(eventEntity1);
+
+        // Given
+        AdminGetVersionsByEventIdResponseResult responseResult = eventMapper.mapToAdminGetEventVersionsResponseForId(eventEntities);
+
+        AdminGetEventResponseDetails currentVersion = responseResult.getCurrentVersion();
+        // Then
+        assertEquals(eventEntity1.getId(), currentVersion.getId());
+        assertEquals(eventEntity1.getLegacyObjectId(), currentVersion.getDocumentumId());
+        assertEquals(eventEntity1.getEventId(), currentVersion.getSourceId());
+        assertEquals(eventEntity1.getMessageId(), currentVersion.getMessageId());
+        assertEquals(eventEntity1.getEventText(), currentVersion.getText());
+        assertEquals(eventEntity1.getEventType().getId(), currentVersion.getEventMapping().getId());
+        assertEquals(eventEntity1.isLogEntry(), currentVersion.getIsLogEntry());
+        assertEquals(eventEntity1.getCourtroom().getId(), currentVersion.getCourtroom().getId());
+        assertEquals(eventEntity1.getCourtroom().getName(), currentVersion.getCourtroom().getName());
+        assertEquals(eventEntity1.getCourtroom().getCourthouse().getId(), currentVersion.getCourthouse().getId());
+        assertEquals(eventEntity1.getCourtroom().getCourthouse().getDisplayName(), currentVersion.getCourthouse().getDisplayName());
+        assertEquals(eventEntity1.getLegacyVersionLabel(), currentVersion.getVersion());
+        assertEquals(eventEntity1.getChronicleId(), currentVersion.getChronicleId());
+        assertEquals(eventEntity1.getAntecedentId(), currentVersion.getAntecedentId());
+        assertEquals(eventEntity1.getTimestamp(), currentVersion.getEventTs());
+        assertEquals(eventEntity1.getIsCurrent(), currentVersion.getIsCurrent());
+        assertEquals(eventEntity1.getCreatedDateTime(), currentVersion.getCreatedAt());
+        assertEquals(eventEntity1.getCreatedBy().getId(), currentVersion.getCreatedBy());
+        assertEquals(eventEntity1.getLastModifiedDateTime(), currentVersion.getLastModifiedAt());
+        assertEquals(eventEntity1.getLastModifiedBy().getId(), currentVersion.getLastModifiedBy());
+        assertEquals(eventEntity1.isDataAnonymised(), currentVersion.getIsDataAnonymised());
+
+        assertNull(responseResult.getPreviousVersions());
+    }
+
+    @Test
+    @SuppressWarnings({"PMD.NcssCount"})
+    void whenMultipleVersionsForAnEvent_mapsEventVersionToAdminGetEventVersionsResponseResult() {
+        // When
+        OffsetDateTime now = OffsetDateTime.now();
+        EventEntity eventEntity1 = setGenericEventDataForTest();
+        eventEntity1.setId(1);
+        eventEntity1.setCreatedDateTime(now.minusDays(1));
+        eventEntity1.setIsCurrent(true);
+
+        EventEntity eventEntity2 = setGenericEventDataForTest();
+        eventEntity2.setId(2);
+        eventEntity2.setCreatedDateTime(now);
+        eventEntity2.setIsCurrent(true);
+
+        EventEntity eventEntity3 = setGenericEventDataForTest();
+        eventEntity3.setId(3);
+        eventEntity3.setCreatedDateTime(now.minusDays(2));
+        eventEntity3.setIsCurrent(true);
+
+        EventEntity eventEntity4 = setGenericEventDataForTest();
+        eventEntity4.setId(4);
+        eventEntity4.setCreatedDateTime(now);
+        eventEntity4.setIsCurrent(false);
+
+        List<EventEntity> eventEntities = List.of(eventEntity1, eventEntity2, eventEntity3, eventEntity4);
+
+        // Given
+        AdminGetVersionsByEventIdResponseResult responseResult = eventMapper.mapToAdminGetEventVersionsResponseForId(eventEntities);
+
+        AdminGetEventResponseDetails currentVersion = responseResult.getCurrentVersion();
+        // Then
+        assertEquals(eventEntity2.getId(), currentVersion.getId());
+        assertEquals(eventEntity2.getLegacyObjectId(), currentVersion.getDocumentumId());
+        assertEquals(eventEntity2.getEventId(), currentVersion.getSourceId());
+        assertEquals(eventEntity2.getMessageId(), currentVersion.getMessageId());
+        assertEquals(eventEntity2.getEventText(), currentVersion.getText());
+        assertEquals(eventEntity2.getEventType().getId(), currentVersion.getEventMapping().getId());
+        assertEquals(eventEntity2.isLogEntry(), currentVersion.getIsLogEntry());
+        assertEquals(eventEntity2.getCourtroom().getId(), currentVersion.getCourtroom().getId());
+        assertEquals(eventEntity2.getCourtroom().getName(), currentVersion.getCourtroom().getName());
+        assertEquals(eventEntity2.getCourtroom().getCourthouse().getId(), currentVersion.getCourthouse().getId());
+        assertEquals(eventEntity2.getCourtroom().getCourthouse().getDisplayName(), currentVersion.getCourthouse().getDisplayName());
+        assertEquals(eventEntity2.getLegacyVersionLabel(), currentVersion.getVersion());
+        assertEquals(eventEntity2.getChronicleId(), currentVersion.getChronicleId());
+        assertEquals(eventEntity2.getAntecedentId(), currentVersion.getAntecedentId());
+        assertEquals(eventEntity2.getTimestamp(), currentVersion.getEventTs());
+        assertEquals(eventEntity2.getIsCurrent(), currentVersion.getIsCurrent());
+        assertEquals(eventEntity2.getCreatedDateTime(), currentVersion.getCreatedAt());
+        assertEquals(eventEntity2.getCreatedBy().getId(), currentVersion.getCreatedBy());
+        assertEquals(eventEntity2.getLastModifiedDateTime(), currentVersion.getLastModifiedAt());
+        assertEquals(eventEntity2.getLastModifiedBy().getId(), currentVersion.getLastModifiedBy());
+        assertEquals(eventEntity2.isDataAnonymised(), currentVersion.getIsDataAnonymised());
+
+        List<AdminGetEventResponseDetails> previousVersions = responseResult.getPreviousVersions();
+        assertEquals(3, previousVersions.size());
+
+        assertEquals(eventEntity4.getId(), previousVersions.getFirst().getId());
+        assertEquals(eventEntity4.getLegacyObjectId(), previousVersions.getFirst().getDocumentumId());
+        assertEquals(eventEntity4.getEventId(), previousVersions.getFirst().getSourceId());
+        assertEquals(eventEntity4.getMessageId(), previousVersions.getFirst().getMessageId());
+        assertEquals(eventEntity4.getEventText(), previousVersions.getFirst().getText());
+        assertEquals(eventEntity4.getEventType().getId(), previousVersions.getFirst().getEventMapping().getId());
+        assertEquals(eventEntity4.isLogEntry(), previousVersions.getFirst().getIsLogEntry());
+        assertEquals(eventEntity4.getCourtroom().getId(), previousVersions.getFirst().getCourtroom().getId());
+        assertEquals(eventEntity4.getCourtroom().getName(), previousVersions.getFirst().getCourtroom().getName());
+        assertEquals(eventEntity4.getCourtroom().getCourthouse().getId(), previousVersions.getFirst().getCourthouse().getId());
+        assertEquals(eventEntity4.getCourtroom().getCourthouse().getDisplayName(), previousVersions.getFirst().getCourthouse().getDisplayName());
+        assertEquals(eventEntity4.getLegacyVersionLabel(), previousVersions.getFirst().getVersion());
+        assertEquals(eventEntity4.getChronicleId(), previousVersions.getFirst().getChronicleId());
+        assertEquals(eventEntity4.getAntecedentId(), previousVersions.getFirst().getAntecedentId());
+        assertEquals(eventEntity4.getTimestamp(), previousVersions.getFirst().getEventTs());
+        assertEquals(eventEntity4.getIsCurrent(), previousVersions.getFirst().getIsCurrent());
+        assertEquals(eventEntity4.getCreatedDateTime(), previousVersions.getFirst().getCreatedAt());
+        assertEquals(eventEntity4.getCreatedBy().getId(), previousVersions.getFirst().getCreatedBy());
+        assertEquals(eventEntity4.getLastModifiedDateTime(), previousVersions.getFirst().getLastModifiedAt());
+        assertEquals(eventEntity4.getLastModifiedBy().getId(), previousVersions.getFirst().getLastModifiedBy());
+        assertEquals(eventEntity4.isDataAnonymised(), previousVersions.getFirst().getIsDataAnonymised());
+
+        assertEquals(eventEntity1.getId(), previousVersions.get(1).getId());
+        assertEquals(eventEntity1.getLegacyObjectId(), previousVersions.get(1).getDocumentumId());
+        assertEquals(eventEntity1.getEventId(), previousVersions.get(1).getSourceId());
+        assertEquals(eventEntity1.getMessageId(), previousVersions.get(1).getMessageId());
+        assertEquals(eventEntity1.getEventText(), previousVersions.get(1).getText());
+        assertEquals(eventEntity1.getEventType().getId(), previousVersions.get(1).getEventMapping().getId());
+        assertEquals(eventEntity1.isLogEntry(), previousVersions.get(1).getIsLogEntry());
+        assertEquals(eventEntity1.getCourtroom().getId(), previousVersions.get(1).getCourtroom().getId());
+        assertEquals(eventEntity1.getCourtroom().getName(), previousVersions.get(1).getCourtroom().getName());
+        assertEquals(eventEntity1.getCourtroom().getCourthouse().getId(), previousVersions.get(1).getCourthouse().getId());
+        assertEquals(eventEntity1.getCourtroom().getCourthouse().getDisplayName(), previousVersions.get(1).getCourthouse().getDisplayName());
+        assertEquals(eventEntity1.getLegacyVersionLabel(), previousVersions.get(1).getVersion());
+        assertEquals(eventEntity1.getChronicleId(), previousVersions.get(1).getChronicleId());
+        assertEquals(eventEntity1.getAntecedentId(), previousVersions.get(1).getAntecedentId());
+        assertEquals(eventEntity1.getTimestamp(), previousVersions.get(1).getEventTs());
+        assertEquals(eventEntity1.getIsCurrent(), previousVersions.get(1).getIsCurrent());
+        assertEquals(eventEntity1.getCreatedDateTime(), previousVersions.get(1).getCreatedAt());
+        assertEquals(eventEntity1.getCreatedBy().getId(), previousVersions.get(1).getCreatedBy());
+        assertEquals(eventEntity1.getLastModifiedDateTime(), previousVersions.get(1).getLastModifiedAt());
+        assertEquals(eventEntity1.getLastModifiedBy().getId(), previousVersions.get(1).getLastModifiedBy());
+        assertEquals(eventEntity1.isDataAnonymised(), previousVersions.get(1).getIsDataAnonymised());
+
+        assertEquals(eventEntity3.getId(), previousVersions.get(2).getId());
+        assertEquals(eventEntity3.getLegacyObjectId(), previousVersions.get(2).getDocumentumId());
+        assertEquals(eventEntity3.getEventId(), previousVersions.get(2).getSourceId());
+        assertEquals(eventEntity3.getMessageId(), previousVersions.get(2).getMessageId());
+        assertEquals(eventEntity3.getEventText(), previousVersions.get(2).getText());
+        assertEquals(eventEntity3.getEventType().getId(), previousVersions.get(2).getEventMapping().getId());
+        assertEquals(eventEntity3.isLogEntry(), previousVersions.get(2).getIsLogEntry());
+        assertEquals(eventEntity3.getCourtroom().getId(), previousVersions.get(2).getCourtroom().getId());
+        assertEquals(eventEntity3.getCourtroom().getName(), previousVersions.get(2).getCourtroom().getName());
+        assertEquals(eventEntity3.getCourtroom().getCourthouse().getId(), previousVersions.get(2).getCourthouse().getId());
+        assertEquals(eventEntity3.getCourtroom().getCourthouse().getDisplayName(), previousVersions.get(2).getCourthouse().getDisplayName());
+        assertEquals(eventEntity3.getLegacyVersionLabel(), previousVersions.get(2).getVersion());
+        assertEquals(eventEntity3.getChronicleId(), previousVersions.get(2).getChronicleId());
+        assertEquals(eventEntity3.getAntecedentId(), previousVersions.get(2).getAntecedentId());
+        assertEquals(eventEntity3.getTimestamp(), previousVersions.get(2).getEventTs());
+        assertEquals(eventEntity3.getIsCurrent(), previousVersions.get(2).getIsCurrent());
+        assertEquals(eventEntity3.getCreatedDateTime(), previousVersions.get(2).getCreatedAt());
+        assertEquals(eventEntity3.getCreatedBy().getId(), previousVersions.get(2).getCreatedBy());
+        assertEquals(eventEntity3.getLastModifiedDateTime(), previousVersions.get(2).getLastModifiedAt());
+        assertEquals(eventEntity3.getLastModifiedBy().getId(), previousVersions.get(2).getLastModifiedBy());
+        assertEquals(eventEntity3.isDataAnonymised(), previousVersions.get(2).getIsDataAnonymised());
+    }
+    
+    private EventEntity setGenericEventDataForTest() {
         EventEntity eventEntity = new EventEntity();
-        eventEntity.setId(1);
+
         eventEntity.setEventId(200);
         eventEntity.setLegacyObjectId("legacyObjectId");
         eventEntity.setMessageId("messageId");
@@ -54,38 +256,13 @@ class EventMapperTest {
         eventEntity.setAntecedentId("antecedentId");
 
         UserAccountEntity uaCreatedEntity = new UserAccountEntity();
-        eventEntity.setCreatedDateTime(OffsetDateTime.now());
         eventEntity.setCreatedBy(uaCreatedEntity);
 
         UserAccountEntity uaLastModifiedEntity = new UserAccountEntity();
         eventEntity.setLastModifiedDateTime(OffsetDateTime.now());
         eventEntity.setLastModifiedBy(uaLastModifiedEntity);
         eventEntity.setTimestamp(OffsetDateTime.now());
-        eventEntity.setIsCurrent(true);
-        // Given
-        AdminGetEventForIdResponseResult responseResult = eventMapper.mapToAdminGetEventsResponseForId(eventEntity);
 
-        // Then
-        Assertions.assertEquals(eventEntity.getId(), responseResult.getId());
-        Assertions.assertEquals(eventEntity.getLegacyObjectId(), responseResult.getDocumentumId());
-        Assertions.assertEquals(eventEntity.getEventId(), responseResult.getSourceId());
-        Assertions.assertEquals(eventEntity.getMessageId(), responseResult.getMessageId());
-        Assertions.assertEquals(eventEntity.getEventText(), responseResult.getText());
-        Assertions.assertEquals(eventEntity.getEventType().getId(), responseResult.getEventMapping().getId());
-        Assertions.assertEquals(eventEntity.isLogEntry(), responseResult.getIsLogEntry());
-        Assertions.assertEquals(eventEntity.getCourtroom().getId(), responseResult.getCourtroom().getId());
-        Assertions.assertEquals(eventEntity.getCourtroom().getName(), responseResult.getCourtroom().getName());
-        Assertions.assertEquals(eventEntity.getCourtroom().getCourthouse().getId(), responseResult.getCourthouse().getId());
-        Assertions.assertEquals(eventEntity.getCourtroom().getCourthouse().getDisplayName(), responseResult.getCourthouse().getDisplayName());
-        Assertions.assertEquals(eventEntity.getLegacyVersionLabel(), responseResult.getVersion());
-        Assertions.assertEquals(eventEntity.getChronicleId(), responseResult.getChronicleId());
-        Assertions.assertEquals(eventEntity.getAntecedentId(), responseResult.getAntecedentId());
-        Assertions.assertEquals(eventEntity.getTimestamp(), responseResult.getEventTs());
-        Assertions.assertEquals(eventEntity.getIsCurrent(), responseResult.getIsCurrent());
-        Assertions.assertEquals(eventEntity.getCreatedDateTime(), responseResult.getCreatedAt());
-        Assertions.assertEquals(eventEntity.getCreatedBy().getId(), responseResult.getCreatedBy());
-        Assertions.assertEquals(eventEntity.getLastModifiedDateTime(), responseResult.getLastModifiedAt());
-        Assertions.assertEquals(eventEntity.getLastModifiedBy().getId(), responseResult.getLastModifiedBy());
-        Assertions.assertEquals(eventEntity.isDataAnonymised(), responseResult.getIsDataAnonymised());
+        return eventEntity;
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -67,6 +67,26 @@ class EventServiceImplTest {
     }
 
     @Test
+    void getEventVersionsForEveId() {
+        EventEntity event = mock(EventEntity.class);
+        when(eventRepository.findById(1)).thenReturn(Optional.of(event));
+        when(eventRepository.findAllByEventIdExcludingEventIdZero(event.getEventId())).thenReturn(List.of(event));
+        assertThat(eventService.getEventVersionsForEveIdExcludingEventIdZero(1)).isEqualTo(List.of(event));
+        verify(eventRepository, times(1)).findById(1);
+        verify(eventRepository, times(1)).findAllByEventIdExcludingEventIdZero(event.getEventId());
+    }
+
+    @Test
+    void getEventVersionsForEveIdNotFound() {
+        when(eventRepository.findById(1)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> eventService.getEventVersionsForEveIdExcludingEventIdZero(1))
+            .isInstanceOf(DartsApiException.class)
+            .hasFieldOrPropertyWithValue("error", CommonApiError.NOT_FOUND);
+        verify(eventRepository, times(1)).findById(1);
+    }
+
+    @Test
     void positiveSaveEvent() {
         EventEntity event = mock(EventEntity.class);
         when(eventRepository.save(event)).thenReturn(event);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-3409


### Change description ###
New endpoint to get all versions associated to an event.
If event id is zero, it means it is the first version of an event which is a bug in XHIBIT and therefore exclude these from the query otherwise millions of events would be pulled back. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
