### PR TITLE
DMP-4691: Delete from Blob Store on addAudio failure from DARTS API

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/service/AudioUploadService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/AudioUploadService.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 
 public interface AudioUploadService {
 
+    void deleteUploadedAudio(UUID guid);
+
     void addAudio(UUID guid, AddAudioMetadataRequest addAudioMetadataRequest);
 
     void linkAudioToHearingInMetadata(AddAudioMetadataRequest addAudioMetadataRequest, MediaEntity mediaEntity);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.darts.audio.component.AddAudioRequestMapper;
 import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequest;
@@ -32,8 +31,6 @@ import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.util.DurationUtil;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -45,7 +42,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static uk.gov.hmcts.darts.audio.exception.AudioApiError.FAILED_TO_UPLOAD_AUDIO_FILE;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
 
 @Service
@@ -71,9 +67,19 @@ public class AudioUploadServiceImpl implements AudioUploadService {
 
 
     @Override
+    public void deleteUploadedAudio(UUID guid) {
+        try {
+            dataManagementApi.deleteBlobDataFromInboundContainer(guid);
+        } catch (AzureDeleteBlobException azureDeleteBlobException) {
+            log.error("Failed to delete blob data from inbound container", azureDeleteBlobException);
+        }
+    }
+
+    @Override
     public void addAudio(UUID guid, AddAudioMetadataRequest addAudioMetadataRequest) {
         String checksum = dataManagementApi.getChecksum(DatastoreContainerType.INBOUND, guid);
         if (!checksum.equals(addAudioMetadataRequest.getChecksum())) {
+            deleteUploadedAudio(guid);
             throw new DartsApiException(AudioApiError.FAILED_TO_ADD_AUDIO_META_DATA,
                                         String.format("Checksum for blob '%s' does not match the one passed in the API request '%s'.",
                                                       checksum, addAudioMetadataRequest.getChecksum()));
@@ -132,14 +138,6 @@ public class AudioUploadServiceImpl implements AudioUploadService {
 
         // version the file upload to the database
         versionUpload(mediaToSupersede, addAudioMetadataRequest, externalLocation, incomingChecksum, currentUser);
-    }
-
-    private UUID saveAudioToInbound(MultipartFile audioFileStream) {
-        try (var bufferedInputStream = new BufferedInputStream(audioFileStream.getInputStream())) {
-            return dataManagementApi.saveBlobDataToInboundContainer(bufferedInputStream);
-        } catch (IOException e) {
-            throw new DartsApiException(FAILED_TO_UPLOAD_AUDIO_FILE, e);
-        }
     }
 
     void versionUpload(List<MediaEntity> mediaToSupersede,

--- a/src/main/java/uk/gov/hmcts/darts/audio/validation/AddAudioMetaDataValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/validation/AddAudioMetaDataValidator.java
@@ -3,7 +3,8 @@ package uk.gov.hmcts.darts.audio.validation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequest;
+import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequestWithStorageGUID;
+import uk.gov.hmcts.darts.audio.service.AudioUploadService;
 import uk.gov.hmcts.darts.common.component.validation.Validator;
 import uk.gov.hmcts.darts.common.exception.CommonApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
@@ -13,13 +14,14 @@ import uk.gov.hmcts.darts.log.service.AudioLoggerService;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class AddAudioMetaDataValidator implements Validator<AddAudioMetadataRequest> {
+public class AddAudioMetaDataValidator implements Validator<AddAudioMetadataRequestWithStorageGUID> {
 
     private final RetrieveCoreObjectService retrieveCoreObjectService;
     private final AudioLoggerService audioLoggerService;
+    private final AudioUploadService audioUploadService;
 
     @Override
-    public void validate(AddAudioMetadataRequest addAudioMetadataRequest) {
+    public void validate(AddAudioMetadataRequestWithStorageGUID addAudioMetadataRequest) {
 
         // attempt to resolve the courthouse
         try {
@@ -28,6 +30,7 @@ public class AddAudioMetaDataValidator implements Validator<AddAudioMetadataRequ
             if (CommonApiError.COURTHOUSE_PROVIDED_DOES_NOT_EXIST.equals(e.getError())) {
                 audioLoggerService.missingCourthouse(addAudioMetadataRequest.getCourthouse(), addAudioMetadataRequest.getCourtroom());
             }
+            audioUploadService.deleteUploadedAudio(addAudioMetadataRequest.getStorageGuid());
             throw e;
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/api/DataManagementApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/api/DataManagementApi.java
@@ -31,8 +31,6 @@ public interface DataManagementApi extends BlobContainerDownloadable {
 
     UUID saveBlobDataToInboundContainer(BinaryData binaryData);
 
-    UUID saveBlobDataToInboundContainer(InputStream inputStream);
-
     UUID saveBlobDataToUnstructuredContainer(BinaryData binaryData);
 
     String getChecksum(DatastoreContainerType datastoreContainerType, UUID guid);

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/api/impl/DataManagementApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/api/impl/DataManagementApiImpl.java
@@ -65,11 +65,6 @@ public class DataManagementApiImpl implements DataManagementApi {
         dataManagementService.deleteBlobData(getUnstructuredContainerName(), blobId);
     }
 
-    @Override
-    public UUID saveBlobDataToInboundContainer(InputStream inputStream) {
-        return dataManagementService.saveBlobData(getInboundContainerName(), inputStream).getBlobName();
-    }
-
     /**
      * @deprecated This implementation is not memory-efficient with large files, use saveBlobDataToInboundContainer(InputStream inputStream) instead.
      */

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
@@ -1,21 +1,28 @@
 package uk.gov.hmcts.darts.audio.service.impl;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.darts.audio.component.AddAudioRequestMapper;
 import uk.gov.hmcts.darts.audio.component.impl.AddAudioRequestMapperImpl;
+import uk.gov.hmcts.darts.audio.exception.AudioApiError;
 import uk.gov.hmcts.darts.audio.model.AddAudioMetadataRequest;
 import uk.gov.hmcts.darts.audio.service.AudioAsyncService;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
+import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.exception.AzureDeleteBlobException;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.helper.MediaLinkedCaseHelper;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
@@ -28,10 +35,12 @@ import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -44,6 +53,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -256,5 +267,240 @@ class AudioUploadServiceImplTest {
         doNothing().when(audioService).saveExternalObjectDirectory(any(), any(), any(), any());
 
         return addAudioMetadataRequest;
+    }
+
+    @Test
+    void linkAudioAndHearingDuplicateCases() {
+        AddAudioMetadataRequest addAudioMetadataRequest = createAddAudioRequest(STARTED_AT, ENDED_AT);
+        addAudioMetadataRequest.setCases(List.of("1", "2", "1"));
+        createMediaEntity(STARTED_AT, ENDED_AT);
+
+        HearingEntity hearing1 = PersistableFactory.getHearingTestData().someMinimalHearing();
+        when(retrieveCoreObjectService.retrieveOrCreateHearing(
+            anyString(),
+            anyString(),
+            eq("1"),
+            any(),
+            any()
+        )).thenReturn(hearing1);
+
+        HearingEntity hearing2 = PersistableFactory.getHearingTestData().someMinimalHearing();
+        when(retrieveCoreObjectService.retrieveOrCreateHearing(
+            anyString(),
+            anyString(),
+            eq("2"),
+            any(),
+            any()
+        )).thenReturn(hearing2);
+
+        CourthouseEntity courthouse = new CourthouseEntity();
+        courthouse.setCourthouseName("SWANSEA");
+        CourtroomEntity courtroomEntity = new CourtroomEntity(1, "1", courthouse);
+        when(retrieveCoreObjectService.retrieveOrCreateCourtroom(eq("SWANSEA"), eq("1"), any(UserAccountEntity.class)))
+            .thenReturn(courtroomEntity);
+
+        UserAccountEntity userAccount = new UserAccountEntity();
+        userAccount.setId(10);
+        when(userIdentity.getUserAccount()).thenReturn(userAccount);
+
+        UUID blobId = UUID.randomUUID();
+        when(dataManagementApi.getChecksum(any(), any()))
+            .thenReturn("123456");
+
+        audioService.addAudio(blobId, addAudioMetadataRequest);
+        verify(hearingRepository, times(2)).saveAndFlush(any());
+        assertEquals(1, hearing1.getMediaList().size());
+        assertEquals(1, hearing2.getMediaList().size());
+    }
+
+    @Test
+    void addAudio_shouldSaveAudio_whenMetaDataIsUsed() {
+        UserAccountEntity userAccount = new UserAccountEntity();
+        userAccount.setId(10);
+        when(userIdentity.getUserAccount()).thenReturn(userAccount);
+
+        // Given
+        HearingEntity hearingEntity = new HearingEntity();
+        when(retrieveCoreObjectService.retrieveOrCreateHearing(
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any()
+        )).thenReturn(hearingEntity);
+        when(mediaRepository.findMediaByDetails(any(), any(), any(), any(), any()))
+            .thenReturn(Collections.emptyList());
+
+        CourthouseEntity courthouse = new CourthouseEntity();
+        courthouse.setCourthouseName("SWANSEA");
+        CourtroomEntity courtroomEntity = new CourtroomEntity(1, "1", courthouse);
+        when(retrieveCoreObjectService.retrieveOrCreateCourtroom(eq("SWANSEA"), eq("1"), any(UserAccountEntity.class)))
+            .thenReturn(courtroomEntity);
+
+        OffsetDateTime startedAt = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime endedAt = OffsetDateTime.now();
+
+        MediaEntity mediaEntity = createMediaEntity(startedAt, endedAt);
+        mediaEntity.setId(10);
+        when(mediaRepository.saveAndFlush(any(MediaEntity.class))).thenReturn(mediaEntity);
+
+
+        AddAudioMetadataRequest addAudioMetadataRequest = createAddAudioRequest(startedAt, endedAt);
+        when(dataManagementApi.getChecksum(any(), any()))
+            .thenReturn("123456");
+
+        // When
+        UUID externalLocation = UUID.randomUUID();
+        audioService.addAudio(externalLocation, addAudioMetadataRequest);
+
+        // Then
+
+        ArgumentCaptor<MediaEntity> mediaEntityArgumentCaptor = ArgumentCaptor.forClass(MediaEntity.class);
+        ArgumentCaptor<ExternalObjectDirectoryEntity> externalObjectDirectoryEntityArgumentCaptor =
+            ArgumentCaptor.forClass(ExternalObjectDirectoryEntity.class);
+
+        verify(mediaRepository).save(mediaEntityArgumentCaptor.capture());
+        verify(hearingRepository, times(3)).saveAndFlush(any());
+        verify(logApi).audioUploaded(addAudioMetadataRequest);
+        verify(externalObjectDirectoryRepository).save(externalObjectDirectoryEntityArgumentCaptor.capture());
+
+        MediaEntity savedMedia = mediaEntityArgumentCaptor.getValue();
+        assertEquals(startedAt, savedMedia.getStart());
+        assertEquals(endedAt, savedMedia.getEnd());
+        assertEquals(1, savedMedia.getChannel());
+        assertEquals(2, savedMedia.getTotalChannels());
+        assertEquals("SWANSEA", savedMedia.getCourtroom().getCourthouse().getCourthouseName());
+        assertEquals("1", savedMedia.getCourtroom().getName());
+
+        ExternalObjectDirectoryEntity externalObjectDirectoryEntity = externalObjectDirectoryEntityArgumentCaptor.getValue();
+        assertEquals(savedMedia.getChecksum(), externalObjectDirectoryEntity.getChecksum());
+        assertNotNull(externalObjectDirectoryEntity.getChecksum());
+        assertEquals(externalLocation, externalObjectDirectoryEntity.getExternalLocation());
+    }
+
+    @Test
+    void addAudio_shouldSaveMediaAndEod_whenMetadataOnly() {
+        UserAccountEntity userAccount = new UserAccountEntity();
+        userAccount.setId(10);
+        when(userIdentity.getUserAccount()).thenReturn(userAccount);
+
+        // Given
+        HearingEntity hearingEntity = new HearingEntity();
+        when(retrieveCoreObjectService.retrieveOrCreateHearing(
+            anyString(),
+            anyString(),
+            anyString(),
+            any(),
+            any()
+        )).thenReturn(hearingEntity);
+
+        CourthouseEntity courthouse = new CourthouseEntity();
+        courthouse.setCourthouseName("SWANSEA");
+        CourtroomEntity courtroomEntity = new CourtroomEntity(1, "1", courthouse);
+        when(retrieveCoreObjectService.retrieveOrCreateCourtroom(eq("SWANSEA"), eq("1"), any(UserAccountEntity.class)))
+            .thenReturn(courtroomEntity);
+
+        OffsetDateTime startedAt = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime endedAt = OffsetDateTime.now();
+
+        MediaEntity mediaEntity = createMediaEntity(startedAt, endedAt);
+        mediaEntity.setId(10);
+        when(mediaRepository.saveAndFlush(any(MediaEntity.class))).thenReturn(mediaEntity);
+
+        AddAudioMetadataRequest addAudioMetadataRequest = createAddAudioRequest(startedAt, endedAt);
+        when(dataManagementApi.getChecksum(any(), any()))
+            .thenReturn(addAudioMetadataRequest.getChecksum());
+
+        // When
+        UUID externalLocation = UUID.randomUUID();
+        audioService.addAudio(externalLocation, addAudioMetadataRequest);
+
+        // Then
+        ArgumentCaptor<MediaEntity> mediaEntityArgumentCaptor = ArgumentCaptor.forClass(MediaEntity.class);
+        ArgumentCaptor<ExternalObjectDirectoryEntity> externalObjectDirectoryEntityArgumentCaptor =
+            ArgumentCaptor.forClass(ExternalObjectDirectoryEntity.class);
+
+        verify(mediaRepository).save(mediaEntityArgumentCaptor.capture());
+        verify(hearingRepository, times(3)).saveAndFlush(any());
+        verify(logApi).audioUploaded(addAudioMetadataRequest);
+        verify(externalObjectDirectoryRepository).save(externalObjectDirectoryEntityArgumentCaptor.capture());
+        verify(dataManagementApi).getChecksum(DatastoreContainerType.INBOUND, externalLocation);
+        MediaEntity savedMedia = mediaEntityArgumentCaptor.getValue();
+        assertEquals(startedAt, savedMedia.getStart());
+        assertEquals(endedAt, savedMedia.getEnd());
+        assertEquals(1, savedMedia.getChannel());
+        assertEquals(2, savedMedia.getTotalChannels());
+        assertEquals("SWANSEA", savedMedia.getCourtroom().getCourthouse().getCourthouseName());
+        assertEquals("1", savedMedia.getCourtroom().getName());
+
+        ExternalObjectDirectoryEntity externalObjectDirectoryEntity = externalObjectDirectoryEntityArgumentCaptor.getValue();
+        assertEquals(savedMedia.getChecksum(), externalObjectDirectoryEntity.getChecksum());
+        assertNotNull(externalObjectDirectoryEntity.getChecksum());
+        assertEquals(externalLocation, externalObjectDirectoryEntity.getExternalLocation());
+    }
+
+    @Test
+    void addAudio_shouldDeleteInboundBlob_whenMetadataOnlyAndAudioIsADuplicate() throws AzureDeleteBlobException {
+        UserAccountEntity userAccount = new UserAccountEntity();
+        userAccount.setId(10);
+        when(userIdentity.getUserAccount()).thenReturn(userAccount);
+
+        // Given
+        CourthouseEntity courthouse = new CourthouseEntity();
+        courthouse.setCourthouseName("SWANSEA");
+        CourtroomEntity courtroomEntity = new CourtroomEntity(1, "1", courthouse);
+        when(retrieveCoreObjectService.retrieveOrCreateCourtroom(eq("SWANSEA"), eq("1"), any(UserAccountEntity.class)))
+            .thenReturn(courtroomEntity);
+
+        OffsetDateTime startedAt = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime endedAt = OffsetDateTime.now();
+        AddAudioMetadataRequest addAudioMetadataRequest = createAddAudioRequest(startedAt, endedAt);
+
+        MediaEntity mediaEntity = createMediaEntity(startedAt, endedAt);
+        mediaEntity.setChecksum(addAudioMetadataRequest.getChecksum());
+        mediaEntity.setId(10);
+
+        when(mediaRepository.findMediaByDetails(any(), any(), any(), any(), any()))
+            .thenReturn(List.of(mediaEntity));
+
+        when(dataManagementApi.getChecksum(any(), any())).thenReturn(addAudioMetadataRequest.getChecksum());
+
+        // When
+        UUID externalLocation = UUID.randomUUID();
+        audioService.addAudio(externalLocation, addAudioMetadataRequest);
+
+        // Then
+        verify(mediaRepository)
+            .findMediaByDetails(courtroomEntity, mediaEntity.getChannel(), mediaEntity.getMediaFile(), startedAt, endedAt);
+        verifyNoMoreInteractions(mediaRepository);
+        verifyNoInteractions(hearingRepository);
+        verifyNoInteractions(logApi);
+        verifyNoInteractions(externalObjectDirectoryRepository);
+        verify(dataManagementApi).getChecksum(DatastoreContainerType.INBOUND, externalLocation);
+        verify(dataManagementApi).deleteBlobDataFromInboundContainer(externalLocation);
+        verifyNoMoreInteractions(dataManagementApi);
+    }
+
+    @Test
+    void addAudioNoUploadChecksumDoNotMatch() throws AzureDeleteBlobException {
+        OffsetDateTime startedAt = OffsetDateTime.now().minusHours(1);
+        OffsetDateTime endedAt = OffsetDateTime.now();
+
+        AddAudioMetadataRequest addAudioMetadataRequest = createAddAudioRequest(startedAt, endedAt);
+        when(dataManagementApi.getChecksum(any(), any()))
+            .thenReturn("123");
+
+        // When
+        UUID externalLocation = UUID.randomUUID();
+
+        Assertions.assertThatThrownBy(() -> audioService.addAudio(externalLocation, addAudioMetadataRequest))
+            .isInstanceOf(DartsApiException.class)
+            .hasMessage("Failed to add audio meta data. Checksum for blob '123' does not match the one passed in the API request '123456'.")
+            .hasFieldOrPropertyWithValue("error", AudioApiError.FAILED_TO_ADD_AUDIO_META_DATA);
+
+        verify(dataManagementApi).getChecksum(DatastoreContainerType.INBOUND, externalLocation);
+        verify(dataManagementApi).deleteBlobDataFromInboundContainer(externalLocation);
+        // Then
+        verifyNoInteractions(mediaRepository, hearingRepository, logApi, externalObjectDirectoryRepository);
     }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4691)


### Change description ###
# Summary of Git Diff

The provided Git diff introduces a new method `deleteUploadedAudio(UUID guid)` to the `AudioUploadService` interface and its implementation. This method is designed to delete uploaded audio files from an inbound container in the Azure storage system. Additionally, several changes were made to the validator and test classes to accommodate this new functionality. Unused imports and methods related to audio file upload have also been removed.

## Highlights

- **New Method Added**: 
  - `deleteUploadedAudio(UUID guid)` method added to `AudioUploadService` interface and its implementation `AudioUploadServiceImpl`.
  
- **Functionality**: 
  - The `deleteUploadedAudio` method attempts to delete an audio blob from the Azure storage, logging an error if the deletion fails.

- **Checksum Validation**: 
  - In the `addAudio` method, if the checksum does not match, `deleteUploadedAudio` is called to remove the previously uploaded audio.

- **Changes in Validators**: 
  - Updated `AddAudioMetaDataValidator` to use `AddAudioMetadataRequestWithStorageGUID`, enabling it to handle the storage GUID and call the delete audio method if validation fails.

- **Removal of Unused Code**:
  - Removed unused imports and methods, including `saveAudioToInbound` from `AudioUploadServiceImpl`.

- **Test Cases Updated**:
  - Multiple test cases in `AudioUploadServiceImplTest` and `AddAudioMetaDataValidatorTest` have been modified to validate the new deletion functionality and ensure that it behaves correctly under various conditions. 

- **Error Handling**:
  - Enhanced error handling by logging errors during the deletion process and ensuring the system behaves as expected when checksums do not match.

This diff enhances the audio upload functionality by ensuring that previously uploaded audio can be deleted if necessary, maintaining data integrity and system reliability.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
