### PR TITLE
DMP-3399: Implement admin endpoint to get hearings details by id

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImpl.java
@@ -173,7 +173,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     public boolean isUserDuplicateAudioRequest(AudioRequestDetails audioRequestDetails) {
 
         var duplicateUserMediaRequests = mediaRequestRepository.findDuplicateUserMediaRequests(
-            hearingsService.getHearingById(audioRequestDetails.getHearingId()),
+            hearingsService.getHearingByIdWithValidation(audioRequestDetails.getHearingId()),
             userAccountRepository.getReferenceById(audioRequestDetails.getRequestor()),
             audioRequestDetails.getStartTime(),
             audioRequestDetails.getEndTime(),
@@ -188,7 +188,7 @@ public class MediaRequestServiceImpl implements MediaRequestService {
     @Override
     public MediaRequestEntity saveAudioRequest(AudioRequestDetails request) {
         MediaRequestEntity mediaRequest = saveAudioRequestToDb(
-            hearingsService.getHearingById(request.getHearingId()),
+            hearingsService.getHearingByIdWithValidation(request.getHearingId()),
             userAccountRepository.getReferenceById(request.getRequestor()),
             request.getStartTime(),
             request.getEndTime(),

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DefenceEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DefenceEntity.java
@@ -13,6 +13,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import uk.gov.hmcts.darts.task.runner.IsNamedEntity;
 import uk.gov.hmcts.darts.util.DataUtil;
 
@@ -21,7 +22,8 @@ import uk.gov.hmcts.darts.util.DataUtil;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = false)
-public class DefenceEntity extends CreatedModifiedBaseEntity implements IsNamedEntity {
+public class DefenceEntity extends CreatedModifiedBaseEntity
+    implements IsNamedEntity, HasIntegerId {
 
     public static final String TABLE_NAME = "defence";
     public static final String ID = "dfc_id";

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DefendantEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DefendantEntity.java
@@ -13,6 +13,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import uk.gov.hmcts.darts.task.runner.IsNamedEntity;
 import uk.gov.hmcts.darts.util.DataUtil;
 
@@ -22,7 +23,7 @@ import uk.gov.hmcts.darts.util.DataUtil;
 @Setter
 @EqualsAndHashCode(callSuper = false)
 public class DefendantEntity extends CreatedModifiedBaseEntity
-    implements IsNamedEntity {
+    implements IsNamedEntity, HasIntegerId {
 
     public static final String TABLE_NAME = "defendant";
     public static final String ID = "dfd_id";

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/JudgeEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/JudgeEntity.java
@@ -11,13 +11,16 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
+import uk.gov.hmcts.darts.task.runner.IsNamedEntity;
 
 @Entity
 @Table(name = JudgeEntity.TABLE_NAME)
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = true)
-public class JudgeEntity extends CreatedModifiedBaseEntity {
+public class JudgeEntity extends CreatedModifiedBaseEntity
+    implements IsNamedEntity, HasIntegerId {
 
     public static final String TABLE_NAME = "judge";
     public static final String ID = "jud_id";

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ProsecutorEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ProsecutorEntity.java
@@ -13,6 +13,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import uk.gov.hmcts.darts.task.runner.IsNamedEntity;
 import uk.gov.hmcts.darts.util.DataUtil;
 
@@ -21,7 +22,8 @@ import uk.gov.hmcts.darts.util.DataUtil;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = false)
-public class ProsecutorEntity extends CreatedModifiedBaseEntity implements IsNamedEntity {
+public class ProsecutorEntity extends CreatedModifiedBaseEntity
+    implements IsNamedEntity, HasIntegerId {
 
     public static final String TABLE_NAME = "prosecutor";
     public static final String ID = "prn_id";

--- a/src/main/java/uk/gov/hmcts/darts/hearings/controller/HearingsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/controller/HearingsController.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.darts.hearings.http.api.HearingsApi;
 import uk.gov.hmcts.darts.hearings.model.Annotation;
 import uk.gov.hmcts.darts.hearings.model.EventResponse;
 import uk.gov.hmcts.darts.hearings.model.GetHearingResponse;
+import uk.gov.hmcts.darts.hearings.model.HearingsResponse;
 import uk.gov.hmcts.darts.hearings.model.HearingsSearchRequest;
 import uk.gov.hmcts.darts.hearings.model.HearingsSearchResponse;
 import uk.gov.hmcts.darts.hearings.model.Transcript;
@@ -82,5 +83,13 @@ public class HearingsController implements HearingsApi {
         globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
     public ResponseEntity<List<HearingsSearchResponse>> adminHearingsSearchPost(HearingsSearchRequest hearingsSearchRequest) {
         return new ResponseEntity<>(adminHearingSearch.adminHearingSearch(hearingsSearchRequest), HttpStatus.OK);
+    }
+
+    @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
+    @Authorisation(contextId = ANY_ENTITY_ID,
+        globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
+    @Override
+    public ResponseEntity<HearingsResponse> adminHearingsIdGet(Integer hearingId) {
+        return new ResponseEntity<>(adminHearingSearch.getAdminHearings(hearingId), HttpStatus.OK);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingMapper.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.darts.hearings.mapper;
+
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.hearings.model.HearingsResponse;
+import uk.gov.hmcts.darts.hearings.model.HearingsResponseCase;
+import uk.gov.hmcts.darts.hearings.model.HearingsResponseHearing;
+
+public class AdminHearingMapper {
+    public static HearingsResponse mapToHearingsResponse(HearingEntity hearingEntity) {
+        if (hearingEntity == null) {
+            return null;
+        }
+        HearingsResponse hearingsResponse = new HearingsResponse();
+        hearingsResponse.setCase(mapToHearingsResponseCase(hearingEntity.getCourtCase()));
+        hearingsResponse.setHearing(mapToHearingsResponseHearing(hearingEntity));
+        return hearingsResponse;
+    }
+
+    public static HearingsResponseHearing mapToHearingsResponseHearing(HearingEntity hearingEntity) {
+        if (hearingEntity == null) {
+            return null;
+        }
+        HearingsResponseHearing hearingsResponseHearing = new HearingsResponseHearing();
+        hearingsResponseHearing.setId(hearingEntity.getId());
+        hearingsResponseHearing.setDate(hearingEntity.getHearingDate());
+        hearingsResponseHearing.setScheduledStartTime(HearingCommonMapper.toTimeString(hearingEntity.getScheduledStartTime()));
+        hearingsResponseHearing.setHearingTookPlace(hearingEntity.getHearingIsActual());
+        hearingsResponseHearing.setAudit(HearingCommonMapper.mapToAudit(hearingEntity));
+        hearingsResponseHearing.setJudges(HearingCommonMapper.asList(hearingEntity.getJudges(), HearingCommonMapper::mapToNameAndIdResponse));
+        hearingsResponseHearing.setLocation(HearingCommonMapper.mapToLocation(hearingEntity.getCourtroom()));
+        return hearingsResponseHearing;
+    }
+
+
+    public static HearingsResponseCase mapToHearingsResponseCase(CourtCaseEntity courtCase) {
+        if (courtCase == null) {
+            return null;
+        }
+        HearingsResponseCase hearingsResponseCase = new HearingsResponseCase();
+        hearingsResponseCase.setId(courtCase.getId());
+        hearingsResponseCase.setNumber(courtCase.getCaseNumber());
+        hearingsResponseCase.setDefendants(HearingCommonMapper.asList(courtCase.getDefendantList(), HearingCommonMapper::mapToNameAndIdResponse));
+        hearingsResponseCase.setProsecutors(HearingCommonMapper.asList(courtCase.getProsecutorList(), HearingCommonMapper::mapToNameAndIdResponse));
+        hearingsResponseCase.setDefence(HearingCommonMapper.asList(courtCase.getDefenceList(), HearingCommonMapper::mapToNameAndIdResponse));
+        return hearingsResponseCase;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/hearings/mapper/HearingCommonMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/mapper/HearingCommonMapper.java
@@ -1,0 +1,114 @@
+package uk.gov.hmcts.darts.hearings.mapper;
+
+import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
+import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.entity.base.CreatedBy;
+import uk.gov.hmcts.darts.common.entity.base.LastModifiedBy;
+import uk.gov.hmcts.darts.hearings.model.Audit;
+import uk.gov.hmcts.darts.hearings.model.Courthouse;
+import uk.gov.hmcts.darts.hearings.model.Courtroom;
+import uk.gov.hmcts.darts.hearings.model.Location;
+import uk.gov.hmcts.darts.hearings.model.NameAndIdResponse;
+import uk.gov.hmcts.darts.hearings.model.User;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
+import uk.gov.hmcts.darts.task.runner.IsNamedEntity;
+
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+public class HearingCommonMapper {
+
+    public static <R, P> List<R> asList(List<P> data, Function<P, R> mapperFunction) {
+        if (data == null) {
+            return new ArrayList<>();
+        }
+        return data.stream()
+            .filter(p -> p != null)
+            .map(p -> mapperFunction.apply(p))
+            .toList();
+    }
+
+
+    public static <T extends IsNamedEntity & HasIntegerId> NameAndIdResponse mapToNameAndIdResponse(T isNamedEntity) {
+        if (isNamedEntity == null) {
+            return null;
+        }
+        NameAndIdResponse nameAndIdResponse = new NameAndIdResponse();
+        nameAndIdResponse.setId(isNamedEntity.getId());
+        nameAndIdResponse.setName(isNamedEntity.getName());
+        return nameAndIdResponse;
+    }
+
+    public static <T extends LastModifiedBy & CreatedBy> Audit mapToAudit(T entity) {
+        if (entity == null) {
+            return null;
+        }
+        Audit audit = new Audit();
+        audit.setCreatedBy(mapToUser(entity.getCreatedBy()));
+        audit.setCreatedAt(entity.getCreatedDateTime());
+        audit.setUpdatedBy(mapToUser(entity.getLastModifiedBy()));
+        audit.setUpdatedAt(entity.getLastModifiedDateTime());
+        return audit;
+    }
+
+    public static User mapToUser(UserAccountEntity userAccount) {
+        if (userAccount == null) {
+            return null;
+        }
+        User user = new User();
+        user.setId(userAccount.getId());
+        user.setName(userAccount.getUserFullName());
+        return user;
+    }
+
+    public static String toTimeString(OffsetDateTime offsetDateTime) {
+        return toTimeString(
+            Optional.ofNullable(offsetDateTime)
+                .map(time -> time.toLocalTime())
+                .orElse(null));
+    }
+
+    public static String toTimeString(LocalTime localTime) {
+        return Optional.ofNullable(localTime)
+            .map(time -> time.format(DateTimeFormatter.ISO_LOCAL_TIME))
+            .orElse(null);
+    }
+
+    public static Location mapToLocation(CourtroomEntity courtroom) {
+        if (courtroom == null) {
+            return null;
+        }
+        Location location = new Location();
+        location.setCourthouse(mapToCourthouse(courtroom.getCourthouse()));
+        location.setCourtroom(mapToCourtroom(courtroom));
+        return location;
+    }
+
+    public static Courtroom mapToCourtroom(CourtroomEntity courtroomEntity) {
+        if(courtroomEntity == null) {
+            return null;
+        }
+        Courtroom courtroom = new Courtroom();
+        courtroom.setId(courtroomEntity.getId());
+        courtroom.setName(courtroomEntity.getName());
+        return courtroom;
+    }
+
+    public static Courthouse mapToCourthouse(CourthouseEntity courthouseEntity) {
+        if(courthouseEntity == null){
+            return null;
+        }
+        Courthouse courthouse = new Courthouse();
+        courthouse.setId(courthouseEntity.getId());
+        courthouse.setCode(courthouseEntity.getCode());
+        courthouse.setName(courthouseEntity.getCourthouseName());
+        courthouse.setDisplayName(courthouseEntity.getDisplayName());
+        return courthouse;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/AdminHearingsService.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/AdminHearingsService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.hearings.service;
 
 
+import uk.gov.hmcts.darts.hearings.model.HearingsResponse;
 import uk.gov.hmcts.darts.hearings.model.HearingsSearchRequest;
 import uk.gov.hmcts.darts.hearings.model.HearingsSearchResponse;
 
@@ -8,4 +9,6 @@ import java.util.List;
 
 public interface AdminHearingsService {
     List<HearingsSearchResponse> adminHearingSearch(HearingsSearchRequest request);
+
+    HearingsResponse getAdminHearings(Integer hearingId);
 }

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/HearingsService.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/HearingsService.java
@@ -12,6 +12,8 @@ public interface HearingsService {
 
     GetHearingResponse getHearings(Integer hearingId);
 
+    HearingEntity getHearingByIdWithValidation(Integer hearingId);
+
     HearingEntity getHearingById(Integer hearingId);
 
     List<EventResponse> getEvents(Integer hearingId);

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/AdminHearingsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/AdminHearingsServiceImpl.java
@@ -9,10 +9,13 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.hearings.exception.HearingApiError;
+import uk.gov.hmcts.darts.hearings.mapper.AdminHearingMapper;
 import uk.gov.hmcts.darts.hearings.mapper.AdminHearingSearchResponseMapper;
+import uk.gov.hmcts.darts.hearings.model.HearingsResponse;
 import uk.gov.hmcts.darts.hearings.model.HearingsSearchRequest;
 import uk.gov.hmcts.darts.hearings.model.HearingsSearchResponse;
 import uk.gov.hmcts.darts.hearings.service.AdminHearingsService;
+import uk.gov.hmcts.darts.hearings.service.HearingsService;
 
 import java.util.List;
 
@@ -21,6 +24,7 @@ import java.util.List;
 @Slf4j
 public class AdminHearingsServiceImpl implements AdminHearingsService {
     private final HearingRepository hearingRepository;
+    private final HearingsService hearingsService;
 
     @Value("${darts.hearings.admin-search.max-results}")
     private Integer adminSearchMaxResults;
@@ -44,11 +48,17 @@ public class AdminHearingsServiceImpl implements AdminHearingsService {
         return AdminHearingSearchResponseMapper.mapResponse(hearingEntityList);
     }
 
+
     Integer getAdminSearchMaxResults() {
         return adminSearchMaxResults;
     }
 
     void setAdminSearchMaxResults(Integer adminSearchMaxResults) {
         this.adminSearchMaxResults = adminSearchMaxResults;
+    }
+
+    @Override
+    public HearingsResponse getAdminHearings(Integer hearingId) {
+        return AdminHearingMapper.mapToHearingsResponse(hearingsService.getHearingById(hearingId));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
@@ -50,17 +50,13 @@ public class HearingsServiceImpl implements HearingsService {
 
     @Override
     public GetHearingResponse getHearings(Integer hearingId) {
-        HearingEntity foundHearing = getHearingById(hearingId);
+        HearingEntity foundHearing = getHearingByIdWithValidation(hearingId);
         return getHearingResponseMapper.map(foundHearing);
     }
 
     @Override
-    public HearingEntity getHearingById(Integer hearingId) {
-        Optional<HearingEntity> foundHearingOpt = hearingRepository.findById(hearingId);
-        if (foundHearingOpt.isEmpty()) {
-            throw new DartsApiException(HearingApiError.HEARING_NOT_FOUND);
-        }
-        HearingEntity hearingEntity = foundHearingOpt.get();
+    public HearingEntity getHearingByIdWithValidation(Integer hearingId) {
+        HearingEntity hearingEntity = getHearingById(hearingId);
         if (!hearingEntity.getHearingIsActual()) {
             throw new DartsApiException(HearingApiError.HEARING_NOT_ACTUAL);
         }
@@ -101,21 +97,26 @@ public class HearingsServiceImpl implements HearingsService {
 
     @Override
     public void removeMediaLinkToHearing(Integer courtCaseId) {
-        hearingRepository.findByCaseIdWithMediaList(courtCaseId).ifPresent(hearing ->
-            hearing.getMediaList().forEach(media -> {
-                // Check all cases linked to a hearing have been expired/anonymised
-                if (!mediaLinkedCaseRepository.areAllAssociatedCasesAnonymised(media)) {
-                    log.info("Media {} link not removed for case id {} as not all associated cases are expired", media.getId(), courtCaseId);
-                } else {
-                    hearingRepository.findHearingIdsByMediaId(media.getId()).forEach(hearingForMedia -> {
-                        hearingForMedia.setMediaList(null);
-                        hearingRepository.save(hearingForMedia);
-                        log.info("Media id {} link removed for hearing id {} on the expiry of case id {}",
-                                 media.getId(), hearingForMedia.getId(), courtCaseId);
-                    });
-                }
-            })
-        );
+        hearingRepository.findByCaseIdWithMediaList(courtCaseId)
+            .ifPresent(hearing ->
+                           hearing.getMediaList().forEach(media -> {
+                               // Check all cases linked to a hearing have been expired/anonymised
+                               if (!mediaLinkedCaseRepository.areAllAssociatedCasesAnonymised(media)) {
+                                   log.info(
+                                       "Media {} link not removed for case id {} as not all associated cases are expired",
+                                       media.getId(), courtCaseId);
+                               } else {
+                                   hearingRepository.findHearingIdsByMediaId(media.getId()).forEach(
+                                       hearingForMedia -> {
+                                           hearingForMedia.setMediaList(null);
+                                           hearingRepository.save(hearingForMedia);
+                                           log.info(
+                                               "Media id {} link removed for hearing id {} on the expiry of case id {}",
+                                               media.getId(), hearingForMedia.getId(), courtCaseId);
+                                       });
+                               }
+                           })
+            );
     }
 
     private void validateCaseIsNotExpiredFromHearingId(Integer hearingId) {

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
@@ -65,6 +65,15 @@ public class HearingsServiceImpl implements HearingsService {
     }
 
     @Override
+    public HearingEntity getHearingById(Integer hearingId) {
+        Optional<HearingEntity> foundHearingOpt = hearingRepository.findById(hearingId);
+        if (foundHearingOpt.isEmpty()) {
+            throw new DartsApiException(HearingApiError.HEARING_NOT_FOUND);
+        }
+        return foundHearingOpt.get();
+    }
+
+    @Override
     public List<EventResponse> getEvents(Integer hearingId) {
         validateCaseIsNotExpiredFromHearingId(hearingId);
         List<EventEntity> eventEntities = eventRepository.findAllByHearingId(hearingId);

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriptionRequestDetailsValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriptionRequestDetailsValidator.java
@@ -48,7 +48,7 @@ public class TranscriptionRequestDetailsValidator implements Validator<Transcrip
     }
 
     private void checkHearingHasValidMedia(TranscriptionRequestDetails transcriptionRequestDetails) {
-        final HearingEntity hearing = hearingsService.getHearingById(transcriptionRequestDetails.getHearingId());
+        final HearingEntity hearing = hearingsService.getHearingByIdWithValidation(transcriptionRequestDetails.getHearingId());
         checkAudioFileExistsAndTimesValid(transcriptionRequestDetails, hearing);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -330,7 +330,7 @@ public class TranscriptionServiceImpl implements TranscriptionService {
         }
 
         if (nonNull(transcriptionRequestDetails.getHearingId())) {
-            HearingEntity hearing = hearingsService.getHearingById(transcriptionRequestDetails.getHearingId());
+            HearingEntity hearing = hearingsService.getHearingByIdWithValidation(transcriptionRequestDetails.getHearingId());
             transcription.addHearing(hearing);
         }
 

--- a/src/main/resources/openapi/hearings.yaml
+++ b/src/main/resources/openapi/hearings.yaml
@@ -215,6 +215,32 @@ paths:
           description: Unauthorised Error
         '403':
           description: Forbidden Error
+  /admin/hearings/{id}:
+    get:
+      tags:
+        - Hearings
+      summary: |-
+        Return details of a hearing
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HearingsResponse'
+        '400':
+          description: Bad Request Error
+        '401':
+          description: Unauthorised Error
+        '403':
+          description: Forbidden Error
 
 components:
   schemas:
@@ -304,6 +330,125 @@ components:
           type: string
           format: date
           example: '2023-07-31'
+    NameAndIdResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: "John Doe"
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: "John Doe"
+      required:
+        - id
+        - name
+    Audit:
+      type: object
+      properties:
+        created_at:
+          type: string
+          format: date-time
+        created_by:
+          $ref: "#/components/schemas/User"
+        updated_at:
+          type: string
+          format: date-time
+        updated_by:
+          $ref: "#/components/schemas/User"
+      required:
+        - created_at
+        - created_by
+        - updated_at
+        - updated_by
+    HearingsResponse:
+      type: object
+      properties:
+        case:
+          type: object
+          properties:
+            id:
+              type: integer
+              example: 1
+            number:
+              type: string
+              example: "C123"
+            defendants:
+              type: array
+              items:
+                $ref: "#/components/schemas/NameAndIdResponse"
+            prosecutors:
+              type: array
+              items:
+                $ref: "#/components/schemas/NameAndIdResponse"
+            defence:
+              type: array
+              items:
+                $ref: "#/components/schemas/NameAndIdResponse"
+        hearing:
+          type: object
+          properties:
+            id:
+              type: integer
+              example: 1
+            date:
+              type: string
+              format: date
+              example: '2023-07-31'
+            scheduled_start_time:
+              type: string
+              format: time
+              example: '10:00'
+            hearing_took_place:
+              type: boolean
+              example: true
+            audit:
+              $ref: "#/components/schemas/Audit"
+            judges:
+              type: array
+              items:
+                $ref: "#/components/schemas/NameAndIdResponse"
+            location:
+              $ref: "#/components/schemas/Location"
+    Location:
+      type: object
+      properties:
+        courthouse:
+          $ref: "#/components/schemas/Courthouse"
+        courtroom:
+          $ref: "#/components/schemas/Courtroom"
+    Courthouse:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        code:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: "Swansea Crown Court"
+        display_name:
+          type: string
+          example: "Swansea Crown Court"
+    Courtroom:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: "Courtroom 1"
     HearingsSearchResponse:
       type: object
       properties:

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/MediaRequestServiceImplTest.java
@@ -213,14 +213,14 @@ class MediaRequestServiceImplTest {
         requestDetails.setEndTime(OffsetDateTime.parse(OFFSET_T_12_00_00_Z));
         requestDetails.setRequestType(DOWNLOAD);
 
-        when(mockHearingService.getHearingById(hearingId)).thenReturn(mockHearingEntity);
+        when(mockHearingService.getHearingByIdWithValidation(hearingId)).thenReturn(mockHearingEntity);
         when(mockMediaRequestRepository.saveAndFlush(any(MediaRequestEntity.class))).thenReturn(mockMediaRequestEntity);
         when(mockUserAccountRepository.getReferenceById(TEST_REQUESTER)).thenReturn(mockUserAccountEntity);
         doNothing().when(auditApi).record(any(), any(), any(CourtCaseEntity.class));
         var request = mediaRequestService.saveAudioRequest(requestDetails);
 
         assertEquals(request.getId(), mockMediaRequestEntity.getId());
-        verify(mockHearingService).getHearingById(hearingId);
+        verify(mockHearingService).getHearingByIdWithValidation(hearingId);
         verify(mockMediaRequestRepository).saveAndFlush(any(MediaRequestEntity.class));
         verify(mockUserAccountRepository).getReferenceById(TEST_REQUESTER);
         verify(auditApi).record(REQUEST_AUDIO, mockUserAccountEntity, mockCourtCaseEntity);
@@ -239,7 +239,7 @@ class MediaRequestServiceImplTest {
         requestDetails.setEndTime(OffsetDateTime.parse(OFFSET_T_12_00_00_Z));
         requestDetails.setRequestType(DOWNLOAD);
 
-        when(mockHearingService.getHearingById(hearingId))
+        when(mockHearingService.getHearingByIdWithValidation(hearingId))
             .thenThrow(new DartsApiException(HearingApiError.HEARING_NOT_FOUND));
 
         DartsApiException exception = assertThrows(DartsApiException.class,
@@ -264,7 +264,7 @@ class MediaRequestServiceImplTest {
         requestDetails.setEndTime(OffsetDateTime.parse(OFFSET_T_12_00_00_Z));
         requestDetails.setRequestType(DOWNLOAD);
 
-        when(mockHearingService.getHearingById(hearingId)).thenReturn(mockHearingEntity);
+        when(mockHearingService.getHearingByIdWithValidation(hearingId)).thenReturn(mockHearingEntity);
         when(mockUserAccountRepository.getReferenceById(TEST_REQUESTER)).thenReturn(mockUserAccountEntity);
         when(mockMediaRequestRepository.findDuplicateUserMediaRequests(
             mockHearingEntity,
@@ -293,7 +293,7 @@ class MediaRequestServiceImplTest {
         requestDetails.setEndTime(OffsetDateTime.parse(OFFSET_T_12_00_00_Z));
         requestDetails.setRequestType(DOWNLOAD);
 
-        when(mockHearingService.getHearingById(hearingId)).thenReturn(mockHearingEntity);
+        when(mockHearingService.getHearingByIdWithValidation(hearingId)).thenReturn(mockHearingEntity);
         when(mockUserAccountRepository.getReferenceById(TEST_REQUESTER)).thenReturn(mockUserAccountEntity);
         when(mockMediaRequestRepository.findDuplicateUserMediaRequests(
             mockHearingEntity,

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingMapperTest.java
@@ -1,0 +1,80 @@
+package uk.gov.hmcts.darts.hearings.mapper;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.hearings.model.HearingsResponse;
+import uk.gov.hmcts.darts.hearings.model.HearingsResponseCase;
+import uk.gov.hmcts.darts.hearings.model.HearingsResponseHearing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+
+class AdminHearingMapperTest {
+    MockedStatic<HearingCommonMapper> hearingCommonMapperMockedStatic;
+    MockedStatic<AdminHearingMapper> adminHearingMapperMockedStatic;
+
+    @BeforeEach
+    void beforeEach() {
+        hearingCommonMapperMockedStatic = Mockito.mockStatic(HearingCommonMapper.class, Mockito.CALLS_REAL_METHODS);
+        adminHearingMapperMockedStatic = Mockito.mockStatic(AdminHearingMapper.class, Mockito.CALLS_REAL_METHODS);
+    }
+
+    @AfterEach
+    void afterEach() {
+        hearingCommonMapperMockedStatic.close();
+        adminHearingMapperMockedStatic.close();
+    }
+
+    @Test
+    void mapToHearingsResponse_hasNullInput_shouldReturnNull() {
+        assertThat(AdminHearingMapper.mapToHearingsResponse(null)).isNull();
+    }
+
+    @Test
+    void mapToHearingsResponse_hasData_shouldReturnMappedValues() {
+        CourtCaseEntity courtCaseEntity = mock(CourtCaseEntity.class);
+        HearingEntity hearingEntity = new HearingEntity();
+        hearingEntity.setCourtCase(courtCaseEntity);
+
+        HearingsResponseHearing hearingsResponseHearing = mock(HearingsResponseHearing.class);
+        HearingsResponseCase hearingsResponseCase = mock(HearingsResponseCase.class);
+
+
+        adminHearingMapperMockedStatic.when(() -> AdminHearingMapper.mapToHearingsResponseHearing(hearingEntity))
+            .thenReturn(hearingsResponseHearing);
+        adminHearingMapperMockedStatic.when(() -> AdminHearingMapper.mapToHearingsResponseCase(courtCaseEntity))
+            .thenReturn(hearingsResponseCase);
+
+
+        HearingsResponse hearingsResponse = AdminHearingMapper.mapToHearingsResponse(hearingEntity);
+        assertThat(hearingsResponse).isNotNull();
+        assertThat(hearingsResponse.getHearing()).isEqualTo(hearingsResponseHearing);
+        assertThat(hearingsResponse.getCase()).isEqualTo(hearingsResponseCase);
+    }
+
+    @Test
+    void mapToHearingsResponseHearing_hasNullInput_shouldReturnNull() {
+        assertThat(AdminHearingMapper.mapToHearingsResponseHearing(null)).isNull();
+    }
+
+    @Test
+    void mapToHearingsResponseHearing_hasData_shouldReturnMappedValues() {
+        fail("TODO");
+    }
+
+    @Test
+    void mapToHearingsResponseCase_hasNullInput_shouldReturnNull() {
+        assertThat(AdminHearingMapper.mapToHearingsResponseCase(null)).isNull();
+    }
+
+    @Test
+    void mapToHearingsResponseCase_hasData_shouldReturnMappedValues() {
+        fail("TODO");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/HearingCommonMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/HearingCommonMapperTest.java
@@ -1,0 +1,259 @@
+package uk.gov.hmcts.darts.hearings.mapper;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
+import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.hearings.model.Audit;
+import uk.gov.hmcts.darts.hearings.model.Courthouse;
+import uk.gov.hmcts.darts.hearings.model.Courtroom;
+import uk.gov.hmcts.darts.hearings.model.Location;
+import uk.gov.hmcts.darts.hearings.model.NameAndIdResponse;
+import uk.gov.hmcts.darts.hearings.model.User;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
+import uk.gov.hmcts.darts.task.runner.IsNamedEntity;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class HearingCommonMapperTest {
+    MockedStatic<HearingCommonMapper> hearingCommonMapperMockedStatic;
+
+    @BeforeEach
+    void beforeEach() {
+        hearingCommonMapperMockedStatic = Mockito.mockStatic(HearingCommonMapper.class, Mockito.CALLS_REAL_METHODS);
+    }
+
+    @AfterEach
+    void afterEach() {
+        hearingCommonMapperMockedStatic.close();
+    }
+
+    @Test
+    void asList_hasNullInput_shouldReturnEmptyList() {
+        assertThat(HearingCommonMapper.asList(null, object -> object))
+            .isNotNull()
+            .isEmpty();
+    }
+
+    @Test
+    void asList_hasNullData_shouldReturnListExcludingNullValues() {
+        List<String> list = new ArrayList<>();
+        list.add("value");
+        list.add(null);
+        list.add("value2");
+
+        List<String> result = HearingCommonMapper.asList(list, object -> {
+            assertThat(object).isNotNull();
+            return object;
+        });
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(2).containsExactly("value", "value2");
+    }
+
+    @Test
+    void asList_hasData_shouldReturnListWithMappedValues() {
+        List<String> list = new ArrayList<>();
+        list.add("value");
+        list.add("value2");
+        list.add("value3");
+
+        List<String> result = HearingCommonMapper.asList(list, object -> {
+            assertThat(object).isNotNull();
+            return object;
+        });
+        assertThat(result).isNotNull();
+        assertThat(result).hasSize(3).containsExactly("value", "value2", "value3");
+
+
+    }
+
+    @Test
+    void mapToNameAndIdResponse_hasNullInput_shouldReturnNull() {
+        assertThat(HearingCommonMapper.mapToNameAndIdResponse(null)).isNull();
+    }
+
+    @Test
+    void mapToNameAndIdResponse_hasData_shouldReturnMappedValues() {
+
+        @Getter
+        @Setter
+        class SupportClass implements IsNamedEntity, HasIntegerId {
+            Integer id;
+            String name;
+        }
+        SupportClass supportClass = new SupportClass();
+        supportClass.setId(123);
+        supportClass.setName("some name");
+        NameAndIdResponse nameAndIdResponse = HearingCommonMapper.mapToNameAndIdResponse(supportClass);
+        assertThat(nameAndIdResponse).isNotNull();
+        assertThat(nameAndIdResponse.getId()).isEqualTo(123);
+        assertThat(nameAndIdResponse.getName()).isEqualTo("some name");
+    }
+
+    @Test
+    void mapToAudit_hasNullInput_shouldReturnNull() {
+        assertThat(HearingCommonMapper.mapToAudit(null)).isNull();
+    }
+
+    @Test
+    void mapToAudit_hasData_shouldReturnMappedValues() {
+        UserAccountEntity createdByUserAccount = mock(UserAccountEntity.class);
+        User createdByUser = mock(User.class);
+        hearingCommonMapperMockedStatic.when(() -> HearingCommonMapper.mapToUser(createdByUserAccount)).thenReturn(createdByUser);
+
+        UserAccountEntity lastModifiedByUserAccount = mock(UserAccountEntity.class);
+        User updatedByUser = mock(User.class);
+        hearingCommonMapperMockedStatic.when(() -> HearingCommonMapper.mapToUser(lastModifiedByUserAccount)).thenReturn(updatedByUser);
+
+        CreatedModifiedBaseEntity createdModifiedBaseEntity = new CreatedModifiedBaseEntity();
+
+        OffsetDateTime cratedTime = OffsetDateTime.now().minusDays(2);
+        createdModifiedBaseEntity.setCreatedBy(createdByUserAccount);
+        createdModifiedBaseEntity.setCreatedDateTime(cratedTime);
+
+        OffsetDateTime updatedTime = OffsetDateTime.now();
+        createdModifiedBaseEntity.setLastModifiedBy(lastModifiedByUserAccount);
+        createdModifiedBaseEntity.setLastModifiedDateTime(updatedTime);
+
+
+        Audit audit = HearingCommonMapper.mapToAudit(createdModifiedBaseEntity);
+        assertThat(audit).isNotNull();
+        assertThat(audit.getCreatedBy()).isEqualTo(createdByUser);
+        assertThat(audit.getCreatedAt()).isEqualTo(cratedTime);
+
+        assertThat(audit.getUpdatedBy()).isEqualTo(updatedByUser);
+        assertThat(audit.getUpdatedAt()).isEqualTo(updatedTime);
+
+    }
+
+    @Test
+    void mapToUser_hasNullInput_shouldReturnNull() {
+        assertThat(HearingCommonMapper.mapToUser(null)).isNull();
+    }
+
+    @Test
+    void mapToUser_hasData_shouldReturnMappedValues() {
+        UserAccountEntity userAccount = new UserAccountEntity();
+        userAccount.setId(123);
+        userAccount.setUserFullName("some full name");
+
+        User user = HearingCommonMapper.mapToUser(userAccount);
+        assertThat(user).isNotNull();
+        assertThat(user.getId()).isEqualTo(123);
+        assertThat(user.getName()).isEqualTo("some full name");
+    }
+
+    @Test
+    void toTimeStringOffsetDateTime_hasNullInput_shouldReturnNull() {
+        assertThat(HearingCommonMapper.toTimeString((OffsetDateTime) null)).isNull();
+    }
+
+    @Test
+    void toTimeStringOffsetDateTime_hasData_shouldReturnMappedValues() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(LocalDate.now(), LocalTime.of(12, 23, 12),
+                                                          OffsetDateTime.now().getOffset());
+        assertThat(HearingCommonMapper.toTimeString(offsetDateTime)).isEqualTo("12:23:12");
+    }
+
+    @Test
+    void toTimeStringOffsetDateTime_hasDataWith0Values_shouldReturnMappedValues() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(LocalDate.now(), LocalTime.of(0, 0, 0),
+                                                          OffsetDateTime.now().getOffset());
+        assertThat(HearingCommonMapper.toTimeString(offsetDateTime)).isEqualTo("00:00:00");
+    }
+
+    @Test
+    void toTimeStringLocalTime_hasNullInput_shouldReturnNull() {
+        assertThat(HearingCommonMapper.toTimeString((LocalTime) null)).isNull();
+    }
+
+    @Test
+    void toTimeStringLocalTime_hasData_shouldReturnMappedValues() {
+        LocalTime localTime = LocalTime.of(12, 23, 12);
+        assertThat(HearingCommonMapper.toTimeString(localTime)).isEqualTo("12:23:12");
+    }
+
+    @Test
+    void toTimeStringLocalTime_hasDataWith0Values_shouldReturnMappedValues() {
+        LocalTime localTime = LocalTime.of(0, 0, 0);
+        assertThat(HearingCommonMapper.toTimeString(localTime)).isEqualTo("00:00:00");
+    }
+
+    @Test
+    void mapToLocation_hasNullInput_shouldReturnNull() {
+        assertThat(HearingCommonMapper.mapToLocation(null)).isNull();
+    }
+
+    @Test
+    void mapToLocation_hasData_shouldReturnMappedValues() {
+        CourtroomEntity courtroomEntity = new CourtroomEntity();
+        CourthouseEntity courthouseEntity = mock(CourthouseEntity.class);
+        courtroomEntity.setCourthouse(courthouseEntity);
+
+        Courtroom courtroom = mock(Courtroom.class);
+        Courthouse courthouse = mock(Courthouse.class);
+
+        hearingCommonMapperMockedStatic.when(() -> HearingCommonMapper.mapToCourtroom(courtroomEntity)).thenReturn(courtroom);
+        hearingCommonMapperMockedStatic.when(() -> HearingCommonMapper.mapToCourthouse(courthouseEntity)).thenReturn(courthouse);
+
+        Location location = HearingCommonMapper.mapToLocation(courtroomEntity);
+
+        assertThat(location).isNotNull();
+        assertThat(location.getCourtroom()).isEqualTo(courtroom);
+        assertThat(location.getCourthouse()).isEqualTo(courthouse);
+    }
+
+    @Test
+    void mapToCourtroom_hasNullInput_shouldReturnNull() {
+        assertThat(HearingCommonMapper.mapToCourtroom(null)).isNull();
+    }
+
+    @Test
+    void mapToCourtroom_hasData_shouldReturnMappedValues() {
+        CourtroomEntity courtroomEntity = new CourtroomEntity();
+        courtroomEntity.setId(123);
+        courtroomEntity.setName("name 1");
+
+        Courtroom courtroom = HearingCommonMapper.mapToCourtroom(courtroomEntity);
+        assertThat(courtroom).isNotNull();
+        assertThat(courtroom.getId()).isEqualTo(123);
+        assertThat(courtroom.getName()).isEqualTo("NAME 1");
+    }
+
+    @Test
+    void mapToCourthouse_hasNullInput_shouldReturnNull() {
+        assertThat(HearingCommonMapper.mapToCourthouse(null)).isNull();
+    }
+
+    @Test
+    void mapToCourthouse_hasData_shouldReturnMappedValues() {
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+        courthouseEntity.setId(123);
+        courthouseEntity.setCode(31);
+        courthouseEntity.setCourthouseName("name 1");
+        courthouseEntity.setDisplayName("display name 1");
+
+        Courthouse courthouse = HearingCommonMapper.mapToCourthouse(courthouseEntity);
+
+        assertThat(courthouse).isNotNull();
+        assertThat(courthouse.getId()).isEqualTo(123);
+        assertThat(courthouse.getCode()).isEqualTo(31);
+        assertThat(courthouse.getName()).isEqualTo("NAME 1");
+        assertThat(courthouse.getDisplayName()).isEqualTo("display name 1");
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
@@ -84,7 +84,7 @@ class HearingsServiceImplTest {
         HearingEntity hearingEntity = createHearingEntity(true);
         when(hearingRepository.findById(hearingEntity.getId())).thenReturn(Optional.of(hearingEntity));
 
-        HearingEntity result = service.getHearingById(hearingEntity.getId());
+        HearingEntity result = service.getHearingByIdWithValidation(hearingEntity.getId());
         assertEquals(1, result.getId());
     }
 
@@ -92,7 +92,7 @@ class HearingsServiceImplTest {
     void testGetHearingsByIdHearingNotFound() {
         when(hearingRepository.findById(1)).thenReturn(Optional.empty());
 
-        DartsApiException exception = assertThrows(DartsApiException.class, () -> service.getHearingById(1));
+        DartsApiException exception = assertThrows(DartsApiException.class, () -> service.getHearingByIdWithValidation(1));
 
         assertEquals("HEARING_100", exception.getError().getErrorTypeNumeric());
     }
@@ -103,7 +103,7 @@ class HearingsServiceImplTest {
         hearingEntity.getCourtCase().setDataAnonymised(true);
         when(hearingRepository.findById(hearingEntity.getId())).thenReturn(Optional.of(hearingEntity));
 
-        DartsApiException exception = assertThrows(DartsApiException.class, () -> service.getHearingById(1));
+        DartsApiException exception = assertThrows(DartsApiException.class, () -> service.getHearingByIdWithValidation(1));
 
         assertThat(exception.getError()).isEqualTo(CaseApiError.CASE_EXPIRED);
         assertThat(exception.getMessage()).isEqualTo("Case has expired.");
@@ -114,7 +114,7 @@ class HearingsServiceImplTest {
         HearingEntity hearingEntity = createHearingEntity(false);
         when(hearingRepository.findById(hearingEntity.getId())).thenReturn(Optional.of(hearingEntity));
 
-        DartsApiException exception = assertThrows(DartsApiException.class, () -> service.getHearingById(hearingEntity.getId()));
+        DartsApiException exception = assertThrows(DartsApiException.class, () -> service.getHearingByIdWithValidation(hearingEntity.getId()));
 
         assertEquals("HEARING_102", exception.getError().getErrorTypeNumeric());
     }

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriptionRequestDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriptionRequestDetailsValidatorTest.java
@@ -76,7 +76,7 @@ class TranscriptionRequestDetailsValidatorTest {
         var hearingEntity = new HearingEntity();
         hearingEntity.setMediaList(mediaEntityList);
 
-        Mockito.when(hearingsServiceMock.getHearingById(DUMMY_HEARING_ID))
+        Mockito.when(hearingsServiceMock.getHearingByIdWithValidation(DUMMY_HEARING_ID))
             .thenReturn(hearingEntity);
 
         var validatable = new TranscriptionRequestDetails();
@@ -143,7 +143,7 @@ class TranscriptionRequestDetailsValidatorTest {
         // Given
         var hearingEntity = new HearingEntity();
         hearingEntity.setMediaList(createMediaList());
-        Mockito.when(hearingsServiceMock.getHearingById(DUMMY_HEARING_ID))
+        Mockito.when(hearingsServiceMock.getHearingByIdWithValidation(DUMMY_HEARING_ID))
             .thenReturn(hearingEntity);
 
         var requestDetails = createRequestDetails(MEDIA_1_START_TIME, MEDIA_1_END_TIME);

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
@@ -201,7 +201,7 @@ class TranscriptionServiceImplTest {
         doNothing().when(duplicateRequestDetector).checkForDuplicate(any(TranscriptionRequestDetails.class), any(Boolean.class));
 
         Integer hearingId = 1;
-        when(mockHearingsService.getHearingById(hearingId)).thenReturn(mockHearing);
+        when(mockHearingsService.getHearingByIdWithValidation(hearingId)).thenReturn(mockHearing);
 
         Integer caseId = 1;
         when(mockCaseService.getCourtCaseById(caseId)).thenReturn(mockCourtCase);
@@ -373,7 +373,7 @@ class TranscriptionServiceImplTest {
         doNothing().when(duplicateRequestDetector).checkForDuplicate(any(TranscriptionRequestDetails.class), any(Boolean.class));
 
         Integer hearingId = 1;
-        when(mockHearingsService.getHearingById(hearingId)).thenReturn(mockHearing);
+        when(mockHearingsService.getHearingByIdWithValidation(hearingId)).thenReturn(mockHearing);
 
         TranscriptionUrgencyEnum transcriptionUrgencyEnum = TranscriptionUrgencyEnum.OVERNIGHT;
         when(mockTranscriptionUrgencyRepository.getReferenceById(transcriptionUrgencyEnum.getId()))
@@ -459,7 +459,7 @@ class TranscriptionServiceImplTest {
         doNothing().when(duplicateRequestDetector).checkForDuplicate(any(TranscriptionRequestDetails.class), any(Boolean.class));
 
         Integer hearingId = 1;
-        when(mockHearingsService.getHearingById(hearingId)).thenReturn(mockHearing);
+        when(mockHearingsService.getHearingByIdWithValidation(hearingId)).thenReturn(mockHearing);
 
         Integer caseId = 1;
         when(mockCaseService.getCourtCaseById(caseId)).thenReturn(mockCourtCase);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3399)


### Change description ###
# Git Diff Summary

This Git diff introduces several improvements and new features within the codebase related to the media request service and hearings management. Key changes include refactoring methods for better validation, the introduction of new mappers, and updates to various entity classes to implement additional interfaces.

## Highlights

- **Media Request Service:**
  - Updated methods to use `getHearingByIdWithValidation` instead of `getHearingById` for stricter validation checks when checking for duplicate audio requests and saving audio requests.

- **Entity Updates:**
  - `DefenceEntity`, `DefendantEntity`, `JudgeEntity`, and `ProsecutorEntity` have been modified to implement the `HasIntegerId` interface, enhancing their functionality.

- **New Mappers:**
  - Introduced `AdminHearingMapper` and `HearingCommonMapper` for converting `HearingEntity` and `CourtCaseEntity` to their respective response models, improving data handling in the hearings API.

- **New Admin Endpoint:**
  - Added an endpoint in the OpenAPI specification to retrieve hearing details through `/admin/hearings/{id}`.

- **Service Interface Changes:**
  - The `HearingsService` interface now includes the `getHearingByIdWithValidation` method to ensure that hearings retrieved are actual and not expired.

- **Test Coverage:**
  - Updated tests for various services and mappers to ensure that they accommodate the newly implemented validation methods and mappers.
  - Added tests for the new `AdminHearingMapper` to verify the mapping functionality.

- **OpenAPI Specification:**
  - Enhanced the OpenAPI documentation to include new response models such as `HearingsResponse`, `Location`, and `Courthouse`.

This diff significantly improves the validation and data mapping mechanisms within the application, leading to a more robust and maintainable codebase.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
