### PR TITLE
DMP-4754: When I search for cases I should get a paginated list of results returned

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelperPaginated.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelperPaginated.java
@@ -70,15 +70,15 @@ public class AdvancedSearchRequestHelperPaginated {
 
     private void addCourtroomNameCriteria(JPQLQuery<HearingEntity> query, GetCasesSearchRequestPaginated request) {
         if (StringUtils.isNotBlank(request.getCourtroom())) {
-            query.where(QHearingEntity.hearingEntity.courtroom.name.likeIgnoreCase(surroundWithPercentages(request.getCourtroom())));
+            query.where(QHearingEntity.hearingEntity.courtroom.name.toUpperCase().like(surroundWithPercentages(request.getCourtroom(), true)));
         }
     }
 
     private void addCourthouseIdCriteria(JPQLQuery<HearingEntity> query, GetCasesSearchRequestPaginated request) {
         if (StringUtils.isNotBlank(request.getCourthouse())) {
             query.where(Expressions.anyOf(
-                QHearingEntity.hearingEntity.courtCase.courthouse.courthouseName.likeIgnoreCase(surroundWithPercentages(request.getCourthouse())),
-                QHearingEntity.hearingEntity.courtCase.courthouse.displayName.likeIgnoreCase(surroundWithPercentages(request.getCourthouse()))
+                QHearingEntity.hearingEntity.courtCase.courthouse.courthouseName.toUpperCase().like(surroundWithPercentages(request.getCourthouse(), true)),
+                QHearingEntity.hearingEntity.courtCase.courthouse.displayName.toUpperCase().like(surroundWithPercentages(request.getCourthouse(), true))
             ));
         }
     }
@@ -91,12 +91,16 @@ public class AdvancedSearchRequestHelperPaginated {
 
     private void addCaseCriteria(JPQLQuery<HearingEntity> query, GetCasesSearchRequestPaginated request) {
         if (StringUtils.isNotBlank(request.getCaseNumber())) {
-            query.where(QHearingEntity.hearingEntity.courtCase.caseNumber.likeIgnoreCase(surroundWithPercentages(request.getCaseNumber())));
+            query.where(QHearingEntity.hearingEntity.courtCase.caseNumber.toUpperCase().like(surroundWithPercentages(request.getCaseNumber(), true)));
         }
     }
 
-    private String surroundWithPercentages(String value) {
-        return surroundValue(value, "%");
+    private String surroundWithPercentages(String value, boolean makeUpperCase) {
+        String updatedValue = surroundValue(value, "%");
+        if (makeUpperCase) {
+            updatedValue = updatedValue.toUpperCase();
+        }
+        return updatedValue;
     }
 
     private String surroundValue(String value, String surroundWith) {
@@ -106,21 +110,21 @@ public class AdvancedSearchRequestHelperPaginated {
     private void addDefendantCriteria(JPQLQuery<HearingEntity> query, GetCasesSearchRequestPaginated request) {
         if (StringUtils.isNotBlank(request.getDefendantName())) {
             query = joinDefendantEntity(query);
-            query.where(QDefendantEntity.defendantEntity.name.likeIgnoreCase(surroundWithPercentages(request.getDefendantName())));
+            query.where(QDefendantEntity.defendantEntity.name.toUpperCase().like(surroundWithPercentages(request.getDefendantName(), true)));
         }
     }
 
     private void addEventCriteria(JPQLQuery<HearingEntity> query, GetCasesSearchRequestPaginated request) {
         if (StringUtils.isNotBlank(request.getEventTextContains())) {
             query = joinEventEntity(query);
-            query.where(QEventEntity.eventEntity.eventText.likeIgnoreCase(surroundWithPercentages(request.getEventTextContains())));
+            query.where(QEventEntity.eventEntity.eventText.toUpperCase().like(surroundWithPercentages(request.getEventTextContains(), true)));
         }
     }
 
     private void addJudgeCriteria(JPQLQuery<HearingEntity> query, GetCasesSearchRequestPaginated request) {
         if (StringUtils.isNotBlank(request.getJudgeName())) {
             query = joinJudge(query);
-            query.where(QJudgeEntity.judgeEntity.name.likeIgnoreCase(surroundWithPercentages(request.getJudgeName())));
+            query.where(QJudgeEntity.judgeEntity.name.toUpperCase().like(surroundWithPercentages(request.getJudgeName(), true)));
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -179,10 +179,7 @@ public class CaseServiceImpl implements CaseService {
         if (caseIds.isEmpty()) {
             return new ArrayList<>();
         }
-        List<HearingEntity> hearings = hearingRepository.findByCaseIds(caseIds).stream()
-            .filter(HearingEntity::getHearingIsActual)
-            .sorted((o1, o2) -> o2.getCourtCase().getCaseNumber().compareTo(o1.getCourtCase().getCaseNumber()))
-            .toList();
+        List<HearingEntity> hearings = hearingRepository.findByCaseIds(caseIds, true);
         return AdvancedSearchResponseMapper.mapResponse(hearings);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
@@ -32,6 +32,15 @@ public interface HearingRepository extends JpaRepository<HearingEntity, Integer>
     List<HearingEntity> findByCaseIds(List<Integer> caseIds);
 
     @Query("""
+        SELECT h FROM HearingEntity h
+        WHERE h.courtCase.id in :caseIds
+        AND h.hearingIsActual = :hearingIsActual
+        ORDER BY h.courtCase.caseNumber desc
+        """
+    )
+    List<HearingEntity> findByCaseIds(List<Integer> caseIds, boolean hearingIsActual);
+
+    @Query("""
         SELECT h.id FROM HearingEntity h
         JOIN h.eventList event
         WHERE event.id = :eventId
@@ -80,7 +89,7 @@ public interface HearingRepository extends JpaRepository<HearingEntity, Integer>
             AND (cast(:endDate as LocalDate) IS NULL OR hearing.hearingDate <= :endDate)
             ORDER BY hearing.hearingDate DESC
             LIMIT :numberOfRecords
-          """)
+        """)
     List<HearingEntity> findHearingDetails(List<Integer> courthouseIds, String caseNumber,
                                            String courtroomName,
                                            LocalDate startDate, LocalDate endDate, Integer numberOfRecords);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4754)


### Change description ###
# Summary of Git Diff

This Git Diff introduces enhancements to the `AdvancedSearchRequestHelperPaginated` class, improves the `CaseServiceImpl` class, and updates the `HearingRepository` interface. The key changes involve transitioning from case-insensitive queries to case-sensitive ones by converting search parameters to uppercase. Additionally, a new method is added to the `HearingRepository` to streamline the retrieval of hearing entities based on case IDs and their actual status.

## Highlights

- **Search Criteria Updates**:
  - Changed all `.likeIgnoreCase()` calls to `.toUpperCase().like()` for courtroom, courthouse, case number, defendant name, event text, and judge name criteria.
  - This ensures all search parameters are treated in a case-sensitive manner for improved accuracy.

- **Method Modification**:
  - Modified the `surroundWithPercentages` method to accept a boolean parameter for converting values to uppercase before surrounding them with percentage signs.

- **Service Class Optimization**:
  - In `CaseServiceImpl`, replaced a stream operation with a direct repository call that incorporates an actual hearing filter for improved performance.

- **New Repository Query**:
  - Added `findByCaseIds(List<Integer> caseIds, boolean hearingIsActual)` method in `HearingRepository` to fetch hearings based on case IDs and their actual status, consolidating the previous functionality into a single query.

These enhancements improve the search functionality and efficiency of the codebase, ensuring more accurate results in case retrieval operations.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
