### PR TITLE
DMP-3392: Include pre-amble/post-amble in job that links cases to audio through events

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/config/AudioConfigurationProperties.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/config/AudioConfigurationProperties.java
@@ -31,7 +31,7 @@ public class AudioConfigurationProperties {
     private String tempBlobWorkspace;
 
     private Duration allowableAudioGapDuration;
-    private Integer preAmbleDuration;
-    private Integer postAmbleDuration;
+    private Duration preAmbleDuration;
+    private Duration postAmbleDuration;
     private List<String> handheldAudioCourtroomNumbers;
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioAsyncServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioAsyncServiceImpl.java
@@ -41,8 +41,8 @@ public class AudioAsyncServiceImpl implements AudioAsyncService {
 
         String courthouse = addAudioMetadataRequest.getCourthouse();
         String courtroom = addAudioMetadataRequest.getCourtroom();
-        OffsetDateTime start = addAudioMetadataRequest.getStartedAt().minusMinutes(audioConfigurationProperties.getPreAmbleDuration());
-        OffsetDateTime end = addAudioMetadataRequest.getEndedAt().plusMinutes(audioConfigurationProperties.getPostAmbleDuration());
+        OffsetDateTime start = addAudioMetadataRequest.getStartedAt().minus(audioConfigurationProperties.getPreAmbleDuration());
+        OffsetDateTime end = addAudioMetadataRequest.getEndedAt().plus(audioConfigurationProperties.getPostAmbleDuration());
         List<EventEntity> courtLogs = courtLogEventRepository.findByCourthouseAndCourtroomBetweenStartAndEnd(
             courthouse,
             courtroom,

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AudioLinkingAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AudioLinkingAutomatedTask.java
@@ -69,9 +69,13 @@ public class AudioLinkingAutomatedTask
         private final EventService eventService;
         private final MediaLinkedCaseHelper mediaLinkedCaseHelper;
 
+
         @Getter
-        @Value("${darts.automated-tasks.audio-linking.audio-buffer:0s}")
-        private final Duration audioBuffer;
+        @Value("${darts.automated-tasks.pre-amble-duration:0s}")
+        private final Duration preAmbleDuration;
+        @Getter
+        @Value("${darts.automated-tasks.post-amble-duration:0s}")
+        private final Duration postAmbleDuration;
         private final UserIdentity userIdentity;
 
 
@@ -84,8 +88,8 @@ public class AudioLinkingAutomatedTask
                 EventEntity event = eventService.getEventByEveId(eveId);
                 List<MediaEntity> mediaEntities = mediaRepository.findAllByMediaTimeContains(
                     event.getCourtroom().getId(),
-                    event.getTimestamp().plus(getAudioBuffer()),
-                    event.getTimestamp().minus(getAudioBuffer()));
+                    event.getTimestamp().minus(getPreAmbleDuration()),
+                    event.getTimestamp().plus(getPostAmbleDuration()));
                 mediaEntities.forEach(mediaEntity -> {
                     mediaLinkedCaseHelper.linkMediaByEvent(event, mediaEntity, MediaLinkedCaseSourceType.AUDIO_LINKING_TASK, userAccount);
                 });

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -128,12 +128,12 @@ darts:
     merge-workspace: ${user.home}/audiotransform/merge
     outbounddeleter:
       last-accessed-deletion-day: 2
-    pre-amble-duration: 30
+    pre-amble-duration: 30m
     preview:
       redis-ttl-mins: ${AUDIO_PREVIEW_REDIS_TTL:10}
       redis-failed-ttl-mins: ${AUDIO_PREVIEW_REDIS_FAILED_TTL:2}
       redis-folder: audio-previews
-    post-amble-duration: 30
+    post-amble-duration: 30m
     re-encode-workspace: ${user.home}/audiotransform/encode
     temp-blob-workspace: ${user.home}/audiotransform/tempworkspace
     audio-transformation-service:
@@ -357,7 +357,8 @@ darts:
           at-most-for: PT90M
       audio-linking:
         system-user-email: system_AudioLinking@hmcts.net
-        audio-buffer: 0s
+        pre-amble-duration: ${darts.audio.pre-amble-duration}
+        post-amble-duration: ${darts.audio.post-amble-duration}
         lock:
           at-least-for: PT1M
           at-most-for: PT90M


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3392)


### Change description ###
# Summary of Git Diff

This Git Diff introduces changes to the `AudioConfigurationProperties` and related classes to update the data types of certain properties from `Integer` to `Duration` for `preAmbleDuration` and `postAmbleDuration`. This change is reflected throughout the service implementation and the application configuration files to ensure consistent handling of audio timing.

## Highlights

- **Property Type Changes**:
  - Changed `preAmbleDuration` and `postAmbleDuration` from `Integer` to `Duration` in `AudioConfigurationProperties.java`.
  
- **Service Logic Updates**:
  - Updated the methods in `AudioAsyncServiceImpl.java` and `AudioLinkingAutomatedTask.java` to use `Duration` for calculating the start and end times instead of minutes offset.

- **Configuration Changes**:
  - In `application.yaml`, the duration values for `pre-amble-duration` and `post-amble-duration` are modified to include the unit (`30m` instead of `30`).

- **Test Adjustments**:
  - Updated the test cases in `AudioLinkingAutomatedTaskTest.java` to reflect the new `Duration` handling for pre- and post-amble durations.

These changes aim to enhance the clarity and functionality of the audio processing logic by leveraging `Duration` types for better time management.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
