### PR TITLE
DMP-4744: Improve automated task - OutboundAudioDeleter

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TransformedMediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TransformedMediaRepository.java
@@ -53,14 +53,14 @@ public interface TransformedMediaRepository extends JpaRepository<TransformedMed
 
 
     @Query("""
-        SELECT tm FROM MediaRequestEntity mr, TransformedMediaEntity tm
+        SELECT tm.id FROM MediaRequestEntity mr, TransformedMediaEntity tm
                JOIN tm.transientObjectDirectoryEntities tod
                WHERE tm.mediaRequest = mr
                AND ((tm.lastAccessed < :createdAtOrLastAccessedDateTime AND mr.status = 'COMPLETED')
                     OR (tm.createdDateTime < :createdAtOrLastAccessedDateTime AND  mr.status <> 'PROCESSING' AND tm.lastAccessed IS NULL))
                AND upper(tod.status.description) <> 'MARKED FOR DELETION'
         """)
-    List<TransformedMediaEntity> findAllDeletableTransformedMedia(OffsetDateTime createdAtOrLastAccessedDateTime, Limit limit);
+    List<Integer> findAllDeletableTransformedMedia(OffsetDateTime createdAtOrLastAccessedDateTime, Limit limit);
 
     @Query(value = """
         SELECT tm

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImplTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.common.repository.TransformedMediaRepository;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,7 +64,9 @@ class OutboundAudioDeleterProcessorImplTest {
         var transformedMedia2 = someTransformedMediaNotOwnedByUserInGroup(List.of(MEDIA_IN_PERPETUITY, SUPER_ADMIN, SUPER_USER));
 
         when(transformedMediaRepository.findAllDeletableTransformedMedia(any(), eq(Limit.of(1000))))
-            .thenReturn(List.of(transformedMedia1, transformedMedia2));
+            .thenReturn(List.of(1, 2));
+        when(transformedMediaRepository.findById(1)).thenReturn(Optional.of(transformedMedia1));
+        when(transformedMediaRepository.findById(2)).thenReturn(Optional.of(transformedMedia2));
 
         var deletedValues = List.of(new TransientObjectDirectoryEntity());
         when(singleElementProcessor.markForDeletion(any(), any()))
@@ -86,8 +89,10 @@ class OutboundAudioDeleterProcessorImplTest {
             List.of(MEDIA_IN_PERPETUITY, SUPER_ADMIN, SUPER_USER));
         when(transformedMediaRepository.findAllDeletableTransformedMedia(any(), eq(Limit.of(1000))))
             .thenReturn(List.of(
-                transformedMediaOwnedByUserInMediaInPerpetuityGroup,
-                transformedMediaNotOwnedByUserInMediaInPerpetuityGroup));
+                1,
+                2));
+        when(transformedMediaRepository.findById(1)).thenReturn(Optional.of(transformedMediaOwnedByUserInMediaInPerpetuityGroup));
+        when(transformedMediaRepository.findById(2)).thenReturn(Optional.of(transformedMediaNotOwnedByUserInMediaInPerpetuityGroup));
 
         // when
         outboundAudioDeleterProcessorImpl.markForDeletion(1000);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4744)


### Change description ###
# Summary of Git Diff

This Git diff introduces several changes to the `OutboundAudioDeleterProcessorImpl.java`, `TransformedMediaRepository.java`, and corresponding test files. The main focus is on modifying the way deletable transformed media is handled, specifically changing the return type of certain methods and improving error handling.

## Highlights

- **Return Type Change**: 
  - The method `findAllDeletableTransformedMedia` in `TransformedMediaRepository` has been modified to return a list of `Integer` IDs instead of `TransformedMediaEntity` objects.
  
- **Improved Error Handling**: 
  - In the `markForDeletion` method of `OutboundAudioDeleterProcessorImpl`, the code now checks if a `TransformedMediaEntity` exists for each ID retrieved and logs an error if not found.

- **Use of HashSet**: 
  - The `mediaRequests` collection is now initialized as a `HashSet` to ensure uniqueness.

- **Refactoring of Media Processing Loop**: 
  - The iteration over `transformedMediaList` has been refactored to loop over IDs instead of entities, enhancing clarity and performance.

- **Test Adjustments**: 
  - Corresponding tests in `OutboundAudioDeleterProcessorImplTest` have been updated to match the new method signatures and ensure that the changes are properly tested, including mocking for the new return types.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
