### PR TITLE
DMP-3945: Whitespaces could cause duplicate cases to be created

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
@@ -187,7 +187,7 @@ public class CaseController implements CasesApi {
         return new ResponseEntity<>(caseService.adminGetCaseById(id), HttpStatus.OK);
     }
 
-    private void validateUppercase(String courthouse, String courtroom) {
+    void validateUppercase(String courthouse, String courtroom) {
         if (!CourtValidationUtils.isUppercase(courthouse, courtroom)) {
             throw new DartsApiException(CaseApiError.INVALID_REQUEST, "Courthouse and courtroom must be uppercase.");
         }

--- a/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
@@ -107,7 +107,7 @@ public class CaseController implements CasesApi {
     ) {
         validateUppercase(advancedSearchRequest.getCourthouse(), advancedSearchRequest.getCourtroom());
         GetCasesSearchRequest request = GetCasesSearchRequest.builder()
-            .caseNumber(StringUtils.trimToNull(advancedSearchRequest.getCaseNumber()))
+            .caseNumber(advancedSearchRequest.getCaseNumber())
             .courthouse(StringUtils.trimToNull(advancedSearchRequest.getCourthouse()))
             .courtroom(StringUtils.trimToNull(advancedSearchRequest.getCourtroom()))
             .judgeName(StringUtils.trimToNull(advancedSearchRequest.getJudgeName()))

--- a/src/test/java/uk/gov/hmcts/darts/cases/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/controller/CaseControllerTest.java
@@ -1,0 +1,117 @@
+package uk.gov.hmcts.darts.cases.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.cases.model.AdvancedSearchRequest;
+import uk.gov.hmcts.darts.cases.model.AdvancedSearchResult;
+import uk.gov.hmcts.darts.cases.model.GetCasesSearchRequest;
+import uk.gov.hmcts.darts.cases.service.CaseService;
+import uk.gov.hmcts.darts.cases.util.RequestValidator;
+import uk.gov.hmcts.darts.log.api.LogApi;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CaseControllerTest {
+
+
+    @Mock
+    private CaseService caseService;
+    @Mock
+    private LogApi logApi;
+
+    @InjectMocks
+    @Spy
+    private CaseController caseController;
+
+    @Test
+    void casesSearchPost_whenProvidedWithStandardData_dataShouldBeMapepdCorrectly() {
+        AdvancedSearchRequest advancedSearchRequest = new AdvancedSearchRequest();
+        advancedSearchRequest.setCaseNumber(" caseNumber ");
+        advancedSearchRequest.setCourthouse(" courthouse ");
+        advancedSearchRequest.setCourtroom(" courtroom ");
+        advancedSearchRequest.setJudgeName(" judgeName ");
+        advancedSearchRequest.setDefendantName(" defendantName ");
+        advancedSearchRequest.dateFrom(LocalDate.now());
+        advancedSearchRequest.dateTo(LocalDate.now().plusDays(1));
+        advancedSearchRequest.setEventTextContains(" eventTextContains ");
+
+        doNothing().when(caseController).validateUppercase(any(), any());
+        try (MockedStatic<RequestValidator> requestValidatorMock = Mockito.mockStatic(RequestValidator.class)) {
+
+            List<AdvancedSearchResult> expected = List.of(mock(AdvancedSearchResult.class), mock(AdvancedSearchResult.class));
+            when(caseService.advancedSearch(any())).thenReturn(expected);
+
+            caseController.casesSearchPost(advancedSearchRequest);
+
+            ArgumentCaptor<GetCasesSearchRequest> requestArgumentCaptor = ArgumentCaptor.forClass(GetCasesSearchRequest.class);
+            verify(caseService).advancedSearch(requestArgumentCaptor.capture());
+            GetCasesSearchRequest request = requestArgumentCaptor.getValue();
+
+            assertThat(request.getCaseNumber()).isEqualTo(" caseNumber ");
+            assertThat(request.getCourthouse()).isEqualTo("courthouse");
+            assertThat(request.getCourtroom()).isEqualTo("courtroom");
+            assertThat(request.getJudgeName()).isEqualTo("judgeName");
+            assertThat(request.getDefendantName()).isEqualTo("defendantName");
+            assertThat(request.getDateFrom()).isEqualTo(advancedSearchRequest.getDateFrom());
+            assertThat(request.getDateTo()).isEqualTo(advancedSearchRequest.getDateTo());
+            assertThat(request.getEventTextContains()).isEqualTo("eventTextContains");
+
+            requestValidatorMock.verify(() -> RequestValidator.validate(request));
+            verify(caseController).validateUppercase(" courthouse ", " courtroom ");
+        }
+    }
+
+    @Test
+    void casesSearchPost_whenProvidedWithDataThatHasNulls_dataShouldBeMapepdCorrectly() {
+        AdvancedSearchRequest advancedSearchRequest = new AdvancedSearchRequest();
+        advancedSearchRequest.setCaseNumber(null);
+        advancedSearchRequest.setCourthouse(null);
+        advancedSearchRequest.setCourtroom(null);
+        advancedSearchRequest.setJudgeName(null);
+        advancedSearchRequest.setDefendantName(null);
+        advancedSearchRequest.dateFrom(null);
+        advancedSearchRequest.dateTo(null);
+        advancedSearchRequest.setEventTextContains(null);
+
+        doNothing().when(caseController).validateUppercase(any(), any());
+        try (MockedStatic<RequestValidator> requestValidatorMock = Mockito.mockStatic(RequestValidator.class)) {
+
+            List<AdvancedSearchResult> expected = List.of(mock(AdvancedSearchResult.class), mock(AdvancedSearchResult.class));
+            when(caseService.advancedSearch(any())).thenReturn(expected);
+
+            caseController.casesSearchPost(advancedSearchRequest);
+
+            ArgumentCaptor<GetCasesSearchRequest> requestArgumentCaptor = ArgumentCaptor.forClass(GetCasesSearchRequest.class);
+            verify(caseService).advancedSearch(requestArgumentCaptor.capture());
+            GetCasesSearchRequest request = requestArgumentCaptor.getValue();
+
+            assertThat(request.getCaseNumber()).isNull();
+            assertThat(request.getCourthouse()).isNull();
+            assertThat(request.getCourtroom()).isNull();
+            assertThat(request.getJudgeName()).isNull();
+            assertThat(request.getDefendantName()).isNull();
+            assertThat(request.getDateFrom()).isNull();
+            assertThat(request.getDateTo()).isNull();
+            assertThat(request.getEventTextContains()).isNull();
+
+            requestValidatorMock.verify(() -> RequestValidator.validate(request));
+            verify(caseController).validateUppercase(null, null);
+        }
+    }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3945)


### Change description ###
# Summary of Changes in CaseController.java

The Git diff shows a modification in the `casesSearchPost` method within the `CaseController.java` file. Specifically, the case number handling has been updated to avoid trimming null values, which may improve the handling of case numbers in search requests.

## Highlights
- **Modification in Case Number Handling**: 
  - The line that sets the `caseNumber` changed from using `StringUtils.trimToNull` to directly using `advancedSearchRequest.getCaseNumber()`. 
- **Impact**: 
  - This change may allow for case numbers that are not trimmed, preventing the potential loss of leading or trailing spaces which could be significant in some cases.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
