### PR TITLE
DMP-3408: Update event endpoint with associated hearings

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
@@ -10,11 +10,13 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.collections4.CollectionUtils;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 
 import java.time.OffsetDateTime;
@@ -54,6 +56,9 @@ public class EventEntity extends CreatedModifiedBaseEntity {
     @JoinColumn(name = "ctr_id", nullable = false)
     private CourtroomEntity courtroom;
 
+    @OneToMany(mappedBy = EventLinkedCaseEntity_.EVENT)
+    private List<EventLinkedCaseEntity> eventLinkedCaseEntities = new ArrayList<>();
+
     @Column(name = "version_label", length = 32)
     private String legacyVersionLabel;
 
@@ -86,5 +91,12 @@ public class EventEntity extends CreatedModifiedBaseEntity {
 
     public void addHearing(HearingEntity hearingEntity) {
         hearingEntities.add(hearingEntity);
+    }
+
+    public List<CourtCaseEntity> getLinkedCases() {
+        if (CollectionUtils.isEmpty(eventLinkedCaseEntities)) {
+            return new ArrayList<>();
+        }
+        return eventLinkedCaseEntities.stream().map(EventLinkedCaseEntity::getCourtCase).toList();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/controller/EventsController.java
@@ -22,7 +22,7 @@ import uk.gov.hmcts.darts.common.service.DataAnonymisationService;
 import uk.gov.hmcts.darts.event.component.DartsEventMapper;
 import uk.gov.hmcts.darts.event.http.api.EventApi;
 import uk.gov.hmcts.darts.event.model.AdminEventSearch;
-import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetEventById200Response;
 import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
 import uk.gov.hmcts.darts.event.model.AdminObfuscateEveByIdsRequest;
 import uk.gov.hmcts.darts.event.model.AdminSearchEventResponseResult;
@@ -181,7 +181,7 @@ public class EventsController implements EventApi {
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID,
         globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
-    public ResponseEntity<AdminGetEventResponseDetails> adminGetEventById(Integer eventId) {
+    public ResponseEntity<AdminGetEventById200Response> adminGetEventById(Integer eventId) {
         return new ResponseEntity<>(eventService.adminGetEventById(eventId), HttpStatus.OK);
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
@@ -1,9 +1,17 @@
 package uk.gov.hmcts.darts.event.mapper;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
+import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.event.model.AdminGetEventById200Response;
 import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetailsCasesCasesInner;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetailsHearingsHearingsInner;
 import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
 import uk.gov.hmcts.darts.event.model.CourthouseResponseDetails;
 import uk.gov.hmcts.darts.event.model.CourtroomResponseDetails;
@@ -18,8 +26,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class EventMapper {
 
-    public AdminGetEventResponseDetails mapToAdminGetEventsResponseForId(EventEntity eventEntity) {
-        AdminGetEventResponseDetails adminGetEventResponseDetail = new AdminGetEventResponseDetails();
+    public AdminGetEventById200Response mapToAdminGetEventsResponseForId(EventEntity eventEntity) {
+        AdminGetEventById200Response adminGetEventResponseDetail = new AdminGetEventById200Response();
 
         adminGetEventResponseDetail.setId(eventEntity.getId());
         adminGetEventResponseDetail.setDocumentumId(eventEntity.getLegacyObjectId());
@@ -53,7 +61,80 @@ public class EventMapper {
         adminGetEventResponseDetail.setLastModifiedAt(eventEntity.getLastModifiedDateTime());
         adminGetEventResponseDetail.setLastModifiedBy(eventEntity.getLastModifiedBy().getId());
         adminGetEventResponseDetail.setIsDataAnonymised(eventEntity.isDataAnonymised());
+
+        adminGetEventResponseDetail.setCases(mapAdminGetEventResponseDetailsCasesCases(eventEntity.getLinkedCases()));
+        adminGetEventResponseDetail.setHearings(mapAdminGetEventResponseDetailsHearingsHearings(eventEntity.getHearingEntities()));
+
         return adminGetEventResponseDetail;
+    }
+
+    List<AdminGetEventResponseDetailsHearingsHearingsInner> mapAdminGetEventResponseDetailsHearingsHearings(
+        List<HearingEntity> hearingEntities) {
+        if (CollectionUtils.isEmpty(hearingEntities)) {
+            return new ArrayList<>();
+        }
+        return hearingEntities.stream()
+            .map(hearingEntity -> mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity))
+            .toList();
+    }
+
+    AdminGetEventResponseDetailsHearingsHearingsInner mapAdminGetEventResponseDetailsHearingsHearing(HearingEntity hearingEntity) {
+        if (hearingEntity == null) {
+            return null;
+        }
+        AdminGetEventResponseDetailsHearingsHearingsInner adminGetEventResponseDetailsHearingsHearingsInner =
+            new AdminGetEventResponseDetailsHearingsHearingsInner();
+        adminGetEventResponseDetailsHearingsHearingsInner.setId(hearingEntity.getId());
+        adminGetEventResponseDetailsHearingsHearingsInner.setCaseId(hearingEntity.getCourtCase().getId());
+        adminGetEventResponseDetailsHearingsHearingsInner.setCaseNumber(hearingEntity.getCourtCase().getCaseNumber());
+        adminGetEventResponseDetailsHearingsHearingsInner.setHearingDate(hearingEntity.getHearingDate());
+        adminGetEventResponseDetailsHearingsHearingsInner.setCourtroom(mapCourtRoom(hearingEntity.getCourtroom()));
+        adminGetEventResponseDetailsHearingsHearingsInner.setCourthouse(
+            mapCourtHouse(Optional.ofNullable(hearingEntity.getCourtroom())
+                              .map(CourtroomEntity::getCourthouse)
+                              .orElse(null)));
+        return adminGetEventResponseDetailsHearingsHearingsInner;
+    }
+
+    List<AdminGetEventResponseDetailsCasesCasesInner> mapAdminGetEventResponseDetailsCasesCases(List<CourtCaseEntity> cases) {
+        if (CollectionUtils.isEmpty(cases)) {
+            return new ArrayList<>();
+        }
+        return cases.stream()
+            .map(caseEntity -> mapAdminGetEventResponseDetailsCasesCase(caseEntity))
+            .toList();
+    }
+
+    AdminGetEventResponseDetailsCasesCasesInner mapAdminGetEventResponseDetailsCasesCase(CourtCaseEntity caseEntity) {
+        if (caseEntity == null) {
+            return null;
+        }
+        AdminGetEventResponseDetailsCasesCasesInner adminGetEventResponseDetailsCasesCasesInner = new AdminGetEventResponseDetailsCasesCasesInner();
+
+        adminGetEventResponseDetailsCasesCasesInner.setId(caseEntity.getId());
+        adminGetEventResponseDetailsCasesCasesInner.setCaseNumber(caseEntity.getCaseNumber());
+        adminGetEventResponseDetailsCasesCasesInner.setCourthouse(mapCourtHouse(caseEntity.getCourthouse()));
+        return adminGetEventResponseDetailsCasesCasesInner;
+    }
+
+    CourthouseResponseDetails mapCourtHouse(CourthouseEntity courthouse) {
+        if (courthouse == null) {
+            return null;
+        }
+        CourthouseResponseDetails courthouseResponseDetails = new CourthouseResponseDetails();
+        courthouseResponseDetails.setId(courthouse.getId());
+        courthouseResponseDetails.setDisplayName(courthouse.getDisplayName());
+        return courthouseResponseDetails;
+    }
+
+    CourtroomResponseDetails mapCourtRoom(CourtroomEntity courtroom) {
+        if (courtroom == null) {
+            return null;
+        }
+        CourtroomResponseDetails courthouseResponseDetails = new CourtroomResponseDetails();
+        courthouseResponseDetails.setId(courtroom.getId());
+        courthouseResponseDetails.setName(courtroom.getName());
+        return courthouseResponseDetails;
     }
 
     public AdminGetVersionsByEventIdResponseResult mapToAdminGetEventVersionsResponseForId(List<EventEntity> eventEntities) {

--- a/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/EventService.java
@@ -2,14 +2,14 @@ package uk.gov.hmcts.darts.event.service;
 
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
-import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetEventById200Response;
 import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
 
 import java.util.List;
 import java.util.Set;
 
 public interface EventService {
-    AdminGetEventResponseDetails adminGetEventById(Integer eventId);
+    AdminGetEventById200Response adminGetEventById(Integer eventId);
 
     AdminGetVersionsByEventIdResponseResult adminGetVersionsByEventId(Integer eventId);
 

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventLinkedCaseRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.event.mapper.EventMapper;
-import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetEventById200Response;
 import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
 import uk.gov.hmcts.darts.event.service.EventService;
 
@@ -28,7 +28,7 @@ public class EventServiceImpl implements EventService {
     private final EventLinkedCaseRepository eventLinkedCaseRepository;
 
     @Override
-    public AdminGetEventResponseDetails adminGetEventById(Integer eventId) {
+    public AdminGetEventById200Response adminGetEventById(Integer eventId) {
         return eventMapper.mapToAdminGetEventsResponseForId(getEventByEveId(eventId));
     }
 

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -528,7 +528,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AdminGetEventResponseDetails'
+                allOf:
+                  - $ref: '#/components/schemas/AdminGetEventResponseDetails'
+                  - $ref: '#/components/schemas/AdminGetEventResponseDetailsCases'
+                  - $ref: '#/components/schemas/AdminGetEventResponseDetailsHearings'
+
         '404':
           description: Not Found - Event id
           content:
@@ -825,7 +829,47 @@ components:
           type: integer
         name:
           type: string
-
+    AdminGetEventResponseDetailsCases:
+      type: object
+      properties:
+        cases:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: 'The case id'
+              case_number:
+                type: string
+                description: 'The case number'
+              courthouse:
+                $ref: '#/components/schemas/CourthouseResponseDetails'
+    AdminGetEventResponseDetailsHearings:
+      type: object
+      properties:
+        hearings:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: 'The hearing id'
+              case_id:
+                type: integer
+                description: 'The case id'
+              case_number:
+                type: string
+                description: 'The case number'
+              hearing_date:
+                type: string
+                format: date
+                description: 'The hearing date'
+              courthouse:
+                $ref: '#/components/schemas/CourthouseResponseDetails'
+              courtroom:
+                $ref: '#/components/schemas/CourtroomResponseDetails'
     AdminGetEventResponseDetails:
       type: object
       properties:
@@ -942,4 +986,4 @@ components:
         MAPPING_INACTIVE,
         MAPPING_IN_USE,
         TOO_MANY_RESULTS,
-        EVENT_ID_NOT_FOUND]
+        EVENT_ID_NOT_FOUND ]

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/EventEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/EventEntityTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.darts.common.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventEntityTest {
+
+    @Test
+    void getLinkedCases_eventLinkedCaseEntitiesIsNull() {
+        EventEntity eventEntity = new EventEntity();
+        eventEntity.setEventLinkedCaseEntities(null);
+        assertThat(eventEntity.getLinkedCases()).isEmpty();
+    }
+
+    @Test
+    void getLinkedCases_eventLinkedCaseEntitiesIsEmpty() {
+        EventEntity eventEntity = new EventEntity();
+        eventEntity.setEventLinkedCaseEntities(new ArrayList<>());
+        assertThat(eventEntity.getLinkedCases()).isEmpty();
+    }
+
+    @Test
+    void getLinkedCases_eventLinkedCaseEntitiesIsNotEmptySingle() {
+        EventEntity eventEntity = new EventEntity();
+        EventLinkedCaseEntity eventLinkedCaseEntity = new EventLinkedCaseEntity();
+        CourtCaseEntity caseEntity = new CourtCaseEntity();
+        eventLinkedCaseEntity.setCourtCase(caseEntity);
+        eventEntity.getEventLinkedCaseEntities().add(eventLinkedCaseEntity);
+        assertThat(eventEntity.getLinkedCases()).containsExactly(caseEntity);
+    }
+
+    @Test
+    void getLinkedCases_eventLinkedCaseEntitiesIsNotEmptyMultiple() {
+        EventEntity eventEntity = new EventEntity();
+        EventLinkedCaseEntity eventLinkedCaseEntity1 = new EventLinkedCaseEntity();
+        CourtCaseEntity caseEntity1 = new CourtCaseEntity();
+        eventLinkedCaseEntity1.setCourtCase(caseEntity1);
+
+        EventLinkedCaseEntity eventLinkedCaseEntity2 = new EventLinkedCaseEntity();
+        CourtCaseEntity caseEntity2 = new CourtCaseEntity();
+        eventLinkedCaseEntity2.setCourtCase(caseEntity2);
+
+        eventEntity.getEventLinkedCaseEntities().add(eventLinkedCaseEntity1);
+        eventEntity.getEventLinkedCaseEntities().add(eventLinkedCaseEntity2);
+        assertThat(eventEntity.getLinkedCases()).containsExactly(caseEntity1, caseEntity2);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
@@ -4,20 +4,33 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.event.model.AdminGetEventById200Response;
 import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetails;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetailsCasesCasesInner;
+import uk.gov.hmcts.darts.event.model.AdminGetEventResponseDetailsHearingsHearingsInner;
 import uk.gov.hmcts.darts.event.model.AdminGetVersionsByEventIdResponseResult;
+import uk.gov.hmcts.darts.event.model.CourthouseResponseDetails;
+import uk.gov.hmcts.darts.event.model.CourtroomResponseDetails;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class EventMapperTest {
@@ -26,22 +39,68 @@ class EventMapperTest {
 
     @BeforeEach
     public void before() {
-        eventMapper = new EventMapper();
+        eventMapper = spy(new EventMapper());
     }
 
     @Test
     void mapsEventToAdminSearchEventResponseResult() {
         // When
-        EventEntity eventEntity = setGenericEventDataForTest();
+        EventEntity eventEntity = spy(setGenericEventDataForTest());
         eventEntity.setId(2);
         eventEntity.setCreatedDateTime(OffsetDateTime.now());
         eventEntity.setIsCurrent(true);
 
+
+        CourtCaseEntity courtCaseEntity1 = mock(CourtCaseEntity.class);
+        CourtCaseEntity courtCaseEntity2 = mock(CourtCaseEntity.class);
+        CourtCaseEntity courtCaseEntity3 = mock(CourtCaseEntity.class);
+        doReturn(List.of(courtCaseEntity1, courtCaseEntity2, courtCaseEntity3)).when(eventEntity).getLinkedCases();
+
+        AdminGetEventResponseDetailsCasesCasesInner adminGetEventResponseDetailsCasesCasesInner1 = mock(AdminGetEventResponseDetailsCasesCasesInner.class);
+        AdminGetEventResponseDetailsCasesCasesInner adminGetEventResponseDetailsCasesCasesInner2 = mock(AdminGetEventResponseDetailsCasesCasesInner.class);
+        AdminGetEventResponseDetailsCasesCasesInner adminGetEventResponseDetailsCasesCasesInner3 = mock(AdminGetEventResponseDetailsCasesCasesInner.class);
+
+        doReturn(adminGetEventResponseDetailsCasesCasesInner1).when(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity1);
+        doReturn(adminGetEventResponseDetailsCasesCasesInner2).when(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity2);
+        doReturn(adminGetEventResponseDetailsCasesCasesInner3).when(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity3);
+
+        HearingEntity hearingEntity1 = mock(HearingEntity.class);
+        HearingEntity hearingEntity2 = mock(HearingEntity.class);
+        HearingEntity hearingEntity3 = mock(HearingEntity.class);
+        doReturn(List.of(hearingEntity1, hearingEntity2, hearingEntity3)).when(eventEntity).getHearingEntities();
+
+        AdminGetEventResponseDetailsHearingsHearingsInner adminGetEventResponseDetailsHearingsHearingsInner1 = mock(
+            AdminGetEventResponseDetailsHearingsHearingsInner.class);
+        AdminGetEventResponseDetailsHearingsHearingsInner adminGetEventResponseDetailsHearingsHearingsInner2 = mock(
+            AdminGetEventResponseDetailsHearingsHearingsInner.class);
+        AdminGetEventResponseDetailsHearingsHearingsInner adminGetEventResponseDetailsHearingsHearingsInner3 = mock(
+            AdminGetEventResponseDetailsHearingsHearingsInner.class);
+
+        doReturn(adminGetEventResponseDetailsHearingsHearingsInner1).when(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity1);
+        doReturn(adminGetEventResponseDetailsHearingsHearingsInner2).when(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity2);
+        doReturn(adminGetEventResponseDetailsHearingsHearingsInner3).when(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity3);
+
+
         // Given
-        AdminGetEventResponseDetails responseResult = eventMapper.mapToAdminGetEventsResponseForId(eventEntity);
+        AdminGetEventById200Response responseResult = eventMapper.mapToAdminGetEventsResponseForId(eventEntity);
 
         // Then
         assertAdminEventResponseDetails(eventEntity, responseResult);
+
+        assertThat(responseResult.getCases())
+            .containsExactly(adminGetEventResponseDetailsCasesCasesInner1, adminGetEventResponseDetailsCasesCasesInner2,
+                             adminGetEventResponseDetailsCasesCasesInner3);
+
+        assertThat(responseResult.getHearings())
+            .containsExactly(adminGetEventResponseDetailsHearingsHearingsInner1, adminGetEventResponseDetailsHearingsHearingsInner2,
+                             adminGetEventResponseDetailsHearingsHearingsInner3);
+
+        verify(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity1);
+        verify(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity2);
+        verify(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity3);
+        verify(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity1);
+        verify(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity2);
+        verify(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity3);
     }
 
     @Test
@@ -143,7 +202,6 @@ class EventMapperTest {
         eventEntity1.setIsCurrent(false);
 
         List<EventEntity> eventEntities = List.of(eventEntity1);
-
         // Given
         AdminGetVersionsByEventIdResponseResult responseResult = eventMapper.mapToAdminGetEventVersionsResponseForId(eventEntities);
 
@@ -189,5 +247,201 @@ class EventMapperTest {
         eventEntity.setTimestamp(OffsetDateTime.now());
 
         return eventEntity;
+    }
+
+
+    @Test
+    void mapAdminGetEventResponseDetailsHearingsHearings_whenHearingEntityIsNull_returnsEmptyList() {
+        assertThat(eventMapper.mapAdminGetEventResponseDetailsHearingsHearings(null)).isEmpty();
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsHearingsHearings_whenHearingEntityIsEmpty_returnsEmptyList() {
+        assertThat(eventMapper.mapAdminGetEventResponseDetailsHearingsHearings(List.of())).isEmpty();
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsHearingsHearings_whenHasListValue_shouldMapAllValues() {
+        HearingEntity hearingEntity1 = mock(HearingEntity.class);
+        HearingEntity hearingEntity2 = mock(HearingEntity.class);
+        HearingEntity hearingEntity3 = mock(HearingEntity.class);
+
+        AdminGetEventResponseDetailsHearingsHearingsInner adminGetEventResponseDetailsHearingsHearingsInner1 = mock(
+            AdminGetEventResponseDetailsHearingsHearingsInner.class);
+        AdminGetEventResponseDetailsHearingsHearingsInner adminGetEventResponseDetailsHearingsHearingsInner2 = mock(
+            AdminGetEventResponseDetailsHearingsHearingsInner.class);
+        AdminGetEventResponseDetailsHearingsHearingsInner adminGetEventResponseDetailsHearingsHearingsInner3 = mock(
+            AdminGetEventResponseDetailsHearingsHearingsInner.class);
+
+        doReturn(adminGetEventResponseDetailsHearingsHearingsInner1).when(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity1);
+        doReturn(adminGetEventResponseDetailsHearingsHearingsInner2).when(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity2);
+        doReturn(adminGetEventResponseDetailsHearingsHearingsInner3).when(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity3);
+
+        assertThat(eventMapper.mapAdminGetEventResponseDetailsHearingsHearings(List.of(hearingEntity1, hearingEntity2, hearingEntity3)))
+            .containsExactly(adminGetEventResponseDetailsHearingsHearingsInner1, adminGetEventResponseDetailsHearingsHearingsInner2,
+                             adminGetEventResponseDetailsHearingsHearingsInner3);
+
+        verify(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity1);
+        verify(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity2);
+        verify(eventMapper).mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity3);
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsHearingsHearing_whenNullValueIsGiven_returnNull() {
+        assertThat(eventMapper.mapAdminGetEventResponseDetailsHearingsHearing(null))
+            .isNull();
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsHearingsHearing_whenValueIsGiven_shouldMapAllValues() {
+        CourthouseResponseDetails courthouseResponseDetails = mock(CourthouseResponseDetails.class);
+        CourthouseEntity courthouseEntity = mock(CourthouseEntity.class);
+        doReturn(courthouseResponseDetails).when(eventMapper).mapCourtHouse(courthouseEntity);
+
+        CourtroomResponseDetails courtroomResponseDetails = mock(CourtroomResponseDetails.class);
+        CourtroomEntity courtroomEntity = mock(CourtroomEntity.class);
+        doReturn(courtroomResponseDetails).when(eventMapper).mapCourtRoom(courtroomEntity);
+        when(courtroomEntity.getCourthouse()).thenReturn(courthouseEntity);
+
+        CourtCaseEntity courtCaseEntity = new CourtCaseEntity();
+        courtCaseEntity.setId(123);
+        courtCaseEntity.setCaseNumber("caseNumber");
+
+        HearingEntity hearingEntity = new HearingEntity();
+        hearingEntity.setId(1);
+        hearingEntity.setCourtCase(courtCaseEntity);
+        LocalDate hearingDate = LocalDate.now();
+        hearingEntity.setHearingDate(hearingDate);
+        hearingEntity.setCourtroom(courtroomEntity);
+
+        AdminGetEventResponseDetailsHearingsHearingsInner result = eventMapper.mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1);
+        assertThat(result.getCaseId()).isEqualTo(123);
+        assertThat(result.getCaseNumber()).isEqualTo("caseNumber");
+        assertThat(result.getHearingDate()).isEqualTo(hearingDate);
+        assertThat(result.getCourtroom()).isEqualTo(courtroomResponseDetails);
+        assertThat(result.getCourthouse()).isEqualTo(courthouseResponseDetails);
+
+        verify(eventMapper).mapCourtHouse(courthouseEntity);
+        verify(eventMapper).mapCourtRoom(courtroomEntity);
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsHearingsHearing_whenMissingCourtRoom_shouldMapAllFieldsBarCourtRoomAndCourtHouse() {
+        CourtCaseEntity courtCaseEntity = new CourtCaseEntity();
+        courtCaseEntity.setId(123);
+        courtCaseEntity.setCaseNumber("caseNumber");
+
+        HearingEntity hearingEntity = new HearingEntity();
+        hearingEntity.setId(1);
+        hearingEntity.setCourtCase(courtCaseEntity);
+        LocalDate hearingDate = LocalDate.now();
+        hearingEntity.setHearingDate(hearingDate);
+
+        AdminGetEventResponseDetailsHearingsHearingsInner result = eventMapper.mapAdminGetEventResponseDetailsHearingsHearing(hearingEntity);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1);
+        assertThat(result.getCaseId()).isEqualTo(123);
+        assertThat(result.getCaseNumber()).isEqualTo("caseNumber");
+        assertThat(result.getHearingDate()).isEqualTo(hearingDate);
+        assertThat(result.getCourtroom()).isNull();
+        assertThat(result.getCourthouse()).isNull();
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsCasesCases_whenHearingEntityIsNull_returnsEmptyList() {
+        assertThat(eventMapper.mapAdminGetEventResponseDetailsCasesCases(null)).isEmpty();
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsCasesCases_whenHearingEntityIsEmpty_returnsEmptyList() {
+        assertThat(eventMapper.mapAdminGetEventResponseDetailsCasesCases(List.of())).isEmpty();
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsCasesCases_whenHasListValue_shouldMapAllValues() {
+        CourtCaseEntity courtCaseEntity1 = mock(CourtCaseEntity.class);
+        CourtCaseEntity courtCaseEntity2 = mock(CourtCaseEntity.class);
+        CourtCaseEntity courtCaseEntity3 = mock(CourtCaseEntity.class);
+
+        AdminGetEventResponseDetailsCasesCasesInner adminGetEventResponseDetailsCasesCasesInner1 = mock(AdminGetEventResponseDetailsCasesCasesInner.class);
+        AdminGetEventResponseDetailsCasesCasesInner adminGetEventResponseDetailsCasesCasesInner2 = mock(AdminGetEventResponseDetailsCasesCasesInner.class);
+        AdminGetEventResponseDetailsCasesCasesInner adminGetEventResponseDetailsCasesCasesInner3 = mock(AdminGetEventResponseDetailsCasesCasesInner.class);
+
+        doReturn(adminGetEventResponseDetailsCasesCasesInner1).when(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity1);
+        doReturn(adminGetEventResponseDetailsCasesCasesInner2).when(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity2);
+        doReturn(adminGetEventResponseDetailsCasesCasesInner3).when(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity3);
+
+        assertThat(eventMapper.mapAdminGetEventResponseDetailsCasesCases(List.of(courtCaseEntity1, courtCaseEntity2, courtCaseEntity3)))
+            .containsExactly(adminGetEventResponseDetailsCasesCasesInner1, adminGetEventResponseDetailsCasesCasesInner2,
+                             adminGetEventResponseDetailsCasesCasesInner3);
+
+        verify(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity1);
+        verify(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity2);
+        verify(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity3);
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsCasesCase_whenNullValueIsGiven_returnNull() {
+        assertThat(eventMapper.mapAdminGetEventResponseDetailsCasesCase(null))
+            .isNull();
+    }
+
+    @Test
+    void mapAdminGetEventResponseDetailsCasesCase_whenValueIsGiven_shouldMapAllValues() {
+        CourthouseResponseDetails courthouseResponseDetails = mock(CourthouseResponseDetails.class);
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+        doReturn(courthouseResponseDetails).when(eventMapper).mapCourtHouse(courthouseEntity);
+
+        CourtCaseEntity courtCaseEntity = new CourtCaseEntity();
+        courtCaseEntity.setId(1);
+        courtCaseEntity.setCaseNumber("caseNumber");
+        courtCaseEntity.setCourthouse(courthouseEntity);
+        AdminGetEventResponseDetailsCasesCasesInner result = eventMapper.mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1);
+        assertThat(result.getCaseNumber()).isEqualTo("caseNumber");
+        assertThat(result.getCourthouse()).isEqualTo(courthouseResponseDetails);
+        verify(eventMapper).mapCourtHouse(courthouseEntity);
+    }
+
+    @Test
+    void mapCourtHouse_whenNullValueIsGiven_returnNull() {
+        assertThat(eventMapper.mapCourtHouse(null))
+            .isNull();
+    }
+
+    @Test
+    void mapCourtHouse_whenValueIsGiven_shouldMapAllValues() {
+        CourthouseEntity courthouseEntity = new CourthouseEntity();
+        courthouseEntity.setId(1);
+        courthouseEntity.setDisplayName("name");
+
+        CourthouseResponseDetails courthouseResponseDetails = eventMapper.mapCourtHouse(courthouseEntity);
+        assertThat(courthouseResponseDetails).isNotNull();
+        assertThat(courthouseResponseDetails.getId()).isEqualTo(1);
+        assertThat(courthouseResponseDetails.getDisplayName()).isEqualTo("name");
+    }
+
+    @Test
+    void mapCourtRoom_whenNullValueIsGiven_returnNull() {
+        assertThat(eventMapper.mapCourtRoom(null))
+            .isNull();
+    }
+
+    @Test
+    void mapCourtRoom_whenValueIsGiven_shouldMapAllValues() {
+        CourtroomEntity courtroomEntity = new CourtroomEntity();
+        courtroomEntity.setId(1);
+        courtroomEntity.setName("name");
+
+        CourtroomResponseDetails courtroomResponseDetails = eventMapper.mapCourtRoom(courtroomEntity);
+        assertThat(courtroomResponseDetails).isNotNull();
+        assertThat(courtroomResponseDetails.getId()).isEqualTo(1);
+        assertThat(courtroomResponseDetails.getName()).isEqualTo("NAME");
     }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3408)


### Change description ###
# Summary of Git Diff

This Git diff introduces enhancements to the `EventEntity` class and related components, mainly adding new functionality to manage linked cases and hearings. It also modifies the API response structures and updates the corresponding tests to ensure that the new features work correctly.

## Highlights

- **New Relationships**: 
  - Introduced a one-to-many relationship in `EventEntity` with `eventLinkedCaseEntities`.
  
- **New Method**: 
  - Added the `getLinkedCases()` method to retrieve linked cases from `eventLinkedCaseEntities`.

- **API Response Changes**:
  - Changed the return type in `EventsController` and `EventService` from `AdminGetEventResponseDetails` to `AdminGetEventById200Response`.
  - Updated OpenAPI specifications to reflect new response structures that include cases and hearings.

- **Mapper Enhancements**:
  - Updated `EventMapper` to handle mapping for new response details related to cases and hearings.
  - Introduced several private methods for mapping case and hearing data.

- **Testing Improvements**:
  - Added extensive unit tests for the new functionalities in both `EventEntity` and `EventMapper` to ensure robustness and correctness of the new logic. 

- **Library Utilization**: 
  - Utilized `CollectionUtils` from Apache Commons Collections to simplify null and empty checks in the new methods.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
