### PR TITLE
DMP-4872: Automatic transcript from legacy with no document shown in case transcripts 

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CasesControllerGetTranscriptsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CasesControllerGetTranscriptsTest.java
@@ -138,6 +138,7 @@ class CasesControllerGetTranscriptsTest extends IntegrationBase {
         transcription4.setIsManualTranscription(false);
         transcription4.setLegacyObjectId("Something");
         dartsDatabase.save(transcription4);
+        dartsDatabase.getTranscriptionDocumentStub().createTranscriptionDocumentForTranscription(transcription4);
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_CASE, hearingEntity.getCourtCase().getId());
         String expected = TestUtils.removeTags(TAGS_TO_IGNORE, getContentsFromFile(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
@@ -78,7 +78,7 @@ class TranscriptionRepositoryTest extends IntegrationBase {
     }
 
     @Test
-    void findByCaseIdManualOrLegacy_shouldReturnLegacyTranscirptionHasDocuments() {
+    void findByCaseIdManualOrLegacy_shouldReturnLegacyTranscriptionHasDocuments() {
         TranscriptionEntity legacyTranscription = createTranscriptionWithDocument(courtCaseEntity, false);
         legacyTranscription.setLegacyObjectId("legacy");
         legacyTranscription.setIsManualTranscription(false);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.darts.test.common.data.TranscriptionDocumentTestData.minimalTranscriptionDocument;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.COMPLETE;
@@ -42,12 +43,13 @@ class TranscriptionRepositoryTest extends IntegrationBase {
     private TranscriptionDocumentStub transcriptionDocumentStub;
 
     private CourtCaseEntity courtCaseEntity;
+    private HearingEntity hearingEntity;
 
     private int caseId;
 
     @BeforeEach
     public void setupData() {
-        HearingEntity hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
+        hearingEntity = dartsDatabase.givenTheDatabaseContainsCourtCaseWithHearingAndCourthouseWithRoom(
             SOME_CASE_ID,
             SOME_COURTHOUSE,
             SOME_COURTROOM,
@@ -55,7 +57,9 @@ class TranscriptionRepositoryTest extends IntegrationBase {
         );
         courtCaseEntity = hearingEntity.getCourtCase();
         caseId = courtCaseEntity.getId();
+    }
 
+    private void createStandardTranscriptionWithDocument() {
         createTranscriptionWithDocument(hearingEntity, false);
         createTranscriptionWithDocument(hearingEntity, true);
         createTranscriptionWithDocument(courtCaseEntity, false);
@@ -64,31 +68,47 @@ class TranscriptionRepositoryTest extends IntegrationBase {
 
     @Test
     void doesNotShowAutomated() {
+        createStandardTranscriptionWithDocument();
         TranscriptionEntity legacyTranscription = createTranscriptionWithDocument(courtCaseEntity, false);
         legacyTranscription.setIsManualTranscription(false);
         dartsDatabase.save(legacyTranscription);
 
         List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByCaseIdManualOrLegacy(caseId, true);
-        assertEquals(4, transcriptionEntities.size());
+        assertThat(transcriptionEntities).isEmpty();
     }
 
     @Test
-    void showsLegacyAutomated() {
+    void findByCaseIdManualOrLegacy_shouldReturnLegacyTranscirptionHasDocuments() {
         TranscriptionEntity legacyTranscription = createTranscriptionWithDocument(courtCaseEntity, false);
         legacyTranscription.setLegacyObjectId("legacy");
         legacyTranscription.setIsManualTranscription(false);
+        dartsDatabase.save(legacyTranscription);
         List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByCaseIdManualOrLegacy(caseId, true);
-        assertEquals(5, transcriptionEntities.size());
+        assertThat(transcriptionEntities).hasSize(1);
+        assertThat(transcriptionEntities.getFirst().getId())
+            .isEqualTo(legacyTranscription.getId());
+    }
+
+    @Test
+    void findByCaseIdManualOrLegacy_dontReturnLegacyTranscirptionIfHasNoDocuments() {
+        TranscriptionEntity legacyTranscription = transcriptionStub.createTranscription(courtCaseEntity);
+        legacyTranscription.setLegacyObjectId("legacy");
+        legacyTranscription.setIsManualTranscription(false);
+        dartsDatabase.save(legacyTranscription);
+        List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByCaseIdManualOrLegacy(caseId, true);
+        assertThat(transcriptionEntities).isEmpty();
     }
 
     @Test
     void includesHidden() {
+        createStandardTranscriptionWithDocument();
         List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByCaseIdManualOrLegacy(caseId, true);
-        assertEquals(4, transcriptionEntities.size());
+        assertThat(transcriptionEntities).isEmpty();
     }
 
     @Test
     void excludesHidden() {
+        createStandardTranscriptionWithDocument();
         var courtCase = PersistableFactory.getCourtCaseTestData().createSomeMinimalCase();
         persistTwoHiddenTwoNotHiddenTranscriptionsFor(courtCase);
 
@@ -100,6 +120,7 @@ class TranscriptionRepositoryTest extends IntegrationBase {
     @Test
     void findAllByTranscriptionStatusNotInWithCreatedDateTimeBefore_ShouldSucceed() {
         // given
+        createStandardTranscriptionWithDocument();
         TranscriptionStatusEntity completeTranscriptionStatus = dartsDatabase.getTranscriptionStub().getTranscriptionStatusByEnum(COMPLETE);
         TranscriptionEntity transcriptionCompleteOld =
             PersistableFactory.getTranscriptionTestData().minimalRawTranscription(completeTranscriptionStatus);
@@ -134,6 +155,7 @@ class TranscriptionRepositoryTest extends IntegrationBase {
     @Test
     void findAllByTranscriptionStatusNotInWithCreatedDateTimeBefore_NoResultsFound() {
         // given
+        createStandardTranscriptionWithDocument();
         TranscriptionEntity transcriptionApproved = PersistableFactory.getTranscriptionTestData().minimalTranscription();
         OffsetDateTime createdDateTime = OffsetDateTime.now().minusDays(1);
         List<TranscriptionStatusEntity> excludedStatuses = List.of(transcriptionApproved.getTranscriptionStatus());
@@ -144,7 +166,41 @@ class TranscriptionRepositoryTest extends IntegrationBase {
         );
 
         // then
-        assertEquals(0, result.size());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findByHearingIdManualOrLegacyIncludeDeletedTranscriptionDocuments_shouldReturnLegacyIfHasDocument() {
+        TranscriptionEntity legacyTranscription = createTranscriptionWithDocument(courtCaseEntity,false);
+        legacyTranscription.addHearing(hearingEntity);
+        legacyTranscription.setLegacyObjectId("legacy");
+        legacyTranscription.setIsManualTranscription(false);
+        dartsDatabase.save(legacyTranscription);
+
+
+        List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByHearingIdManualOrLegacyIncludeDeletedTranscriptionDocuments(
+            hearingEntity.getId()
+        );
+
+        assertThat(transcriptionEntities).hasSize(1);
+        assertThat(transcriptionEntities.getFirst().getId())
+            .isEqualTo(legacyTranscription.getId());
+    }
+
+    @Test
+    void findByHearingIdManualOrLegacyIncludeDeletedTranscriptionDocuments_shouldNotReturnLegacyIfNoDocument() {
+        TranscriptionEntity legacyTranscription = transcriptionStub.createTranscription(courtCaseEntity);
+        legacyTranscription.addHearing(hearingEntity);
+        legacyTranscription.setLegacyObjectId("legacy");
+        legacyTranscription.setIsManualTranscription(false);
+        dartsDatabase.save(legacyTranscription);
+
+
+        List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByHearingIdManualOrLegacyIncludeDeletedTranscriptionDocuments(
+            hearingEntity.getId()
+        );
+
+        assertThat(transcriptionEntities).isEmpty();
     }
 
     private void persistTwoHiddenTwoNotHiddenTranscriptionsFor(CourtCaseEntity courtCaseEntity) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
@@ -68,10 +68,10 @@ class TranscriptionRepositoryTest extends IntegrationBase {
 
     @Test
     void doesNotShowAutomated() {
-        createStandardTranscriptionWithDocument();
         TranscriptionEntity legacyTranscription = createTranscriptionWithDocument(courtCaseEntity, false);
         legacyTranscription.setIsManualTranscription(false);
         dartsDatabase.save(legacyTranscription);
+        dartsDatabase.getTranscriptionDocumentStub().createTranscriptionDocumentForTranscription(legacyTranscription);
 
         List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByCaseIdManualOrLegacy(caseId, true);
         assertThat(transcriptionEntities).isEmpty();
@@ -103,7 +103,7 @@ class TranscriptionRepositoryTest extends IntegrationBase {
     void includesHidden() {
         createStandardTranscriptionWithDocument();
         List<TranscriptionEntity> transcriptionEntities = transcriptionRepository.findByCaseIdManualOrLegacy(caseId, true);
-        assertThat(transcriptionEntities).isEmpty();
+        assertThat(transcriptionEntities).hasSize(4);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
@@ -90,7 +90,7 @@ class TranscriptionRepositoryTest extends IntegrationBase {
     }
 
     @Test
-    void findByCaseIdManualOrLegacy_dontReturnLegacyTranscirptionIfHasNoDocuments() {
+    void findByCaseIdManualOrLegacy_dontReturnLegacyTranscriptionIfHasNoDocuments() {
         TranscriptionEntity legacyTranscription = transcriptionStub.createTranscription(courtCaseEntity);
         legacyTranscription.setLegacyObjectId("legacy");
         legacyTranscription.setIsManualTranscription(false);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsControllerGetTranscriptsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsControllerGetTranscriptsTest.java
@@ -154,6 +154,7 @@ class HearingsControllerGetTranscriptsTest extends IntegrationBase {
         transcription4.setIsManualTranscription(false);
         transcription4.setLegacyObjectId("Something");
         dartsDatabase.save(transcription4);
+        dartsDatabase.getTranscriptionDocumentStub().createTranscriptionDocumentForTranscription(transcription4);
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL_HEARINGS, hearingEntity.getId());
         String expected = TestUtils.removeTags(TAGS_TO_IGNORE, getContentsFromFile(

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepository.java
@@ -74,7 +74,8 @@ public interface TranscriptionRepository extends RevisionRepository<Transcriptio
         JOIN darts.hearing_transcription_ae ht ON ht.tra_id = t.tra_id
         JOIN darts.hearing h ON h.hea_id = ht.hea_id
         WHERE h.hea_id = :hearingId
-        AND (t.is_manual_transcription = true OR (t.transcription_object_id IS NOT NULL and EXISTS(SELECT 1 FROM darts.transcription_document trd WHERE trd.tra_id = t.tra_id)))
+        AND (t.is_manual_transcription = true 
+                         OR (t.transcription_object_id IS NOT NULL and EXISTS(SELECT 1 FROM darts.transcription_document trd WHERE trd.tra_id = t.tra_id)))
         AND (EXISTS (
             SELECT 1
             FROM darts.transcription_document td

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepository.java
@@ -19,38 +19,39 @@ public interface TranscriptionRepository extends RevisionRepository<Transcriptio
 
     // transcriptions with is_current=false are filtered out downstream
     @Query(value = """
-        SELECT *
-        FROM darts.transcription tr
-        WHERE tr.tra_id IN (
-            SELECT ht.tra_id
-            FROM darts.hearing h
-            JOIN darts.hearing_transcription_ae ht ON ht.hea_id = h.hea_id
-            WHERE h.cas_id = :caseId
-            UNION
-            SELECT ct.tra_id
-            FROM darts.court_case cc
-            JOIN darts.case_transcription_ae ct ON ct.cas_id = cc.cas_id
-            WHERE cc.cas_id = :caseId
-        )
-        AND (
-            tr.is_manual_transcription = true OR tr.transcription_object_id IS NOT NULL
-        )
-        AND (
-            :includeHidden = true
-            OR
-            EXISTS (
-                SELECT 1
-                FROM darts.transcription_document trd
-                WHERE trd.tra_id = tr.tra_id
-                AND trd.is_hidden = false
-            )
-            OR
-            NOT EXISTS (
-                SELECT 1
-                FROM darts.transcription_document trd
-                WHERE trd.tra_id = tr.tra_id
-            )
-        )
+         SELECT *
+         FROM darts.transcription tr
+         WHERE tr.tra_id IN (
+             SELECT ht.tra_id
+             FROM darts.hearing h
+             JOIN darts.hearing_transcription_ae ht ON ht.hea_id = h.hea_id
+             WHERE h.cas_id = :caseId
+             UNION
+             SELECT ct.tra_id
+             FROM darts.court_case cc
+             JOIN darts.case_transcription_ae ct ON ct.cas_id = cc.cas_id
+             WHERE cc.cas_id = :caseId
+         )
+         AND (
+             tr.is_manual_transcription = true 
+                         OR (tr.transcription_object_id IS NOT NULL AND EXISTS(SELECT 1 FROM darts.transcription_document trd WHERE trd.tra_id = tr.tra_id))
+         )
+         AND (
+             :includeHidden = true
+             OR
+             EXISTS (
+                 SELECT 1
+                 FROM darts.transcription_document trd
+                 WHERE trd.tra_id = tr.tra_id
+                 AND trd.is_hidden = false
+             )
+             OR
+             NOT EXISTS (
+                 SELECT 1
+                 FROM darts.transcription_document trd
+                 WHERE trd.tra_id = tr.tra_id
+             )
+         )
         """, nativeQuery = true
     )
     List<TranscriptionEntity> findByCaseIdManualOrLegacy(Integer caseId, Boolean includeHidden);
@@ -73,7 +74,7 @@ public interface TranscriptionRepository extends RevisionRepository<Transcriptio
         JOIN darts.hearing_transcription_ae ht ON ht.tra_id = t.tra_id
         JOIN darts.hearing h ON h.hea_id = ht.hea_id
         WHERE h.hea_id = :hearingId
-        AND (t.is_manual_transcription = true OR t.transcription_object_id IS NOT NULL)
+        AND (t.is_manual_transcription = true OR (t.transcription_object_id IS NOT NULL and EXISTS(SELECT 1 FROM darts.transcription_document trd WHERE trd.tra_id = t.tra_id)))
         AND (EXISTS (
             SELECT 1
             FROM darts.transcription_document td


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4872)


### Change description ###
# Summary of Git Diff

This Git diff shows updates made to the `TranscriptionRepositoryTest` and `TranscriptionRepository` classes in the `uk.gov.hmcts.darts` project. The changes primarily involve enhancing the testing of transcription retrieval methods and refining the SQL queries used for fetching transcriptions.

## Highlights

### Changes in `TranscriptionRepositoryTest.java`
- **Imports**: Added `assertThat` from AssertJ for better assertions.
- **Setup Method**: Refactored the `setupData` method to directly assign `hearingEntity` instead of declaring it as a new local variable.
- **New Methods**: Introduced `createStandardTranscriptionWithDocument` to streamline the creation of standard transcriptions.
- **Tests Enhanced**:
  - Updated assertions in tests to use `assertThat` instead of `assertEquals`.
  - Added new tests:
    - `findByCaseIdManualOrLegacy_shouldReturnLegacyTranscriptionHasDocuments`
    - `findByCaseIdManualOrLegacy_dontReturnLegacyTranscriptionIfHasNoDocuments`
    - `findByHearingIdManualOrLegacyIncludeDeletedTranscriptionDocuments_shouldReturnLegacyIfHasDocument`
    - `findByHearingIdManualOrLegacyIncludeDeletedTranscriptionDocuments_shouldNotReturnLegacyIfNoDocument`

### Changes in `TranscriptionRepository.java`
- **SQL Query Updates**: Modified the SQL queries used in `findByCaseIdManualOrLegacy` and `findAllByTranscriptionStatusNotInWithCreatedDateTimeBefore` to ensure they correctly filter and include transcriptions based on document existence and status.
- **Logical Adjustments**: Added checks to verify the existence of transcription documents in the query conditions, enhancing the accuracy of the data retrieval logic. 

These updates collectively improve the robustness of the transcription repository's functionality and the reliability of corresponding tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
