### PR TITLE
DMP-4826: Return error when search does not meet minimum characters to prevent performance impacting queries from running

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.cases.controller;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -10,6 +11,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import uk.gov.hmcts.darts.authorisation.exception.AuthorisationError;
 import uk.gov.hmcts.darts.cases.model.AdminCasesSearchRequest;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -630,6 +632,149 @@ class CaseControllerSearchPostTest extends IntegrationBase {
             .content(requestBody);
         mockMvc.perform(requestBuilder)
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void casesSearchPost_shouldReturn400_whenEventTextLengthIs2() throws Exception {
+        user = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+        setupUserAccountAndSecurityGroup(swanseaCourthouse);
+        String requestBody = """
+            {
+             "courthouse": "SWANSEA",
+              "courtroom": "1",
+              "event_text_contains": "t5"
+            }""";
+
+        MockHttpServletRequestBuilder requestBuilder = post("/cases/search")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody);
+        MvcResult response = mockMvc.perform(requestBuilder)
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+
+        String expectedResponse = """
+            {
+              "violations": [
+                {
+                  "field": "eventTextContains",
+                  "message": "size must be between 3 and 2000"
+                }
+              ],
+              "type": "https://zalando.github.io/problem/constraint-violation",
+              "status": 400,
+              "title": "Constraint Violation"
+            }
+            """;
+        String actualResponse = response.getResponse().getContentAsString();
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    void casesSearchPost_shouldReturn400_whenJudgeNameLengthIs2() throws Exception {
+        user = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+        setupUserAccountAndSecurityGroup(swanseaCourthouse);
+        String requestBody = """
+            {
+             "courthouse": "SWANSEA",
+              "courtroom": "1",
+              "judge_name": "t5"
+            }""";
+
+        MockHttpServletRequestBuilder requestBuilder = post("/cases/search")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody);
+        MvcResult response = mockMvc.perform(requestBuilder)
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+
+        String expectedResponse = """
+            {
+              "violations": [
+                {
+                  "field": "judgeName",
+                  "message": "size must be between 3 and 2000"
+                }
+              ],
+              "type": "https://zalando.github.io/problem/constraint-violation",
+              "status": 400,
+              "title": "Constraint Violation"
+            }
+            """;
+        String actualResponse = response.getResponse().getContentAsString();
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    void casesSearchPost_shouldReturn400_whenDefendantNameLengthIs2() throws Exception {
+        user = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+        setupUserAccountAndSecurityGroup(swanseaCourthouse);
+        String requestBody = """
+            {
+             "courthouse": "SWANSEA",
+              "courtroom": "1",
+              "defendant_name": "t5"
+            }""";
+
+        MockHttpServletRequestBuilder requestBuilder = post("/cases/search")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody);
+        MvcResult response = mockMvc.perform(requestBuilder)
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+
+        String expectedResponse = """
+            {
+              "violations": [
+                {
+                  "field": "defendantName",
+                  "message": "size must be between 3 and 2000"
+                }
+              ],
+              "type": "https://zalando.github.io/problem/constraint-violation",
+              "status": 400,
+              "title": "Constraint Violation"
+            }
+            """;
+        String actualResponse = response.getResponse().getContentAsString();
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+    }
+
+    @Test
+    void casesSearchPost_shouldReturn400_whenCourthouseNameLengthIs2() throws Exception {
+        user = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
+        setupUserAccountAndSecurityGroup(swanseaCourthouse);
+        String requestBody = """
+            {
+             "courthouse": "SW",
+              "courtroom": "1"
+            }""";
+
+        MockHttpServletRequestBuilder requestBuilder = post("/cases/search")
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .content(requestBody);
+        MvcResult response = mockMvc.perform(requestBuilder)
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+
+        String expectedResponse = """
+            {
+              "violations": [
+                {
+                  "field": "courthouse",
+                  "message": "size must be between 3 and 2000"
+                }
+              ],
+              "type": "https://zalando.github.io/problem/constraint-violation",
+              "status": 400,
+              "title": "Constraint Violation"
+            }
+            """;
+        String actualResponse = response.getResponse().getContentAsString();
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.darts.cases.controller;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -11,7 +10,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import uk.gov.hmcts.darts.authorisation.exception.AuthorisationError;
 import uk.gov.hmcts.darts.cases.model.AdminCasesSearchRequest;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
@@ -667,7 +665,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
             }
             """;
         String actualResponse = response.getResponse().getContentAsString();
-        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+        assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -703,7 +701,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
             }
             """;
         String actualResponse = response.getResponse().getContentAsString();
-        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+        assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -739,7 +737,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
             }
             """;
         String actualResponse = response.getResponse().getContentAsString();
-        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+        assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test
@@ -774,7 +772,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
             }
             """;
         String actualResponse = response.getResponse().getContentAsString();
-        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
+        assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/darts/cases/util/RequestValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/util/RequestValidator.java
@@ -36,16 +36,29 @@ public class RequestValidator {
      */
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     private static void checkComplexity(GetCasesSearchRequest request) {
+        boolean courthouseProvided = StringUtils.length(request.getCourthouse()) >= SEARCH_TEXT_LENGTH_THRESHOLD;
+        boolean anyDateProvided = request.getDateFrom() != null || request.getDateTo() != null;
+
+        if (courthouseProvided && anyDateProvided) {
+            //allowed case
+            return;
+        }
+
         int totalPoints = 0;
         //give a point for every letter more than 3
         totalPoints += Math.max(0, StringUtils.length(request.getCaseNumber()) - SEARCH_TEXT_LENGTH_THRESHOLD);
+        totalPoints += courthouseProvided ? 1 : 0;
         boolean courtroomProvided = request.getCourtroom() != null;
         totalPoints += courtroomProvided ? 1 : 0;
-        totalPoints += getPoints(request.getJudgeName());
-        totalPoints += getPoints(request.getDefendantName());
-        totalPoints += getPoints(request.getEventTextContains());
+        boolean judgeNameLengthOk = StringUtils.length(request.getJudgeName()) >= SEARCH_TEXT_LENGTH_THRESHOLD;
+        totalPoints += judgeNameLengthOk ? 1 : 0;
+        boolean defendantNameLengthOk = StringUtils.length(request.getDefendantName()) >= SEARCH_TEXT_LENGTH_THRESHOLD;
+        totalPoints += defendantNameLengthOk ? 1 : 0;
+        totalPoints += anyDateProvided ? 1 : 0;
         boolean specificDateProvided = request.getDateFrom() != null && request.getDateFrom().equals(request.getDateTo());
         totalPoints += specificDateProvided ? 1 : 0;
+        boolean eventTextLengthOk = StringUtils.length(request.getEventTextContains()) >= SEARCH_TEXT_LENGTH_THRESHOLD;
+        totalPoints += eventTextLengthOk ? 1 : 0;
 
         //Do this at the end to ensure getPoints CRITERIA_TOO_BROAD gets chucked first
         boolean courthouseProvided = getPoints(request.getCourthouse()) != 0 || CollectionUtils.isNotEmpty(request.getCourthouseIds());
@@ -53,27 +66,13 @@ public class RequestValidator {
         totalPoints += anyDateProvided ? 1 : 0;
         totalPoints += courthouseProvided ? 1 : 0;
 
-        if (courthouseProvided && anyDateProvided) {
-            //allowed case
-            return;
-        }
         if (totalPoints < SEARCH_COMPLEXITY_THRESHOLD) {
             throw new DartsApiException(CaseApiError.CRITERIA_TOO_BROAD);
         }
     }
 
-    private static int getPoints(String str) {
-        long length = StringUtils.length(str);
-        if (length == 0) {
-            return 0;
-        }
-        if (length >= SEARCH_TEXT_LENGTH_THRESHOLD) {
-            return 1;
-        }
-        throw new DartsApiException(CaseApiError.CRITERIA_TOO_BROAD,
-                                    "Please include at least " + SEARCH_TEXT_LENGTH_THRESHOLD + " characters.");
-    }
 
+    @SuppressWarnings({"PMD.UnnecessaryVarargsArrayCreation"})
     private static void checkNoCriteriaProvided(GetCasesSearchRequest request) {
         if (BooleanUtils.and(new boolean[]{
             StringUtils.isBlank(request.getCaseNumber()),

--- a/src/main/java/uk/gov/hmcts/darts/cases/util/RequestValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/util/RequestValidator.java
@@ -36,29 +36,16 @@ public class RequestValidator {
      */
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     private static void checkComplexity(GetCasesSearchRequest request) {
-        boolean courthouseProvided = StringUtils.length(request.getCourthouse()) >= SEARCH_TEXT_LENGTH_THRESHOLD;
-        boolean anyDateProvided = request.getDateFrom() != null || request.getDateTo() != null;
-
-        if (courthouseProvided && anyDateProvided) {
-            //allowed case
-            return;
-        }
-
         int totalPoints = 0;
         //give a point for every letter more than 3
         totalPoints += Math.max(0, StringUtils.length(request.getCaseNumber()) - SEARCH_TEXT_LENGTH_THRESHOLD);
-        totalPoints += courthouseProvided ? 1 : 0;
         boolean courtroomProvided = request.getCourtroom() != null;
         totalPoints += courtroomProvided ? 1 : 0;
-        boolean judgeNameLengthOk = StringUtils.length(request.getJudgeName()) >= SEARCH_TEXT_LENGTH_THRESHOLD;
-        totalPoints += judgeNameLengthOk ? 1 : 0;
-        boolean defendantNameLengthOk = StringUtils.length(request.getDefendantName()) >= SEARCH_TEXT_LENGTH_THRESHOLD;
-        totalPoints += defendantNameLengthOk ? 1 : 0;
-        totalPoints += anyDateProvided ? 1 : 0;
+        totalPoints += getPoints(request.getJudgeName());
+        totalPoints += getPoints(request.getDefendantName());
+        totalPoints += getPoints(request.getEventTextContains());
         boolean specificDateProvided = request.getDateFrom() != null && request.getDateFrom().equals(request.getDateTo());
         totalPoints += specificDateProvided ? 1 : 0;
-        boolean eventTextLengthOk = StringUtils.length(request.getEventTextContains()) >= SEARCH_TEXT_LENGTH_THRESHOLD;
-        totalPoints += eventTextLengthOk ? 1 : 0;
 
         //Do this at the end to ensure getPoints CRITERIA_TOO_BROAD gets chucked first
         boolean courthouseProvided = getPoints(request.getCourthouse()) != 0 || CollectionUtils.isNotEmpty(request.getCourthouseIds());
@@ -66,9 +53,25 @@ public class RequestValidator {
         totalPoints += anyDateProvided ? 1 : 0;
         totalPoints += courthouseProvided ? 1 : 0;
 
+        if (courthouseProvided && anyDateProvided) {
+            //allowed case
+            return;
+        }
         if (totalPoints < SEARCH_COMPLEXITY_THRESHOLD) {
             throw new DartsApiException(CaseApiError.CRITERIA_TOO_BROAD);
         }
+    }
+
+    private static int getPoints(String str) {
+        long length = StringUtils.length(str);
+        if (length == 0) {
+            return 0;
+        }
+        if (length >= SEARCH_TEXT_LENGTH_THRESHOLD) {
+            return 1;
+        }
+        throw new DartsApiException(CaseApiError.CRITERIA_TOO_BROAD,
+                                    "Please include at least " + SEARCH_TEXT_LENGTH_THRESHOLD + " characters.");
     }
 
 

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -898,10 +898,12 @@ components:
           type: string
           example: Judge Walker
           maxLength: 2000
+          minLength: 3
         defendant_name:
           type: string
           example: 'David Defendant'
           maxLength: 2000
+          minLength: 3
         date_from:
           type: string
           format: date
@@ -912,6 +914,7 @@ components:
           type: string
           example: 'Event text'
           maxLength: 2000
+          minLength: 3
 
     AdminSingleCaseResponseItem:
       type: object

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -886,6 +886,8 @@ components:
         courthouse:
           type: string
           example: Swansea
+          maxLength: 2000
+          minLength: 3
         courthouse_ids:
           type: array
           items:

--- a/src/test/java/uk/gov/hmcts/darts/cases/util/RequestValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/util/RequestValidatorTest.java
@@ -1,15 +1,16 @@
 package uk.gov.hmcts.darts.cases.util;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.cases.exception.CaseApiError;
 import uk.gov.hmcts.darts.cases.model.GetCasesSearchRequest;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@SuppressWarnings("PMD.ShortMethodName")
 class RequestValidatorTest {
 
     @Test
@@ -114,4 +115,65 @@ class RequestValidatorTest {
         RequestValidator.validate(request);
     }
 
+    @Test
+    void courthouseExists_butIsTooShort_shouldThrowError() {
+        GetCasesSearchRequest request = buildValidRequest();
+        request.setCourthouse("a");
+
+        DartsApiException exception = assertThrows(
+            DartsApiException.class,
+            () -> RequestValidator.validate(request)
+        );
+        assertThat(exception.getError()).isEqualTo(CaseApiError.CRITERIA_TOO_BROAD);
+        assertThat(exception.getMessage()).contains("Please include at least 3 characters.");
+    }
+
+    @Test
+    void judgeNameExists_butIsTooShort_shouldThrowError() {
+        GetCasesSearchRequest request = buildValidRequest();
+        request.setJudgeName("a");
+
+        DartsApiException exception = assertThrows(
+            DartsApiException.class,
+            () -> RequestValidator.validate(request)
+        );
+        assertThat(exception.getError()).isEqualTo(CaseApiError.CRITERIA_TOO_BROAD);
+        assertThat(exception.getMessage()).contains("Please include at least 3 characters.");
+    }
+
+    @Test
+    void defendantNameExists_butIsTooShort_shouldThrowError() {
+        GetCasesSearchRequest request = buildValidRequest();
+        request.setDefendantName("a");
+
+        DartsApiException exception = assertThrows(
+            DartsApiException.class,
+            () -> RequestValidator.validate(request)
+        );
+        assertThat(exception.getError()).isEqualTo(CaseApiError.CRITERIA_TOO_BROAD);
+        assertThat(exception.getMessage()).contains("Please include at least 3 characters.");
+    }
+
+    @Test
+    void eventTextExists_butIsTooShort_shouldThrowError() {
+        GetCasesSearchRequest request = buildValidRequest();
+        request.setEventTextContains("a");
+
+        DartsApiException exception = assertThrows(
+            DartsApiException.class,
+            () -> RequestValidator.validate(request)
+        );
+        assertThat(exception.getError()).isEqualTo(CaseApiError.CRITERIA_TOO_BROAD);
+        assertThat(exception.getMessage()).contains("Please include at least 3 characters.");
+    }
+
+    private GetCasesSearchRequest buildValidRequest() {
+        return GetCasesSearchRequest.builder()
+            .courthouse("swansea")
+            .judgeName("judge")
+            .defendantName("defendant")
+            .eventTextContains("event")
+            .caseNumber("123456")
+            .build();
+    }
 }

--- a/src/test/java/uk/gov/hmcts/darts/cases/util/RequestValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/util/RequestValidatorTest.java
@@ -1,16 +1,15 @@
 package uk.gov.hmcts.darts.cases.util;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.darts.cases.exception.CaseApiError;
 import uk.gov.hmcts.darts.cases.model.GetCasesSearchRequest;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 
 import java.time.LocalDate;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@SuppressWarnings("PMD.ShortMethodName")
 class RequestValidatorTest {
 
     @Test
@@ -115,65 +114,4 @@ class RequestValidatorTest {
         RequestValidator.validate(request);
     }
 
-    @Test
-    void courthouseExists_butIsTooShort_shouldThrowError() {
-        GetCasesSearchRequest request = buildValidRequest();
-        request.setCourthouse("a");
-
-        DartsApiException exception = assertThrows(
-            DartsApiException.class,
-            () -> RequestValidator.validate(request)
-        );
-        assertThat(exception.getError()).isEqualTo(CaseApiError.CRITERIA_TOO_BROAD);
-        assertThat(exception.getMessage()).contains("Please include at least 3 characters.");
-    }
-
-    @Test
-    void judgeNameExists_butIsTooShort_shouldThrowError() {
-        GetCasesSearchRequest request = buildValidRequest();
-        request.setJudgeName("a");
-
-        DartsApiException exception = assertThrows(
-            DartsApiException.class,
-            () -> RequestValidator.validate(request)
-        );
-        assertThat(exception.getError()).isEqualTo(CaseApiError.CRITERIA_TOO_BROAD);
-        assertThat(exception.getMessage()).contains("Please include at least 3 characters.");
-    }
-
-    @Test
-    void defendantNameExists_butIsTooShort_shouldThrowError() {
-        GetCasesSearchRequest request = buildValidRequest();
-        request.setDefendantName("a");
-
-        DartsApiException exception = assertThrows(
-            DartsApiException.class,
-            () -> RequestValidator.validate(request)
-        );
-        assertThat(exception.getError()).isEqualTo(CaseApiError.CRITERIA_TOO_BROAD);
-        assertThat(exception.getMessage()).contains("Please include at least 3 characters.");
-    }
-
-    @Test
-    void eventTextExists_butIsTooShort_shouldThrowError() {
-        GetCasesSearchRequest request = buildValidRequest();
-        request.setEventTextContains("a");
-
-        DartsApiException exception = assertThrows(
-            DartsApiException.class,
-            () -> RequestValidator.validate(request)
-        );
-        assertThat(exception.getError()).isEqualTo(CaseApiError.CRITERIA_TOO_BROAD);
-        assertThat(exception.getMessage()).contains("Please include at least 3 characters.");
-    }
-
-    private GetCasesSearchRequest buildValidRequest() {
-        return GetCasesSearchRequest.builder()
-            .courthouse("swansea")
-            .judgeName("judge")
-            .defendantName("defendant")
-            .eventTextContains("event")
-            .caseNumber("123456")
-            .build();
-    }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4826)


### Change description ###
# Summary of Git Diff

The recent changes to the `CaseControllerSearchPostTest.java`, `RequestValidator.java`, and OpenAPI specifications introduce additional validation tests for the `/cases/search` endpoint. Specifically, the changes enforce minimum length requirements for several fields in the request body, ensuring they are between 3 and 2000 characters. These updates enhance the robustness of the API by preventing invalid requests from being processed.

## Highlights

- **New Test Cases Added:**
  - Tests to validate the length of `event_text_contains`, `judge_name`, `defendant_name`, and `courthouse` fields. Each must be at least 3 characters long.
  - Each test checks for a "400 Bad Request" response when the corresponding field is less than the required length.

- **Validation Rules Defined:**
  - Updated OpenAPI specification to include `minLength` and `maxLength` constraints for:
    - `courthouse`
    - `judge_name`
    - `defendant_name`
    - `event_text_contains`

- **Code Adjustments:**
  - Import of `JSONAssert` and `MockMvcResultMatchers` to support JSON response validation in test cases.
  - Minor formatting changes to ensure consistency, including the addition of newlines at the end of files where necessary.

This update aims to improve input validation and error handling for the API, enhancing overall reliability and user experience.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
