### PR TITLE
Tidy up exception log formatting

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/retention/controller/RetentionControllerPostRetentionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/retention/controller/RetentionControllerPostRetentionIntTest.java
@@ -312,7 +312,7 @@ class RetentionControllerPostRetentionIntTest extends IntegrationBase {
             .content(requestBody);
         mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
             .andExpect(jsonPath("type", is("RETENTION_101")))
-            .andExpect(jsonPath("title", is("The retention date being applied is too early.")))
+            .andExpect(jsonPath("title", is("The retention date being applied is too early")))
             .andExpect(jsonPath("status", is(422)))
             .andExpect(jsonPath(
                 "detail",
@@ -357,7 +357,7 @@ class RetentionControllerPostRetentionIntTest extends IntegrationBase {
             .content(requestBody);
         mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
             .andExpect(jsonPath("type", is("RETENTION_107")))
-            .andExpect(jsonPath("title", is("The retention date being applied is too late.")))
+            .andExpect(jsonPath("title", is("The retention date being applied is too late")))
             .andExpect(jsonPath("status", is(422)))
             .andExpect(jsonPath(
                 "detail",

--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImpl.java
@@ -131,7 +131,7 @@ public class OutboundFileProcessorImpl implements OutboundFileProcessor {
                     );
                     concatenatedAndMergedAudioFileInfos.add(reEncode(trimmedAudio));
                 } else {
-                    throw new DartsApiException(AudioApiError.FAILED_TO_PROCESS_AUDIO_REQUEST, "No media present to process");
+                    throw new DartsApiException(AudioApiError.FAILED_TO_PROCESS_AUDIO_REQUEST, "No media present to process.");
                 }
             }
         }

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiException.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiException.java
@@ -54,10 +54,4 @@ public class DartsApiException extends RuntimeException {
         this.customProperties.putAll(customProperties);
     }
 
-    public DartsApiException(DartsApiError error, String detail, Throwable throwable) {
-        super(String.format(EXCEPTION_MESSAGE_FORMAT, error.getTitle(), detail), throwable);
-
-        this.error = error;
-        this.detail = detail;
-    }
 }

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -1070,7 +1070,7 @@ components:
         - "Too many results have been returned. Please change search criteria."
         - "No search criteria has been specified, please add at least 1 criteria to search for."
         - "Search criteria is too broad, please add at least 1 more criteria to search for."
-        - "The request is not valid.."
+        - "The request is not valid"
         - "The requested case cannot be found"
         - "The request does not contain any values that are supported by the PATCH operation."
         - "The requested case does not contain any actual hearings."

--- a/src/main/resources/openapi/retentions.yaml
+++ b/src/main/resources/openapi/retentions.yaml
@@ -452,14 +452,14 @@ components:
     RetentionTitleErrors:
       type: string
       enum:
-        - "You do not have permission to reduce the retention period."
-        - "The retention date being applied is too early."
-        - "The request is invalid."
-        - "The requested caseId cannot be found."
-        - "The case must be closed before the retention period can be amended."
-        - "The case must have a retention policy applied before being changed."
-        - "An Internal server error has occurred."
-        - "The retention date being applied is too late."
+        - "You do not have permission to reduce the retention period"
+        - "The retention date being applied is too early"
+        - "The request is invalid"
+        - "The requested caseId cannot be found"
+        - "The case must be closed before the retention period can be amended"
+        - "The case must have a retention policy applied before being changed"
+        - "An Internal server error has occurred"
+        - "The retention date being applied is too late"
         - "The retention policy type id does not exist."
         - "Policy name must be unique"
         - "Display name must be unique"
@@ -470,7 +470,7 @@ components:
         - "Fixed policy key not recognised"
         - "Live policies cannot be edited"
         - "Target policy has pending revision"
-        - "The retention date cannot be amended as the case is already expired."
+        - "The retention date cannot be amended as the case is already expired"
       x-enum-varnames: [ NO_PERMISSION_REDUCE_RETENTION, RETENTION_DATE_TOO_EARLY, INVALID_REQUEST, CASE_NOT_FOUND, CASE_NOT_CLOSED,
                          NO_RETENTION_POLICIES_APPLIED, INTERNAL_SERVER_ERROR, RETENTION_DATE_TOO_LATE, RETENTION_POLICY_TYPE_ID_NOT_FOUND,
                          NON_UNIQUE_POLICY_NAME, NON_UNIQUE_POLICY_DISPLAY_NAME, DURATION_TOO_SHORT, POLICY_START_MUST_BE_FUTURE,

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/OutboundFileProcessorImplTest.java
@@ -743,7 +743,7 @@ class OutboundFileProcessorImplTest {
         var exception = assertThrows(DartsApiException.class, () ->
             outboundFileProcessor.processAudioForPlaybacks(mediaEntityToDownloadLocation, TIME_12_00, TIME_13_00));
 
-        assertEquals("Failed to process audio request. No media present to process", exception.getMessage());
+        assertEquals("Failed to process audio request. No media present to process.", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/cases/util/RequestValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/util/RequestValidatorTest.java
@@ -98,7 +98,7 @@ class RequestValidatorTest {
             () -> RequestValidator.validate(request)
         );
         assertEquals(
-            "The request is not valid... The 'From' date cannot be after the 'To' date.",
+            "The request is not valid. The 'From' date cannot be after the 'To' date.",
             exception.getMessage()
         );
     }


### PR DESCRIPTION
### Change description ###
Some exception messages were adding a full stop where the log formatter was also adding a full stop, so ended up with double full stop in the logged out message. This change fixes this. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
