### PR TITLE
DMP-4932: Duplicate indexes should be removed from the database

### DIFF
--- a/src/main/resources/db/migration/common/V1_467__index_update.sql
+++ b/src/main/resources/db/migration/common/V1_467__index_update.sql
@@ -1,0 +1,7 @@
+drop index if exists cas_cn_idx;
+drop index if exists ctr_cth_fk;
+drop index if exists dfc_cas_fk;
+drop index if exists dfd_cas_fk;
+drop index if exists event_event_id_is_current_idx;
+drop index if exists hes_cas_fk;
+drop index if exists prn_cas_fk;


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4932)


### Change description ###
# Summary

A new SQL migration file has been added that drops several existing database indexes.

## Highlights

- **File Created**: `V1_467__index_update.sql`
- **Indexes Dropped**:
  - `cas_cn_idx`
  - `ctr_cth_fk`
  - `dfc_cas_fk`
  - `dfd_cas_fk`
  - `event_event_id_is_current_idx`
  - `hes_cas_fk`
  - `prn_cas_fk`
- **SQL Commands**: Uses the command `DROP INDEX IF EXISTS` to ensure that the indexes are removed if they exist.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
