### PR TITLE
DMP-4890: update auto transcript urgency to up to 12 days 

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
@@ -30,6 +30,7 @@ import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.buildUserW
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.APPROVED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.REQUESTED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionUrgencyEnum.STANDARD;
+import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionUrgencyEnum.WORKING_DAYS_12;
 
 class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
 
@@ -159,7 +160,7 @@ class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {
         assertThat(persistedTranscription.getHearing()).isNotNull();
         assertThat(persistedTranscription.getCourtCase().getCaseNumber()).isEqualTo(SOME_CASE_NUMBER);
         assertThat(persistedTranscription.getTranscriptionStatus().getId()).isEqualTo(APPROVED.getId());
-        assertThat(persistedTranscription.getTranscriptionUrgency().getId()).isEqualTo(STANDARD.getId());
+        assertThat(persistedTranscription.getTranscriptionUrgency().getId()).isEqualTo(WORKING_DAYS_12.getId());
 
         var transcriptionWorkflows = dartsDatabase.getTranscriptionWorkflowRepository().findAll().stream()
             .filter(t -> SOME_CASE_NUMBER.equals(t.getTranscription().getCourtCase().getCaseNumber()))

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/SentencingRemarksAndRetentionPolicyHandlerTest.java
@@ -29,7 +29,6 @@ import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.buildUserWithRoleFor;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.APPROVED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.REQUESTED;
-import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionUrgencyEnum.STANDARD;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionUrgencyEnum.WORKING_DAYS_12;
 
 class SentencingRemarksAndRetentionPolicyHandlerTest extends HandlerTestData {

--- a/src/main/java/uk/gov/hmcts/darts/event/service/handler/SentencingRemarksAndRetentionPolicyHandler.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/handler/SentencingRemarksAndRetentionPolicyHandler.java
@@ -22,7 +22,7 @@ import uk.gov.hmcts.darts.util.DataUtil;
 import static uk.gov.hmcts.darts.event.mapper.TranscriptionRequestDetailsMapper.transcriptionRequestDetailsFrom;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.APPROVED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionTypeEnum.SENTENCING_REMARKS;
-import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionUrgencyEnum.STANDARD;
+import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionUrgencyEnum.WORKING_DAYS_12;
 
 @Slf4j
 @Service
@@ -57,7 +57,7 @@ public class SentencingRemarksAndRetentionPolicyHandler extends EventHandlerBase
             hearingAndEvent.getHearingEntity());
 
         transcriptionRequestDetails.setTranscriptionTypeId(SENTENCING_REMARKS.getId());
-        transcriptionRequestDetails.setTranscriptionUrgencyId(STANDARD.getId());
+        transcriptionRequestDetails.setTranscriptionUrgencyId(WORKING_DAYS_12.getId());
 
         try {
             var transcriptionResponse = transcriptionsApi.saveTranscriptionRequest(transcriptionRequestDetails, false);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4890)


### Change description ###
# Summary
The provided Git Diff indicates updates to the `SentencingRemarksAndRetentionPolicyHandlerTest` and `SentencingRemarksAndRetentionPolicyHandler` classes in a Java project. The primary change involves updating the transcription urgency from `STANDARD` to `WORKING_DAYS_12` in both the test and the service handler classes.

## Highlights
- **File Changes:**
  - `SentencingRemarksAndRetentionPolicyHandlerTest.java`
    - Added import for `WORKING_DAYS_12` urgency.
    - Updated test assertion to check for `WORKING_DAYS_12` instead of `STANDARD`.
  
  - `SentencingRemarksAndRetentionPolicyHandler.java`
    - Changed the import from `STANDARD` to `WORKING_DAYS_12`.
    - Updated the transcription urgency ID set in transcription request details from `STANDARD` to `WORKING_DAYS_12`. 

These changes ensure that the application now uses the updated urgency level for transcription requests related to sentencing remarks.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
