### PR TITLE
DMP-4883: SUPER_ADMIN and SUPER_USER roles should not prevent transformed media expiry

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/UserAccountStub.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.SecurityGroupEnum;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.repository.CourthouseRepository;
 import uk.gov.hmcts.darts.common.repository.SecurityGroupRepository;
@@ -370,5 +371,11 @@ public class UserAccountStub {
             .thenReturn(true);
 
         return user;
+    }
+
+    public void addSecurityGroup(UserAccountEntity currentOwner, SecurityGroupEnum securityGroupEnum) {
+        SecurityGroupEntity securityGroupEntity = securityGroupRepository.findByGroupNameIgnoreCase(securityGroupEnum.name()).orElseThrow();
+        currentOwner.getSecurityGroupEntities().add(securityGroupEntity);
+        userAccountRepository.save(currentOwner);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/OutboundAudioDeleterProcessor.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/OutboundAudioDeleterProcessor.java
@@ -7,6 +7,4 @@ import java.util.List;
 public interface OutboundAudioDeleterProcessor {
 
     List<TransientObjectDirectoryEntity> markForDeletion(Integer batchSize);
-
-    void setDeletionDays(int deletionDays);
 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.audio.service.impl;
 
-import com.azure.core.annotation.Get;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/OutboundAudioDeleterProcessorImpl.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.darts.audio.service.impl;
 
+import com.azure.core.annotation.Get;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -35,6 +37,7 @@ public class OutboundAudioDeleterProcessorImpl implements OutboundAudioDeleterPr
     private final TransformedMediaEntityProcessor transformedMediaEntityProcessor;
 
     @Value("${darts.audio.outbounddeleter.last-accessed-deletion-day:2}")
+    @Getter
     private int deletionDays;
 
     @Override
@@ -44,7 +47,7 @@ public class OutboundAudioDeleterProcessorImpl implements OutboundAudioDeleterPr
 
         UserAccountEntity systemUser = userIdentity.getUserAccount();
 
-        OffsetDateTime deletionStartDateTime = deletionDayCalculator.getStartDateForDeletion(deletionDays);
+        OffsetDateTime deletionStartDateTime = deletionDayCalculator.getStartDateForDeletion(getDeletionDays());
 
         List<Integer> transformedMediaListIds = transformedMediaRepository.findAllDeletableTransformedMedia(deletionStartDateTime, Limit.of(batchSize));
 
@@ -87,10 +90,5 @@ public class OutboundAudioDeleterProcessorImpl implements OutboundAudioDeleterPr
             }
             return null;
         }
-    }
-
-    @Override
-    public void setDeletionDays(int deletionDays) {
-        this.deletionDays = deletionDays;
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TransformedMediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TransformedMediaRepository.java
@@ -61,7 +61,7 @@ public interface TransformedMediaRepository extends JpaRepository<TransformedMed
         )
         AND upper(tod.status.description) <> 'MARKED FOR DELETION'   
         AND not exists (SELECT sge from tm.mediaRequest.currentOwner.securityGroupEntities sge 
-               where sge.securityRoleEntity.roleName in ('MEDIA_IN_PERPETUITY', 'SUPER_ADMIN', 'SUPER_USER')) 
+               where sge.securityRoleEntity.roleName = 'MEDIA_IN_PERPETUITY') 
         """)
     List<Integer> findAllDeletableTransformedMedia(OffsetDateTime createdAtOrLastAccessedDateTime, Limit limit);
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4883)


### Change description ###
# Summary of Git Diff

This diff introduces significant changes to the `OutboundAudioDeleterProcessorTest` class and related components in the Darts audio processing module. Key modifications include the addition of parameterized tests for security group handling and the refactoring of deletion logic in the `OutboundAudioDeleterProcessorImpl` class.

## Highlights

- **Test Class Modifications**:
  - Added parameterized tests to handle different `SecurityGroupEnum` values, particularly excluding "MEDIA_IN_PERPETUITY".
  - Refactored setup methods and replaced direct field injection with Mockito's `@MockitoSpyBean` for better test isolation and mocking.

- **New Test Cases**:
  - Implemented tests to verify that media requests owned by security groups other than "MEDIA_IN_PERPETUITY" are marked for deletion.
  - Added checks to confirm that media requests owned by "MEDIA_IN_PERPETUITY" security groups are not updated during the deletion process.

- **Code Refactoring**:
  - Removed the `setDeletionDays` method from the `OutboundAudioDeleterProcessor` interface.
  - Changed the implementation in `OutboundAudioDeleterProcessorImpl` to use a getter for `deletionDays`, allowing better encapsulation.

- **User Account Stubbing**:
  - Enhanced the `UserAccountStub` class to include a method for adding security groups to user accounts, facilitating the creation of more complex test scenarios.

- **Database Interaction**:
  - Adjusted how media requests are created and managed within the tests, ensuring they align with the updated deletion logic and security group checks. 

These changes aim to improve the reliability of the `OutboundAudioDeleterProcessor` tests, ensuring that different security scenarios are correctly handled.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
