### PR TITLE
DMP-4795: DataIntegrityViolationException when deleting duplicate events

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventSearchControllerTest.java
@@ -89,7 +89,7 @@ class EventSearchControllerTest extends IntegrationBase {
     @EnumSource(value = SecurityRoleEnum.class, names = {"SUPER_ADMIN", "SUPER_USER"}, mode = EnumSource.Mode.INCLUDE)
     void adminEventSearch_ShouldAllowSuperUsers() throws Exception {
         List<EventEntity> entity = eventsGivensBuilder.persistedEventsWithHearings(1, 1);
-        CourtCaseEntity courtCaseEntity = entity.getFirst().getHearingEntities().getFirst().getCourtCase();
+        CourtCaseEntity courtCaseEntity = entity.getFirst().getHearingEntity().getCourtCase();
         courtCaseEntity.setDataAnonymisedTs(now());
         dartsDatabase.save(courtCaseEntity);
         AdminEventSearch request = new AdminEventSearch();
@@ -111,7 +111,7 @@ class EventSearchControllerTest extends IntegrationBase {
         given.anAuthenticatedUserWithGlobalAccessAndRole(SUPER_ADMIN);
 
         List<EventEntity> entity = eventsGivensBuilder.persistedEventsWithHearings(eventsCount, eventHearingsCount);
-        CourtCaseEntity courtCaseEntity = entity.getFirst().getHearingEntities().getFirst().getCourtCase();
+        CourtCaseEntity courtCaseEntity = entity.getFirst().getHearingEntity().getCourtCase();
         courtCaseEntity.setDataAnonymisedTs(now());
         dartsDatabase.save(courtCaseEntity);
         AdminEventSearch request = new AdminEventSearch();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/AdminEventSearchTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/service/impl/AdminEventSearchTest.java
@@ -151,7 +151,7 @@ class AdminEventSearchTest extends IntegrationBaseWithWiremock {
 
     private List<Integer> courthouseIdsAssociatedWithEvents(List<EventEntity> events) {
         return events.stream()
-            .map(eve -> eve.getHearingEntities().getFirst().getCourtroom().getCourthouse().getId())
+            .map(eve -> eve.getHearingEntity().getCourtroom().getCourthouse().getId())
             .toList();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/runner/impl/CaseExpiryDeletionAutomatedTaskITest.java
@@ -260,7 +260,7 @@ class CaseExpiryDeletionAutomatedTaskITest extends PostgresIntegrationBase {
         assertThat(hearingEntity.getMediaRequests()).hasSizeGreaterThan(0);
         hearingEntity.getTranscriptions().forEach(transcriptionEntity -> assertTranscription(transcriptionEntity, isAnonymised));
         hearingEntity.getMediaRequests().forEach(mediaRequestEntity -> assertMediaRequest(mediaRequestEntity, isAnonymised));
-        hearingEntity.getEventList().forEach(eventEntity -> assertEvent(eventEntity, isAnonymised));
+        hearingEntity.getEvents().forEach(eventEntity -> assertEvent(eventEntity, isAnonymised));
     }
 
     private void assertMediaRequest(MediaRequestEntity mediaRequestEntity, boolean isAnonymised) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsDatabaseStub.java
@@ -125,10 +125,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static java.time.LocalDateTime.now;
@@ -819,10 +820,10 @@ public class DartsDatabaseStub {
 
     private void saveSingleEventForHearing(HearingEntity hearing, EventEntity event) {
         if (event.getHearingEntities().isEmpty()) {
-            event.setHearingEntities(List.of(hearingRepository.getReferenceById(hearing.getId())));
+            event.setHearingEntities(Set.of(hearingRepository.getReferenceById(hearing.getId())));
             dartsDatabaseSaveStub.save(event);
         } else {
-            List<HearingEntity> hearingEntities = new ArrayList<>();
+            Set<HearingEntity> hearingEntities = new HashSet<>();
             hearingEntities.addAll(event.getHearingEntities());
             boolean alreadyExists = hearingEntities.stream().anyMatch(hearingEntity -> hearingEntity.getId().equals(hearing.getId()));
             if (!alreadyExists) {

--- a/src/main/java/uk/gov/hmcts/darts/casedocument/mapper/CourtCaseDocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/casedocument/mapper/CourtCaseDocumentMapper.java
@@ -59,7 +59,7 @@ public abstract class CourtCaseDocumentMapper {
     abstract CaseRetentionCaseDocument.CaseManagementRetentionCaseDocument mapToCaseDocument(CaseManagementRetentionEntity caseManagementRetentionEntity);
 
     @Mappings({
-        @Mapping(source = "eventList", target = "events"),
+        @Mapping(source = "events", target = "events"),
         @Mapping(source = "mediaList", target = "medias"),
         @Mapping(target = "lastModifiedBy", source = "lastModifiedById"),
         @Mapping(target = "createdBy", source = "createdById")

--- a/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/helper/AdvancedSearchRequestHelper.java
@@ -251,6 +251,6 @@ public class AdvancedSearchRequestHelper {
 
     private Join<CourtCaseEntity, EventEntity> joinEventEntity(Root<CourtCaseEntity> caseRoot) {
         Join<CourtCaseEntity, HearingEntity> hearingJoin = joinHearing(caseRoot);
-        return hearingJoin.join(HearingEntity_.EVENT_LIST, JoinType.INNER);
+        return hearingJoin.join(HearingEntity_.EVENTS, JoinType.INNER);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
@@ -25,6 +25,7 @@ public class EventMapper {
             .collect(Collectors.toList());
     }
 
+    @SuppressWarnings("java:S1874")//Required as we replaced getFirst with getHearingEntity(). A ticket will be raised clean this up across the app
     private Event map(EventEntity eventEntity) {
         HearingEntity hearingEntity = eventEntity.getHearingEntity();
 

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
@@ -26,7 +26,7 @@ public class EventMapper {
     }
 
     private Event map(EventEntity eventEntity) {
-        HearingEntity hearingEntity = eventEntity.getHearingEntities().getFirst();
+        HearingEntity hearingEntity = eventEntity.getHearingEntity();
 
         Event event = new Event();
         event.setId(eventEntity.getId());

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CloseOldCasesProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CloseOldCasesProcessorImpl.java
@@ -91,7 +91,7 @@ public class CloseOldCasesProcessorImpl implements CloseOldCasesProcessor {
             log.debug("About to close court case id {}", courtCase.getId());
             List<EventEntity> eventList = new ArrayList<>();
             for (HearingEntity hearingEntity : courtCase.getHearings()) {
-                eventList.addAll(hearingEntity.getEventList());
+                eventList.addAll(hearingEntity.getEvents());
             }
             if (CollectionUtils.isNotEmpty(eventList)) {
                 eventList.sort(Comparator.comparing(EventEntity::getCreatedDateTime).reversed());

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
@@ -17,10 +17,12 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
+import uk.gov.hmcts.darts.cases.model.Event;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -117,6 +119,8 @@ public class EventEntity extends CreatedModifiedBaseEntity {
     @Deprecated
     public HearingEntity getHearingEntity() {
         return this.getHearingEntities().stream()
+            .sorted(Comparator.comparing(HearingEntity::getCreatedDateTime)
+                        .thenComparing(HearingEntity::getId))
             .findFirst()
             .orElseThrow(NoSuchElementException::new);
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
@@ -17,7 +17,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
-import uk.gov.hmcts.darts.cases.model.Event;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 
 import java.time.OffsetDateTime;

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventLinkedCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventLinkedCaseEntity.java
@@ -28,6 +28,7 @@ public class EventLinkedCaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "eve_id")
+    @EqualsAndHashCode.Exclude
     private EventEntity event;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventLinkedCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventLinkedCaseEntity.java
@@ -28,7 +28,6 @@ public class EventLinkedCaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "eve_id")
-    @EqualsAndHashCode.Exclude
     private EventEntity event;
 
     @ManyToOne
@@ -48,5 +47,10 @@ public class EventLinkedCaseEntity {
      * Use {@link CourtCaseEntity#getCaseNumber()} instead
      */
     private String caseNumber;
+
+    @EqualsAndHashCode.Include(replaces = "event")
+    public Integer getEventId() {
+        return event != null ? event.getId() : null;
+    }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -26,7 +26,9 @@ import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = "hearing")
@@ -80,7 +82,7 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     @JoinTable(name = "hearing_event_ae",
         joinColumns = {@JoinColumn(name = HEA_ID)},
         inverseJoinColumns = {@JoinColumn(name = "eve_id")})
-    private List<EventEntity> eventList = new ArrayList<>();
+    private Set<EventEntity> events = new HashSet<>();
 
     @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinColumn(name = "cas_id")

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
@@ -41,7 +41,7 @@ public interface HearingRepository extends JpaRepository<HearingEntity, Integer>
 
     @Query("""
         SELECT h.id FROM HearingEntity h
-        JOIN h.eventList event
+        JOIN h.events event
         WHERE event.id = :eventId
         """
     )

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventEntityToCourtLogMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventEntityToCourtLogMapper.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.event.mapper;
 
 import lombok.experimental.UtilityClass;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.event.model.CourtLog;
 
 import java.util.ArrayList;
@@ -24,14 +25,12 @@ public class EventEntityToCourtLogMapper {
     private CourtLog mapToCourtLog(EventEntity eventEntity) {
 
         CourtLog log = new CourtLog();
-
-        log.setCourthouse(eventEntity.getHearingEntities().getFirst().getCourtroom().getCourthouse().getDisplayName());
-        log.setCaseNumber(eventEntity.getHearingEntities().getFirst().getCourtCase().getCaseNumber());
+        HearingEntity hearingEntity = eventEntity.getHearingEntity();
+        log.setCourthouse(hearingEntity.getCourtroom().getCourthouse().getDisplayName());
+        log.setCaseNumber(hearingEntity.getCourtCase().getCaseNumber());
         log.setEventText(eventEntity.getEventText());
         log.setTimestamp(eventEntity.getTimestamp());
 
         return log;
-
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventEntityToCourtLogMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventEntityToCourtLogMapper.java
@@ -22,6 +22,7 @@ public class EventEntityToCourtLogMapper {
         return logs;
     }
 
+    @SuppressWarnings("java:S1874")//Required as we replaced getFirst with getHearingEntity(). A ticket will be raised clean this up across the app
     private CourtLog mapToCourtLog(EventEntity eventEntity) {
 
         CourtLog log = new CourtLog();

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.darts.event.model.CourtroomResponseDetails;
 import uk.gov.hmcts.darts.event.model.EventMapping;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -76,12 +77,12 @@ public class EventMapper {
     }
 
 
-    List<AdminGetEventResponseDetailsHearingsHearingsInner> mapAdminGetEventResponseDetailsHearings(
-        List<HearingEntity> hearingEntities) {
+    List<AdminGetEventResponseDetailsHearingsHearingsInner> mapAdminGetEventResponseDetailsHearings(Collection<HearingEntity> hearingEntities) {
         if (CollectionUtils.isEmpty(hearingEntities)) {
             return new ArrayList<>();
         }
         return hearingEntities.stream()
+            .sorted(Comparator.comparing(HearingEntity::getId))
             .map(hearingEntity -> mapAdminGetEventResponseDetailsHearing(hearingEntity))
             .toList();
     }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/CleanupCurrentFlagEventProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/CleanupCurrentFlagEventProcessorImpl.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -74,7 +75,7 @@ public class CleanupCurrentFlagEventProcessorImpl implements CleanupCurrentFlagE
                     continue;
                 }
                 eventToBeSuperseded.setIsCurrent(false);
-                eventToBeSuperseded.setHearingEntities(new ArrayList<>());
+                eventToBeSuperseded.setHearingEntities(new HashSet<>());
                 eventsThatHaveBeenSuperseded.add(eventToBeSuperseded);
             }
 

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundFileZipGeneratorHelperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/OutboundFileZipGeneratorHelperImplTest.java
@@ -34,6 +34,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -344,7 +345,7 @@ class OutboundFileZipGeneratorHelperImplTest {
         );
 
         eventEntities.add(eventEntity);
-        hearingEntity.setEventList(eventEntities);
+        hearingEntity.setEvents(new HashSet<>(eventEntities));
         when(eventRepository.findAllByHearingId(anyInt())).thenReturn(eventEntities);
         return hearingEntity;
     }

--- a/src/test/java/uk/gov/hmcts/darts/common/helper/MediaLinkedCaseHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/helper/MediaLinkedCaseHelperTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.repository.MediaLinkedCaseRepository;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -57,7 +56,7 @@ class MediaLinkedCaseHelperTest {
         when(hearingEntity2.getCourtCase()).thenReturn(courtCaseEntity1);
         when(hearingEntity3.getCourtCase()).thenReturn(courtCaseEntity2);
 
-        List<HearingEntity> hearingEntities = List.of(hearingEntity1, hearingEntity2, hearingEntity3);
+        Set<HearingEntity> hearingEntities = Set.of(hearingEntity1, hearingEntity2, hearingEntity3);
 
         EventEntity event = mock(EventEntity.class);
         when(event.getHearingEntities()).thenReturn(hearingEntities);
@@ -104,7 +103,7 @@ class MediaLinkedCaseHelperTest {
         CourtCaseEntity courtCaseEntity1 = mock(CourtCaseEntity.class);
         when(hearingEntity1.getCourtCase()).thenReturn(courtCaseEntity1);
 
-        List<HearingEntity> hearingEntities = List.of(hearingEntity1, hearingEntity2, hearingEntity3);
+        Set<HearingEntity> hearingEntities = Set.of(hearingEntity1, hearingEntity2, hearingEntity3);
 
         EventEntity event = mock(EventEntity.class);
         when(event.getHearingEntities()).thenReturn(hearingEntities);

--- a/src/test/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImplTest.java
@@ -333,7 +333,7 @@ class DataAnonymisationServiceImplTest {
 
         EventEntity entityEntity1 = mock(EventEntity.class);
         EventEntity entityEntity2 = mock(EventEntity.class);
-        hearingEntity.setEventList(List.of(entityEntity1, entityEntity2));
+        hearingEntity.setEvents(Set.of(entityEntity1, entityEntity2));
 
         doNothing().when(dataAnonymisationService).anonymiseTranscriptionEntity(any(), any(), anyBoolean());
 

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -42,8 +42,8 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.time.ZoneOffset.UTC;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -43,9 +43,9 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Set;
 
 import static java.time.ZoneOffset.UTC;
-import static java.util.Arrays.asList;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 
 @SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount", "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects", "PMD.CyclomaticComplexity"})
@@ -93,7 +93,7 @@ public class CommonTestDataUtil {
                                               boolean isCurrent) {
 
         EventEntity event = new EventEntity();
-        event.setHearingEntities(asList(hearingEntity));
+        event.setHearingEntities(Set.of(hearingEntity));
         event.setCourtroom(hearingEntity.getCourtroom());
         event.setEventText(eventText);
         event.setId(id);

--- a/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.darts.event.model.CourtroomResponseDetails;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,9 +66,12 @@ class EventMapperTest {
         doReturn(adminGetEventResponseDetailsCasesCasesInner3).when(eventMapper).mapAdminGetEventResponseDetailsCasesCase(courtCaseEntity3);
 
         HearingEntity hearingEntity1 = mock(HearingEntity.class);
+        when(hearingEntity1.getId()).thenReturn(1);
         HearingEntity hearingEntity2 = mock(HearingEntity.class);
+        when(hearingEntity2.getId()).thenReturn(2);
         HearingEntity hearingEntity3 = mock(HearingEntity.class);
-        doReturn(List.of(hearingEntity1, hearingEntity2, hearingEntity3)).when(eventEntity).getHearingEntities();
+        when(hearingEntity3.getId()).thenReturn(3);
+        doReturn(Set.of(hearingEntity3, hearingEntity1, hearingEntity2)).when(eventEntity).getHearingEntities();
 
         AdminGetEventResponseDetailsHearingsHearingsInner adminGetEventResponseDetailsHearingsHearingsInner1 = mock(
             AdminGetEventResponseDetailsHearingsHearingsInner.class);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/EventTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/EventTestData.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.darts.test.common.data.builder.TestEventEntity;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 import static uk.gov.hmcts.darts.event.enums.EventStatus.AUDIO_LINK_NOT_DONE_MODERNISED;
 import static uk.gov.hmcts.darts.test.common.data.CourtroomTestData.someMinimalCourtRoom;
@@ -40,7 +41,7 @@ public final class EventTestData
 
     public static EventEntity createEventWith(String eventName, String eventText, HearingEntity hearingEntity, OffsetDateTime eventTime) {
         EventEntity event = someMinimalEvent();
-        event.setHearingEntities(List.of(hearingEntity));
+        event.setHearingEntities(Set.of(hearingEntity));
         event.setCourtroom(hearingEntity.getCourtroom());
         event.setEventText(eventText);
         event.setTimestamp(eventTime);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestEventEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestEventEntity.java
@@ -11,7 +11,8 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.OffsetDateTime;
-import java.util.List;
+import java.util.Collection;
+import java.util.Set;
 
 import static java.util.Objects.nonNull;
 
@@ -33,7 +34,7 @@ public class TestEventEntity extends EventEntity implements DbInsertable<EventEn
         boolean isLogEntry,
         String chronicleId,
         String antecedentId,
-        List<HearingEntity> hearingEntities,
+        Collection<HearingEntity> hearingEntities,
         Integer eventStatus,
         Boolean isCurrent,
         boolean isDataAnonymised,
@@ -55,7 +56,7 @@ public class TestEventEntity extends EventEntity implements DbInsertable<EventEn
         setLogEntry(isLogEntry);
         setChronicleId(chronicleId);
         setAntecedentId(antecedentId);
-        setHearingEntities(nonNull(hearingEntities) ? hearingEntities : List.of());
+        setHearingEntities(nonNull(hearingEntities) ? Set.of(hearingEntities.toArray(new HearingEntity[0])) : Set.of());
         setEventStatus(eventStatus);
         setIsCurrent(isCurrent);
         setDataAnonymised(isDataAnonymised);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestHearingEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestHearingEntity.java
@@ -18,7 +18,9 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.ConstructorCallsOverridableMethod"})
 @RequiredArgsConstructor
@@ -55,7 +57,7 @@ public class TestHearingEntity extends HearingEntity implements DbInsertable<Hea
         setTranscriptions(transcriptions != null ? transcriptions : new ArrayList<>());
         setMediaRequests(mediaRequests != null ? mediaRequests : new ArrayList<>());
         setNew(isNew);
-        setEventList(eventList != null ? eventList : new ArrayList<>());
+        setEvents(eventList != null ? Set.of(eventList.toArray(new EventEntity[0])) : new HashSet<>());
         setCourtCase(courtCase);
         setAnnotations(annotations != null ? annotations : new ArrayList<>());
         setCreatedDateTime(createdDateTime);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4795)


### Change description ###
# Summary of Git Diff

This Git diff primarily involves refactoring the handling of `HearingEntity` collections in various Java classes, changing from `List<HearingEntity>` to `Set<HearingEntity>`. This change aims to improve data integrity when managing relationships between events and hearings, reducing issues related to duplication and deletion of entries.

## Highlights

- **Refactoring of Hearing Entities**:
  - Changed the type for `hearingEntities` from `List` to `Set` in `EventEntity`, which prevents data integrity issues during insertion/deletion.
  - Updated methods across multiple tests and classes to accommodate the switch to `Set`, including `getHearingEntities()` and other related methods.

- **Controller and Mapper Adjustments**:
  - The `EventSearchControllerTest` and `EventMapper` were updated to use the new `getHearingEntity()` method that returns a single `HearingEntity` appropriately from the `Set`.

- **Database Stub Update**:
  - In the `DartsDatabaseStub`, `hearingEntities` are now managed as a `Set`, ensuring unique entries.

- **Test Cases Modified**:
  - Multiple test files were adjusted to reflect the change to `Set`, including `MediaLinkedCaseHelperTest`, `EventMapperTest`, and various test data utilities.

- **Deprecation Notice**:
  - A deprecation notice was added to the `getHearingEntity()` method in `EventEntity`, indicating it is not safe for many-to-many relationships and suggesting future refactoring.

- **Improved Collection Handling**:
  - Changes in how collections are handled throughout the codebase, ensuring that methods now expect `Collection<HearingEntity>` instead of a specific `List<HearingEntity>` type.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
