### PR TITLE
DMP-4975: Handle transcription documents marked for deletion linked through case_transcription_ae

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -54,7 +54,9 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.util.Comparator.comparing;
 import static java.util.Objects.isNull;
@@ -391,7 +393,7 @@ public class TranscriptionResponseMapper {
     }
 
     private AdminAction buildAdminAction(TranscriptionDocumentEntity entity) {
-        if (entity.getAdminActions().isEmpty()) {
+        if (CollectionUtils.isEmpty(entity.getAdminActions())) {
             return null;
         }
 
@@ -451,46 +453,94 @@ public class TranscriptionResponseMapper {
     }
 
     public AdminMarkedForDeletionResponseItem mapTranscriptionDocumentMarkedForDeletion(TranscriptionDocumentEntity transcriptionDocumentEntity) {
-        AdminMarkedForDeletionResponseItem response = new AdminMarkedForDeletionResponseItem();
+        TranscriptionEntity transcription = transcriptionDocumentEntity.getTranscription();
+        HearingEntity hearingEntity = transcription.getHearing();
 
-        response.setTranscriptionDocumentId(transcriptionDocumentEntity.getId());
+        CourtCaseEntity courtCaseEntity = getFirstNotNull(
+            hearingEntity == null ? null : hearingEntity.getCourtCase(),
+            transcription.getCourtCase()
+        );
+
+        CourtroomEntity courtroom = getFirstNotNull(
+            hearingEntity == null ? null : hearingEntity.getCourtroom(),
+            transcription.getCourtroom()
+        );
+
+        CourthouseEntity courthouseEntity = getFirstNotNull(
+            courtroom == null ? null : courtroom.getCourthouse(),
+            courtCaseEntity == null ? null : courtCaseEntity.getCourthouse()
+        );
 
         AdminAction adminAction = buildAdminAction(transcriptionDocumentEntity);
 
-        // if the hearing is null then don't read any associated information
-        if (transcriptionDocumentEntity.getTranscription().getHearing() != null) {
-            CaseResponseDetails caseResponseDetails = new CaseResponseDetails();
-            caseResponseDetails.setId(transcriptionDocumentEntity.getTranscription().getHearing().getCourtCase().getId());
-            caseResponseDetails.setCaseNumber(transcriptionDocumentEntity.getTranscription().getHearing().getCourtCase().getCaseNumber());
-
-            HearingEntity hearingEntity = transcriptionDocumentEntity.getTranscription().getHearing();
-
-            CourthouseResponseDetails courthouseResponseDetails = new CourthouseResponseDetails();
-            courthouseResponseDetails.setId(hearingEntity.getCourtroom().getCourthouse().getId());
-            courthouseResponseDetails.setDisplayName(hearingEntity.getCourtroom().getCourthouse().getDisplayName());
-
-            CourtroomResponseDetails courtroomResponseDetails = new CourtroomResponseDetails();
-            courtroomResponseDetails.setId(hearingEntity.getCourtroom().getId());
-            courtroomResponseDetails.setName(hearingEntity.getCourtroom().getName());
-
-            HearingResponseDetails hearingResponseDetails = new HearingResponseDetails();
-            hearingResponseDetails.setId(transcriptionDocumentEntity.getTranscription().getHearing().getId());
-            hearingResponseDetails.setHearingDate(hearingEntity.getHearingDate());
-
-            response.setCourthouse(courthouseResponseDetails);
-            response.setCourtroom(courtroomResponseDetails);
-            response.setHearing(hearingResponseDetails);
-            response.setCase(caseResponseDetails);
-        }
-
-        TranscriptionResponseDetails transcriptionResponseDetails = new TranscriptionResponseDetails();
-        transcriptionResponseDetails.setId(transcriptionDocumentEntity.getTranscription().getId());
-
+        AdminMarkedForDeletionResponseItem response = new AdminMarkedForDeletionResponseItem();
+        response.setTranscriptionDocumentId(transcriptionDocumentEntity.getId());
+        response.setTranscription(mapTranscriptionEntity(transcription));
+        response.setHearing(mapHearing(hearingEntity));
+        response.setCourthouse(mapCourthouse(courthouseEntity));
+        response.setCourtroom(mapCourtroom(courtroom));
+        response.setCase(mapCase(courtCaseEntity));
         response.setAdminAction(adminAction);
-        response.setTranscription(transcriptionResponseDetails);
         response.setTranscriptionDocumentId(transcriptionDocumentEntity.getId());
 
         return response;
     }
 
+    TranscriptionResponseDetails mapTranscriptionEntity(TranscriptionEntity transcription) {
+        if (transcription == null) {
+            return null;
+        }
+        TranscriptionResponseDetails transcriptionResponseDetails = new TranscriptionResponseDetails();
+        transcriptionResponseDetails.setId(transcription.getId());
+        return transcriptionResponseDetails;
+    }
+
+    HearingResponseDetails mapHearing(HearingEntity hearingEntity) {
+        if (hearingEntity == null) {
+            return null;
+        }
+        HearingResponseDetails hearingResponseDetails = new HearingResponseDetails();
+        hearingResponseDetails.setId(hearingEntity.getId());
+        hearingResponseDetails.setHearingDate(hearingEntity.getHearingDate());
+        return hearingResponseDetails;
+    }
+
+    CaseResponseDetails mapCase(CourtCaseEntity courtCaseEntity) {
+        if (courtCaseEntity == null) {
+            return null;
+        }
+        CaseResponseDetails caseResponseDetails = new CaseResponseDetails();
+        caseResponseDetails.setId(courtCaseEntity.getId());
+        caseResponseDetails.setCaseNumber(courtCaseEntity.getCaseNumber());
+        return caseResponseDetails;
+    }
+
+    CourtroomResponseDetails mapCourtroom(CourtroomEntity courtroom) {
+        if (courtroom == null) {
+            return null;
+        }
+        CourtroomResponseDetails courtroomResponseDetails = new CourtroomResponseDetails();
+        courtroomResponseDetails.setId(courtroom.getId());
+        courtroomResponseDetails.setName(courtroom.getName());
+        return courtroomResponseDetails;
+    }
+
+    CourthouseResponseDetails mapCourthouse(CourthouseEntity courthouseEntity) {
+        if (courthouseEntity == null) {
+            return null;
+        }
+
+        CourthouseResponseDetails courthouseResponseDetails = new CourthouseResponseDetails();
+        courthouseResponseDetails.setId(courthouseEntity.getId());
+        courthouseResponseDetails.setDisplayName(courthouseEntity.getDisplayName());
+        return courthouseResponseDetails;
+    }
+
+    @SafeVarargs
+    final <T> T getFirstNotNull(T... objects) {
+        return Stream.of(objects)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
@@ -34,13 +34,18 @@ import uk.gov.hmcts.darts.transcriptions.exception.TranscriptionApiError;
 import uk.gov.hmcts.darts.transcriptions.model.AdminActionResponse;
 import uk.gov.hmcts.darts.transcriptions.model.AdminApproveDeletionResponse;
 import uk.gov.hmcts.darts.transcriptions.model.AdminMarkedForDeletionResponseItem;
+import uk.gov.hmcts.darts.transcriptions.model.CaseResponseDetails;
+import uk.gov.hmcts.darts.transcriptions.model.CourthouseResponseDetails;
+import uk.gov.hmcts.darts.transcriptions.model.CourtroomResponseDetails;
 import uk.gov.hmcts.darts.transcriptions.model.GetTranscriptionByIdResponse;
 import uk.gov.hmcts.darts.transcriptions.model.GetTranscriptionDetailAdminResponse;
 import uk.gov.hmcts.darts.transcriptions.model.GetTranscriptionDocumentByIdResponse;
 import uk.gov.hmcts.darts.transcriptions.model.GetTranscriptionWorkflowsResponse;
+import uk.gov.hmcts.darts.transcriptions.model.HearingResponseDetails;
 import uk.gov.hmcts.darts.transcriptions.model.SearchTranscriptionDocumentResponse;
 import uk.gov.hmcts.darts.transcriptions.model.TranscriptionDocumentHideResponse;
 import uk.gov.hmcts.darts.transcriptions.model.TranscriptionDocumentResult;
+import uk.gov.hmcts.darts.transcriptions.model.TranscriptionResponseDetails;
 import uk.gov.hmcts.darts.transcriptions.model.TranscriptionTypeResponse;
 import uk.gov.hmcts.darts.transcriptions.model.TranscriptionUrgencyResponse;
 import uk.gov.hmcts.darts.transcriptions.model.TranscriptionWorkflowsComment;
@@ -52,12 +57,15 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.test.common.TestUtils.getContentsFromFile;
 import static uk.gov.hmcts.darts.test.common.data.TranscriptionDocumentTestData.minimalTranscriptionDocument;
@@ -67,6 +75,7 @@ import static uk.gov.hmcts.darts.util.EntityIdPopulator.withIdsPopulated;
 
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("PMD.CouplingBetweenObjects")//Required to accuratly test the code
 class TranscriptionResponseMapperTest {
     private final ObjectMapper objectMapper = new ObjectMapperConfig().objectMapper();
 
@@ -77,7 +86,7 @@ class TranscriptionResponseMapperTest {
 
     @BeforeEach
     void setUp() {
-        transcriptionResponseMapper = new TranscriptionResponseMapper(hearingReportingRestrictionsRepository);
+        transcriptionResponseMapper = spy(new TranscriptionResponseMapper(hearingReportingRestrictionsRepository));
     }
 
     @Test
@@ -903,4 +912,172 @@ class TranscriptionResponseMapperTest {
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
     }
 
+    @Test
+    void mapTranscriptionDocumentMarkedForDeletion_nullHearing_shouldReutrnTranscriptionCaseDetails() {
+        CourtCaseEntity courtCaseEntity = mock(CourtCaseEntity.class);
+        CourtroomEntity courtroomEntity = mock(CourtroomEntity.class);
+        CourthouseEntity courtHouseEntity = mock(CourthouseEntity.class);
+        doReturn(courtHouseEntity).when(courtroomEntity).getCourthouse();
+
+        TranscriptionEntity transcription = new TranscriptionEntity();
+        transcription.setHearings(null);
+        transcription.setCourtCases(List.of(courtCaseEntity));
+        transcription.setCourtroom(courtroomEntity);
+        TranscriptionDocumentEntity transcriptionDocumentEntity = new TranscriptionDocumentEntity();
+        transcriptionDocumentEntity.setTranscription(transcription);
+
+        CaseResponseDetails caseResponseDetails = mock(CaseResponseDetails.class);
+        CourtroomResponseDetails courtroomResponseDetails = mock(CourtroomResponseDetails.class);
+        CourthouseResponseDetails courthouseResponseDetails = mock(CourthouseResponseDetails.class);
+        TranscriptionResponseDetails transcriptionResponseDetails = mock(TranscriptionResponseDetails.class);
+
+        doReturn(caseResponseDetails).when(transcriptionResponseMapper).mapCase(courtCaseEntity);
+        doReturn(courtroomResponseDetails).when(transcriptionResponseMapper).mapCourtroom(courtroomEntity);
+        doReturn(courthouseResponseDetails).when(transcriptionResponseMapper).mapCourthouse(courtHouseEntity);
+        doReturn(transcriptionResponseDetails).when(transcriptionResponseMapper).mapTranscriptionEntity(transcription);
+
+        AdminMarkedForDeletionResponseItem responseDetails = transcriptionResponseMapper
+            .mapTranscriptionDocumentMarkedForDeletion(transcriptionDocumentEntity);
+
+
+        assertThat(responseDetails).isNotNull();
+        assertThat(responseDetails.getCase()).isEqualTo(caseResponseDetails);
+        assertThat(responseDetails.getCourtroom()).isEqualTo(courtroomResponseDetails);
+        assertThat(responseDetails.getCourthouse()).isEqualTo(courthouseResponseDetails);
+        assertThat(responseDetails.getTranscription()).isEqualTo(transcriptionResponseDetails);
+        assertThat(responseDetails.getHearing()).isNull();
+    }
+
+    @Test
+    void mapTranscriptionDocumentMarkedForDeletion_nullHearingAndNullTranscriptionCourtroom_shouldReutrnCourtHouseFromCase() {
+        CourtCaseEntity courtCaseEntity = mock(CourtCaseEntity.class);
+        CourtroomEntity courtroomEntity = mock(CourtroomEntity.class);
+        CourthouseEntity courtHouseEntity = mock(CourthouseEntity.class);
+        doReturn(courtHouseEntity).when(courtCaseEntity).getCourthouse();
+
+        TranscriptionEntity transcription = new TranscriptionEntity();
+        transcription.setHearings(null);
+        transcription.setCourtCases(List.of(courtCaseEntity));
+        transcription.setCourtroom(courtroomEntity);
+        TranscriptionDocumentEntity transcriptionDocumentEntity = new TranscriptionDocumentEntity();
+        transcriptionDocumentEntity.setTranscription(transcription);
+
+        CaseResponseDetails caseResponseDetails = mock(CaseResponseDetails.class);
+        CourtroomResponseDetails courtroomResponseDetails = mock(CourtroomResponseDetails.class);
+        CourthouseResponseDetails courthouseResponseDetails = mock(CourthouseResponseDetails.class);
+        TranscriptionResponseDetails transcriptionResponseDetails = mock(TranscriptionResponseDetails.class);
+
+        doReturn(caseResponseDetails).when(transcriptionResponseMapper).mapCase(courtCaseEntity);
+        doReturn(courtroomResponseDetails).when(transcriptionResponseMapper).mapCourtroom(courtroomEntity);
+        doReturn(courthouseResponseDetails).when(transcriptionResponseMapper).mapCourthouse(courtHouseEntity);
+        doReturn(transcriptionResponseDetails).when(transcriptionResponseMapper).mapTranscriptionEntity(transcription);
+
+        AdminMarkedForDeletionResponseItem responseDetails = transcriptionResponseMapper
+            .mapTranscriptionDocumentMarkedForDeletion(transcriptionDocumentEntity);
+
+        assertThat(responseDetails).isNotNull();
+        assertThat(responseDetails.getCase()).isEqualTo(caseResponseDetails);
+        assertThat(responseDetails.getCourtroom()).isEqualTo(courtroomResponseDetails);
+        assertThat(responseDetails.getCourthouse()).isEqualTo(courthouseResponseDetails);
+        assertThat(responseDetails.getTranscription()).isEqualTo(transcriptionResponseDetails);
+        assertThat(responseDetails.getHearing()).isNull();
+    }
+
+    @Test
+    void mapTranscriptionEntity_whenNull_shouldReturnNull() {
+        assertNull(transcriptionResponseMapper.mapTranscriptionEntity(null));
+    }
+
+    @Test
+    void mapTranscriptionEntity_whenNotNull_shouldReturnCorrectlyMappedData() {
+        TranscriptionEntity transcription = new TranscriptionEntity();
+        transcription.setId(123);
+
+        TranscriptionResponseDetails responseDetails = transcriptionResponseMapper.mapTranscriptionEntity(transcription);
+        assertThat(responseDetails).isNotNull();
+        assertThat(responseDetails.getId()).isEqualTo(123);
+    }
+
+    @Test
+    void mapHearing_whenNull_shouldReturnNull() {
+        assertNull(transcriptionResponseMapper.mapHearing(null));
+    }
+
+    @Test
+    void mapHearing_whenNotNull_shouldReturnCorrectlyMappedData() {
+        HearingEntity hearing = new HearingEntity();
+        hearing.setId(123);
+        hearing.setHearingDate(LocalDate.of(2023, 6, 20));
+
+        HearingResponseDetails responseDetails = transcriptionResponseMapper.mapHearing(hearing);
+        assertThat(responseDetails).isNotNull();
+        assertThat(responseDetails.getId()).isEqualTo(123);
+        assertThat(responseDetails.getHearingDate()).isEqualTo(LocalDate.of(2023, 6, 20));
+    }
+
+    @Test
+    void mapCase_whenNull_shouldReturnNull() {
+        assertNull(transcriptionResponseMapper.mapCase(null));
+    }
+
+    @Test
+    void mapCase_whenNotNull_shouldReturnCorrectlyMappedData() {
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        courtCase.setId(123);
+        courtCase.setCaseNumber("some-case-number");
+
+        CaseResponseDetails responseDetails = transcriptionResponseMapper.mapCase(courtCase);
+        assertThat(responseDetails).isNotNull();
+        assertThat(responseDetails.getId()).isEqualTo(123);
+        assertThat(responseDetails.getCaseNumber()).isEqualTo("some-case-number");
+    }
+
+    @Test
+    void mapCourtroom_whenNull_shouldReturnNull() {
+        assertNull(transcriptionResponseMapper.mapCourtroom(null));
+    }
+
+    @Test
+    void mapCourtroom_whenNotNull_shouldReturnCorrectlyMappedData() {
+        CourtroomEntity courtroom = new CourtroomEntity();
+        courtroom.setId(123);
+        courtroom.setName("some-name");
+
+        CourtroomResponseDetails responseDetails = transcriptionResponseMapper.mapCourtroom(courtroom);
+        assertThat(responseDetails).isNotNull();
+        assertThat(responseDetails.getId()).isEqualTo(123);
+        assertThat(responseDetails.getName()).isEqualTo("SOME-NAME");
+    }
+
+    @Test
+    void mapCourthouse_whenNull_shouldReturnNull() {
+        assertNull(transcriptionResponseMapper.mapTranscriptionEntity(null));
+    }
+
+    @Test
+    void mapCourthouse_whenNotNull_shouldReturnCorrectlyMappedData() {
+        CourthouseEntity courthouse = new CourthouseEntity();
+        courthouse.setId(123);
+        courthouse.setDisplayName("some-display-name");
+
+        CourthouseResponseDetails responseDetails = transcriptionResponseMapper.mapCourthouse(courthouse);
+        assertThat(responseDetails).isNotNull();
+        assertThat(responseDetails.getId()).isEqualTo(123);
+        assertThat(responseDetails.getDisplayName()).isEqualTo("some-display-name");
+    }
+
+    @Test
+    void getFirstNotNull_whenAllNull_shouldReturnNull() {
+        assertNull(transcriptionResponseMapper.getFirstNotNull(null, null, null));
+    }
+
+    @Test
+    void getFirstNotNull_whenFirstNull_shouldReturnSecond() {
+        assertEquals("second", transcriptionResponseMapper.getFirstNotNull(null, "second", null));
+    }
+
+    @Test
+    void getFirstNotNull_whenFirstNotNull_shouldReturnFirst() {
+        assertEquals("first", transcriptionResponseMapper.getFirstNotNull("first", "second", null));
+    }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4975)


### Change description ###
# Summary of Changes in `TranscriptionResponseMapper.java`

The recent changes to the `TranscriptionResponseMapper.java` file primarily involve refactoring and enhancements to the mapping logic for various entities related to transcriptions. The updates introduce new helper methods to streamline the mapping process and improve code readability. These changes include the addition of a method to retrieve the first non-null object from a list of objects and modifications to existing methods for better handling of null values.

## Highlights

- **New Method Added**:
  - `getFirstNotNull(T... objects)`: A utility method that returns the first non-null object from the provided arguments.

- **Refactoring of Mapping Logic**:
  - Updated the `mapTranscriptionDocumentMarkedForDeletion` method to utilize new helper methods for mapping `TranscriptionEntity`, `HearingEntity`, `CourtroomEntity`, and `CourtCaseEntity`.
  - Replaced direct null checks with the newly introduced `getFirstNotNull` method to minimize code duplication and enhance maintainability.

- **Enhanced Null Handling**:
  - Improved handling of null values when mapping entities, ensuring that methods return null gracefully when input entities are null.

- **JUnit Tests Updated**:
  - Added several new tests in `TranscriptionResponseMapperTest.java` to cover the new logic and ensure the correctness of the mapping functions, including tests for null handling and verification of mapped data for various entities.
  - Enhanced existing tests to assert the behavior of the mapper methods under different conditions, including scenarios with null values.

These changes aim to improve the overall structure and reliability of the transcription mapping functionality within the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
