### PR TITLE
DMP-4795: DataIntegrityViolationException when deleting duplicate events

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
@@ -295,7 +295,7 @@ class EventRepositoryTest extends PostgresIntegrationBase {
 
 
     @Test
-    void deleteAllAssocaiatedHearing_shouldOnlyDeleteAssociatedHearingsForProvidedIds() {
+    void deleteAllAssociatedHearings_shouldOnlyDeleteAssociatedHearingsForProvidedIds() {
         final EventEntity event1HasHearingsIncluded = EventTestData.someMinimalEvent();
         final EventEntity event2HasHearingsIncluded = EventTestData.someMinimalEvent();
         final EventEntity event3HasHearingsExcluded = EventTestData.someMinimalEvent();
@@ -319,7 +319,7 @@ class EventRepositoryTest extends PostgresIntegrationBase {
         dartsDatabase.save(event4NoHearingsIncluded);
 
 
-        eventRepository.deleteAllAssocaiatedHearing(List.of(
+        eventRepository.deleteAllAssociatedHearings(List.of(
             event1HasHearingsIncluded.getId(),
             event2HasHearingsIncluded.getId(),
             event4NoHearingsIncluded.getId()

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryTest.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.darts.common.repository;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Limit;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
-import uk.gov.hmcts.darts.common.util.DateConverterUtil;
 import uk.gov.hmcts.darts.event.enums.EventStatus;
 import uk.gov.hmcts.darts.test.common.data.EventTestData;
 import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
@@ -17,11 +15,9 @@ import uk.gov.hmcts.darts.testutils.stubs.HearingStub;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EventRepositoryTest extends PostgresIntegrationBase {
     @Autowired
@@ -34,62 +30,6 @@ class EventRepositoryTest extends PostgresIntegrationBase {
     private HearingStub hearingStub;
     @Autowired
     private EventLinkedCaseStub eventLinkedCaseStub;
-
-    @Test
-    void testEventProcessing() {
-        dartsDatabase.createCase("Bristol", "case1");
-        dartsDatabase.createCase("Bristol", "case2");
-        dartsDatabase.createCase("Bristol", "case3");
-
-        Map<Integer, List<EventEntity>> eventIdMap = eventStub.generateEventIdEventsIncludingZeroEventId(3);
-
-        List<Integer> eventIdsToBeProcessed1 = eventRepository.findCurrentEventIdsWithDuplicates(1);
-        assertEquals(1, eventIdsToBeProcessed1.size());
-        EventRepository.EventIdAndHearingIds eventPkid = eventRepository.getTheLatestCreatedEventPrimaryKeyForTheEventId(eventIdsToBeProcessed1.getFirst())
-            .getFirst();
-        eventRepository.updateAllEventIdEventsToNotCurrentWithTheExclusionOfTheCurrentEventPrimaryKey(
-            eventPkid.getEveId(), eventPkid.getEventId(), eventPkid.getHearingIds(), 0);
-        assertTrue(eventStub.isOnlyOneOfTheEventIdSetToCurrent(eventIdMap.get(eventIdsToBeProcessed1.getFirst())));
-
-        List<Integer> eventIdsToBeProcessed2 = eventRepository.findCurrentEventIdsWithDuplicates(1);
-        EventRepository.EventIdAndHearingIds eventPkidSecond =
-            eventRepository.getTheLatestCreatedEventPrimaryKeyForTheEventId(eventIdsToBeProcessed2.getFirst())
-                .getFirst();
-        eventRepository.updateAllEventIdEventsToNotCurrentWithTheExclusionOfTheCurrentEventPrimaryKey(
-            eventPkidSecond.getEveId(), eventPkidSecond.getEventId(), eventPkidSecond.getHearingIds(), 0);
-
-        assertEquals(1, eventIdsToBeProcessed1.size());
-        assertTrue(eventIdMap.containsKey(eventIdsToBeProcessed2.getFirst()));
-        Assertions.assertNotEquals(eventIdsToBeProcessed1, eventIdsToBeProcessed2);
-
-        // ENSURE WE DONT PROCESS THE THIRD BATCH I.E. THE ZERO EVENT ID
-        List<Integer> eventIdsToBeProcessed3 = eventRepository.findCurrentEventIdsWithDuplicates(1);
-        assertTrue(eventIdsToBeProcessed3.isEmpty());
-    }
-
-    @Test
-    void givenEventCleanUpTask_whenVersionedEventsAreFound_thenOlderVersionsAreNotMarkedAsNonCurrentWhenHearingsDoNotMatch() {
-        dartsDatabase.createCase("Bristol", "case1");
-        dartsDatabase.createCase("Bristol", "case2");
-        dartsDatabase.createCase("Bristol", "case3");
-
-        Map<Integer, List<EventEntity>> eventIdMap = eventStub.generateEventIdEventsIncludingZeroEventId(3);
-
-        List<Integer> eventIdsToBeProcessed1 = eventRepository.findCurrentEventIdsWithDuplicates(1);
-        assertEquals(1, eventIdsToBeProcessed1.size());
-        List<EventEntity> eventEntities = eventIdMap.get(eventIdsToBeProcessed1.getFirst());
-        EventEntity eventEntity = eventEntities.getFirst();
-        eventEntity.getHearingEntities().add(
-            hearingStub.createHearing("Bristol", "1", "case1", DateConverterUtil.toLocalDateTime(EventStub.STARTED_AT))
-        );
-        eventRepository.save(eventEntity);
-
-        EventRepository.EventIdAndHearingIds eventPkid = eventRepository.getTheLatestCreatedEventPrimaryKeyForTheEventId(eventIdsToBeProcessed1.getFirst())
-            .getFirst();
-        eventRepository.updateAllEventIdEventsToNotCurrentWithTheExclusionOfTheCurrentEventPrimaryKey(
-            eventPkid.getEveId(), eventPkid.getEventId(), eventPkid.getHearingIds(), 0);
-        Assertions.assertFalse(eventStub.isOnlyOneOfTheEventIdSetToCurrent(eventEntities));
-    }
 
 
     @Test
@@ -173,32 +113,6 @@ class EventRepositoryTest extends PostgresIntegrationBase {
 
         List<Integer> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId());
         assertThat(duplicates).isEmpty();
-    }
-
-    @Test
-    void findAllByEventIdExcludingEventIdZero_whenEventIdIsSetAboveZero_willReturnVersions() {
-        final EventEntity event1 = EventTestData.someMinimalEvent();
-        final EventEntity event2 = EventTestData.someMinimalEvent();
-        event1.setEventText("eventText");
-        event2.setEventText("eventText");
-        event1.setEventId(1);
-        event2.setEventId(1);
-        dartsDatabase.save(event1);
-        dartsDatabase.save(event2);
-
-        List<EventEntity> eventVersions = eventRepository.findAllByEventIdExcludingEventIdZero(event1.getEventId());
-        assertThat(eventVersions).hasSize(2);
-    }
-
-    @Test
-    void findAllByEventIdExcludingEventIdZero_whenEventIdIsSetToZero_willNotReturnVersions() {
-        final EventEntity event1 = EventTestData.someMinimalEvent();
-        event1.setEventText("eventText");
-        event1.setEventId(0);
-        dartsDatabase.save(event1);
-
-        List<EventEntity> eventVersions = eventRepository.findAllByEventIdExcludingEventIdZero(event1.getEventId());
-        assertThat(eventVersions).isEmpty();
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -126,6 +126,12 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
         """)
     List<Integer> findDuplicateEventIds(Integer eventId);
 
+
+    @Transactional
+    @Modifying
+    @Query(value = "DELETE FROM darts.hearing_event_ae WHERE eve_id IN (:eventEntitiesIdsToDelete)", nativeQuery = true)
+    void deleteAllAssocaiatedHearing(List<Integer> eventEntitiesIdsToDelete);
+
     interface EventIdAndHearingIds {
 
         @Column(name = "eve_id")

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -194,7 +194,7 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
     @Transactional
     @Modifying
     @Query(value = "DELETE FROM darts.hearing_event_ae WHERE eve_id IN (:eventEntitiesIdsToDelete)", nativeQuery = true)
-    void deleteAllAssocaiatedHearing(List<Integer> eventEntitiesIdsToDelete);
+    void deleteAllAssociatedHearings(List<Integer> eventEntitiesIdsToDelete);
 
     interface EventIdAndHearingIds {
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.event.model.EventSearchResult;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Repository
@@ -83,6 +84,23 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
         Limit limit);
 
     @Query(value = """
+        SELECT distinct e2.event_id
+        FROM (
+          SELECT e.event_id, he.eve_id, string_agg(he.hea_id::varchar, ',' order by he.hea_id) as hearing_ids
+          FROM darts.event e
+          LEFT JOIN darts.hearing_event_ae he ON he.eve_id = e.eve_id
+          WHERE e.is_current = true
+          AND e.event_id <> 0
+          AND e.event_id IS NOT null
+          GROUP by he.eve_id, e.event_id
+        ) e2
+        GROUP BY e2.event_id, e2.hearing_ids
+        HAVING count(e2.event_id) > 1
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<Integer> findCurrentEventIdsWithDuplicates(long limit);
+
+    @Query(value = """
         select distinct on (event_id, hearing_ids) e.* from (
             SELECT e.eve_id, event_id, e.created_ts, string_agg(he.hea_id::varchar, ',' order by he.hea_id) as hearing_ids
             FROM darts.event e
@@ -92,6 +110,52 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
         ) e ORDER BY event_id, hearing_ids, e.created_ts DESC
         """, nativeQuery = true)
     List<EventIdAndHearingIds> getTheLatestCreatedEventPrimaryKeyForTheEventId(Integer eventId);
+
+    /**
+     * string_agg(he.hea_id::varchar, ',' order by he.hea_id) to ensure we only update the events that have the same hearing ids
+     * This is done by reading the hearing ids from the latest event created and only updating the events that have the same hearing ids
+     *
+     * @param eventIdsPrimaryKey the primary key of the event that is the latest created
+     * @param eventId            the event id that we want to close old events for
+     * @param hearingIds         the hearing ids that we want to close old events for (Should match hearing ids of the latest event created)
+     */
+    @Transactional
+    @Modifying
+    @Query(value = """
+        UPDATE darts.event e
+        SET is_current = false,
+            last_modified_ts = current_timestamp,
+            last_modified_by = :userId
+        FROM (
+           SELECT he.eve_id, string_agg(he.hea_id::varchar, ',' order by he.hea_id) as hearing_ids
+           FROM darts.event e
+           LEFT JOIN darts.hearing_event_ae he ON he.eve_id = e.eve_id
+           WHERE e.event_id = :eventId
+           GROUP by he.eve_id
+        ) h
+        WHERE e.eve_id != :eventIdsPrimaryKey
+        AND e.event_id = :eventId
+        AND h.hearing_ids = :hearingIds
+        AND h.eve_id = e.eve_id
+        """, nativeQuery = true)
+    void updateAllEventIdEventsToNotCurrentWithTheExclusionOfTheCurrentEventPrimaryKey(
+        Integer eventIdsPrimaryKey, Integer eventId, String hearingIds, int userId);
+
+    @Query("""
+        SELECT ee
+        FROM EventEntity ee
+        WHERE ee.timestamp >= :startDateTime
+        AND ee.timestamp <= :endDateTime
+        """)
+    List<EventEntity> findAllBetweenDateTimesInclusive(OffsetDateTime startDateTime, OffsetDateTime endDateTime);
+
+    @Query("""
+        SELECT ee
+        FROM EventEntity ee
+        WHERE ee.eventId = :eventId
+        AND ee.eventId <> 0
+        """)
+    List<EventEntity> findAllByEventIdExcludingEventIdZero(Integer eventId);
 
     @Query("""
          SELECT ee

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
@@ -39,6 +39,7 @@ public class RemoveDuplicateEventsProcessorImpl implements RemoveDuplicateEvents
         caseManagementRetentionRepository.flush();
         eventLinkedCaseRepository.deleteAllByEventIn(eventEntitiesIdsToDelete);
         eventLinkedCaseRepository.flush();
+        eventRepository.deleteAllAssocaiatedHearing(eventEntitiesIdsToDelete);
         eventRepository.deleteAllById(eventEntitiesIdsToDelete);
         eventRepository.flush();
 

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
@@ -39,7 +39,7 @@ public class RemoveDuplicateEventsProcessorImpl implements RemoveDuplicateEvents
         caseManagementRetentionRepository.flush();
         eventLinkedCaseRepository.deleteAllByEventIn(eventEntitiesIdsToDelete);
         eventLinkedCaseRepository.flush();
-        eventRepository.deleteAllAssocaiatedHearing(eventEntitiesIdsToDelete);
+        eventRepository.deleteAllAssociatedHearings(eventEntitiesIdsToDelete);
         eventRepository.deleteAllById(eventEntitiesIdsToDelete);
         eventRepository.flush();
 

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImplTest.java
@@ -88,7 +88,7 @@ class RemoveDuplicateEventsProcessorImplTest {
         verify(caseManagementRetentionRepository).flush();
         verify(eventLinkedCaseRepository).deleteAllByEventIn(toBeDeleted);
         verify(eventLinkedCaseRepository).flush();
-        verify(eventRepository).deleteAllAssocaiatedHearing(toBeDeleted);
+        verify(eventRepository).deleteAllAssociatedHearings(toBeDeleted);
         verify(eventRepository).deleteAllById(toBeDeleted);
         verify(eventRepository).flush();
         verifyNoMoreInteractions(eventRepository);

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImplTest.java
@@ -88,6 +88,7 @@ class RemoveDuplicateEventsProcessorImplTest {
         verify(caseManagementRetentionRepository).flush();
         verify(eventLinkedCaseRepository).deleteAllByEventIn(toBeDeleted);
         verify(eventLinkedCaseRepository).flush();
+        verify(eventRepository).deleteAllAssocaiatedHearing(toBeDeleted);
         verify(eventRepository).deleteAllById(toBeDeleted);
         verify(eventRepository).flush();
         verifyNoMoreInteractions(eventRepository);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4795)


### Change description ###
# Summary of Git Diff

This Git diff showcases modifications made to the `EventRepositoryTest.java`, `EventRepository.java`, `RemoveDuplicateEventsProcessorImpl.java`, and `RemoveDuplicateEventsProcessorImplTest.java` files. The changes primarily involve the removal of outdated test methods and the addition of new functionality to manage associated hearings for events.

## Highlights

- **Removed Test Methods**: Several test methods related to event processing and cleanup tasks were removed from `EventRepositoryTest.java`, indicating a cleanup of unnecessary or redundant tests.
  
- **Addition of Delete Functionality**: A new method `deleteAllAssocaiatedHearing` was added to the `EventRepository`, which allows for the deletion of hearings associated with specific event IDs.

- **Updated Test Cases**: The `RemoveDuplicateEventsProcessorImpl` and its test class were updated to incorporate the new hearing deletion functionality, ensuring that associated hearings are also removed when duplicate events are processed.

- **Use of `Set`**: The `Set` collection type is now used for managing hearing entities in `EventRepositoryTest.java`, enhancing the handling of unique hearing records.

- **Database Transactions**: The new hearing deletion logic is wrapped in database transactions to ensure data integrity.

These changes reflect a shift towards more streamlined event management within the application, emphasizing the importance of maintaining accurate associations between events and their related hearings.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
