### PR TITLE
DMP-4979: Investigate why we have 20 set as the sequence number in DB

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/entity/MediaRequestEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/entity/MediaRequestEntity.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity_;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class MediaRequestEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = ID_COLUMN_NAME)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "media_request_gen")
-    @SequenceGenerator(name = "media_request_gen", sequenceName = "mer_seq", allocationSize = 1)
+    @SequenceGenerator(name = "media_request_gen", sequenceName = "mer_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     @Audited
     private Integer id;
 

--- a/src/main/java/uk/gov/hmcts/darts/audit/model/RevisionInfo.java
+++ b/src/main/java/uk/gov/hmcts/darts/audit/model/RevisionInfo.java
@@ -31,7 +31,7 @@ public class RevisionInfo implements Serializable {
 
     @Id
     @GeneratedValue(generator = GENERATOR_NAME, strategy = GenerationType.SEQUENCE)
-    @SequenceGenerator(name = GENERATOR_NAME, sequenceName = "revinfo_seq")
+    @SequenceGenerator(name = GENERATOR_NAME, sequenceName = "revinfo_seq", allocationSize = 1)
     @RevisionNumber
     @Column(name = "rev")
     private Integer revision;

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationDocumentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationDocumentEntity.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.darts.task.runner.CanReturnExternalObjectDirectoryEntities;
 import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import uk.gov.hmcts.darts.task.runner.HasRetention;
 import uk.gov.hmcts.darts.task.runner.SoftDelete;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ public class AnnotationDocumentEntity extends ModifiedBaseEntity
     @Id
     @Column(name = "ado_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ado_gen")
-    @SequenceGenerator(name = "ado_gen", sequenceName = "ado_seq", allocationSize = 1)
+    @SequenceGenerator(name = "ado_gen", sequenceName = "ado_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
@@ -17,6 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -32,7 +33,7 @@ public class AnnotationEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "ann_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ann_gen")
-    @SequenceGenerator(name = "ann_gen", sequenceName = "ann_seq", allocationSize = 1)
+    @SequenceGenerator(name = "ann_gen", sequenceName = "ann_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "annotation_text")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ArmAutomatedTaskEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ArmAutomatedTaskEntity.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -29,7 +30,7 @@ public class ArmAutomatedTaskEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "aat_seq")
-    @SequenceGenerator(name = "aat_seq", sequenceName = "aat_seq", allocationSize = 1)
+    @SequenceGenerator(name = "aat_seq", sequenceName = "aat_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     @Column(name = "aat_id", nullable = false)
     private Integer id;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoExecutionDetailEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoExecutionDetailEntity.java
@@ -13,6 +13,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.MandatoryCreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -25,7 +26,7 @@ public class ArmRpoExecutionDetailEntity extends MandatoryCreatedModifiedBaseEnt
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ard_seq")
-    @SequenceGenerator(name = "ard_seq", sequenceName = "ard_seq", allocationSize = 1)
+    @SequenceGenerator(name = "ard_seq", sequenceName = "ard_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     @Column(name = "ard_id", nullable = false)
     private Integer id;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoStateEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoStateEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "arm_rpo_state")
@@ -20,7 +21,7 @@ public class ArmRpoStateEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "are_seq")
-    @SequenceGenerator(name = "are_seq", sequenceName = "are_seq", allocationSize = 1)
+    @SequenceGenerator(name = "are_seq", sequenceName = "are_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     @Column(name = "are_id", nullable = false)
     private Integer id;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoStatusEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ArmRpoStatusEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "arm_rpo_status")
@@ -20,7 +21,7 @@ public class ArmRpoStatusEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "aru_seq")
-    @SequenceGenerator(name = "aru_seq", sequenceName = "aru_seq", allocationSize = 1)
+    @SequenceGenerator(name = "aru_seq", sequenceName = "aru_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     @Column(name = "aru_id", nullable = false)
     private Integer id;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AuditActivityEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AuditActivityEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "audit_activity")
@@ -19,7 +20,7 @@ public class AuditActivityEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "aua_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "aua_gen")
-    @SequenceGenerator(name = "aua_gen", sequenceName = "aua_seq", allocationSize = 1)
+    @SequenceGenerator(name = "aua_gen", sequenceName = "aua_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "activity_name")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AuditEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AuditEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "audit")
@@ -22,7 +23,7 @@ public class AuditEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "aud_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "aud_gen")
-    @SequenceGenerator(name = "aud_gen", sequenceName = "aud_seq", allocationSize = 1)
+    @SequenceGenerator(name = "aud_gen", sequenceName = "aud_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AutomatedTaskEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AutomatedTaskEntity.java
@@ -15,6 +15,7 @@ import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import uk.gov.hmcts.darts.common.entity.base.MandatoryCreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = AutomatedTaskEntity.TABLE_NAME)
@@ -38,7 +39,7 @@ public class AutomatedTaskEntity extends MandatoryCreatedModifiedBaseEntity {
     @Id
     @Column(name = AUTOMATED_TASK_ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = TASK_GEN)
-    @SequenceGenerator(name = TASK_GEN, sequenceName = AUTOMATED_TASK_SEQ, allocationSize = 1)
+    @SequenceGenerator(name = TASK_GEN, sequenceName = AUTOMATED_TASK_SEQ, allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = TASK_NAME)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CaseDocumentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CaseDocumentEntity.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.darts.task.runner.CanReturnExternalObjectDirectoryEntities;
 import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import uk.gov.hmcts.darts.task.runner.HasRetention;
 import uk.gov.hmcts.darts.task.runner.SoftDelete;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ public class CaseDocumentEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "cad_gen")
-    @SequenceGenerator(name = "cad_gen", sequenceName = "cad_seq", allocationSize = 1)
+    @SequenceGenerator(name = "cad_gen", sequenceName = "cad_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CaseManagementRetentionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CaseManagementRetentionEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = CaseManagementRetentionEntity.TABLE_NAME)
@@ -24,7 +25,7 @@ public class CaseManagementRetentionEntity {
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "cmr_gen")
-    @SequenceGenerator(name = "cmr_gen", sequenceName = "cmr_seq", allocationSize = 1)
+    @SequenceGenerator(name = "cmr_gen", sequenceName = "cmr_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CaseRetentionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CaseRetentionEntity.java
@@ -16,6 +16,7 @@ import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
 import uk.gov.hmcts.darts.task.runner.HasIntegerId;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -33,7 +34,7 @@ public class CaseRetentionEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "car_gen")
-    @SequenceGenerator(name = "car_gen", sequenceName = "car_seq", allocationSize = 1)
+    @SequenceGenerator(name = "car_gen", sequenceName = "car_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceReasonEnum;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceScoreEnum;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -55,7 +56,7 @@ public class CourtCaseEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = CAS_ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "cas_gen")
-    @SequenceGenerator(name = "cas_gen", sequenceName = "cas_seq", allocationSize = 1)
+    @SequenceGenerator(name = "cas_gen", sequenceName = "cas_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     /**

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CourtroomEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CourtroomEntity.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.hmcts.darts.common.entity.base.CreatedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = CourtroomEntity.TABLE_NAME, uniqueConstraints = {@UniqueConstraint(columnNames = {CourtroomEntity.CTH_ID, CourtroomEntity.COURTROOM_NAME})})
@@ -33,7 +34,7 @@ public class CourtroomEntity extends CreatedBaseEntity {
     @Id
     @Column(name = CTR_ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ctr_gen")
-    @SequenceGenerator(name = "ctr_gen", sequenceName = "ctr_seq", allocationSize = 1)
+    @SequenceGenerator(name = "ctr_gen", sequenceName = "ctr_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = COURTROOM_NAME)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DailyListEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DailyListEntity.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.dailylist.enums.JobStatusType;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -48,7 +49,7 @@ public class DailyListEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "dal_gen")
-    @SequenceGenerator(name = "dal_gen", sequenceName = "dal_seq", allocationSize = 1)
+    @SequenceGenerator(name = "dal_gen", sequenceName = "dal_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = LISTING_COURTHOUSE)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DataAnonymisationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DataAnonymisationEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -26,7 +27,7 @@ public class DataAnonymisationEntity {
     @Id
     @Column(name = "dan_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "dan_gen")
-    @SequenceGenerator(name = "dan_gen", sequenceName = "dan_seq", allocationSize = 1)
+    @SequenceGenerator(name = "dan_gen", sequenceName = "dan_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DefenceEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DefenceEntity.java
@@ -33,7 +33,7 @@ public class DefenceEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "dfc_gen")
-    @SequenceGenerator(name = "dfc_gen", sequenceName = "dfc_seq", allocationSize = 1)
+    @SequenceGenerator(name = "dfc_gen", sequenceName = "dfc_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(optional = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/DefendantEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/DefendantEntity.java
@@ -33,7 +33,7 @@ public class DefendantEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "dfd_gen")
-    @SequenceGenerator(name = "dfd_gen", sequenceName = "dfd_seq", allocationSize = 1)
+    @SequenceGenerator(name = "dfd_gen", sequenceName = "dfd_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(optional = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.collections4.CollectionUtils;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ public class EventEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "eve_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eve_gen")
-    @SequenceGenerator(name = "eve_gen", sequenceName = "eve_seq", allocationSize = 1)
+    @SequenceGenerator(name = "eve_gen", sequenceName = "eve_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "event_object_id", unique = true, length = 16)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventHandlerEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventHandlerEntity.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import uk.gov.hmcts.darts.common.entity.base.CreatedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "event_handler")
@@ -24,7 +25,7 @@ public class EventHandlerEntity extends CreatedBaseEntity {
     @Id
     @Column(name = "evh_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "evh_gen")
-    @SequenceGenerator(name = "evh_gen", sequenceName = "evh_seq", allocationSize = 1)
+    @SequenceGenerator(name = "evh_gen", sequenceName = "evh_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "event_type", nullable = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventLinkedCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventLinkedCaseEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "event_linked_case")
@@ -23,7 +24,7 @@ public class EventLinkedCaseEntity {
     @Id
     @Column(name = "elc_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "elc_gen")
-    @SequenceGenerator(name = "elc_gen", sequenceName = "elc_seq", allocationSize = 1)
+    @SequenceGenerator(name = "elc_gen", sequenceName = "elc_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalLocationTypeEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalLocationTypeEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "external_location_type")
@@ -24,7 +25,7 @@ public class ExternalLocationTypeEntity {
     @Id
     @Column(name = "elt_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "elt_gen")
-    @SequenceGenerator(name = "elt_gen", sequenceName = "elt_seq", allocationSize = 1)
+    @SequenceGenerator(name = "elt_gen", sequenceName = "elt_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "elt_description")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalObjectDirectoryEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalObjectDirectoryEntity.java
@@ -17,6 +17,7 @@ import lombok.Setter;
 import org.hibernate.annotations.NaturalId;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -29,7 +30,7 @@ public class ExternalObjectDirectoryEntity extends CreatedModifiedBaseEntity imp
     @Id
     @Column(name = "eod_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "eod_gen")
-    @SequenceGenerator(name = "eod_gen", sequenceName = "eod_seq", allocationSize = 1)
+    @SequenceGenerator(name = "eod_gen", sequenceName = "eod_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalObjectDirectoryProcessDetailEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalObjectDirectoryProcessDetailEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import uk.gov.hmcts.darts.common.entity.base.MandatoryCreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -24,7 +25,7 @@ public class ExternalObjectDirectoryProcessDetailEntity extends MandatoryCreated
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "epd_gen")
-    @SequenceGenerator(name = "epd_gen", sequenceName = "epd_seq", allocationSize = 1)
+    @SequenceGenerator(name = "epd_gen", sequenceName = "epd_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     @Column(name = "epd_id")
     private Integer id;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalServiceAuthTokenEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ExternalServiceAuthTokenEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -22,7 +23,7 @@ public class ExternalServiceAuthTokenEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "esa_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "esa_gen")
-    @SequenceGenerator(name = "esa_gen", sequenceName = "esa_seq", allocationSize = 1)
+    @SequenceGenerator(name = "esa_gen", sequenceName = "esa_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "external_service_userid")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity_;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.task.runner.HasIntegerId;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -41,7 +42,7 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = HEA_ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "hea_gen")
-    @SequenceGenerator(name = "hea_gen", sequenceName = "hea_seq", allocationSize = 1)
+    @SequenceGenerator(name = "hea_gen", sequenceName = "hea_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @JoinColumn(name = "ctr_id")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/JudgeEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/JudgeEntity.java
@@ -13,6 +13,7 @@ import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import uk.gov.hmcts.darts.task.runner.IsNamedEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = JudgeEntity.TABLE_NAME)
@@ -29,7 +30,7 @@ public class JudgeEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "jud_gen")
-    @SequenceGenerator(name = "jud_gen", sequenceName = "jud_seq", allocationSize = 1)
+    @SequenceGenerator(name = "jud_gen", sequenceName = "jud_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = JUDGE_NAME)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.darts.task.runner.CanReturnExternalObjectDirectoryEntities;
 import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import uk.gov.hmcts.darts.task.runner.HasRetention;
 import uk.gov.hmcts.darts.task.runner.SoftDelete;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class MediaEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = "med_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "med_gen")
-    @SequenceGenerator(name = "med_gen", sequenceName = "med_seq", allocationSize = 1)
+    @SequenceGenerator(name = "med_gen", sequenceName = "med_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/MediaLinkedCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/MediaLinkedCaseEntity.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedBaseEntity;
 import uk.gov.hmcts.darts.common.enums.MediaLinkedCaseSourceType;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "media_linked_case")
@@ -29,7 +30,7 @@ public class MediaLinkedCaseEntity extends CreatedBaseEntity {
     @Id
     @Column(name = "mlc_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "mlc_gen")
-    @SequenceGenerator(name = "mlc_gen", sequenceName = "mlc_seq", allocationSize = 1)
+    @SequenceGenerator(name = "mlc_gen", sequenceName = "mlc_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectAdminActionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectAdminActionEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -26,7 +27,7 @@ public class ObjectAdminActionEntity {
     @Id
     @Column(name = "oaa_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "oaa_gen")
-    @SequenceGenerator(name = "oaa_gen", sequenceName = "oaa_seq", allocationSize = 1)
+    @SequenceGenerator(name = "oaa_gen", sequenceName = "oaa_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectHiddenReasonEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectHiddenReasonEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.Immutable;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "object_hidden_reason")
@@ -21,7 +22,7 @@ public class ObjectHiddenReasonEntity {
     @Id
     @Column(name = "ohr_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ohr_gen")
-    @SequenceGenerator(name = "ohr_gen", sequenceName = "ohr_seq", allocationSize = 1)
+    @SequenceGenerator(name = "ohr_gen", sequenceName = "ohr_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "ohr_reason")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectRetrievalQueueEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectRetrievalQueueEntity.java
@@ -13,6 +13,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -26,7 +27,7 @@ public class ObjectRetrievalQueueEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "orq_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "orq_gen")
-    @SequenceGenerator(name = "orq_gen", sequenceName = "orq_seq", allocationSize = 1)
+    @SequenceGenerator(name = "orq_gen", sequenceName = "orq_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ProsecutorEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ProsecutorEntity.java
@@ -33,7 +33,7 @@ public class ProsecutorEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "prn_gen")
-    @SequenceGenerator(name = "prn_gen", sequenceName = "prn_seq", allocationSize = 1)
+    @SequenceGenerator(name = "prn_gen", sequenceName = "prn_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(optional = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/RegionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/RegionEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -26,7 +27,7 @@ public class RegionEntity {
     @Id
     @Column(name = "reg_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "reg_gen")
-    @SequenceGenerator(name = "reg_gen", sequenceName = "reg_seq", allocationSize = 1)
+    @SequenceGenerator(name = "reg_gen", sequenceName = "reg_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "region_name")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ReportEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ReportEntity.java
@@ -11,6 +11,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 
 @Entity
@@ -23,7 +24,7 @@ public class ReportEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "rep_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "rep_gen")
-    @SequenceGenerator(name = "rep_gen", sequenceName = "rep_seq", allocationSize = 1)
+    @SequenceGenerator(name = "rep_gen", sequenceName = "rep_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "report_object_id", length = 16)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/RetentionConfidenceCategoryMapperEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/RetentionConfidenceCategoryMapperEntity.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.common.entity.base.MandatoryCreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceReasonEnum;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceScoreEnum;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "retention_confidence_category_mapper")
@@ -27,7 +28,7 @@ public class RetentionConfidenceCategoryMapperEntity extends MandatoryCreatedMod
     @Id
     @Column(name = "rcc_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "rcc_gen")
-    @SequenceGenerator(name = "rcc_gen", sequenceName = "rcc_seq", allocationSize = 1)
+    @SequenceGenerator(name = "rcc_gen", sequenceName = "rcc_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "ret_conf_score")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/RetentionPolicyTypeEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/RetentionPolicyTypeEntity.java
@@ -13,6 +13,7 @@ import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -29,7 +30,7 @@ public class RetentionPolicyTypeEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "rpt_gen")
-    @SequenceGenerator(name = "rpt_gen", sequenceName = "rpt_seq", allocationSize = 1)
+    @SequenceGenerator(name = "rpt_gen", sequenceName = "rpt_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "fixed_policy_key", nullable = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/SecurityGroupEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/SecurityGroupEntity.java
@@ -21,6 +21,7 @@ import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import uk.gov.hmcts.darts.common.entity.base.MandatoryCreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -38,7 +39,7 @@ public class SecurityGroupEntity extends MandatoryCreatedModifiedBaseEntity {
     @Id
     @Column(name = "grp_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "grp_gen")
-    @SequenceGenerator(name = "grp_gen", sequenceName = "grp_seq", allocationSize = 1)
+    @SequenceGenerator(name = "grp_gen", sequenceName = "grp_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @NotAudited

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/SecurityPermissionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/SecurityPermissionEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "security_permission")
@@ -20,7 +21,7 @@ public class SecurityPermissionEntity {
     @Id
     @Column(name = "per_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "per_gen")
-    @SequenceGenerator(name = "per_gen", sequenceName = "per_seq", allocationSize = 1)
+    @SequenceGenerator(name = "per_gen", sequenceName = "per_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "permission_name", nullable = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/SecurityRoleEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/SecurityRoleEntity.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Table;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -26,7 +27,7 @@ public class SecurityRoleEntity {
     @Id
     @Column(name = "rol_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "rol_gen")
-    @SequenceGenerator(name = "rol_gen", sequenceName = "rol_seq", allocationSize = 1)
+    @SequenceGenerator(name = "rol_gen", sequenceName = "rol_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = "role_name", nullable = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionCommentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionCommentEntity.java
@@ -16,6 +16,7 @@ import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 
@@ -32,7 +33,7 @@ public class TranscriptionCommentEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "trc_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "trc_gen")
-    @SequenceGenerator(name = "trc_gen", sequenceName = "trc_seq", allocationSize = 1)
+    @SequenceGenerator(name = "trc_gen", sequenceName = "trc_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Audited(targetAuditMode = NOT_AUDITED)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionDocumentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionDocumentEntity.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.darts.task.runner.CanReturnExternalObjectDirectoryEntities;
 import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import uk.gov.hmcts.darts.task.runner.HasRetention;
 import uk.gov.hmcts.darts.task.runner.SoftDelete;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -38,7 +39,7 @@ public class TranscriptionDocumentEntity extends ModifiedBaseEntity
     @Id
     @Column(name = "trd_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "trd_gen")
-    @SequenceGenerator(name = "trd_gen", sequenceName = "trd_seq", allocationSize = 1)
+    @SequenceGenerator(name = "trd_gen", sequenceName = "trd_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntity.java
@@ -20,6 +20,7 @@ import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -43,7 +44,7 @@ public class TranscriptionEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = "tra_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tra_gen")
-    @SequenceGenerator(name = "tra_gen", sequenceName = "tra_seq", allocationSize = 1)
+    @SequenceGenerator(name = "tra_gen", sequenceName = "tra_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @NotAudited

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionLinkedCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionLinkedCaseEntity.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "transcription_linked_case")
@@ -25,7 +26,7 @@ public class TranscriptionLinkedCaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tlc_gen")
-    @SequenceGenerator(name = "tlc_gen", sequenceName = "tlc_seq", allocationSize = 1)
+    @SequenceGenerator(name = "tlc_gen", sequenceName = "tlc_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     @Column(name = "tlc_id")
     private Integer id;
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionWorkflowEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionWorkflowEntity.java
@@ -17,6 +17,7 @@ import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ public class TranscriptionWorkflowEntity {
     @Id
     @Column(name = "trw_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "trw_gen")
-    @SequenceGenerator(name = "trw_gen", sequenceName = "trw_seq", allocationSize = 1)
+    @SequenceGenerator(name = "trw_gen", sequenceName = "trw_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne(optional = false)

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TransientObjectDirectoryEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TransientObjectDirectoryEntity.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.NaturalId;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 @Entity
 @Table(name = "transient_object_directory")
@@ -24,7 +25,7 @@ public class TransientObjectDirectoryEntity extends CreatedModifiedBaseEntity im
     @Id
     @Column(name = "tod_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "tod_gen")
-    @SequenceGenerator(name = "tod_gen", sequenceName = "tod_seq", allocationSize = 1)
+    @SequenceGenerator(name = "tod_gen", sequenceName = "tod_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @ManyToOne

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/UserAccountEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/UserAccountEntity.java
@@ -20,6 +20,7 @@ import org.hibernate.envers.NotAudited;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityGroupEnum;
 import uk.gov.hmcts.darts.task.runner.HasIntegerId;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.LinkedHashSet;
@@ -40,7 +41,7 @@ public class UserAccountEntity extends CreatedModifiedBaseEntity
     @Id
     @Column(name = "usr_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "usr_gen")
-    @SequenceGenerator(name = "usr_gen", sequenceName = "usr_seq", allocationSize = 1)
+    @SequenceGenerator(name = "usr_gen", sequenceName = "usr_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @NotAudited

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/TransientObjectDirectoryServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/TransientObjectDirectoryServiceImpl.java
@@ -29,9 +29,8 @@ public class TransientObjectDirectoryServiceImpl implements TransientObjectDirec
         transientObjectDirectoryEntity.setStatus(objectRecordStatusRepository.getReferenceById(STORED.getId()));
         transientObjectDirectoryEntity.setExternalLocation(blobName);
         transientObjectDirectoryEntity.setTransferAttempts(null);
-        var systemUser = userAccountRepository.getReferenceById(SystemUsersEnum.DEFAULT.getId());
-        transientObjectDirectoryEntity.setCreatedBy(systemUser);
-        transientObjectDirectoryEntity.setLastModifiedBy(systemUser);
+        transientObjectDirectoryEntity.setCreatedById(SystemUsersEnum.DEFAULT.getId());
+        transientObjectDirectoryEntity.setLastModifiedById(SystemUsersEnum.DEFAULT.getId());
 
         return transientObjectDirectoryRepository.saveAndFlush(transientObjectDirectoryEntity);
     }

--- a/src/main/java/uk/gov/hmcts/darts/notification/entity/NotificationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/notification/entity/NotificationEntity.java
@@ -19,6 +19,7 @@ import lombok.NoArgsConstructor;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.notification.enums.NotificationStatus;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import static jakarta.persistence.CascadeType.MERGE;
 import static jakarta.persistence.CascadeType.PERSIST;
@@ -43,7 +44,7 @@ public class NotificationEntity extends CreatedModifiedBaseEntity {
     @Id
     @Column(name = ID)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "not_gen")
-    @SequenceGenerator(name = "not_gen", sequenceName = "not_seq", allocationSize = 1)
+    @SequenceGenerator(name = "not_gen", sequenceName = "not_seq", allocationSize = DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE)
     private Integer id;
 
     @Column(name = EVENT_ID)

--- a/src/main/java/uk/gov/hmcts/darts/util/DataUtil.java
+++ b/src/main/java/uk/gov/hmcts/darts/util/DataUtil.java
@@ -13,6 +13,9 @@ import static java.util.Objects.isNull;
 
 
 public final class DataUtil {
+
+    public static final int DEFAULT_SEQUENCE_ALLOCATION_SIZE = 20;
+
     private DataUtil() {
 
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4979)


### Change description ###
# Summary of Git Diff Changes

This Git Diff reflects updates across multiple Java entity classes in the HMCTS DARTS project. The main change involves the modification of the `@SequenceGenerator` allocation size for various entities to utilize a constant value defined in the `DataUtil` class. This change improves consistency and maintainability in the allocation size for database sequence generators.

## Highlights

- **New Import**: Added `import uk.gov.hmcts.darts.util.DataUtil;` in multiple entity classes.
  
- **Modified Allocation Sizes**: 
  - Updated the `allocationSize` in `@SequenceGenerator` annotations from a hard-coded value of `1` to `DataUtil.DEFAULT_SEQUENCE_ALLOCATION_SIZE` (set to `20`).
  
- **Affected Classes**: Changes were made to the following entities:
  - `MediaRequestEntity`
  - `RevisionInfo`
  - `AnnotationDocumentEntity`
  - `AnnotationEntity`
  - `ArmAutomatedTaskEntity`
  - `ArmRpoExecutionDetailEntity`
  - `ArmRpoStateEntity`
  - `ArmRpoStatusEntity`
  - `AuditActivityEntity`
  - `AuditEntity`
  - `AutomatedTaskEntity`
  - `CaseDocumentEntity`
  - `CaseManagementRetentionEntity`
  - `CaseRetentionEntity`
  - `CourtCaseEntity`
  - `CourtroomEntity`
  - `DailyListEntity`
  - `DataAnonymisationEntity`
  - `DefenceEntity`
  - `DefendantEntity`
  - `EventEntity`
  - `EventHandlerEntity`
  - `EventLinkedCaseEntity`
  - `ExternalLocationTypeEntity`
  - `ExternalObjectDirectoryEntity`
  - `ExternalObjectDirectoryProcessDetailEntity`
  - `ExternalServiceAuthTokenEntity`
  - `HearingEntity`
  - `JudgeEntity`
  - `MediaEntity`
  - `MediaLinkedCaseEntity`
  - `ObjectAdminActionEntity`
  - `ObjectHiddenReasonEntity`
  - `ObjectRetrievalQueueEntity`
  - `ProsecutorEntity`
  - `RegionEntity`
  - `ReportEntity`
  - `RetentionConfidenceCategoryMapperEntity`
  - `RetentionPolicyTypeEntity`
  - `SecurityGroupEntity`
  - `SecurityPermissionEntity`
  - `SecurityRoleEntity`
  - `TranscriptionCommentEntity`
  - `TranscriptionDocumentEntity`
  - `TranscriptionEntity`
  - `TranscriptionLinkedCaseEntity`
  - `TranscriptionWorkflowEntity`
  - `TransientObjectDirectoryEntity`
  - `UserAccountEntity`
  - `TransientObjectDirectoryServiceImpl`
  - `NotificationEntity` 

These changes enhance the consistency of sequence allocation sizes throughout the codebase, facilitating easier future adjustments.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
