### PR TITLE
DMP-4946: Paginate the court log tab

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -112,9 +112,9 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
             [{"id":<event-id>,
             "hearing_id":<hearing-id>,
             "hearing_date":"2023-01-01",
-            "timestamp":"2023-01-01T12:00:00Z",
+            "timestamp":"2023-01-01T12:01:00Z",
             "name":"Section 11 of the Contempt of Court Act 1981",
-            "text":"some-event-text-1",
+            "text":"some-event-text-2023-01-01T12:01",
             "is_data_anonymised": false
             }]
             """;
@@ -162,19 +162,19 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                 "id": 2,
                 "hearing_id": 1,
                 "hearing_date": "2023-01-01",
-                "timestamp": "2023-01-02T12:00:00Z",
+                "timestamp": "2023-01-02T12:01:00Z",
                 "name": "Section 11 of the Contempt of Court Act 1981",
                 "is_data_anonymised": false,
-                "text": "some-event-text-1"
+                "text": "some-event-text-2023-01-01T12:01"
               },
               {
                 "id": 1,
                 "hearing_id": 1,
                 "hearing_date": "2023-01-01",
-                "timestamp": "2023-01-01T12:00:00Z",
+                "timestamp": "2023-01-01T12:01:00Z",
                 "name": "Section 11 of the Contempt of Court Act 1981",
                 "is_data_anonymised": false,
-                "text": "some-event-text-1"
+                "text": "some-event-text-2023-01-01T12:01"
               }
             ]
             """;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.testutils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,8 +76,6 @@ public class IntegrationBase extends TestBase {
 
     @Autowired
     protected DartsDatabaseRetrieval dartsDataRetrieval;
-    @Autowired
-    protected ObjectMapper objectMapper;
     @Autowired
     private List<AutomatedOnDemandTask> automatedOnDemandTask;
     @Autowired

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/TestBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/TestBase.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.testutils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import org.junit.jupiter.api.BeforeEach;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -32,6 +33,8 @@ public class TestBase {
 
     @Autowired
     protected TransactionalUtil transactionalUtil;
+    @Autowired
+    protected ObjectMapper objectMapper;
 
     @Autowired
     @Qualifier("inMemoryCacheManager")

--- a/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/controller/CaseController.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.darts.cases.model.AdminSingleCaseResponseItem;
 import uk.gov.hmcts.darts.cases.model.AdvancedSearchRequest;
 import uk.gov.hmcts.darts.cases.model.AdvancedSearchResult;
 import uk.gov.hmcts.darts.cases.model.Annotation;
+import uk.gov.hmcts.darts.cases.model.CasesCaseIdEventsGet200Response;
 import uk.gov.hmcts.darts.cases.model.Event;
 import uk.gov.hmcts.darts.cases.model.GetCasesRequest;
 import uk.gov.hmcts.darts.cases.model.GetCasesSearchRequest;
@@ -34,8 +35,11 @@ import uk.gov.hmcts.darts.common.util.AdminSearchRequestValidator;
 import uk.gov.hmcts.darts.common.util.CourtValidationUtils;
 import uk.gov.hmcts.darts.log.api.LogApi;
 import uk.gov.hmcts.darts.util.DataUtil;
+import uk.gov.hmcts.darts.util.pagination.PaginatedList;
+import uk.gov.hmcts.darts.util.pagination.PaginationDto;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
@@ -147,9 +151,38 @@ public class CaseController implements CasesApi {
     @Authorisation(contextId = CASE_ID,
         securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
         globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA, DARTS})
-    public ResponseEntity<List<Event>> casesCaseIdEventsGet(Integer caseId) {
+    public ResponseEntity<CasesCaseIdEventsGet200Response> casesCaseIdEventsGet(
+        Integer caseId,
+        List<String> sortBy,
+        List<String> sortOrder,
+        Integer pageNumber,
+        Integer pageSize
+    ) {
+        PaginationDto<Event> paginationDto = new PaginationDto<>(
+            CasesCaseIdEventsGet200PaginatedResponse::new,
+            pageNumber,
+            pageSize,
+            PaginationDto.toSortBy(sortBy),
+            PaginationDto.toSortDirection(sortOrder)
+        );
 
-        return new ResponseEntity<>(caseService.getEventsByCaseId(caseId), HttpStatus.OK);
+        if (paginationDto.shouldPaginate()) {
+            return new ResponseEntity<>(
+                caseService.getEventsByCaseId(caseId, paginationDto)
+                    .asClass(CasesCaseIdEventsGet200PaginatedResponse.class), HttpStatus.OK);
+        }
+        return new ResponseEntity<>(new CasesCaseIdEventsGet200PaginatedResponseList(caseService.getEventsByCaseId(caseId)), HttpStatus.OK);
+    }
+
+    public static class CasesCaseIdEventsGet200PaginatedResponse extends PaginatedList<Event>
+        implements CasesCaseIdEventsGet200Response {
+    }
+
+    public static class CasesCaseIdEventsGet200PaginatedResponseList extends ArrayList<Event>
+        implements CasesCaseIdEventsGet200Response {
+        public CasesCaseIdEventsGet200PaginatedResponseList(List<Event> events) {
+            super(events);
+        }
     }
 
     @Override
@@ -209,5 +242,4 @@ public class CaseController implements CasesApi {
             throw new DartsApiException(CaseApiError.INVALID_REQUEST, "Courthouse and courtroom must be uppercase.");
         }
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
@@ -20,13 +20,13 @@ public class EventMapper {
         List<EventEntity> latestEvents = GetEventsResponseMapper.filterNonLatestEvents(eventEntities);
 
         return emptyIfNull(latestEvents).stream()
-            .map(EventMapper::map)
+            .map(EventMapper::mapToEvent)
             .sorted((e1, e2) -> e2.getHearingDate().compareTo(e1.getHearingDate()))
             .collect(Collectors.toList());
     }
 
     @SuppressWarnings("java:S1874")//Required as we replaced getFirst with getHearingEntity(). A ticket will be raised clean this up across the app
-    private Event map(EventEntity eventEntity) {
+    public Event mapToEvent(EventEntity eventEntity) {
         HearingEntity hearingEntity = eventEntity.getHearingEntity();
 
         Event event = new Event();

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/CaseService.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/CaseService.java
@@ -15,6 +15,8 @@ import uk.gov.hmcts.darts.cases.model.ScheduledCase;
 import uk.gov.hmcts.darts.cases.model.SingleCase;
 import uk.gov.hmcts.darts.cases.model.Transcript;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.util.pagination.PaginatedList;
+import uk.gov.hmcts.darts.util.pagination.PaginationDto;
 
 import java.util.List;
 
@@ -33,6 +35,8 @@ public interface CaseService {
     CourtCaseEntity getCourtCaseById(Integer caseId);
 
     List<Event> getEventsByCaseId(Integer caseId);
+
+    PaginatedList<Event> getEventsByCaseId(Integer caseId, PaginationDto<Event> paginationDto);
 
     List<Transcript> getTranscriptsByCaseId(Integer caseId);
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -2,6 +2,8 @@ package uk.gov.hmcts.darts.common.repository;
 
 import jakarta.persistence.Column;
 import org.springframework.data.domain.Limit;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -37,6 +39,17 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
           ORDER BY he.hearingDate DESC, ee.timestamp DESC
         """)
     List<EventEntity> findAllByCaseId(Integer caseId);
+
+
+    @Query("""
+           SELECT ee
+           FROM EventEntity ee
+           JOIN ee.hearingEntities he
+           LEFT JOIN ee.eventType et        
+           WHERE he.courtCase.id = :caseId
+        """)
+    Page<EventEntity> findAllByCaseIdPaginated(Integer caseId, Pageable pageable);
+
 
     @Query("""
             SELECT EXISTS (

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
@@ -84,7 +84,7 @@ public class EventMapper {
         }
         return hearingEntities.stream()
             .sorted(Comparator.comparing(HearingEntity::getId))
-            .map(hearingEntity -> mapAdminGetEventResponseDetailsHearing(hearingEntity))
+            .map(this::mapAdminGetEventResponseDetailsHearing)
             .toList();
     }
 
@@ -111,7 +111,7 @@ public class EventMapper {
             return new ArrayList<>();
         }
         return cases.stream()
-            .map(caseEntity -> mapAdminGetEventResponseDetailsCasesCase(caseEntity))
+            .map(this::mapAdminGetEventResponseDetailsCasesCase)
             .toList();
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/util/pagination/PaginatedList.java
+++ b/src/main/java/uk/gov/hmcts/darts/util/pagination/PaginatedList.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.darts.util.pagination;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.apache.commons.collections.CollectionUtils;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class PaginatedList<T> {
+
+    @JsonProperty("current_page")
+    @NotNull
+    @Min(1)
+    private Integer currentPage;
+
+    @JsonProperty("total_pages")
+    @NotNull
+    @Min(1)
+    private Integer totalPages;
+
+    @JsonProperty("page_size")
+    @NotNull
+    @Min(1)
+    private Integer pageSize;
+
+    @JsonProperty("total_items")
+    @NotNull
+    @Min(0)
+    private Integer totalItems;
+
+    @JsonProperty("data")
+    private List<@NotNull T> data;
+
+
+    public void setTotalItems(int totalItems, int pageLimit) {
+        this.totalItems = totalItems;
+        this.totalPages = this.totalItems / pageLimit
+            + (this.totalItems % pageLimit == 0 ? 0 : 1);
+    }
+
+    @JsonIgnore
+    public boolean isEmpty() {
+        return CollectionUtils.isEmpty(data);
+    }
+
+    @JsonIgnore
+    @SuppressWarnings("unchecked")//False positive
+    public <T> T asClass(Class<T> clazz) {
+        if (clazz.isInstance(this)) {
+            return (T) this;
+        }
+        throw new DartsApiException(
+            CommonApiError.INTERNAL_SERVER_ERROR,
+            "Invalid class type provided for conversion: " + clazz.getName() +
+                ". Expected: " + this.getClass().getName() + "."
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/util/pagination/PaginationDto.java
+++ b/src/main/java/uk/gov/hmcts/darts/util/pagination/PaginationDto.java
@@ -1,0 +1,122 @@
+package uk.gov.hmcts.darts.util.pagination;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class PaginationDto<T> {
+    private Supplier<PaginatedList<T>> paginatedListSupplier;
+    private Integer pageNumber;
+    private Integer pageSize;
+    List<String> sortBy;
+    List<Sort.Direction> sortDirection;
+
+    public static List<Sort.Direction> toSortDirection(List<String> sortOrder) {
+        if (sortOrder == null) {
+            return null;
+        }
+        return sortOrder.stream()
+            .map(string -> string.split(","))
+            .flatMap(Arrays::stream)
+            .map(Sort.Direction::fromString)
+            .collect(Collectors.toList());
+    }
+
+    public static List<String> toSortBy(List<String> sortBy) {
+        if (sortBy == null) {
+            return null;
+        }
+        return sortBy.stream()
+            .map(string -> string.split(","))
+            .flatMap(Arrays::stream)
+            .collect(Collectors.toList());
+    }
+
+    public boolean shouldPaginate() {
+        return pageNumber != null && pageSize != null;
+    }
+
+    void setupAndValidate() {
+        if (sortBy == null) {
+            sortBy = new ArrayList<>();
+        }
+        if (sortDirection == null) {
+            sortDirection = new ArrayList<>();
+        }
+        if (paginatedListSupplier == null) {
+            paginatedListSupplier = PaginatedList::new;
+        }
+        //If sortBy and sortDirection are not null, then they should be of the same size
+        if (sortBy != null && sortDirection != null && sortBy.size() != sortDirection.size()) {
+            throw new DartsApiException(CommonApiError.INVALID_REQUEST, "sortBy and sortDirection must be of the same size");
+        }
+    }
+
+    public Pageable toPagable(List<String> defaultSortOrder, List<Sort.Direction> defaultSortDirection,
+                              Map<String, String> sortByMapper) {
+        this.setupAndValidate();
+        //Minus one from page number to convert to zero based index
+        return PageRequest.of(this.getPageNumber() - 1, this.getPageSize(), this.getSort(defaultSortOrder, defaultSortDirection, sortByMapper));
+    }
+
+    Sort getSort(List<String> defaultSortBy, List<Sort.Direction> defaultSortDirection,
+                 Map<String, String> sortByMapper) {
+        List<String> combinedSortBy = new ArrayList<>(this.getSortBy());
+        List<Sort.Direction> combinedSortDirections = new ArrayList<>(this.getSortDirection());
+
+        //Add default sort order and direction to the end of the existing sort stack
+        combinedSortBy.addAll(defaultSortBy);
+        combinedSortDirections.addAll(defaultSortDirection);
+
+        //Combined all sort orders and directions into a single list
+        List<Sort.Order> sortOrders = new ArrayList<>();
+        for (int index = 0; index < combinedSortBy.size(); index++) {
+            String currentSortBy = combinedSortBy.get(index);
+            currentSortBy = sortByMapper.getOrDefault(currentSortBy, currentSortBy);//Check if sortBy has a mapper else return default value
+            Sort.Direction currentDirection = combinedSortDirections.get(index);
+            sortOrders.add(new Sort.Order(currentDirection, currentSortBy));
+        }
+        return Sort.by(sortOrders);
+    }
+
+
+    public <I> PaginatedList<T> toPaginatedList(Function<Pageable, Page<I>> page,
+                                                Function<I, T> dataMapper,
+                                                List<String> sortOrder,
+                                                List<Sort.Direction> sortDirection) {
+        return toPaginatedList(page, dataMapper, sortOrder, sortDirection, Map.of());
+    }
+
+    public <I> PaginatedList<T> toPaginatedList(Function<Pageable, Page<I>> page,
+                                                Function<I, T> dataMapper,
+                                                List<String> sortOrder,
+                                                List<Sort.Direction> sortDirection,
+                                                Map<String, String> sortByMapper) {
+
+        Page<I> results = page.apply(toPagable(sortOrder, sortDirection, sortByMapper));
+        PaginatedList<T> paginatedList = paginatedListSupplier.get();
+        paginatedList.setCurrentPage(this.getPageNumber());
+        paginatedList.setPageSize(this.getPageSize());
+        paginatedList.setTotalItems((int) results.getTotalElements(), this.getPageSize());
+        paginatedList.setData(results.get().map(dataMapper).toList());
+
+        return paginatedList;
+    }
+}

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -53,7 +53,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: A required parameter is missing or an invalid datatype or value was provided for property.
           content:
@@ -105,7 +105,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request - Invalid XML Document
           content:
@@ -152,7 +152,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request - Invalid XML Document
           content:
@@ -286,13 +286,52 @@ paths:
             type: integer
           description: "case_id is the internal cas_id of the case."
           required: true
+        - in: query
+          name: sort_by
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - "hearingDate"
+                - "timestamp"
+                - "eventName"
+        - in: query
+          name: sort_order
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - "ASC"
+                - "DESC"
+        - in: query
+          name: page_number
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: page_size
+          schema:
+            type: integer
+            minimum: 1
+            default: 25
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/events'
+                oneOf:
+                  - $ref: '#/components/schemas/events'
+                    description: Returned if no page_limit or page_number is provided
+                  - $ref: './common.yaml#/components/schemas/paginated_list_common'
+                    description: Returned if page_limit or page_number is provided
+                    properties:  #Fix data tab in spec
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/event'
         '401':
           description: Unauthorised Error
         '403':
@@ -413,7 +452,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: A required parameter is missing or an invalid datatype or value was provided for property.
         '409':
@@ -447,7 +486,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request Error
         '401':
@@ -491,7 +530,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: A required parameter is missing or an invalid datatype or value was provided for property.
         '500':
@@ -521,7 +560,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request Error
         '401':

--- a/src/main/resources/openapi/common.yaml
+++ b/src/main/resources/openapi/common.yaml
@@ -67,6 +67,22 @@ components:
     MarkedForDeletion:
       type: boolean
 
+    paginated_list_common:
+      type: object
+      properties:
+        current_page:
+          type: integer
+        page_size:
+          type: integer
+        total_pages:
+          type: integer
+        total_items:
+          type: integer
+      required:
+        - current_page
+        - page_size
+        - total_pages
+        - total_items
     reporting_restrictions:
       type: array
       default: [ ]

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRetentionEventDateProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRetentionEventDateProcessorImplTest.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.service.impl.EodHelperMocks;
-import uk.gov.hmcts.darts.common.util.EodHelper;
 import uk.gov.hmcts.darts.testutils.ExternalObjectDirectoryTestData;
 
 import java.time.OffsetDateTime;
@@ -27,7 +26,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
-import static uk.gov.hmcts.darts.common.util.EodHelper.armLocation;
 import static uk.gov.hmcts.darts.testutils.ExternalObjectDirectoryTestData.TEST_EXTERNAL_OBJECT_DIRECTORY_ID;
 
 @ExtendWith(MockitoExtension.class)
@@ -67,6 +65,7 @@ class ArmRetentionEventDateProcessorImplTest {
         externalObjectDirectoryEntity.setUpdateRetention(true);
 
     }
+
     @AfterEach
     void tearDown() {
         eodHelperMocks.close();
@@ -76,7 +75,10 @@ class ArmRetentionEventDateProcessorImplTest {
     void calculateEventDates() {
         // given
         List<Integer> eods = List.of(TEST_EXTERNAL_OBJECT_DIRECTORY_ID);
-        when(externalObjectDirectoryRepository.findByExternalLocationTypeAndUpdateRetention(eodHelperMocks.getArmLocation(), true, Limit.of(10_000))).thenReturn(eods);
+        when(
+            externalObjectDirectoryRepository.findByExternalLocationTypeAndUpdateRetention(
+                eodHelperMocks.getArmLocation(), true, Limit.of(10_000))).thenReturn(
+            eods);
 
         externalObjectDirectoryEntity.setEventDateTs(MEDIA_RETENTION_DATE_TIME);
 
@@ -84,7 +86,8 @@ class ArmRetentionEventDateProcessorImplTest {
         armRetentionEventDateProcessor.calculateEventDates(10_000);
 
         // then
-        verify(externalObjectDirectoryRepository).findByExternalLocationTypeAndUpdateRetention(eodHelperMocks.getArmLocation(), true, Limit.of(10_000));
+        verify(externalObjectDirectoryRepository).findByExternalLocationTypeAndUpdateRetention(
+            eodHelperMocks.getArmLocation(), true, Limit.of(10_000));
         verify(armRetentionEventDateCalculator).calculateRetentionEventDate(TEST_EXTERNAL_OBJECT_DIRECTORY_ID);
 
         verifyNoMoreInteractions(
@@ -97,13 +100,16 @@ class ArmRetentionEventDateProcessorImplTest {
     void calculateEventDates_NoRowsToProcess() {
         // given
         List<Integer> eods = new ArrayList<>();
-        when(externalObjectDirectoryRepository.findByExternalLocationTypeAndUpdateRetention(eodHelperMocks.getArmLocation(), true, Limit.of(10_000))).thenReturn(eods);
+        when(
+            externalObjectDirectoryRepository.findByExternalLocationTypeAndUpdateRetention(
+                eodHelperMocks.getArmLocation(), true, Limit.of(10_000))).thenReturn(eods);
 
         // when
         armRetentionEventDateProcessor.calculateEventDates(10_000);
 
         // then
-        verify(externalObjectDirectoryRepository).findByExternalLocationTypeAndUpdateRetention(eodHelperMocks.getArmLocation(), true, Limit.of(10_000));
+        verify(externalObjectDirectoryRepository).findByExternalLocationTypeAndUpdateRetention(
+            eodHelperMocks.getArmLocation(), true, Limit.of(10_000));
 
         verifyNoMoreInteractions(
             externalObjectDirectoryRepository,

--- a/src/test/java/uk/gov/hmcts/darts/cases/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/controller/CaseControllerTest.java
@@ -9,20 +9,27 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.darts.cases.model.AdvancedSearchRequest;
 import uk.gov.hmcts.darts.cases.model.AdvancedSearchResult;
+import uk.gov.hmcts.darts.cases.model.CasesCaseIdEventsGet200Response;
+import uk.gov.hmcts.darts.cases.model.Event;
 import uk.gov.hmcts.darts.cases.model.GetCasesSearchRequest;
 import uk.gov.hmcts.darts.cases.service.CaseService;
 import uk.gov.hmcts.darts.cases.util.RequestValidator;
 import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.util.pagination.PaginationDto;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -104,5 +111,49 @@ class CaseControllerTest {
 
             requestValidatorMock.verify(() -> RequestValidator.validate(request));
         }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+//Caused by argument captor this can never be incorrect
+    void casesCaseIdEventsGet_hasPageNumber_shouldUsePaginatedRoute() {
+        final int caseId = 123;
+        final int pageNumber = 3;
+        final int pageSize = 20;
+        final List<String> sortBy = List.of("ABC,DEF");
+        final List<String> sortOrder = List.of("ASC", "DESC");
+
+        CaseController.CasesCaseIdEventsGet200PaginatedResponse response = mock(CaseController.CasesCaseIdEventsGet200PaginatedResponse.class);
+        doReturn(response).when(response).asClass(CaseController.CasesCaseIdEventsGet200PaginatedResponse.class);
+
+        doReturn(response).when(caseService).getEventsByCaseId(any(), any());
+
+        ResponseEntity<CasesCaseIdEventsGet200Response> responseEntity = caseController
+            .casesCaseIdEventsGet(caseId, sortBy, sortOrder, pageNumber, pageSize);
+
+        assertThat(responseEntity.getBody()).isEqualTo(response);
+        ArgumentCaptor<PaginationDto<Event>> argumentCaptor = ArgumentCaptor.forClass(PaginationDto.class);
+        verify(caseService).getEventsByCaseId(eq(caseId), argumentCaptor.capture());
+        PaginationDto<Event> paginationDto = argumentCaptor.getValue();
+        assertThat(paginationDto).isNotNull();
+        assertThat(paginationDto.getPageNumber()).isEqualTo(pageNumber);
+        assertThat(paginationDto.getPageSize()).isEqualTo(pageSize);
+        assertThat(paginationDto.getSortBy()).isEqualTo(PaginationDto.toSortBy(sortBy));
+        assertThat(paginationDto.getSortDirection()).isEqualTo(PaginationDto.toSortDirection(sortOrder));
+        verifyNoMoreInteractions(caseService);
+    }
+
+    @Test
+    void casesCaseIdEventsGet_doesNotHasPageNumber_shouldUseNonPaginatedRoute() {
+        final int caseId = 123;
+        List<Event> responseObj = List.of(mock(Event.class), mock(Event.class), mock(Event.class));
+        doReturn(responseObj).when(caseService).getEventsByCaseId(any());
+
+        ResponseEntity<CasesCaseIdEventsGet200Response> responseEntity = caseController.casesCaseIdEventsGet(caseId, null, null, null, null);
+
+        assertThat(responseEntity.getBody())
+            .isEqualTo(new CaseController.CasesCaseIdEventsGet200PaginatedResponseList(responseObj));
+        verify(caseService).getEventsByCaseId(caseId);
+        verifyNoMoreInteractions(caseService);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/cases/controller/CaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/controller/CaseControllerTest.java
@@ -114,8 +114,7 @@ class CaseControllerTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-//Caused by argument captor this can never be incorrect
+    @SuppressWarnings("unchecked")//Caused by argument captor this can never be incorrect
     void casesCaseIdEventsGet_hasPageNumber_shouldUsePaginatedRoute() {
         final int caseId = 123;
         final int pageNumber = 3;

--- a/src/test/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/datamanagement/api/DataManagementFacadeImplTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.darts.common.datamanagement.api;
 import com.azure.core.util.BinaryData;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -120,7 +122,7 @@ class DataManagementFacadeImplTest {
     @SneakyThrows
     @BeforeEach
     void setup() {
-
+        Files.createDirectories(Paths.get(SOME_TEMP_WORKSPACE));
         List<DatastoreContainerType> datastoreOrder = new ArrayList<>();
         datastoreOrder.add(DatastoreContainerType.UNSTRUCTURED);
         datastoreOrder.add(DatastoreContainerType.DETS);
@@ -168,7 +170,7 @@ class DataManagementFacadeImplTest {
         downloadResponseMetaData.close();
 
         FileStore.getFileStore().remove();
-
+        FileUtils.cleanDirectory(new File(SOME_TEMP_WORKSPACE));
         try (Stream<Path> files = Files.list(tempDirectory.toPath())) {
             assertEquals(0, files.count());
         }

--- a/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginatedListTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginatedListTest.java
@@ -1,0 +1,123 @@
+package uk.gov.hmcts.darts.util.pagination;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PaginatedListTest {
+
+    private PaginatedList<String> createValidObject() {
+        return createValidObject(new PaginatedList<>());
+    }
+
+    private PaginatedList<String> createValidObject(PaginatedList<String> paginatedList) {
+        paginatedList.setCurrentPage(1);
+        paginatedList.setTotalPages(1);
+        paginatedList.setTotalItems(1);
+        return paginatedList;
+    }
+
+
+    @Test
+    void positiveSetTotalItemsTypicalMultiplePagesOnLimit() {
+        PaginatedList<String> list = createValidObject();
+        list.setTotalItems(100, 25);
+        assertThat(list.getTotalItems()).isEqualTo(100L);
+        assertThat(list.getTotalPages()).isEqualTo(4L);
+    }
+
+    @Test
+    void positiveSetTotalItemsTypicalMultiplePagesBelowLimit() {
+        PaginatedList<String> list = createValidObject();
+        list.setTotalItems(100, 24);
+        assertThat(list.getTotalItems()).isEqualTo(100L);
+        assertThat(list.getTotalPages()).isEqualTo(5L);
+    }
+
+    @Test
+    void positiveSetTotalItemsTypicalSinglePageOnLimit() {
+        PaginatedList<String> list = createValidObject();
+        list.setTotalItems(25, 25);
+        assertThat(list.getTotalItems()).isEqualTo(25L);
+        assertThat(list.getTotalPages()).isEqualTo(1L);
+    }
+
+    @Test
+    void positiveSetTotalItemsTypicalSingleBelowLimit() {
+        PaginatedList<String> list = createValidObject();
+        list.setTotalItems(20, 25);
+        assertThat(list.getTotalItems()).isEqualTo(20L);
+        assertThat(list.getTotalPages()).isEqualTo(1L);
+    }
+
+    @Test
+    void positiveSetTotalItemsZeroTotalItems() {
+        PaginatedList<String> list = createValidObject();
+        list.setTotalItems(0, 25);
+        assertThat(list.getTotalItems()).isEqualTo(0L);
+        assertThat(list.getTotalPages()).isEqualTo(0L);
+
+    }
+
+    @Test
+    void positiveIsEmptyTrueEmptyList() {
+        PaginatedList<String> list = createValidObject();
+        list.setData(List.of());
+        assertThat(list.isEmpty()).isTrue();
+    }
+
+    @Test
+    void positiveIsEmptyTrueNullList() {
+        PaginatedList<String> list = createValidObject();
+        list.setData(null);
+        assertThat(list.isEmpty()).isTrue();
+    }
+
+    @Test
+    void positiveIsEmptyFalse() {
+        PaginatedList<String> list = createValidObject();
+        list.setData(List.of("Any"));
+        assertThat(list.isEmpty()).isFalse();
+    }
+
+
+    @Nested
+    class AsClassTests {
+        @SuppressWarnings("PMD.TestClassWithoutTestCases")//False positive This is a support class not a test class
+        class TestClass1 extends PaginatedList<String> {
+        }
+
+        @SuppressWarnings("PMD.TestClassWithoutTestCases")//False positive This is a support class not a test class
+        class TestClass2 extends PaginatedList<String> {
+        }
+
+        @Test
+        void asClass_paginatedListIsSameAsClass_shouldReturnCastedInstance() {
+            PaginatedList<String> list = createValidObject(new TestClass1());
+            TestClass1 testClass = list.asClass(TestClass1.class);
+            assertThat(testClass).isNotNull();
+        }
+
+        @Test
+        void asClass_paginatedListIsNotSameAsClass_shouldReturnNull() {
+            PaginatedList<String> list = createValidObject(new TestClass1());
+            DartsApiException exception = assertThrows(DartsApiException.class,
+                                                       () -> list.asClass(TestClass2.class));
+            assertThat(exception.getError()).isEqualTo(CommonApiError.INTERNAL_SERVER_ERROR);
+            assertThat(exception.getMessage())
+                .isEqualTo("Internal server error. Invalid class type provided for conversion: "
+                               + "uk.gov.hmcts.darts.util.pagination.PaginatedListTest$asClassTests$TestClass2. "
+                               + "Expected: "
+                               + "uk.gov.hmcts.darts.util.pagination.PaginatedListTest$asClassTests$TestClass1."
+                );
+
+
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginatedListTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginatedListTest.java
@@ -112,9 +112,9 @@ class PaginatedListTest {
             assertThat(exception.getError()).isEqualTo(CommonApiError.INTERNAL_SERVER_ERROR);
             assertThat(exception.getMessage())
                 .isEqualTo("Internal server error. Invalid class type provided for conversion: "
-                               + "uk.gov.hmcts.darts.util.pagination.PaginatedListTest$asClassTests$TestClass2. "
+                               + "uk.gov.hmcts.darts.util.pagination.PaginatedListTest$AsClassTests$TestClass2. "
                                + "Expected: "
-                               + "uk.gov.hmcts.darts.util.pagination.PaginatedListTest$asClassTests$TestClass1."
+                               + "uk.gov.hmcts.darts.util.pagination.PaginatedListTest$AsClassTests$TestClass1."
                 );
 
 

--- a/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginatedListTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginatedListTest.java
@@ -25,62 +25,62 @@ class PaginatedListTest {
 
 
     @Test
-    void positiveSetTotalItemsTypicalMultiplePagesOnLimit() {
+    void setTotalItems_TypicalMultiplePagesOnLimit() {
         PaginatedList<String> list = createValidObject();
         list.setTotalItems(100, 25);
-        assertThat(list.getTotalItems()).isEqualTo(100L);
-        assertThat(list.getTotalPages()).isEqualTo(4L);
+        assertThat(list.getTotalItems()).isEqualTo(100);
+        assertThat(list.getTotalPages()).isEqualTo(4);
     }
 
     @Test
-    void positiveSetTotalItemsTypicalMultiplePagesBelowLimit() {
+    void setTotalItems_TypicalMultiplePagesBelowLimit() {
         PaginatedList<String> list = createValidObject();
         list.setTotalItems(100, 24);
-        assertThat(list.getTotalItems()).isEqualTo(100L);
-        assertThat(list.getTotalPages()).isEqualTo(5L);
+        assertThat(list.getTotalItems()).isEqualTo(100);
+        assertThat(list.getTotalPages()).isEqualTo(5);
     }
 
     @Test
-    void positiveSetTotalItemsTypicalSinglePageOnLimit() {
+    void setTotalItems_TypicalSinglePageOnLimit() {
         PaginatedList<String> list = createValidObject();
         list.setTotalItems(25, 25);
-        assertThat(list.getTotalItems()).isEqualTo(25L);
-        assertThat(list.getTotalPages()).isEqualTo(1L);
+        assertThat(list.getTotalItems()).isEqualTo(25);
+        assertThat(list.getTotalPages()).isEqualTo(1);
     }
 
     @Test
-    void positiveSetTotalItemsTypicalSingleBelowLimit() {
+    void setTotalItems_TypicalSingleBelowLimit() {
         PaginatedList<String> list = createValidObject();
         list.setTotalItems(20, 25);
-        assertThat(list.getTotalItems()).isEqualTo(20L);
-        assertThat(list.getTotalPages()).isEqualTo(1L);
+        assertThat(list.getTotalItems()).isEqualTo(20);
+        assertThat(list.getTotalPages()).isEqualTo(1);
     }
 
     @Test
-    void positiveSetTotalItemsZeroTotalItems() {
+    void setTotalItems_ZeroTotalItems() {
         PaginatedList<String> list = createValidObject();
         list.setTotalItems(0, 25);
-        assertThat(list.getTotalItems()).isEqualTo(0L);
-        assertThat(list.getTotalPages()).isEqualTo(0L);
+        assertThat(list.getTotalItems()).isEqualTo(0);
+        assertThat(list.getTotalPages()).isEqualTo(0);
 
     }
 
     @Test
-    void positiveIsEmptyTrueEmptyList() {
+    void isEmpty_TrueEmptyList() {
         PaginatedList<String> list = createValidObject();
         list.setData(List.of());
         assertThat(list.isEmpty()).isTrue();
     }
 
     @Test
-    void positiveIsEmptyTrueNullList() {
+    void isEmpty_TrueNullList() {
         PaginatedList<String> list = createValidObject();
         list.setData(null);
         assertThat(list.isEmpty()).isTrue();
     }
 
     @Test
-    void positiveIsEmptyFalse() {
+    void isEmpty_False() {
         PaginatedList<String> list = createValidObject();
         list.setData(List.of("Any"));
         assertThat(list.isEmpty()).isFalse();

--- a/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginationDtoTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginationDtoTest.java
@@ -1,0 +1,272 @@
+package uk.gov.hmcts.darts.util.pagination;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import uk.gov.hmcts.darts.common.exception.CommonApiError;
+import uk.gov.hmcts.darts.common.exception.DartsApiException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")//Caused by mockio this can never be incorrect
+class PaginationDtoTest {
+
+    private PaginationDto<String> createValidObject() {
+        return spy(new PaginationDto<>(
+            PaginatedList::new,
+            2,
+            10,
+            List.of("ABC", "ZXC"),
+            List.of(Sort.Direction.ASC, Sort.Direction.DESC)
+        ));
+    }
+
+    @Test
+    void toSortDirection_whenNullIsProvided_nullShouldBeRetured() {
+        assertThat(PaginationDto.toSortDirection(null)).isNull();
+    }
+
+    @Test
+    void toSortDirection_whenValuesAreProvided_shouldReturnMappedList() {
+        assertThat(PaginationDto.toSortDirection(List.of("ASC", "DESC")))
+            .hasSize(2)
+            .containsExactly(Sort.Direction.ASC, Sort.Direction.DESC);
+    }
+
+    @Test
+    void toSortDirection_whenValuesAreProvidedCommaSeperated_shouldReturnMappedList() {
+        assertThat(PaginationDto.toSortDirection(List.of("ASC,DESC")))
+            .hasSize(2)
+            .containsExactly(Sort.Direction.ASC, Sort.Direction.DESC);
+    }
+
+    @Test
+    void toSortDirection_whenValuesAreProvidedCommaSeperatedAndStandard_shouldReturnMappedList() {
+        assertThat(PaginationDto.toSortDirection(List.of("ASC,DESC", "DESC")))
+            .hasSize(3)
+            .containsExactly(Sort.Direction.ASC, Sort.Direction.DESC, Sort.Direction.DESC);
+    }
+
+    @Test
+    void toSortBy_whenNullIsProvided_nullShouldBeRetured() {
+        assertThat(PaginationDto.toSortBy(null)).isNull();
+    }
+
+    @Test
+    void toSortBy_whenValuesAreProvided_shouldReturnMappedList() {
+        assertThat(PaginationDto.toSortBy(List.of("ABC", "ZXC")))
+            .hasSize(2)
+            .containsExactly("ABC", "ZXC");
+    }
+
+    @Test
+    void toSortBy_whenValuesAreProvidedCommaSeperated_shouldReturnMappedList() {
+        assertThat(PaginationDto.toSortBy(List.of("ABC,ZXC")))
+            .hasSize(2)
+            .containsExactly("ABC", "ZXC");
+    }
+
+    @Test
+    void toSortBy_whenValuesAreProvidedCommaSeperatedAndStandard_shouldReturnMappedList() {
+        assertThat(PaginationDto.toSortBy(List.of("ABC,ZXC", "QWERTY")))
+            .hasSize(3)
+            .containsExactly("ABC", "ZXC", "QWERTY");
+    }
+
+    @Test
+    void shouldPaginate_whenPageNumberAndPageSizeAreProvided_shouldReturnTrue() {
+        PaginationDto<String> paginationDto = new PaginationDto<>(
+            null,
+            1,
+            10,
+            null,
+            null
+        );
+        assertThat(paginationDto.shouldPaginate()).isTrue();
+    }
+
+    @Test
+    void shouldPaginate_whenPageNumberAndPageSizeAreNotProvided_shouldReturnFalse() {
+        PaginationDto<String> paginationDto = new PaginationDto<>(
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        assertThat(paginationDto.shouldPaginate()).isFalse();
+    }
+
+    @Test
+    void setupAndValidate_nullSortByAndSortDirection_shouldSetEmptyList() {
+        PaginationDto<String> paginationDto = new PaginationDto<>(
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        paginationDto.setupAndValidate();
+        assertThat(paginationDto.getSortBy()).isEmpty();
+        assertThat(paginationDto.getSortDirection()).isEmpty();
+    }
+
+    @Test
+    void setupAndValidate_nullPaginatedListSupplier_shouldSetDefault() {
+        PaginationDto<String> paginationDto = new PaginationDto<>(
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        paginationDto.setupAndValidate();
+        assertThat(paginationDto.getPaginatedListSupplier()).isNotNull();
+        assertThat(paginationDto.getPaginatedListSupplier().get()).isEqualTo(new PaginatedList<>());
+    }
+
+    @Test
+    void setupAndValidate_sortByAndSortDirectionOfDifferentSize_shouldThrowException() {
+        PaginationDto<String> paginationDto = new PaginationDto<>(
+            null,
+            null,
+            null,
+            List.of("ASC"),
+            List.of(Sort.Direction.ASC, Sort.Direction.DESC)
+        );
+        DartsApiException exception = assertThrows(DartsApiException.class, () -> paginationDto.setupAndValidate());
+        assertThat(exception.getError()).isEqualTo(CommonApiError.INVALID_REQUEST);
+        assertThat(exception.getMessage()).isEqualTo("Invalid request. sortBy and sortDirection must be of the same size");
+    }
+
+    @Test
+    void toPagable_whenProvidedStandardData_shouldReturnCorrectPageable() {
+        List<String> defaultSortOrder = List.of("defaultSortField");
+        List<Sort.Direction> defaultSortDirection = List.of(Sort.Direction.ASC);
+        Map<String, String> sortByMapper = Map.of("defaultSortField", "defaultSortField");
+        PaginationDto<String> paginationDto = createValidObject();
+
+        doNothing().when(paginationDto).setupAndValidate();
+        Sort sort = Sort.unsorted();
+        doReturn(sort).when(paginationDto).getSort(any(), any(), any());
+
+        assertThat(paginationDto.toPagable(defaultSortOrder, defaultSortDirection, sortByMapper))
+            .isEqualTo(PageRequest.of(1, 10, sort));
+
+        verify(paginationDto).setupAndValidate();
+        verify(paginationDto).getSort(
+            defaultSortOrder,
+            defaultSortDirection,
+            sortByMapper
+        );
+    }
+
+    @Test
+    void getSort_hasNoSortByOverrides_shouldReturnDefaultSort() {
+        PaginationDto<String> paginationDto = createValidObject();
+        paginationDto.sortBy = List.of();
+        paginationDto.sortDirection = List.of();
+        Sort sort = paginationDto.getSort(
+            List.of("123D"),
+            List.of(Sort.Direction.ASC),
+            Map.of("123D", "D321"));
+        assertThat(sort).isEqualTo(Sort.by(Sort.Direction.ASC, "D321"));
+    }
+
+    @Test
+    void getSort_hasSortOverrides_shouldSortByOverridesThenDefaultSort() {
+        PaginationDto<String> paginationDto = createValidObject();
+        Sort sort = paginationDto.getSort(
+            List.of("123D", "312"),
+            List.of(Sort.Direction.ASC, Sort.Direction.ASC),
+            Map.of("123D", "D321",
+                   "ABC", "CBA"));
+        assertThat(sort).isEqualTo(
+            Sort.by(
+                new Sort.Order(Sort.Direction.ASC, "CBA"),//From override... ABC gets mapped to CBA
+                new Sort.Order(Sort.Direction.DESC, "ZXC"),//From override... No mapper for so use provided value
+                new Sort.Order(Sort.Direction.ASC, "D321"),//From default... 123D gets mapped to D321
+                new Sort.Order(Sort.Direction.ASC, "312") //From default... No mapper for so use provided value
+            ));
+    }
+
+    @Test
+    void toPaginatedList_withoutMapper_shouldUseDefaultMapper() {
+        PaginationDto<String> paginationDto = createValidObject();
+
+        PaginatedList<String> paginatedList = mock(PaginatedList.class);
+        doReturn(paginatedList).when(paginationDto)
+            .toPaginatedList(any(), any(), any(), any(), any());
+
+        Function<Pageable, Page<String>> page = mock(Function.class);
+        Function<String, String> dataMapper = mock(Function.class);
+        List<String> sortOrder = List.of("defaultSortField");
+        List<Sort.Direction> sortDirection = List.of(Sort.Direction.ASC);
+
+        assertThat(paginationDto.toPaginatedList(page, dataMapper, sortOrder, sortDirection))
+            .isEqualTo(paginatedList);
+
+        verify(paginationDto).toPaginatedList(
+            page,
+            dataMapper,
+            sortOrder,
+            sortDirection,
+            Map.of()
+        );
+    }
+
+    @Test
+    void toPaginatedList_withMapper_shouldCreateTheCorrectData() {
+        PaginationDto<String> paginationDto = createValidObject();
+
+        Map<String, String> sortByMapper = Map.of("defaultSortField", "defaultSortField234");
+
+        Function<Pageable, Page<Integer>> pageFunction = mock(Function.class);
+        Function<Integer, String> dataMapperFunction = integer -> integer.toString();
+
+        List<String> sortOrder = List.of("defaultSortField");
+        List<Sort.Direction> sortDirection = List.of(Sort.Direction.ASC);
+
+        Pageable pageable = mock(Pageable.class);
+        doReturn(pageable).when(paginationDto).toPagable(any(), any(), any());
+
+        Page<Integer> page = mock(Page.class);
+        long totalElements = 100L;
+        when(page.getTotalElements()).thenReturn(totalElements);
+        doReturn(page).when(pageFunction).apply(any());
+        when(page.get()).thenReturn(List.of(123, 456, 789, 101_112).stream());
+
+
+        PaginatedList<String> result = paginationDto.toPaginatedList(pageFunction, dataMapperFunction, sortOrder, sortDirection, sortByMapper);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCurrentPage()).isEqualTo(2);
+        assertThat(result.getPageSize()).isEqualTo(10);
+        assertThat(result.getTotalItems()).isEqualTo(totalElements);
+        assertThat(result.getTotalPages()).isEqualTo(10);
+        assertThat(result.getData()).hasSize(4)
+            .containsExactly("123", "456", "789", "101112");
+
+        verify(paginationDto)
+            .toPagable(
+                sortOrder,
+                sortDirection,
+                sortByMapper
+            );
+        verify(pageFunction).apply(pageable);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginationDtoTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/pagination/PaginationDtoTest.java
@@ -245,8 +245,7 @@ class PaginationDtoTest {
         doReturn(pageable).when(paginationDto).toPagable(any(), any(), any());
 
         Page<Integer> page = mock(Page.class);
-        long totalElements = 100L;
-        when(page.getTotalElements()).thenReturn(totalElements);
+        when(page.getTotalElements()).thenReturn(100L);
         doReturn(page).when(pageFunction).apply(any());
         when(page.get()).thenReturn(List.of(123, 456, 789, 101_112).stream());
 
@@ -256,7 +255,7 @@ class PaginationDtoTest {
         assertThat(result).isNotNull();
         assertThat(result.getCurrentPage()).isEqualTo(2);
         assertThat(result.getPageSize()).isEqualTo(10);
-        assertThat(result.getTotalItems()).isEqualTo(totalElements);
+        assertThat(result.getTotalItems()).isEqualTo(100);
         assertThat(result.getTotalPages()).isEqualTo(10);
         assertThat(result.getData()).hasSize(4)
             .containsExactly("123", "456", "789", "101112");

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/PaginationTestSupport.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/PaginationTestSupport.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.darts.test.common;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.hmcts.darts.util.pagination.PaginatedList;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Component
+public class PaginationTestSupport {
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    public <T> PaginatedList<T> assertPaginationDetails(MvcResult mvcResult, Class<T> clazz,
+                                                        int currentPage, int pageSize, int totalPages, int totalItems) {
+        PaginatedList<T> paginatedList = getPaginatedList(mvcResult, clazz);
+        return assertPaginationDetails(paginatedList, currentPage, pageSize, totalPages, totalItems);
+    }
+
+    public <T> PaginatedList<T> assertPaginationDetails(PaginatedList<T> paginatedList, int currentPage, int pageSize, int totalPages, int totalItems) {
+        assertThat(paginatedList.getCurrentPage())
+            .describedAs("Current page should be %s", currentPage)
+            .isEqualTo(currentPage);
+        assertThat(paginatedList.getTotalPages())
+            .describedAs("Total pages should be %s", totalPages)
+            .isEqualTo(totalPages);
+        assertThat(paginatedList.getTotalItems())
+            .describedAs("Total items should be %s", totalItems)
+            .isEqualTo(totalItems);
+        assertThat(paginatedList.getPageSize())
+            .describedAs("Page size should be %s", pageSize)
+            .isEqualTo(pageSize);
+        return paginatedList;
+    }
+
+    @SneakyThrows
+    public <T> PaginatedList<T> getPaginatedList(MvcResult mvcResult, Class<T> clazz) {
+        JavaType javaType = objectMapper.getTypeFactory().constructParametricType(PaginatedList.class, clazz);
+        PaginatedList<T> paginatedList = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), javaType);
+        return paginatedList;
+    }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4946)


### Change description ###
# Git Diff Summary

This Git diff introduces significant changes to the `CaseControllerGetEventByCaseIdTest` class, adding pagination support to the event retrieval process for court cases. It also modifies related classes and introduces new utility classes for pagination.

## Highlights

- **New Pagination Support**:
  - A new nested class `CasesGetEventsPaginated` is added to `CaseControllerGetEventByCaseIdTest`.
  - New test cases are implemented to verify pagination functionality for event retrieval based on various criteria.

- **Modified Method Signatures**:
  - The method `casesCaseIdEventsGet` in `CaseController` now accepts pagination parameters (`sortBy`, `sortOrder`, `pageNumber`, `pageSize`).
  
- **New Pagination Classes**:
  - Introduced `PaginatedList` and `PaginationDto` classes to handle pagination details and operations.

- **Changes in `EventRepository`**:
  - Added a new query method `findAllByCaseIdPaginated` to support fetching paginated events.

- **Refactoring**:
  - Updated `CaseService` to include a method that retrieves events in a paginated manner.
  - Refactored event mapping to utilize a new method `mapToEvent`.

- **Test Enhancements**:
  - Added tests to ensure the pagination logic works as expected, including tests for sorting by different fields and handling pagination correctly.

- **OpenAPI Specification Updates**:
  - The OpenAPI definitions were updated to reflect the new query parameters for pagination capabilities in the API.

These changes collectively enhance the functionality and maintainability of the event retrieval system in the court case management application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
