### PR TITLE
DMP-4832: Validate "isHidden: null" in hide media request

### DIFF
--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -53,7 +53,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request Error
           content:
@@ -117,7 +117,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request Error
           content:
@@ -273,7 +273,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request Error
           content:
@@ -326,7 +326,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request Error
           content:
@@ -485,7 +485,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: A required parameter is missing or an invalid datatype or value was provided for property.
         '409':
@@ -530,7 +530,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: A required parameter is missing or an invalid datatype or value was provided for property.
         '500':
@@ -1029,10 +1029,11 @@ components:
 
     MediaHideRequest:
       type: object
+      required:
+        - is_hidden
       properties:
         is_hidden:
           type: boolean
-          default: true
         admin_action:
           $ref: '#/components/schemas/AdminActionRequest'
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4832)


### Change description ###
# Summary of Git Diff

This diff introduces new functionality to the `MediaControllerAdminPostMediaIntTest` Java class, specifically adding a test to validate the handling of a null value for the `isHidden` field in `MediaHideRequest`. Additionally, it updates the OpenAPI specification to reflect changes related to the required field for `MediaHideRequest`.

## Highlights

- **New Test Case Added**: 
  - A test method `postAdminHideMediaId_usingNullIsHidden_shouldBeRejected` is introduced to ensure that a null value for `isHidden` in `MediaHideRequest` is properly rejected, returning a 400 error with a specific violation message.
  
- **Modification in MediaHideRequest**:
  - The `is_hidden` property in the `MediaHideRequest` schema is now marked as a required field.

- **OpenAPI Specification Updates**:
  - Minor adjustments were made to the formatting of the OpenAPI YAML file, ensuring consistent reference formatting for the `problem.yaml` schema.
  - Error descriptions for 400 responses were included to clarify the nature of the constraints.

This update improves the robustness of the media hiding feature in the application by enforcing stricter validation on input data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
