### PR TITLE
DMP-4915: update backend to make is_data_anonymised and event_status available on the FE eventID screen

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerTest.java
@@ -167,6 +167,8 @@ class EventsControllerTest extends IntegrationBase {
         Assertions.assertEquals(eventEntity.getCreatedById(), responseResult.getCreatedBy());
         Assertions.assertEquals(eventEntity.getLastModifiedDateTime().atZoneSameInstant(ZoneOffset.UTC).toOffsetDateTime(), responseResult.getLastModifiedAt());
         Assertions.assertEquals(eventEntity.getLastModifiedById(), responseResult.getLastModifiedBy());
+        Assertions.assertEquals(eventEntity.isDataAnonymised(), responseResult.getIsDataAnonymised());
+        Assertions.assertEquals(eventEntity.getEventStatus(), responseResult.getEventStatus());
 
         assertThat(responseResult.getHearings()).hasSize(1);
         AdminGetEventResponseDetailsHearingsHearingsInner hearingsInner = responseResult.getHearings().getFirst();

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
@@ -73,6 +73,7 @@ public class EventMapper {
         adminGetEventResponseDetail.setLastModifiedAt(eventEntity.getLastModifiedDateTime());
         adminGetEventResponseDetail.setLastModifiedBy(eventEntity.getLastModifiedById());
         adminGetEventResponseDetail.setIsDataAnonymised(eventEntity.isDataAnonymised());
+        adminGetEventResponseDetail.setEventStatus(eventEntity.getEventStatus());
         return adminGetEventResponseDetail;
     }
 

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -923,6 +923,8 @@ components:
           type: string
         is_data_anonymised:
           type: boolean
+        event_status:
+          type: integer
         event_ts:
           type: string
           format: date-time

--- a/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
@@ -142,6 +142,8 @@ class EventMapperTest {
         eventEntity2.setId(2);
         eventEntity2.setCreatedDateTime(now);
         eventEntity2.setIsCurrent(true);
+        eventEntity2.setDataAnonymised(true);
+        eventEntity2.setEventStatus(123);
 
         EventEntity eventEntity3 = setGenericEventDataForTest();
         eventEntity3.setId(3);
@@ -194,6 +196,7 @@ class EventMapperTest {
         assertEquals(eventEntity2.getLastModifiedDateTime(), currentVersion.getLastModifiedAt());
         assertEquals(eventEntity2.getLastModifiedById(), currentVersion.getLastModifiedBy());
         assertEquals(eventEntity2.isDataAnonymised(), currentVersion.getIsDataAnonymised());
+        assertEquals(eventEntity2.getEventStatus(), currentVersion.getEventStatus());
     }
 
     @Test


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4915)


### Change description ###
# Summary of Git Diff

The recent changes to the codebase involve updates to the `EventsControllerTest`, `EventMapper`, and `EventMapperTest` files. The modifications primarily focus on adding new assertions and mappings related to the `eventStatus` and `isDataAnonymised` fields, ensuring that these properties are correctly handled and tested in the API responses.

## Highlights

- **New Assertions in EventsControllerTest**:
  - Added assertions to verify that `isDataAnonymised` and `eventStatus` properties of the event entity are accurately reflected in the API response.

- **Mapping Enhancements in EventMapper**:
  - Updated the `mapToAdminGetEventsResponseFor` method to include the `eventStatus` mapping along with the existing `isDataAnonymised`.

- **OpenAPI Specification Update**:
  - The OpenAPI configuration (`event.yaml`) has been modified to include the new `event_status` field as an integer.

- **Test Updates in EventMapperTest**:
  - Enhanced tests to cover new properties, including setting and asserting `dataAnonymised` and `eventStatus` values for event entities.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
