### PR TITLE
DMP-4969: DEV ONLY: Many to Many mappings should be changed from List to Set to avoid data integrity issues

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationGetTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationGetTest.java
@@ -21,7 +21,6 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
 import java.io.InputStream;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationGetTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationGetTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyList;
@@ -142,7 +143,7 @@ class AnnotationGetTest extends IntegrationBase {
             .currentOwner(userAccount)
             .createdById(0)
             .lastModifiedById(0)
-            .hearingList(new ArrayList<>(List.of(PersistableFactory.getHearingTestData().someMinimalHearing())));
+            .hearings(new HashSet<>(List.of(PersistableFactory.getHearingTestData().someMinimalHearing())));
 
         return dartsPersistence.save(annotation.build().getEntity());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetAdminMediasByIdIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetAdminMediasByIdIntTest.java
@@ -22,9 +22,8 @@ import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
 
 import java.net.URI;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
@@ -339,7 +338,7 @@ class AudioControllerGetAdminMediasByIdIntTest extends IntegrationBase {
             .orElseThrow();
 
         // Create media and link it to hearing
-        var mediaEntity = createAndSaveMediaEntity(List.of(hearingEntity1, hearingEntity2, hearingEntity3), userAccountEntity, false);
+        var mediaEntity = createAndSaveMediaEntity(Set.of(hearingEntity1, hearingEntity2, hearingEntity3), userAccountEntity, false);
 
         // Create media linked case with court case
         databaseStub.createMediaLinkedCase(mediaEntity, hearingEntity1.getCourtCase());
@@ -368,7 +367,7 @@ class AudioControllerGetAdminMediasByIdIntTest extends IntegrationBase {
             .orElseThrow();
 
         // Create media without hearing
-        var mediaEntity = createAndSaveMediaEntity(new ArrayList<>(), userAccountEntity, false);
+        var mediaEntity = createAndSaveMediaEntity(new HashSet<>(), userAccountEntity, false);
 
         // Create media linked case without court case
         databaseStub.createMediaLinkedCase(
@@ -389,10 +388,10 @@ class AudioControllerGetAdminMediasByIdIntTest extends IntegrationBase {
     }
 
     private MediaEntity createAndSaveMediaEntity(HearingEntity hearingEntity, UserAccountEntity userAccountEntity, boolean isDeleted) {
-        return createAndSaveMediaEntity(List.of(hearingEntity), userAccountEntity, isDeleted);
+        return createAndSaveMediaEntity(Set.of(hearingEntity), userAccountEntity, isDeleted);
     }
 
-    private MediaEntity createAndSaveMediaEntity(List<HearingEntity> hearingEntities, UserAccountEntity userAccountEntity, boolean isDeleted) {
+    private MediaEntity createAndSaveMediaEntity(Set<HearingEntity> hearingEntities, UserAccountEntity userAccountEntity, boolean isDeleted) {
         MediaEntity mediaEntity = databaseStub.createMediaEntity(COURTHOUSE_NAME,
                                                                  COURTROOM_NAME,
                                                                  MEDIA_START_AT,
@@ -412,9 +411,9 @@ class AudioControllerGetAdminMediasByIdIntTest extends IntegrationBase {
         mediaEntity.setLastModifiedBy(userAccountEntity);
         mediaEntity.setIsCurrent(true);
 
-        mediaEntity.setHearingList(hearingEntities);
+        mediaEntity.setHearings(hearingEntities);
         for (HearingEntity hearingEntity : hearingEntities) {
-            hearingEntity.setMediaList(Collections.singletonList(mediaEntity));
+            hearingEntity.setMedias(Set.of(mediaEntity));
             databaseStub.getHearingRepository().save(hearingEntity);
         }
 
@@ -423,7 +422,7 @@ class AudioControllerGetAdminMediasByIdIntTest extends IntegrationBase {
     }
 
     private MediaEntity createAndSaveMediaEntityWithHiddenAndDeletedAndCurrentSetFalse(HearingEntity hearingEntity, UserAccountEntity userAccountEntity) {
-        var mediaEntity = createAndSaveMediaEntity(List.of(hearingEntity), userAccountEntity, false);
+        var mediaEntity = createAndSaveMediaEntity(Set.of(hearingEntity), userAccountEntity, false);
 
         mediaEntity.setHidden(false);
         mediaEntity.setIsCurrent(false);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetAdminMediasIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetAdminMediasIntTest.java
@@ -158,17 +158,17 @@ class AudioControllerGetAdminMediasIntTest extends IntegrationBase {
                                                                                        .getResponse().getContentAsString(), GetAdminMediaResponseItem[].class);
 
                 String expectedJsonBefore = getExpectedJson(mediaEntityBefore.getId(),
-                                                            mediaEntityBefore.getHearingList().getFirst().getCourtroom().getCourthouse().getId(),
-                                                            mediaEntityBefore.getHearingList().getFirst().getCourtroom().getId(),
-                                                            mediaEntityBefore.getHearingList().getFirst().getCourtCase().getId(),
-                                                            mediaEntityBefore.getHearingList().getFirst().getId(), mediaEntityBefore.getStart(),
+                                                            mediaEntityBefore.getHearing().getCourtroom().getCourthouse().getId(),
+                                                            mediaEntityBefore.getHearing().getCourtroom().getId(),
+                                                            mediaEntityBefore.getHearing().getCourtCase().getId(),
+                                                            mediaEntityBefore.getHearing().getId(), mediaEntityBefore.getStart(),
                                                             mediaEntityBefore.getEnd());
 
                 String expectedJsonNow = getExpectedJson(mediaEntityNow.getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtroom().getCourthouse().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtroom().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtCase().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getId(), mediaEntityNow.getStart(),
+                                                         mediaEntityNow.getHearing().getCourtroom().getCourthouse().getId(),
+                                                         mediaEntityNow.getHearing().getCourtroom().getId(),
+                                                         mediaEntityNow.getHearing().getCourtCase().getId(),
+                                                         mediaEntityNow.getHearing().getId(), mediaEntityNow.getStart(),
                                                          mediaEntityNow.getEnd());
 
                 JSONAssert.assertEquals(expectedJsonBefore, objectMapper.writeValueAsString(responseItems[0]), JSONCompareMode.NON_EXTENSIBLE);
@@ -203,17 +203,17 @@ class AudioControllerGetAdminMediasIntTest extends IntegrationBase {
                 MediaEntity mediaEntityAfter = dartsDatabase.getMediaRepository().findById(mediaEntityAfterBefore.getId()).get();
 
                 String expectedJsonNow = getExpectedJson(mediaEntityNow.getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtroom().getCourthouse().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtroom().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtCase().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getId(), mediaEntityNow.getStart(),
+                                                         mediaEntityNow.getHearing().getCourtroom().getCourthouse().getId(),
+                                                         mediaEntityNow.getHearing().getCourtroom().getId(),
+                                                         mediaEntityNow.getHearing().getCourtCase().getId(),
+                                                         mediaEntityNow.getHearing().getId(), mediaEntityNow.getStart(),
                                                          mediaEntityNow.getEnd());
 
                 String expectedJsonAfter = getExpectedJson(mediaEntityAfter.getId(),
-                                                           mediaEntityAfter.getHearingList().getFirst().getCourtroom().getCourthouse().getId(),
-                                                           mediaEntityAfter.getHearingList().getFirst().getCourtroom().getId(),
-                                                           mediaEntityAfter.getHearingList().getFirst().getCourtCase().getId(),
-                                                           mediaEntityAfter.getHearingList().getFirst().getId(), mediaEntityAfter.getStart(),
+                                                           mediaEntityAfter.getHearing().getCourtroom().getCourthouse().getId(),
+                                                           mediaEntityAfter.getHearing().getCourtroom().getId(),
+                                                           mediaEntityAfter.getHearing().getCourtCase().getId(),
+                                                           mediaEntityAfter.getHearing().getId(), mediaEntityAfter.getStart(),
                                                            mediaEntityAfter.getEnd());
                 GetAdminMediaResponseItem[] responseItems = objectMapper.readValue(mvcResult.getResponse()
                                                                                        .getContentAsString(), GetAdminMediaResponseItem[].class);
@@ -251,24 +251,24 @@ class AudioControllerGetAdminMediasIntTest extends IntegrationBase {
                 MediaEntity mediaEntityAfter = dartsDatabase.getMediaRepository().findById(preMediaEntityAfter.getId()).get();
 
                 String expectedJsonBefore = getExpectedJson(mediaEntityBefore.getId(),
-                                                            mediaEntityBefore.getHearingList().getFirst().getCourtroom().getCourthouse().getId(),
-                                                            mediaEntityBefore.getHearingList().getFirst().getCourtroom().getId(),
-                                                            mediaEntityBefore.getHearingList().getFirst().getCourtCase().getId(),
-                                                            mediaEntityBefore.getHearingList().getFirst().getId(),
+                                                            mediaEntityBefore.getHearing().getCourtroom().getCourthouse().getId(),
+                                                            mediaEntityBefore.getHearing().getCourtroom().getId(),
+                                                            mediaEntityBefore.getHearing().getCourtCase().getId(),
+                                                            mediaEntityBefore.getHearing().getId(),
                                                             mediaEntityBefore.getStart(), mediaEntityBefore.getEnd());
 
                 String expectedJsonNow = getExpectedJson(mediaEntityNow.getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtroom().getCourthouse().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtroom().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getCourtCase().getId(),
-                                                         mediaEntityNow.getHearingList().getFirst().getId(), mediaEntityNow.getStart(),
+                                                         mediaEntityNow.getHearing().getCourtroom().getCourthouse().getId(),
+                                                         mediaEntityNow.getHearing().getCourtroom().getId(),
+                                                         mediaEntityNow.getHearing().getCourtCase().getId(),
+                                                         mediaEntityNow.getHearing().getId(), mediaEntityNow.getStart(),
                                                          mediaEntityNow.getEnd());
 
                 String expectedJsonAfter = getExpectedJson(mediaEntityAfter.getId(),
-                                                           mediaEntityAfter.getHearingList().getFirst().getCourtroom().getCourthouse().getId(),
-                                                           mediaEntityAfter.getHearingList().getFirst().getCourtroom().getId(),
-                                                           mediaEntityAfter.getHearingList().getFirst().getCourtCase().getId(),
-                                                           mediaEntityAfter.getHearingList().getFirst().getId(), mediaEntityAfter.getStart(),
+                                                           mediaEntityAfter.getHearing().getCourtroom().getCourthouse().getId(),
+                                                           mediaEntityAfter.getHearing().getCourtroom().getId(),
+                                                           mediaEntityAfter.getHearing().getCourtCase().getId(),
+                                                           mediaEntityAfter.getHearing().getId(), mediaEntityAfter.getStart(),
                                                            mediaEntityAfter.getEnd());
                 GetAdminMediaResponseItem[] responseItems = objectMapper.readValue(mvcResult
                                                                                        .getResponse().getContentAsString(), GetAdminMediaResponseItem[].class);
@@ -304,10 +304,10 @@ class AudioControllerGetAdminMediasIntTest extends IntegrationBase {
 
                 String actualJson = mvcResult.getResponse().getContentAsString();
                 String expectedJsonNow = getExpectedJsonRoot(mediaEntityNow.getId(),
-                                                             mediaEntityNow.getHearingList().getFirst().getCourtroom().getCourthouse().getId(),
-                                                             mediaEntityNow.getHearingList().getFirst().getCourtroom().getId(),
-                                                             mediaEntityNow.getHearingList().getFirst().getCourtCase().getId(),
-                                                             mediaEntityNow.getHearingList().getFirst().getId(), mediaEntityNow.getStart(),
+                                                             mediaEntityNow.getHearing().getCourtroom().getCourthouse().getId(),
+                                                             mediaEntityNow.getHearing().getCourtroom().getId(),
+                                                             mediaEntityNow.getHearing().getCourtCase().getId(),
+                                                             mediaEntityNow.getHearing().getId(), mediaEntityNow.getStart(),
                                                              mediaEntityNow.getEnd());
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetMetadataIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetMetadataIntTest.java
@@ -108,42 +108,48 @@ class AudioControllerGetMetadataIntTest extends IntegrationBase {
         String expectedJson = """
             [
                 {
-                  "id": 4,
+                  "id": %s,
                   "media_start_timestamp": "2023-01-01T12:08:00Z",
                   "media_end_timestamp": "2023-01-01T13:08:00Z",
                   "is_archived": false,
                   "is_available": false
                 },
                 {
-                  "id": 5,
+                  "id": %s,
                   "media_start_timestamp": "2023-01-01T12:05:00Z",
                   "media_end_timestamp": "2023-01-01T13:06:00Z",
                   "is_archived": false,
                   "is_available": false
                 },
                 {
-                  "id": 2,
+                  "id": %s,
                   "media_start_timestamp": "2023-01-01T12:05:00Z",
                   "media_end_timestamp": "2023-01-01T13:05:00Z",
                   "is_archived": false,
                   "is_available": true
                 },
                 {
-                  "id": 3,
+                  "id": %s,
                   "media_start_timestamp": "2023-01-01T12:01:00Z",
                   "media_end_timestamp": "2023-01-01T13:01:00Z",
                   "is_archived": false,
                   "is_available": false
                 },
                 {
-                  "id": 1,
+                  "id": %s,
                   "media_start_timestamp": "2023-01-01T12:00:00Z",
                   "media_end_timestamp": "2023-01-01T13:00:00Z",
                   "is_archived": false,
                   "is_available": true
                 }
               ]
-            """.formatted(mediaChannel1.getId());
+            """.formatted(
+                mediaChannel4.getId(),
+                mediaChannel5.getId(),
+                mediaChannel2.getId(),
+                mediaChannel3.getId(),
+                mediaChannel1.getId()
+        );
         JSONAssert.assertEquals(expectedJson, actualJson, JSONCompareMode.STRICT);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPatchAdminMediasByIdIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPatchAdminMediasByIdIntTest.java
@@ -260,9 +260,9 @@ class AudioControllerPatchAdminMediasByIdIntTest extends IntegrationBase {
             MediaEntity media = databaseStub.getMediaRepository().findById(mediaId).orElseThrow();
             assertThat(media.getIsCurrent()).isEqualTo(isCurrent);
             if (isCurrent) {
-                assertThat(media.getHearingList()).isNotEmpty();
+                assertThat(media.getHearings()).isNotEmpty();
             } else {
-                assertThat(media.getHearingList()).isEmpty();
+                assertThat(media.getHearings()).isEmpty();
             }
         });
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreviewIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerPreviewIntTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.darts.authorisation.component.Authorisation;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.service.RedisService;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
@@ -61,7 +62,7 @@ class AudioControllerPreviewIntTest extends IntegrationBase {
     @BeforeEach
     void setupData() {
         var hearing = dartsPersistence.save(hearingWithMedia());
-        mediaEntity = hearing.getMediaList().getFirst();
+        mediaEntity = TestUtils.getFirst(hearing.getMedias());
 
         dartsPersistence.save(PersistableFactory.getExternalObjectDirectoryTestData().eodStoredInUnstructuredLocationForMedia(mediaEntity));
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import uk.gov.hmcts.darts.testutils.IntegrationBaseWithWiremock;
-import wiremock.org.eclipse.jetty.util.UrlEncoded;
 
 import java.net.URLEncoder;
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/LogoutIntTest.java
@@ -2,11 +2,15 @@ package uk.gov.hmcts.darts.authentication.controller.impl;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import uk.gov.hmcts.darts.testutils.IntegrationBaseWithWiremock;
+import wiremock.org.eclipse.jetty.util.UrlEncoded;
+
+import java.net.URLEncoder;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -18,6 +22,9 @@ class LogoutIntTest extends IntegrationBaseWithWiremock {
     private static final String EXTERNAL_USER_LOGOUT_ENDPOINT = "/external-user/logout";
     private static final String EXTERNAL_USER_LOGOUT_ENDPOINT_WITH_OVERRIDE = "/external-user/logout?redirect_uri=https://darts-portal.com/auth/logout-callback";
 
+    @Value("${spring.security.oauth2.client.registration.external-azure-ad.logout-redirect-uri}")
+    private String logoutRedirectUri;
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -27,7 +34,7 @@ class LogoutIntTest extends IntegrationBaseWithWiremock {
 
         String expectedUri = "http://localhost:" + wiremockPort + "/B2C_1_darts_externaluser_signin/oauth2/v2.0/logout?id_token_hint=" +
                              accessToken +
-                             "&post_logout_redirect_uri=https%3A%2F%2Fdarts.staging.apps.hmcts.net%2Fauth%2Flogout-callback";
+                             "&post_logout_redirect_uri=" + URLEncoder.encode(logoutRedirectUri);
 
         MockHttpServletRequestBuilder requestBuilder = get(EXTERNAL_USER_LOGOUT_ENDPOINT)
             .header("Authorization", "Bearer " + accessToken);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/CourtCaseDocumentMapperIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/CourtCaseDocumentMapperIntTest.java
@@ -8,8 +8,10 @@ import uk.gov.hmcts.darts.casedocument.mapper.CourtCaseDocumentMapper;
 import uk.gov.hmcts.darts.casedocument.model.CourtCaseDocument;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
+import uk.gov.hmcts.darts.common.entity.JudgeEntity;
 import uk.gov.hmcts.darts.common.repository.CaseDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.CourtCaseStub;
 
@@ -139,14 +141,15 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
             () -> assertThat(doc.getDefences().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(cc.getDefenceList().getFirst().getLastModifiedById())
         );
 
+        JudgeEntity judge = TestUtils.getFirst(cc.getJudges());
         assertAll(
             "Grouped assertions for Case Document judges",
-            () -> assertThat(doc.getJudges().getFirst().getId()).isNotNull().isEqualTo(cc.getJudges().getFirst().getId()),
-            () -> assertThat(doc.getJudges().getFirst().getName()).isNotNull().isEqualTo(cc.getJudges().getFirst().getName()),
-            () -> assertThat(doc.getJudges().getFirst().getCreatedDateTime()).isNotNull().isEqualTo(cc.getJudges().getFirst().getCreatedDateTime()),
-            () -> assertThat(doc.getJudges().getFirst().getLastModifiedDateTime()).isNotNull().isEqualTo(cc.getJudges().getFirst().getLastModifiedDateTime()),
-            () -> assertThat(doc.getJudges().getFirst().getCreatedBy()).isNotNull().isEqualTo(cc.getJudges().getFirst().getCreatedById()),
-            () -> assertThat(doc.getJudges().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(cc.getJudges().getFirst().getLastModifiedById())
+            () -> assertThat(doc.getJudges().getFirst().getId()).isNotNull().isEqualTo(judge.getId()),
+            () -> assertThat(doc.getJudges().getFirst().getName()).isNotNull().isEqualTo(judge.getName()),
+            () -> assertThat(doc.getJudges().getFirst().getCreatedDateTime()).isNotNull().isEqualTo(judge.getCreatedDateTime()),
+            () -> assertThat(doc.getJudges().getFirst().getLastModifiedDateTime()).isNotNull().isEqualTo(judge.getLastModifiedDateTime()),
+            () -> assertThat(doc.getJudges().getFirst().getCreatedBy()).isNotNull().isEqualTo(judge.getCreatedById()),
+            () -> assertThat(doc.getJudges().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(judge.getLastModifiedById())
         );
 
         assertAll(
@@ -253,6 +256,7 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
                 cc.getCaseRetentionEntities().getFirst().getCaseManagementRetention().getEventEntity().getEventType().isReportingRestriction())
         );
 
+        JudgeEntity ccFirstHearingFirstJudge = TestUtils.getFirst(cc.getHearings().getFirst().getJudges());
         assertAll(
             "Grouped assertions for Case Document hearings",
             () -> assertThat(doc.getHearings().getFirst().getId()).isNotNull().isEqualTo(cc.getHearings().getFirst().getId()),
@@ -268,17 +272,17 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
                 cc.getHearings().getFirst().getCourtroom().getCreatedDateTime()),
 
             () -> assertThat(doc.getHearings().getFirst().getJudges().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getJudges().getFirst().getId()),
+                ccFirstHearingFirstJudge.getId()),
             () -> assertThat(doc.getHearings().getFirst().getJudges().getFirst().getName()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getJudges().getFirst().getName()),
+                ccFirstHearingFirstJudge.getName()),
             () -> assertThat(doc.getHearings().getFirst().getJudges().getFirst().getCreatedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getJudges().getFirst().getCreatedDateTime()),
+                ccFirstHearingFirstJudge.getCreatedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getJudges().getFirst().getLastModifiedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getJudges().getFirst().getLastModifiedDateTime()),
+                ccFirstHearingFirstJudge.getLastModifiedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getJudges().getFirst().getCreatedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getJudges().getFirst().getCreatedById()),
+                ccFirstHearingFirstJudge.getCreatedById()),
             () -> assertThat(doc.getHearings().getFirst().getJudges().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getJudges().getFirst().getLastModifiedById())
+                ccFirstHearingFirstJudge.getLastModifiedById())
         );
 
         assertAll(

--- a/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/CourtCaseDocumentMapperIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/CourtCaseDocumentMapperIntTest.java
@@ -3,12 +3,15 @@ package uk.gov.hmcts.darts.casedocument.service;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.casedocument.mapper.CourtCaseDocumentMapper;
 import uk.gov.hmcts.darts.casedocument.model.CourtCaseDocument;
+import uk.gov.hmcts.darts.common.entity.AnnotationEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.JudgeEntity;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
+import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.repository.CaseDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.test.common.TestUtils;
@@ -34,8 +37,6 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
     @Autowired
     CourtCaseStub courtCaseStub;
     @Autowired
-    UserIdentity userIdentity;
-    @Autowired
     CourtCaseDocumentMapper mapper;
 
     @Test
@@ -47,15 +48,10 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
         when(eodRepository.findByTranscriptionDocumentEntity(any())).thenReturn(List.of(transcriptionDocumentEodEntity));
         ExternalObjectDirectoryEntity annotationDocumentEodEntity = dartsDatabase.getExternalObjectDirectoryStub().createEodWithRandomValues();
         when(eodRepository.findByAnnotationDocumentEntity(any())).thenReturn(List.of(annotationDocumentEodEntity));
-        dartsDatabase.getCaseDocumentStub().createCaseDocumentWithRandomValues();
         ExternalObjectDirectoryEntity caseDocumentEodEntity = dartsDatabase.getExternalObjectDirectoryStub().createEodWithRandomValues();
         when(eodRepository.findByCaseDocument(any())).thenReturn(List.of(caseDocumentEodEntity));
 
         CourtCaseEntity cc = courtCaseStub.createCourtCaseAndAssociatedEntitiesWithRandomValues();
-
-        givenBearerTokenExists("darts.global.user@hmcts.net");
-        cc.setLastModifiedBy(userIdentity.getUserAccount());
-        cc.setCreatedBy(userIdentity.getUserAccount());
 
         // when
         CourtCaseDocument doc = mapper.mapToCaseDocument(cc);
@@ -64,9 +60,9 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
         assertAll(
             "Grouped assertions for Case Document top level properties",
             () -> assertThat(doc.getCaseId()).isNotNull().isEqualTo(cc.getId()),
-            () -> assertThat(doc.getCreatedBy()).isNotNull().isEqualTo(userIdentity.getUserAccount().getId()),
+            () -> assertThat(doc.getCreatedBy()).isNotNull().isEqualTo(cc.getCreatedById()),
             () -> assertThat(doc.getCreatedDateTime()).isNotNull().isCloseToUtcNow(within(1, SECONDS)),
-            () -> assertThat(doc.getLastModifiedBy()).isNotNull().isEqualTo(userIdentity.getUserAccount().getId()),
+            () -> assertThat(doc.getLastModifiedBy()).isNotNull().isEqualTo(cc.getLastModifiedById()),
             () -> assertThat(doc.getLastModifiedDateTime()).isNotNull().isCloseToUtcNow(within(1, SECONDS)),
             () -> assertThat(doc.getLegacyCaseObjectId()).isNotNull().isEqualTo(cc.getLegacyCaseObjectId()),
             () -> assertThat(doc.getCaseNumber()).isNotNull().isEqualTo(cc.getCaseNumber()),
@@ -285,122 +281,124 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
                 ccFirstHearingFirstJudge.getLastModifiedById())
         );
 
+        MediaRequestEntity ccFirstHearingFirstMediaRequest = TestUtils.getFirst(cc.getHearings().getFirst().getMediaRequests());
         assertAll(
             "Grouped assertions for Case Document hearings media requests",
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getId()),
+                ccFirstHearingFirstMediaRequest.getId()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getCurrentOwner()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getCurrentOwner().getId()),
+                ccFirstHearingFirstMediaRequest.getCurrentOwner().getId()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getRequestor()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getRequestor().getId()),
+                ccFirstHearingFirstMediaRequest.getRequestor().getId()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getStatus()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getStatus()),
+                ccFirstHearingFirstMediaRequest.getStatus()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getRequestType()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getRequestType()),
+                ccFirstHearingFirstMediaRequest.getRequestType()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getAttempts()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getAttempts()),
+                ccFirstHearingFirstMediaRequest.getAttempts()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getStartTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getStartTime()),
+                ccFirstHearingFirstMediaRequest.getStartTime()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getEndTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getEndTime()),
+                ccFirstHearingFirstMediaRequest.getEndTime()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getCreatedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getCreatedDateTime()),
+                ccFirstHearingFirstMediaRequest.getCreatedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getLastModifiedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getLastModifiedDateTime()),
+                ccFirstHearingFirstMediaRequest.getLastModifiedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getCreatedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getCreatedById()),
+                ccFirstHearingFirstMediaRequest.getCreatedById()),
             () -> assertThat(doc.getHearings().getFirst().getMediaRequests().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaRequests().getFirst().getLastModifiedById())
+                ccFirstHearingFirstMediaRequest.getLastModifiedById())
         );
 
 
+        MediaEntity ccFirstHearingFirstMedia = TestUtils.getFirst(cc.getHearings().getFirst().getMedias());
         assertAll(
             "Grouped assertions for Case Document hearings medias",
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getId()),
+                ccFirstHearingFirstMedia.getId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getCreatedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getCreatedDateTime()),
+                ccFirstHearingFirstMedia.getCreatedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getLastModifiedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getLastModifiedDateTime()),
+                ccFirstHearingFirstMedia.getLastModifiedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getCreatedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getCreatedById()),
+                ccFirstHearingFirstMedia.getCreatedById()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getLastModifiedById()),
+                ccFirstHearingFirstMedia.getLastModifiedById()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getLegacyObjectId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getLegacyObjectId()),
+                ccFirstHearingFirstMedia.getLegacyObjectId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getChannel()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getChannel()),
+                ccFirstHearingFirstMedia.getChannel()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getTotalChannels()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getTotalChannels()),
+                ccFirstHearingFirstMedia.getTotalChannels()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getStart()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getStart()),
+                ccFirstHearingFirstMedia.getStart()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getEnd()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getEnd()),
+                ccFirstHearingFirstMedia.getEnd()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getLegacyVersionLabel()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getLegacyVersionLabel()),
+                ccFirstHearingFirstMedia.getLegacyVersionLabel()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getMediaFile()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getMediaFile()),
+                ccFirstHearingFirstMedia.getMediaFile()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getMediaFormat()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getMediaFormat()),
+                ccFirstHearingFirstMedia.getMediaFormat()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getChecksum()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getChecksum()),
+                ccFirstHearingFirstMedia.getChecksum()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getFileSize()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getFileSize()),
+                ccFirstHearingFirstMedia.getFileSize()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getMediaType()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getMediaType()),
+                ccFirstHearingFirstMedia.getMediaType()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getContentObjectId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getContentObjectId()),
+                ccFirstHearingFirstMedia.getContentObjectId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getClipId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getClipId()),
+                ccFirstHearingFirstMedia.getClipId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getChronicleId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getChronicleId()),
+                ccFirstHearingFirstMedia.getChronicleId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getAntecedentId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getAntecedentId()),
+                ccFirstHearingFirstMedia.getAntecedentId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().isHidden()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().isHidden()),
+                ccFirstHearingFirstMedia.isHidden()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().isDeleted()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().isDeleted()),
+                ccFirstHearingFirstMedia.isDeleted()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getDeletedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getDeletedBy().getId()),
+                ccFirstHearingFirstMedia.getDeletedBy().getId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getDeletedTimestamp()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getDeletedTimestamp()),
+                ccFirstHearingFirstMedia.getDeletedTimestamp()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getMediaStatus()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getMediaStatus()),
+                ccFirstHearingFirstMedia.getMediaStatus()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getRetainUntilTs()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getRetainUntilTs()),
+                ccFirstHearingFirstMedia.getRetainUntilTs()),
 
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getId()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getAnnotationDocument()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getAnnotationDocument().getId()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getAnnotationDocument().getId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getCaseDocument()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getCaseDocument().getId()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getCaseDocument().getId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getMedia()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getMedia().getId()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getMedia().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getTranscriptionDocument()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getTranscriptionDocument().getId()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getTranscriptionDocument().getId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getHiddenBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getHiddenBy().getId()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getHiddenBy().getId()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getHiddenDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getHiddenDateTime()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getHiddenDateTime()),
             () -> assertThat(
                 doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().isMarkedForManualDeletion()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().isMarkedForManualDeletion()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().isMarkedForManualDeletion()),
             () -> assertThat(
                 doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getMarkedForManualDelBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getMarkedForManualDelBy().getId()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getMarkedForManualDelBy().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getMarkedForManualDelDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getMarkedForManualDelDateTime()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getMarkedForManualDelDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getTicketReference()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getTicketReference()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getTicketReference()),
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getComments()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getComments()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getComments()),
             () -> assertThat(
                 doc.getHearings().getFirst().getMedias().getFirst().getAdminActionReasons().getFirst().getObjectHiddenReason()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getMediaList().getFirst().getObjectAdminActions().getFirst().getObjectHiddenReason()),
+                ccFirstHearingFirstMedia.getObjectAdminActions().getFirst().getObjectHiddenReason()),
 
             () -> assertThat(doc.getHearings().getFirst().getMedias().getFirst().getExternalObjectDirectories().getFirst().getId()).isNotNull().isEqualTo(
                 mediaEodEntity.getId()),
@@ -466,133 +464,134 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
                 mediaEodEntity.getLastModifiedDateTime())
         );
 
+        TranscriptionEntity ccFirstHearingFirstTranscription = TestUtils.getFirst(cc.getHearings().getFirst().getTranscriptions());
         assertAll(
             "Grouped assertions for Case Document hearings transcriptions",
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getId()),
+                ccFirstHearingFirstTranscription.getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getCreatedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getCreatedDateTime()),
+                ccFirstHearingFirstTranscription.getCreatedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getLastModifiedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getLastModifiedDateTime()),
+                ccFirstHearingFirstTranscription.getLastModifiedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getCreatedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getCreatedById()),
+                ccFirstHearingFirstTranscription.getCreatedById()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getLastModifiedById()),
+                ccFirstHearingFirstTranscription.getLastModifiedById()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getLegacyObjectId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getLegacyObjectId()),
+                ccFirstHearingFirstTranscription.getLegacyObjectId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionType()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionType()),
+                ccFirstHearingFirstTranscription.getTranscriptionType()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionUrgency()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionUrgency()),
+                ccFirstHearingFirstTranscription.getTranscriptionUrgency()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionStatus()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionStatus()),
+                ccFirstHearingFirstTranscription.getTranscriptionStatus()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getHearingDate()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getHearingDate()),
+                ccFirstHearingFirstTranscription.getHearingDate()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getLegacyVersionLabel()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getLegacyVersionLabel()),
+                ccFirstHearingFirstTranscription.getLegacyVersionLabel()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getStartTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getStartTime()),
+                ccFirstHearingFirstTranscription.getStartTime()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getEndTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getEndTime()),
+                ccFirstHearingFirstTranscription.getEndTime()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getIsManualTranscription()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getIsManualTranscription()),
+                ccFirstHearingFirstTranscription.getIsManualTranscription()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getHideRequestFromRequestor()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getHideRequestFromRequestor()),
+                ccFirstHearingFirstTranscription.getHideRequestFromRequestor()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getDeleted()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().isDeleted()),
+                ccFirstHearingFirstTranscription.isDeleted()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getChronicleId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getChronicleId()),
+                ccFirstHearingFirstTranscription.getChronicleId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getAntecedentId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getAntecedentId()),
+                ccFirstHearingFirstTranscription.getAntecedentId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getDeletedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getDeletedBy().getId()),
+                ccFirstHearingFirstTranscription.getDeletedBy().getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getDeletedTimestamp()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getDeletedTimestamp()),
+                ccFirstHearingFirstTranscription.getDeletedTimestamp()),
 
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getLastModifiedById()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getLastModifiedById()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getLastModifiedTimestamp()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getLastModifiedTimestamp()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getLastModifiedTimestamp()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getClipId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getClipId()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getClipId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getFileName()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getFileName()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getFileName()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getFileSize()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getFileSize()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getFileSize()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getFileType()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getFileType()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getFileType()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getUploadedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getUploadedBy().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getUploadedBy().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getUploadedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getUploadedDateTime()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getUploadedDateTime()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getChecksum()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getChecksum()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getChecksum()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getContentObjectId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getContentObjectId()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getContentObjectId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().isHidden()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().isHidden()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().isHidden()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getRetainUntilTs()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getRetainUntilTs()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getRetainUntilTs()),
 
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getAnnotationDocument()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
                     0).getAnnotationDocument().getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getCaseDocument()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
                     0).getCaseDocument().getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getMedia()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getMedia().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getMedia().getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getTranscriptionDocument()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
                     0).getTranscriptionDocument().getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getHiddenBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getHiddenBy().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getHiddenBy().getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getHiddenDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getHiddenDateTime()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getHiddenDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).isMarkedForManualDeletion()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
                     0).isMarkedForManualDeletion()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getMarkedForManualDelBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
                     0).getMarkedForManualDelBy().getId()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getMarkedForManualDelDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().get(
                     0).getMarkedForManualDelDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getTicketReference()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getTicketReference()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getTicketReference()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getComments()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getComments()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getComments()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getAdminActions().get(
                 0).getObjectHiddenReason()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getObjectHiddenReason()),
+                ccFirstHearingFirstTranscription.getTranscriptionDocumentEntities().getFirst().getAdminActions().getFirst().getObjectHiddenReason()),
 
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionDocuments().getFirst().getExternalObjectDirectories().get(
@@ -662,94 +661,95 @@ class CourtCaseDocumentMapperIntTest extends IntegrationBase {
                     0).getLastModifiedDateTime()).isNotNull().isEqualTo(transcriptionDocumentEodEntity.getLastModifiedDateTime()),
 
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflows().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflowEntities().getFirst().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionWorkflowEntities().getFirst().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflows().getFirst().getTranscriptionStatus()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflowEntities().getFirst().getTranscriptionStatus()),
+                ccFirstHearingFirstTranscription.getTranscriptionWorkflowEntities().getFirst().getTranscriptionStatus()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflows().getFirst().getWorkflowActor()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflowEntities().getFirst().getWorkflowActor().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionWorkflowEntities().getFirst().getWorkflowActor().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflows().getFirst().getWorkflowTimestamp()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflowEntities().getFirst().getWorkflowTimestamp()),
+                ccFirstHearingFirstTranscription.getTranscriptionWorkflowEntities().getFirst().getWorkflowTimestamp()),
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflows().getFirst().getTranscriptionComments().get(
                 0).getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionWorkflowEntities().getFirst().getTranscriptionComments().getFirst().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionWorkflowEntities().getFirst().getTranscriptionComments().getFirst().getId()),
 
             () -> assertThat(doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionComments().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionCommentEntities().getFirst().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionCommentEntities().getFirst().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionComments().getFirst().getTranscriptionWorkflow()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionCommentEntities().getFirst().getTranscriptionWorkflow().getId()),
+                ccFirstHearingFirstTranscription.getTranscriptionCommentEntities().getFirst().getTranscriptionWorkflow().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionComments().getFirst().getLegacyTranscriptionObjectId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionCommentEntities().getFirst().getLegacyTranscriptionObjectId()),
+                ccFirstHearingFirstTranscription.getTranscriptionCommentEntities().getFirst().getLegacyTranscriptionObjectId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionComments().getFirst().getComment()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionCommentEntities().getFirst().getComment()),
+                ccFirstHearingFirstTranscription.getTranscriptionCommentEntities().getFirst().getComment()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionComments().getFirst().getCommentTimestamp()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionCommentEntities().getFirst().getCommentTimestamp()),
+                ccFirstHearingFirstTranscription.getTranscriptionCommentEntities().getFirst().getCommentTimestamp()),
             () -> assertThat(
                 doc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionComments().getFirst().getAuthorUserId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getTranscriptions().getFirst().getTranscriptionCommentEntities().getFirst().getAuthorUserId())
+                ccFirstHearingFirstTranscription.getTranscriptionCommentEntities().getFirst().getAuthorUserId())
         );
 
+        AnnotationEntity ccFirstHearingFirstAnnotation = TestUtils.getFirst(cc.getHearings().getFirst().getAnnotations());
         assertAll(
             "Grouped assertions for Case Document hearings annotations",
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getId()),
+                ccFirstHearingFirstAnnotation.getId()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getCreatedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getCreatedDateTime()),
+                ccFirstHearingFirstAnnotation.getCreatedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getLastModifiedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getLastModifiedDateTime()),
+                ccFirstHearingFirstAnnotation.getLastModifiedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getCreatedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getCreatedById()),
+                ccFirstHearingFirstAnnotation.getCreatedById()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getLastModifiedById()),
+                ccFirstHearingFirstAnnotation.getLastModifiedById()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getLegacyObjectId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getLegacyObjectId()),
+                ccFirstHearingFirstAnnotation.getLegacyObjectId()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getLegacyVersionLabel()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getLegacyVersionLabel()),
+                ccFirstHearingFirstAnnotation.getLegacyVersionLabel()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getDeletedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getDeletedBy().getId()),
+                ccFirstHearingFirstAnnotation.getDeletedBy().getId()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().isDeleted()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().isDeleted()),
+                ccFirstHearingFirstAnnotation.isDeleted()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getDeletedTimestamp()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getDeletedTimestamp()),
+                ccFirstHearingFirstAnnotation.getDeletedTimestamp()),
 
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getId()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getLastModifiedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getLastModifiedById()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getLastModifiedById()),
             () -> assertThat(
                 doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getLastModifiedTimestamp()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getLastModifiedTimestamp()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getLastModifiedTimestamp()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getClipId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getClipId()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getClipId()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getFileName()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getFileName()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getFileName()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getFileSize()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getFileSize()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getFileSize()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getFileType()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getFileType()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getFileType()),
             () -> assertThat(
                 doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getUploadedBy()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getUploadedBy().getId()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getUploadedBy().getId()),
             () -> assertThat(
                 doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getUploadedDateTime()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getUploadedDateTime()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getUploadedDateTime()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getChecksum()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getChecksum()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getChecksum()),
             () -> assertThat(
                 doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getContentObjectId()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getContentObjectId()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getContentObjectId()),
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().isHidden()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().isHidden()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().isHidden()),
             () -> assertThat(
                 doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getRetainUntilTs()).isNotNull().isEqualTo(
-                cc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getRetainUntilTs()),
+                ccFirstHearingFirstAnnotation.getAnnotationDocuments().getFirst().getRetainUntilTs()),
 
             () -> assertThat(doc.getHearings().getFirst().getAnnotations().getFirst().getAnnotationDocuments().getFirst().getExternalObjectDirectories().get(
                 0).getId()).isNotNull().isEqualTo(annotationDocumentEodEntity.getId()),

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -232,7 +232,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
 
         String expectedResponse = getContentsFromFile(
             "tests/cases/CaseControllerSearchGetTest/casesSearchGetEndpoint/expectedResponseMultiple.json");
-        assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
+        assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/AnnotationDocumentRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/AnnotationDocumentRepositoryIntTest.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.AnnotationStub;
 import uk.gov.hmcts.darts.testutils.stubs.CourtCaseStub;
 
+import java.util.stream.Collectors;
+
 import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,7 +71,7 @@ class AnnotationDocumentRepositoryIntTest extends IntegrationBase {
     }
 
     private AnnotationDocumentEntity createAnnotationDocumentForCases(CourtCaseEntity... courtCases) {
-        var hearingEntities = stream(courtCases).map(PersistableFactory.getHearingTestData()::createHearingFor).toList();
+        var hearingEntities = stream(courtCases).map(PersistableFactory.getHearingTestData()::createHearingFor).collect(Collectors.toSet());
         var annotationDocument = PersistableFactory.getAnnotationDocumentTestData().createAnnotationDocumentForHearings(hearingEntities);
         return dartsPersistence.save(annotationDocument);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentTest.java
@@ -84,7 +84,7 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         List<TranscriptionDocumentResult> transcriptionDocumentResults
             = transcriptionDocumentRepository
             .findTranscriptionMedia(generatedDocumentEntities.get(nameMatchIndex)
-                                        .getTranscription().getCourtCases().getFirst().getCaseNumber(), null, null, null, null, null, null, null);
+                                        .getTranscription().getCourtCase().getCaseNumber(), null, null, null, null, null, null, null);
         if (TestType.MODENISED.equals(testType)) {
             //Mod has two items due to joins that are not valid for legacy data
             Assertions.assertEquals(2, transcriptionDocumentResults.size());
@@ -98,7 +98,7 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         transcription.setIsCurrent(false);
         dartsDatabase.save(transcription);
         transcriptionDocumentResults = transcriptionDocumentRepository
-            .findTranscriptionMedia(transcription.getCourtCases().getFirst().getCaseNumber(), null, null, null, null, null, null, null);
+            .findTranscriptionMedia(transcription.getCourtCase().getCaseNumber(), null, null, null, null, null, null, null);
 
         Assertions.assertEquals(0, transcriptionDocumentResults.size());
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentTest.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.TranscriptionDocumentStub;
 import uk.gov.hmcts.darts.transcriptions.model.TranscriptionDocumentResult;
@@ -66,7 +67,7 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         List<TranscriptionDocumentResult> transcriptionDocumentResults
             = transcriptionDocumentRepository
             .findTranscriptionMedia(generatedDocumentEntities.get(nameMatchIndex)
-                                        .getTranscription().getCourtCases().getFirst().getCaseNumber(), null, null, null, null, null, null, null);
+                                        .getTranscription().getCourtCase().getCaseNumber(), null, null, null, null, null, null, null);
         if (TestType.MODENISED.equals(testType)) {
             //Mod has two items due to joins that are not valid for legacy data
             Assertions.assertEquals(2, transcriptionDocumentResults.size());
@@ -151,10 +152,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
                                                                                .get(nameMatchIndex)
-                                                                               .getTranscription().getCourtCases().getFirst()),
+                                                                               .getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -170,10 +172,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -188,11 +191,12 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities
                                                                                .get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
 
     }
 
@@ -209,12 +213,12 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities
                                                                                .get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex)
-                                                                               .getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -230,16 +234,18 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.getFirst(),
                                                                            generatedDocumentEntities.getFirst()
-                                                                               .getTranscription().getCourtCases().getFirst()),
+                                                                               .getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst()
-                                                                               .getTranscription().getCourtCases().get(1)),
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.getFirst()
+                                                                                   .getTranscription().getCourtCases()).get(1)),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
                                                                            generatedDocumentEntities.get(1)
-                                                                               .getTranscription().getCourtCases().getFirst()),
+                                                                               .getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1)
-                                                                               .getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(1)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -257,17 +263,19 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.getFirst(),
                                                                            generatedDocumentEntities
-                                                                               .getFirst().getTranscription().getCourtCases().getFirst()),
+                                                                               .getFirst().getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities
-                                                                               .getFirst().getTranscription().getCourtCases().get(1)),
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.getFirst()
+                                                                                   .getTranscription().getCourtCases()).get(1)),
                                                          getExpectedResult(testType, generatedDocumentEntities
                                                                                .get(1),
                                                                            generatedDocumentEntities
-                                                                               .get(1).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(1).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities
-                                                                               .get(1).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(1)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -285,17 +293,19 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.getFirst(),
                                                                            generatedDocumentEntities
-                                                                               .getFirst().getTranscription().getCourtCases().getFirst()),
+                                                                               .getFirst().getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities
-                                                                               .getFirst().getTranscription().getCourtCases().get(1)),
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.getFirst()
+                                                                                   .getTranscription().getCourtCases()).get(1)),
                                                          getExpectedResult(testType, generatedDocumentEntities
                                                                                .get(1),
                                                                            generatedDocumentEntities
-                                                                               .get(1).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(1).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities
-                                                                               .get(1).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(1)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -312,11 +322,12 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities
                                                                                .get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     private LocalDate getHearingDate(TestType testType, TranscriptionEntity transcription) {
@@ -364,10 +375,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -384,10 +396,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -405,10 +418,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -425,10 +439,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -447,10 +462,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -462,15 +478,18 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
             null, null, null, null,
             null, null, null, TranscriptionDocumentSubStringQueryEnum.OWNER.getQueryStringPrefix());
         Assertions.assertEquals(4, transcriptionDocumentResults.size());
+
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCases().getFirst()),
+                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCases().get(1)),
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.getFirst().getTranscription().getCourtCases()).get(1)),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCases().getFirst()),
+                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(1).getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -489,10 +508,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -510,10 +530,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -533,10 +554,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -553,10 +575,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -574,10 +597,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
                                                                            generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().getFirst()),
+                                                                               .get(nameMatchIndex).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(nameMatchIndex),
-                                                                           generatedDocumentEntities
-                                                                               .get(nameMatchIndex).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(nameMatchIndex)
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -590,13 +614,15 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
             TranscriptionDocumentSubStringQueryEnum.REQUESTED_BY.getQueryStringPostfix(), null, null, null, null);
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCases().getFirst()),
+                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCases().get(1)),
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.getFirst().getTranscription().getCourtCases()).get(1)),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCases().getFirst()),
+                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(1).getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -613,9 +639,11 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
 
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCases().getFirst()),
+                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.getFirst()
+                                                                                   .getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -629,9 +657,10 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
             null, generatedDocumentEntities.get(fromAtPosition).getTranscription().getCreatedDateTime(), null, null, null);
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCases().getFirst()),
+                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(1).getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")
@@ -647,13 +676,15 @@ class TranscriptionDocumentTest extends PostgresIntegrationBase {
                                                                          .getTranscription().getCreatedDateTime(), null, null);
         Assertions.assertTrue(assertResultEquals(transcriptionDocumentResults,
                                                  List.of(getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCases().getFirst()),
+                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.getFirst(),
-                                                                           generatedDocumentEntities.getFirst().getTranscription().getCourtCases().get(1)),
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.getFirst().getTranscription().getCourtCases()).get(1)),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCases().getFirst()),
+                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCase()),
                                                          getExpectedResult(testType, generatedDocumentEntities.get(1),
-                                                                           generatedDocumentEntities.get(1).getTranscription().getCourtCases().get(1)))));
+                                                                           TestUtils.getOrderedByCreatedByAndId(
+                                                                               generatedDocumentEntities.get(1).getTranscription().getCourtCases()).get(1)))));
     }
 
     @ParameterizedTest(name = "{0}")

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/TranscriptionRepositoryTest.java
@@ -17,8 +17,8 @@ import uk.gov.hmcts.darts.testutils.stubs.TranscriptionStub;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 
-import static java.util.Arrays.asList;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -209,7 +209,7 @@ class TranscriptionRepositoryTest extends IntegrationBase {
                 var transcriptionDocument = minimalTranscriptionDocument();
                 var transcription = transcriptionDocument.getTranscription();
                 transcription.setIsManualTranscription(true);
-                transcription.setCourtCases(asList(courtCaseEntity));
+                transcription.setCourtCases(Set.of(courtCaseEntity));
                 transcriptionDocument.setHidden(i % 2 == 0);
                 dartsDatabase.save(transcription);
             });

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundToUnstructuredProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/InboundToUnstructuredProcessorIntTest.java
@@ -112,10 +112,11 @@ class InboundToUnstructuredProcessorIntTest extends IntegrationBase {
         // given
         var transcription = dartsDatabase.getTranscriptionStub().createMinimalTranscription();
 
-        dartsDatabase.getTranscriptionStub().updateTranscriptionWithDocument(transcription, STORED, INBOUND, UUID.randomUUID().toString());
+        TranscriptionDocumentEntity transcriptionDocumentEntity = dartsDatabase.getTranscriptionStub()
+            .updateTranscriptionWithDocument(transcription, STORED, INBOUND, UUID.randomUUID().toString());
 
         dartsDatabase.getExternalObjectDirectoryStub().createAndSaveExternalObjectDirectory(
-            transcription.getTranscriptionDocumentEntities().getFirst().getId(),
+            transcriptionDocumentEntity.getId(),
             dartsDatabase.getObjectRecordStatusEntity(STORED),
             dartsDatabase.getExternalLocationTypeEntity(UNSTRUCTURED)
         );
@@ -137,10 +138,11 @@ class InboundToUnstructuredProcessorIntTest extends IntegrationBase {
         // given
         var transcription = dartsDatabase.getTranscriptionStub().createMinimalTranscription();
 
-        dartsDatabase.getTranscriptionStub().updateTranscriptionWithDocument(transcription, STORED, INBOUND, UUID.randomUUID().toString());
+        TranscriptionDocumentEntity transcriptionDocumentEntity = dartsDatabase.getTranscriptionStub()
+            .updateTranscriptionWithDocument(transcription, STORED, INBOUND, UUID.randomUUID().toString());
 
         dartsDatabase.getExternalObjectDirectoryStub().createAndSaveExternalObjectDirectory(
-            transcription.getTranscriptionDocumentEntities().getFirst().getId(),
+            transcriptionDocumentEntity.getId(),
             dartsDatabase.getObjectRecordStatusEntity(FAILURE),
             dartsDatabase.getExternalLocationTypeEntity(UNSTRUCTURED)
         );

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AnnotationStubComposable.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AnnotationStubComposable.java
@@ -47,7 +47,7 @@ public class AnnotationStubComposable {
 
         // this is so that annotation becomes managed by JPA and its hearing list is loaded
         var managedAnnotation = annotationRepository.findById(annotation.getId()).get();
-        managedAnnotation.getHearingList().size();
+        managedAnnotation.getHearings().size();
 
         UserAccountEntity testUser = userAccountStubComposable.getIntegrationTestUserAccountEntity();
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseDocumentStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/CaseDocumentStub.java
@@ -2,9 +2,6 @@ package uk.gov.hmcts.darts.testutils.stubs;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.jeasy.random.EasyRandom;
-import org.jeasy.random.EasyRandomParameters;
-import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
@@ -64,15 +61,5 @@ public class CaseDocumentStub {
         caseDocumentEntity.setCreatedDateTime(OffsetDateTime.now(UTC));
         caseDocumentEntity.setLastModifiedBy(uploadedBy);
         return caseDocumentEntity;
-    }
-
-    public CaseDocumentEntity createCaseDocumentWithRandomValues() {
-        EasyRandomParameters parameters = new EasyRandomParameters()
-            .randomize(Integer.class, new IntegerRangeRandomizer(1, 100))
-            .collectionSizeRange(1, 1)
-            .overrideDefaultInitialization(true);
-
-        EasyRandom generator = new EasyRandom(parameters);
-        return generator.nextObject(CaseDocumentEntity.class);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsPersistence.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsPersistence.java
@@ -187,7 +187,7 @@ public class DartsPersistence {
         hearing.setJudges(saveJudgeList(hearing.getJudges()));
         hearing.setCourtCase(save(hearing.getCourtCase()));
         hearing.setCourtroom(save(hearing.getCourtroom()));
-        saveMediaList(hearing.getMediaList());
+        saveMediaList(hearing.getMedias());
         hearing.setCreatedById(Optional.ofNullable(hearing.getCreatedById()).orElse(0));
         hearing.setLastModifiedById(Optional.ofNullable(hearing.getLastModifiedById()).orElse(0));
 
@@ -206,7 +206,7 @@ public class DartsPersistence {
             annotationEntity.setCreatedById(Optional.ofNullable(annotationEntity.getCreatedById()).orElse(0));
             annotationEntity.setLastModifiedById(Optional.ofNullable(annotationEntity.getLastModifiedById()).orElse(0));
             if (annotationEntity.getHearings() != null) {
-                annotationEntity.setHearings(saveHearingEntity(annotationEntity.getHearings(), new HashSet<>()));
+                annotationEntity.setHearings(saveHearingEntity(annotationEntity.getHearings()));
             }
             return annotationRepository.save(annotationEntity);
         } else {
@@ -451,7 +451,7 @@ public class DartsPersistence {
 
         if (transcription.getId() == null) {
             if (transcription.getHearing() != null) {
-                transcription.setHearings(saveHearingEntity(transcription.getHearings(), new ArrayList<>()));
+                transcription.setHearings(saveHearingEntity(transcription.getHearings()));
             }
 
             if (transcription.getCourtroom() != null) {
@@ -459,7 +459,7 @@ public class DartsPersistence {
             }
 
             if (transcription.getCourtCases() != null) {
-                List<CourtCaseEntity> listOfCases = new ArrayList<>();
+                Set<CourtCaseEntity> listOfCases = new HashSet<>();
                 for (CourtCaseEntity courtCase : transcription.getCourtCases()) {
                     listOfCases.add(save(courtCase));
                 }
@@ -747,7 +747,7 @@ public class DartsPersistence {
         externalObjectDirectoryEntities.forEach(this::save);
     }
 
-    private void saveMediaList(List<MediaEntity> mediaList) {
+    private void saveMediaList(Collection<MediaEntity> mediaList) {
         if (mediaList == null
             || TestUtils.isProxy(mediaList)
             || mediaList.isEmpty()) {
@@ -757,7 +757,7 @@ public class DartsPersistence {
             if (media.getId() == null) {
                 media = (MediaEntity) preCheckPersist(media);
                 save(media);
-                saveHearingList(media.getHearingList());
+                saveHearing(media.getHearings());
             }
         });
 
@@ -784,12 +784,13 @@ public class DartsPersistence {
         return judgeEntityListReturn;
     }
 
-    private <T extends Collection<HearingEntity>> T saveHearingEntity(Collection<HearingEntity> hearingEntityList, T newCollection) {
+    private Set<HearingEntity> saveHearingEntity(Collection<HearingEntity> hearingEntityList) {
+        Set<HearingEntity> newCollection = new HashSet<>();
         hearingEntityList.forEach(hearingEntity -> newCollection.add(save(hearingEntity)));
         return newCollection;
     }
 
-    private void saveHearingList(List<HearingEntity> hearings) {
+    private void saveHearing(Collection<HearingEntity> hearings) {
         hearings.forEach(media -> {
             if (media.getId() == null) {
                 save(media);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsPersistence.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsPersistence.java
@@ -94,8 +94,11 @@ import uk.gov.hmcts.darts.test.common.data.builder.DbInsertable;
 import uk.gov.hmcts.darts.testutils.TransactionalUtil;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
@@ -202,8 +205,8 @@ public class DartsPersistence {
             annotationEntity.setCurrentOwner(save(annotationEntity.getCurrentOwner()));
             annotationEntity.setCreatedById(Optional.ofNullable(annotationEntity.getCreatedById()).orElse(0));
             annotationEntity.setLastModifiedById(Optional.ofNullable(annotationEntity.getLastModifiedById()).orElse(0));
-            if (annotationEntity.getHearingList() != null) {
-                annotationEntity.setHearingList(saveHearingEntity(annotationEntity.getHearingList()));
+            if (annotationEntity.getHearings() != null) {
+                annotationEntity.setHearings(saveHearingEntity(annotationEntity.getHearings(), new HashSet<>()));
             }
             return annotationRepository.save(annotationEntity);
         } else {
@@ -448,7 +451,7 @@ public class DartsPersistence {
 
         if (transcription.getId() == null) {
             if (transcription.getHearing() != null) {
-                transcription.setHearings(saveHearingEntity(transcription.getHearings()));
+                transcription.setHearings(saveHearingEntity(transcription.getHearings(), new ArrayList<>()));
             }
 
             if (transcription.getCourtroom() != null) {
@@ -781,12 +784,9 @@ public class DartsPersistence {
         return judgeEntityListReturn;
     }
 
-    private List<HearingEntity> saveHearingEntity(List<HearingEntity> hearingEntityList) {
-        List<HearingEntity> hearingEntityArrayListReturn = new ArrayList<>();
-
-        hearingEntityList.forEach(hearingEntity -> hearingEntityArrayListReturn.add(save(hearingEntity)));
-
-        return hearingEntityArrayListReturn;
+    private <T extends Collection<HearingEntity>> T saveHearingEntity(Collection<HearingEntity> hearingEntityList, T newCollection) {
+        hearingEntityList.forEach(hearingEntity -> newCollection.add(save(hearingEntity)));
+        return newCollection;
     }
 
     private void saveHearingList(List<HearingEntity> hearings) {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsPersistence.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/DartsPersistence.java
@@ -776,8 +776,8 @@ public class DartsPersistence {
         return mediaLinkedCaseEntityArrayList;
     }
 
-    private List<JudgeEntity> saveJudgeList(List<JudgeEntity> judges) {
-        List<JudgeEntity> judgeEntityListReturn = new ArrayList<>();
+    private Set<JudgeEntity> saveJudgeList(Collection<JudgeEntity> judges) {
+        Set<JudgeEntity> judgeEntityListReturn = new HashSet<>();
 
         judges.forEach(judge -> judgeEntityListReturn.add(save(judge)));
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ExternalObjectDirectoryStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/ExternalObjectDirectoryStub.java
@@ -295,6 +295,11 @@ public class ExternalObjectDirectoryStub {
         return objectRecordStatusRepository.getReferenceById(objectRecordStatusEnum.getId());
     }
 
+    /**
+     * Creates an ExternalObjectDirectoryEntity with random values.
+     * @deprecated use new PersistableFactory builders
+     */
+    @Deprecated
     public ExternalObjectDirectoryEntity createEodWithRandomValues() {
         EasyRandomParameters parameters = new EasyRandomParameters()
             .randomize(Integer.class, new IntegerRangeRandomizer(1, 100))

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/MediaStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/MediaStub.java
@@ -134,6 +134,6 @@ public class MediaStub {
     @Transactional
     public Integer getHearingId(Integer id) {
         Optional<MediaEntity> mediaEntity = mediaRepository.findById(id);
-        return mediaEntity.get().getHearingList().getFirst().getId();
+        return mediaEntity.get().getHearing().getId();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminGetTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminGetTranscriptionIntTest.java
@@ -577,9 +577,9 @@ class TranscriptionControllerAdminGetTranscriptionIntTest extends IntegrationBas
         assertThat(transcriptionDocumentResultsLegacy.get(1).getTranscription().getHearingDate()).isNotEqualTo(hearingDate);
 
 
-        assertThat(transcriptionDocumentResultsMod.getFirst().getTranscription().getHearings().getFirst().getHearingDate()).isEqualTo(hearingDate);
+        assertThat(transcriptionDocumentResultsMod.getFirst().getTranscription().getHearing().getHearingDate()).isEqualTo(hearingDate);
         assertThat(transcriptionDocumentResultsMod.getFirst().getTranscription().getHearingDate()).isNull();
-        assertThat(transcriptionDocumentResultsMod.get(1).getTranscription().getHearings().getFirst().getHearingDate()).isNotEqualTo(hearingDate);
+        assertThat(transcriptionDocumentResultsMod.get(1).getTranscription().getHearing().getHearingDate()).isNotEqualTo(hearingDate);
         assertThat(transcriptionDocumentResultsMod.get(1).getTranscription().getHearingDate()).isNull();
 
         superAdminUserStub.givenUserIsAuthorised(userIdentity);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerDownloadTranscriptIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerDownloadTranscriptIntTest.java
@@ -190,10 +190,8 @@ class TranscriptionControllerDownloadTranscriptIntTest extends IntegrationBase {
         final String fileName = "Test Document.docx";
         final String fileType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
         final int fileSize = 11_937;
-        final ObjectRecordStatusEntity storedStatus = dartsDatabase.getObjectRecordStatusEntity(
-            STORED);
-        final ExternalLocationTypeEntity unstructuredLocation = dartsDatabase.getExternalLocationTypeEntity(
-            UNSTRUCTURED);
+        final ObjectRecordStatusEntity storedStatus = dartsDatabase.getObjectRecordStatusEntity(STORED);
+        final ExternalLocationTypeEntity unstructuredLocation = dartsDatabase.getExternalLocationTypeEntity(UNSTRUCTURED);
         final String externalLocation = UUID.randomUUID().toString();
         final String checksum = "xi/XkzD2HuqTUzDafW8Cgw==";
         final String confidenceReason = "reason";
@@ -221,7 +219,7 @@ class TranscriptionControllerDownloadTranscriptIntTest extends IntegrationBase {
             checksum,
             confidenceScore,
             confidenceReason
-        );
+        ).getTranscription();
 
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get(URL_TEMPLATE, transcriptionId)
             .header(
@@ -285,7 +283,7 @@ class TranscriptionControllerDownloadTranscriptIntTest extends IntegrationBase {
             checksum,
             confidenceScore,
             confidenceReason
-        );
+        ).getTranscription();
 
         var mockFileBasedDownloadResponseMetaData = mock(FileBasedDownloadResponseMetaData.class);
         when(mockDataManagementFacade.retrieveFileFromStorage(any(TranscriptionDocumentEntity.class))).thenReturn(mockFileBasedDownloadResponseMetaData);

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerRequestTranscriptionIntTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
 import uk.gov.hmcts.darts.common.entity.AuditEntity;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionCommentEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionLinkedCaseEntity;
@@ -29,6 +30,7 @@ import uk.gov.hmcts.darts.common.repository.AuditRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionLinkedCaseRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionRepository;
 import uk.gov.hmcts.darts.notification.entity.NotificationEntity;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.AuthorisationStub;
 import uk.gov.hmcts.darts.testutils.stubs.TranscriptionStub;
@@ -266,7 +268,7 @@ class TranscriptionControllerRequestTranscriptionIntTest extends IntegrationBase
             transcriptionTypeEnum.getId(), TEST_COMMENT, START_TIME, END_TIME
         );
 
-        hearing.setMediaList(null);
+        hearing.setMedias(null);
         dartsDatabase.save(hearing);
 
         MockHttpServletRequestBuilder requestBuilder = post(ENDPOINT_URI)
@@ -300,8 +302,9 @@ class TranscriptionControllerRequestTranscriptionIntTest extends IntegrationBase
         TranscriptionUrgencyEnum transcriptionUrgencyEnum = TranscriptionUrgencyEnum.STANDARD;
         TranscriptionTypeEnum transcriptionTypeEnum = TranscriptionTypeEnum.SENTENCING_REMARKS;
 
-        OffsetDateTime startTime = hearing.getMediaList().getFirst().getStart().truncatedTo(ChronoUnit.SECONDS);
-        OffsetDateTime endTime = hearing.getMediaList().getFirst().getEnd().truncatedTo(ChronoUnit.SECONDS);
+        MediaEntity mediaEntity = TestUtils.getFirst(hearing.getMedias());
+        OffsetDateTime startTime = mediaEntity.getStart().truncatedTo(ChronoUnit.SECONDS);
+        OffsetDateTime endTime = mediaEntity.getEnd().truncatedTo(ChronoUnit.SECONDS);
 
         TranscriptionRequestDetails transcriptionRequestDetails = createTranscriptionRequestDetails(
             hearing.getId(), courtCase.getId(), transcriptionUrgencyEnum.getId(),
@@ -330,8 +333,9 @@ class TranscriptionControllerRequestTranscriptionIntTest extends IntegrationBase
         TranscriptionUrgencyEnum transcriptionUrgencyEnum = TranscriptionUrgencyEnum.STANDARD;
         TranscriptionTypeEnum transcriptionTypeEnum = TranscriptionTypeEnum.SENTENCING_REMARKS;
 
-        OffsetDateTime startTime = hearing.getMediaList().getFirst().getStart().plusMinutes(5);
-        OffsetDateTime endTime = hearing.getMediaList().getFirst().getEnd().minusMinutes(15);
+        MediaEntity mediaEntity = TestUtils.getFirst(hearing.getMedias());
+        OffsetDateTime startTime = mediaEntity.getStart().plusMinutes(5);
+        OffsetDateTime endTime = mediaEntity.getEnd().minusMinutes(15);
 
         TranscriptionRequestDetails transcriptionRequestDetails = createTranscriptionRequestDetails(
             hearing.getId(), courtCase.getId(), transcriptionUrgencyEnum.getId(),

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/given/MigratedTranscriptionSearchGivensBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/given/MigratedTranscriptionSearchGivensBuilder.java
@@ -7,7 +7,7 @@ import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
 import uk.gov.hmcts.darts.test.common.data.UserAccountTestData;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import static java.util.stream.IntStream.range;
@@ -82,7 +82,7 @@ public class MigratedTranscriptionSearchGivensBuilder extends TranscriptionSearc
         var courtroom = someMinimalCourtRoom();
         dartsDatabase.save(courtroom.getCourthouse());
         dartsDatabase.save(courtroom);
-        transcription.setHearings(new ArrayList<>());
+        transcription.setHearings(new HashSet<>());
         transcription.setCourtroom(courtroom);
         transcription.setIsCurrent(true);
         dartsDatabase.save(transcription.getCourtCase());
@@ -95,7 +95,7 @@ public class MigratedTranscriptionSearchGivensBuilder extends TranscriptionSearc
         var courtroom = someMinimalCourtRoom();
         dartsDatabase.save(courtroom.getCourthouse());
         dartsDatabase.save(courtroom);
-        transcription.setHearings(new ArrayList<>());
+        transcription.setHearings(new HashSet<>());
         transcription.setCourtroom(courtroom);
         dartsDatabase.save(transcription.getCourtCase());
         transcription.setIsCurrent(true);

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/AnnotationArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/AnnotationArchiveRecordMapperImpl.java
@@ -175,7 +175,7 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
         return dateTime;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private String getHearingDate(AnnotationDocumentEntity annotationDocument) {
         String hearingDate = null;
         if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {
@@ -200,7 +200,7 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
         return cases;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourthouse(AnnotationDocumentEntity annotationDocument) {
         String courthouse = null;
         if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {
@@ -209,7 +209,7 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
         return courthouse;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourtroom(AnnotationDocumentEntity annotationDocument) {
         String courtroom = null;
         if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/AnnotationArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/AnnotationArchiveRecordMapperImpl.java
@@ -175,6 +175,7 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
         return dateTime;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private String getHearingDate(AnnotationDocumentEntity annotationDocument) {
         String hearingDate = null;
         if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {
@@ -199,6 +200,7 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
         return cases;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourthouse(AnnotationDocumentEntity annotationDocument) {
         String courthouse = null;
         if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {
@@ -207,6 +209,7 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
         return courthouse;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourtroom(AnnotationDocumentEntity annotationDocument) {
         String courtroom = null;
         if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/AnnotationArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/AnnotationArchiveRecordMapperImpl.java
@@ -177,8 +177,8 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
 
     private String getHearingDate(AnnotationDocumentEntity annotationDocument) {
         String hearingDate = null;
-        if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearingList())) {
-            hearingDate = OffsetDateTime.of(annotationDocument.getAnnotation().getHearingList().getFirst().getHearingDate().atTime(0, 0, 0),
+        if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {
+            hearingDate = OffsetDateTime.of(annotationDocument.getAnnotation().getHearingEntity().getHearingDate().atTime(0, 0, 0),
                                             ZoneOffset.UTC).format(dateTimeFormatter);
         }
         return hearingDate;
@@ -186,8 +186,8 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
 
     private String getCaseNumbers(AnnotationDocumentEntity annotationDocument) {
         String cases = null;
-        if (nonNull(annotationDocument.getAnnotation().getHearingList())) {
-            List<String> caseNumbers = annotationDocument.getAnnotation().getHearingList()
+        if (nonNull(annotationDocument.getAnnotation().getHearings())) {
+            List<String> caseNumbers = annotationDocument.getAnnotation().getHearings()
                 .stream()
                 .map(HearingEntity::getCourtCase)
                 .map(CourtCaseEntity::getCaseNumber)
@@ -201,16 +201,16 @@ public class AnnotationArchiveRecordMapperImpl extends BaseArchiveRecordMapper i
 
     private static String getCourthouse(AnnotationDocumentEntity annotationDocument) {
         String courthouse = null;
-        if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearingList())) {
-            courthouse = annotationDocument.getAnnotation().getHearingList().getFirst().getCourtCase().getCourthouse().getDisplayName();
+        if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {
+            courthouse = annotationDocument.getAnnotation().getHearingEntity().getCourtCase().getCourthouse().getDisplayName();
         }
         return courthouse;
     }
 
     private static String getCourtroom(AnnotationDocumentEntity annotationDocument) {
         String courtroom = null;
-        if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearingList())) {
-            courtroom = annotationDocument.getAnnotation().getHearingList().getFirst().getCourtroom().getName();
+        if (CollectionUtils.isNotEmpty(annotationDocument.getAnnotation().getHearings())) {
+            courtroom = annotationDocument.getAnnotation().getHearingEntity().getCourtroom().getName();
         }
         return courtroom;
     }

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/MediaArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/MediaArchiveRecordMapperImpl.java
@@ -174,8 +174,8 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
 
     private String getHearingDate(MediaEntity media) {
         String hearingDate = null;
-        if (CollectionUtils.isNotEmpty(media.getHearingList())) {
-            hearingDate = OffsetDateTime.of(media.getHearingList().getFirst().getHearingDate().atTime(0, 0, 0),
+        if (CollectionUtils.isNotEmpty(media.getHearings())) {
+            hearingDate = OffsetDateTime.of(media.getHearing().getHearingDate().atTime(0, 0, 0),
                                             ZoneOffset.UTC).format(dateTimeFormatter);
         }
         return hearingDate;
@@ -183,8 +183,8 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
 
     private String getCaseNumbers(MediaEntity media) {
         String cases = null;
-        if (CollectionUtils.isNotEmpty(media.getHearingList())) {
-            List<String> caseNumbers = media.getHearingList()
+        if (CollectionUtils.isNotEmpty(media.getHearings())) {
+            List<String> caseNumbers = media.getHearings()
                 .stream()
                 .map(HearingEntity::getCourtCase)
                 .map(CourtCaseEntity::getCaseNumber)
@@ -196,8 +196,8 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
 
     private static String getCourthouse(MediaEntity media) {
         String courthouse = null;
-        if (CollectionUtils.isNotEmpty(media.getHearingList()) && nonNull(media.getHearingList().getFirst().getCourtroom())) {
-            courthouse = media.getHearingList().getFirst().getCourtroom().getCourthouse().getDisplayName();
+        if (CollectionUtils.isNotEmpty(media.getHearings()) && nonNull(media.getHearing().getCourtroom())) {
+            courthouse = media.getHearing().getCourtroom().getCourthouse().getDisplayName();
         } else if (nonNull(media.getCourtroom()) && nonNull(media.getCourtroom().getCourthouse())) {
             courthouse = media.getCourtroom().getCourthouse().getDisplayName();
         }
@@ -206,8 +206,8 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
 
     private static String getCourtroom(MediaEntity media) {
         String courtroom = null;
-        if (CollectionUtils.isNotEmpty(media.getHearingList()) && nonNull(media.getHearingList().getFirst().getCourtroom())) {
-            courtroom = media.getHearingList().getFirst().getCourtroom().getName();
+        if (CollectionUtils.isNotEmpty(media.getHearings()) && nonNull(media.getHearing().getCourtroom())) {
+            courtroom = media.getHearing().getCourtroom().getName();
         } else if (nonNull(media.getCourtroom())) {
             courtroom = media.getCourtroom().getName();
         }

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/MediaArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/MediaArchiveRecordMapperImpl.java
@@ -172,7 +172,7 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
         return dateTime;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private String getHearingDate(MediaEntity media) {
         String hearingDate = null;
         if (CollectionUtils.isNotEmpty(media.getHearings())) {
@@ -195,7 +195,7 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
         return cases;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourthouse(MediaEntity media) {
         String courthouse = null;
         if (CollectionUtils.isNotEmpty(media.getHearings()) && nonNull(media.getHearing().getCourtroom())) {
@@ -206,7 +206,7 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
         return courthouse;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourtroom(MediaEntity media) {
         String courtroom = null;
         if (CollectionUtils.isNotEmpty(media.getHearings()) && nonNull(media.getHearing().getCourtroom())) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/MediaArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/MediaArchiveRecordMapperImpl.java
@@ -172,6 +172,7 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
         return dateTime;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private String getHearingDate(MediaEntity media) {
         String hearingDate = null;
         if (CollectionUtils.isNotEmpty(media.getHearings())) {
@@ -194,6 +195,7 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
         return cases;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourthouse(MediaEntity media) {
         String courthouse = null;
         if (CollectionUtils.isNotEmpty(media.getHearings()) && nonNull(media.getHearing().getCourtroom())) {
@@ -204,6 +206,7 @@ public class MediaArchiveRecordMapperImpl extends BaseArchiveRecordMapper implem
         return courthouse;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourtroom(MediaEntity media) {
         String courtroom = null;
         if (CollectionUtils.isNotEmpty(media.getHearings()) && nonNull(media.getHearing().getCourtroom())) {

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/TranscriptionArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/TranscriptionArchiveRecordMapperImpl.java
@@ -300,7 +300,7 @@ public class TranscriptionArchiveRecordMapperImpl extends BaseArchiveRecordMappe
         return transcriptRquest;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private String getHearingDate(TranscriptionDocumentEntity transcriptionDocument) {
         String hearingDate = null;
         if (nonNull(transcriptionDocument.getTranscription().getHearingDate())) {
@@ -313,7 +313,7 @@ public class TranscriptionArchiveRecordMapperImpl extends BaseArchiveRecordMappe
         return hearingDate;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourtroom(TranscriptionDocumentEntity transcriptionDocument) {
         String courtroom = null;
         if (nonNull(transcriptionDocument.getTranscription().getHearing())
@@ -325,7 +325,7 @@ public class TranscriptionArchiveRecordMapperImpl extends BaseArchiveRecordMappe
         return courtroom;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourthouse(TranscriptionDocumentEntity transcriptionDocument) {
         String courthouse = null;
         if (nonNull(transcriptionDocument.getTranscription().getHearing())

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/TranscriptionArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/TranscriptionArchiveRecordMapperImpl.java
@@ -300,6 +300,7 @@ public class TranscriptionArchiveRecordMapperImpl extends BaseArchiveRecordMappe
         return transcriptRquest;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private String getHearingDate(TranscriptionDocumentEntity transcriptionDocument) {
         String hearingDate = null;
         if (nonNull(transcriptionDocument.getTranscription().getHearingDate())) {
@@ -312,6 +313,7 @@ public class TranscriptionArchiveRecordMapperImpl extends BaseArchiveRecordMappe
         return hearingDate;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourtroom(TranscriptionDocumentEntity transcriptionDocument) {
         String courtroom = null;
         if (nonNull(transcriptionDocument.getTranscription().getHearing())
@@ -323,6 +325,7 @@ public class TranscriptionArchiveRecordMapperImpl extends BaseArchiveRecordMappe
         return courtroom;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private static String getCourthouse(TranscriptionDocumentEntity transcriptionDocument) {
         String courthouse = null;
         if (nonNull(transcriptionDocument.getTranscription().getHearing())

--- a/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/TranscriptionArchiveRecordMapperImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/mapper/impl/TranscriptionArchiveRecordMapperImpl.java
@@ -306,7 +306,7 @@ public class TranscriptionArchiveRecordMapperImpl extends BaseArchiveRecordMappe
             hearingDate = OffsetDateTime.of(transcriptionDocument.getTranscription().getHearingDate().atTime(0, 0, 0),
                                             ZoneOffset.UTC).format(dateTimeFormatter);
         } else if (CollectionUtils.isNotEmpty(transcriptionDocument.getTranscription().getHearings())) {
-            hearingDate = OffsetDateTime.of(transcriptionDocument.getTranscription().getHearings().getFirst().getHearingDate().atTime(0, 0, 0),
+            hearingDate = OffsetDateTime.of(transcriptionDocument.getTranscription().getHearing().getHearingDate().atTime(0, 0, 0),
                                             ZoneOffset.UTC).format(dateTimeFormatter);
         }
         return hearingDate;

--- a/src/main/java/uk/gov/hmcts/darts/audio/entity/MediaRequestEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/entity/MediaRequestEntity.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity_;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ import java.util.List;
 @Getter
 @Setter
 @AuditTable("media_request_aud")
-public class MediaRequestEntity extends CreatedModifiedBaseEntity {
+public class MediaRequestEntity extends CreatedModifiedBaseEntity implements HasIntegerId {
 
     public static final String ID_COLUMN_NAME = "mer_id";
     public static final String HEARING_ID_COLUMN_NAME = "hea_id";

--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/PostAdminMediasSearchHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/PostAdminMediasSearchHelper.java
@@ -160,10 +160,10 @@ public class PostAdminMediasSearchHelper {
     @SuppressWarnings("unchecked")
     private Join<MediaEntity, HearingEntity> getHearingJoin(Root<MediaEntity> mediaRoot) {
         Optional<Join<MediaEntity, ?>> foundJoin = mediaRoot.getJoins().stream()
-            .filter(join -> MediaEntity_.HEARING_LIST.equals(join.getAttribute().getName())).findAny();
+            .filter(join -> MediaEntity_.HEARINGS.equals(join.getAttribute().getName())).findAny();
 
         return foundJoin.map(join -> (Join<MediaEntity, HearingEntity>) join)
-            .orElseGet(() -> mediaRoot.join(MediaEntity_.HEARING_LIST, JoinType.INNER));
+            .orElseGet(() -> mediaRoot.join(MediaEntity_.HEARINGS, JoinType.INNER));
     }
 
     private Join<MediaEntity, CourtCaseEntity> getCaseJoin(Root<MediaEntity> mediaRoot) {

--- a/src/main/java/uk/gov/hmcts/darts/audio/mapper/AdminMediaMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/mapper/AdminMediaMapper.java
@@ -42,7 +42,7 @@ public interface AdminMediaMapper {
         @Mapping(target = "lastModifiedById", source = "lastModifiedById"),
         @Mapping(target = "courthouse", source = "courtroom.courthouse"),
         @Mapping(target = "courtroom", source = "courtroom"),
-        @Mapping(target = "hearings", source = "hearingList"),
+        @Mapping(target = "hearings", source = "hearings"),
         @Mapping(target = "cases", source = "mediaLinkedCaseList"),
         @Mapping(target = "isCurrent", source = "isCurrent")
     })

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImpl.java
@@ -61,6 +61,7 @@ import uk.gov.hmcts.darts.common.validation.IdRequest;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -158,7 +159,7 @@ public class AdminMediaServiceImpl implements AdminMediaService {
         List<MediaEntity> mediaList = mediaRepository.findMediaByDetails(hearingIds, startAt, endAt);
 
         mediaList.forEach(mediaEntity -> {
-            List<HearingEntity> hearingEntityList = getApplicableMediaHearings(mediaEntity, hearingIds);
+            Collection<HearingEntity> hearingEntityList = getApplicableMediaHearings(mediaEntity, hearingIds);
 
             hearingEntityList.forEach(hearing -> {
                 responseMediaItemList.add(GetAdminMediaResponseMapper.createResponseItem(mediaEntity, hearing));
@@ -250,11 +251,11 @@ public class AdminMediaServiceImpl implements AdminMediaService {
     }
 
 
-    private List<HearingEntity> getApplicableMediaHearings(MediaEntity mediaEntity, List<Integer> hearingsToMatchOn) {
-        List<HearingEntity> hearingEntityList = CollectionUtils.isEmpty(hearingsToMatchOn) ? mediaEntity.getHearingList() : new ArrayList<>();
+    private Collection<HearingEntity> getApplicableMediaHearings(MediaEntity mediaEntity, List<Integer> hearingsToMatchOn) {
+        Collection<HearingEntity> hearingEntityList = CollectionUtils.isEmpty(hearingsToMatchOn) ? mediaEntity.getHearings() : new ArrayList<>();
 
         if (!CollectionUtils.isEmpty(hearingsToMatchOn)) {
-            for (HearingEntity hearingEntity : mediaEntity.getHearingList()) {
+            for (HearingEntity hearingEntity : mediaEntity.getHearings()) {
                 if (hearingsToMatchOn.contains(hearingEntity.getId())) {
                     hearingEntityList.add(hearingEntity);
                 }

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioAsyncServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioAsyncServiceImpl.java
@@ -58,7 +58,7 @@ public class AudioAsyncServiceImpl implements AudioAsyncService {
 
         for (var hearing : associatedHearings) {
             mediaLinkedCaseHelper.linkMediaToCase(savedMedia, hearing.getCourtCase(), MediaLinkedCaseSourceType.ADD_AUDIO_EVENT_LINKING, userAccount);
-            List<Integer> mediaIdList = hearing.getMediaList().stream().map(MediaEntity::getId).toList();
+            List<Integer> mediaIdList = hearing.getMedias().stream().map(MediaEntity::getId).toList();
             if (!mediaIdList.contains(savedMedia.getId())) {
                 hearing.addMedia(savedMedia);
                 hearing.setHearingIsActual(true);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
@@ -225,7 +226,7 @@ public class AudioUploadServiceImpl implements AudioUploadService {
 
     @Override
     public void deleteMediaLinkingAndSetCurrentFalse(MediaEntity mediaEntity) {
-        List<HearingEntity> hearingList = mediaEntity.getHearingList();
+        Set<HearingEntity> hearingList = mediaEntity.getHearings();
         for (HearingEntity hearing : hearingList) {
             mediaEntity.removeHearing(hearing);
         }

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImpl.java
@@ -163,7 +163,7 @@ public class AuthorisationImpl implements Authorisation {
     @Override
     public void authoriseByAnnotationId(Integer annotationId, Set<SecurityRoleEnum> securityRoles) {
         var annotation = annotationRepository.findById(annotationId).orElseThrow(this::logAndThrowAnnotationNotFound);
-        var courthouses = annotation.getHearingList().stream()
+        var courthouses = annotation.getHearings().stream()
             .map(hea -> hea.getCourtroom().getCourthouse())
             .toList();
 

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImpl.java
@@ -94,7 +94,7 @@ public class AuthorisationImpl implements Authorisation {
     public void authoriseByMediaId(Integer mediaId, Set<SecurityRoleEnum> securityRoles) {
         try {
             final Set<CourthouseEntity> courthouses = mediaRepository.getReferenceById(mediaId)
-                .getHearingList()
+                .getHearings()
                 .stream()
                 .map(hearingEntity -> hearingEntity.getCourtroom().getCourthouse())
                 .collect(Collectors.toUnmodifiableSet());

--- a/src/main/java/uk/gov/hmcts/darts/casedocument/mapper/CourtCaseDocumentMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/casedocument/mapper/CourtCaseDocumentMapper.java
@@ -64,7 +64,7 @@ public abstract class CourtCaseDocumentMapper {
 
     @Mappings({
         @Mapping(source = "events", target = "events"),
-        @Mapping(source = "mediaList", target = "medias"),
+        @Mapping(source = "medias", target = "medias"),
         @Mapping(target = "lastModifiedBy", source = "lastModifiedById"),
         @Mapping(target = "createdBy", source = "createdById")
     })

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -238,7 +238,7 @@ public class CaseServiceImpl implements CaseService {
                         .toList());
 
             for (AnnotationEntity annotationEntity : annotationsEntities) {
-                for (HearingEntity hearingEntity : annotationEntity.getHearingList()) {
+                for (HearingEntity hearingEntity : annotationEntity.getHearings()) {
                     annotations.add(annotationMapper.map(hearingEntity, annotationEntity));
                 }
             }
@@ -251,7 +251,7 @@ public class CaseServiceImpl implements CaseService {
                         .toList(), authorisationApi.getCurrentUser());
 
             for (AnnotationEntity annotationEntity : annotationsEntities) {
-                for (HearingEntity hearingEntity : annotationEntity.getHearingList()) {
+                for (HearingEntity hearingEntity : annotationEntity.getHearings()) {
                     annotations.add(annotationMapper.map(hearingEntity, annotationEntity));
                 }
             }

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CloseOldCasesProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CloseOldCasesProcessorImpl.java
@@ -115,7 +115,7 @@ public class CloseOldCasesProcessorImpl implements CloseOldCasesProcessor {
                 //look for the last audio and use its recorded date
                 List<MediaEntity> mediaList = new ArrayList<>();
                 for (HearingEntity hearingEntity : courtCase.getHearings()) {
-                    mediaList.addAll(hearingEntity.getMediaList());
+                    mediaList.addAll(hearingEntity.getMedias());
                 }
                 if (mediaList.isEmpty()) {
                     //look for the last hearing date and use that

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationDocumentEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationDocumentEntity.java
@@ -109,7 +109,7 @@ public class AnnotationDocumentEntity extends ModifiedBaseEntity
 
 
     public List<CourtCaseEntity> associatedCourtCases() {
-        var cases = annotation.getHearingList().stream().map(HearingEntity::getCourtCase);
+        var cases = annotation.getHearings().stream().map(HearingEntity::getCourtCase);
         return io.vavr.collection.List.ofAll(cases).distinctBy(CourtCaseEntity::getId).toJavaList();
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
@@ -88,7 +88,7 @@ public class AnnotationEntity extends CreatedModifiedBaseEntity implements HasIn
      * This switch was needed to prevent data integirty issues when inserting/deleting values.
      * As when using a list spring will first delete all values on the mapping table. Then reinsert only the new ones.
      * Where as using a Set it will only add the new values and remove the old ones.
-     * A tech debt ticket has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
+     * A tech debt ticket (DMP-4972) has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
      *
      * @return the first hearing entity found within the set
      * @deprecated because this is not many to many safe. Implementation should account for multiple hearings

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
@@ -81,6 +81,7 @@ public class AnnotationEntity extends CreatedModifiedBaseEntity {
         }
         hearings.add(hearingEntity);
     }
+
     /**
      * This method was added to simplify the switch from List to Set on HearingEntity in which existing code uses .getFirst()
      * This switch was needed to prevent data integirty issues when inserting/deleting values.

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
@@ -17,6 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ import java.util.Set;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = false)
-public class AnnotationEntity extends CreatedModifiedBaseEntity {
+public class AnnotationEntity extends CreatedModifiedBaseEntity implements HasIntegerId {
 
     @Id
     @Column(name = "ann_id")

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/AnnotationEntity.java
@@ -20,7 +20,11 @@ import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 @Entity
 @Table(name = "annotation")
@@ -64,18 +68,36 @@ public class AnnotationEntity extends CreatedModifiedBaseEntity {
     @OneToMany(fetch = FetchType.EAGER, mappedBy = AnnotationDocumentEntity_.ANNOTATION)
     private List<AnnotationDocumentEntity> annotationDocuments = new ArrayList<>();
 
-    @ManyToMany()
+    @ManyToMany
     @JoinTable(name = "hearing_annotation_ae",
         joinColumns = {@JoinColumn(name = "ann_id")},
         inverseJoinColumns = {@JoinColumn(name = "hea_id")})
-    private List<HearingEntity> hearingList = new ArrayList<>();
+    private Set<HearingEntity> hearings = new HashSet<>();
 
 
     public void addHearing(HearingEntity hearingEntity) {
         if (hearingEntity == null) {
             return;
         }
-        hearingList.add(hearingEntity);
+        hearings.add(hearingEntity);
+    }
+    /**
+     * This method was added to simplify the switch from List to Set on HearingEntity in which existing code uses .getFirst()
+     * This switch was needed to prevent data integirty issues when inserting/deleting values.
+     * As when using a list spring will first delete all values on the mapping table. Then reinsert only the new ones.
+     * Where as using a Set it will only add the new values and remove the old ones.
+     * A tech debt ticket has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
+     *
+     * @return the first hearing entity found within the set
+     * @deprecated because this is not many to many safe. Implementation should account for multiple hearings
+     */
+    @Deprecated
+    public HearingEntity getHearingEntity() {
+        return this.getHearings().stream()
+            .sorted(Comparator.comparing(HearingEntity::getCreatedDateTime)
+                        .thenComparing(HearingEntity::getId))
+            .findFirst()
+            .orElseThrow(NoSuchElementException::new);
     }
 
     public boolean isOwnedBy(UserAccountEntity userAccount) {

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
@@ -28,7 +28,9 @@ import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceScoreEnum;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Table(name = CourtCaseEntity.TABLE_NAME)
@@ -125,7 +127,7 @@ public class CourtCaseEntity extends CreatedModifiedBaseEntity {
     @JoinTable(name = "case_judge_ae",
         joinColumns = {@JoinColumn(name = "cas_id")},
         inverseJoinColumns = {@JoinColumn(name = "jud_id")})
-    private List<JudgeEntity> judges = new ArrayList<>();
+    private Set<JudgeEntity> judges = new HashSet<>();
 
     @OneToMany(mappedBy = MediaLinkedCaseEntity_.COURT_CASE)
     private List<MediaLinkedCaseEntity> mediaLinkedCaseList = new ArrayList<>();

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntity.java
@@ -25,6 +25,7 @@ import uk.gov.hmcts.darts.common.entity.base.CreatedModifiedBaseEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceReasonEnum;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceScoreEnum;
+import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -38,7 +39,7 @@ import java.util.Set;
 @Getter
 @Setter
 @Slf4j
-public class CourtCaseEntity extends CreatedModifiedBaseEntity {
+public class CourtCaseEntity extends CreatedModifiedBaseEntity implements HasIntegerId {
 
     public static final String COURT_CASE = "courtCase";
     public static final String CASE_CLOSED_TS = "case_closed_ts";

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/EventEntity.java
@@ -110,7 +110,7 @@ public class EventEntity extends CreatedModifiedBaseEntity {
      * This switch was needed to prevent data integirty issues when inserting/deleting values.
      * As when using a list spring will first delete all values on the mapping table. Then reinsert only the new ones.
      * Where as using a Set it will only add the new values and remove the old ones.
-     * A tech debt ticket has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
+     * A tech debt ticket (DMP-4972) has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
      *
      * @return the first hearing entity found within the set
      * @deprecated because this is not many to many safe. Implementation should account for multiple hearings

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -61,7 +62,7 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     @JoinTable(name = "hearing_judge_ae",
         joinColumns = {@JoinColumn(name = HEA_ID)},
         inverseJoinColumns = {@JoinColumn(name = "jud_id")})
-    private List<JudgeEntity> judges = new ArrayList<>();
+    private Set<JudgeEntity> judges = new HashSet<>();
 
     @ManyToMany
     @JoinTable(name = "hearing_media_ae",
@@ -111,7 +112,7 @@ public class HearingEntity extends CreatedModifiedBaseEntity
         }
     }
 
-    public void addJudges(List<JudgeEntity> judges) {
+    public void addJudges(Collection<JudgeEntity> judges) {
         for (JudgeEntity judge : judges) {
             addJudge(judge, false);
         }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/HearingEntity.java
@@ -25,7 +25,6 @@ import uk.gov.hmcts.darts.task.runner.HasIntegerId;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -68,13 +67,13 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     @JoinTable(name = "hearing_media_ae",
         joinColumns = {@JoinColumn(name = HEA_ID)},
         inverseJoinColumns = {@JoinColumn(name = "med_id")})
-    private List<MediaEntity> mediaList = new ArrayList<>();
+    private Set<MediaEntity> medias = new HashSet<>();
 
     @ManyToMany(fetch = FetchType.EAGER, mappedBy = TranscriptionEntity_.HEARINGS)
-    private List<TranscriptionEntity> transcriptions = new ArrayList<>();
+    private Set<TranscriptionEntity> transcriptions = new HashSet<>();
 
     @OneToMany(mappedBy = MediaRequestEntity_.HEARING)
-    private List<MediaRequestEntity> mediaRequests = new ArrayList<>();
+    private Set<MediaRequestEntity> mediaRequests = new HashSet<>();
 
     @Transient
     private boolean isNew; //helper flag to indicate that the entity was just created, and so to notify DAR PC
@@ -93,11 +92,11 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     @JoinTable(name = "hearing_annotation_ae",
         joinColumns = {@JoinColumn(name = HEA_ID)},
         inverseJoinColumns = {@JoinColumn(name = "ann_id")})
-    private List<AnnotationEntity> annotations = new ArrayList<>();
+    private Set<AnnotationEntity> annotations = new HashSet<>();
 
     public void addMedia(MediaEntity mediaEntity) {
         if (!containsMedia(mediaEntity)) {
-            mediaList.add(mediaEntity);
+            medias.add(mediaEntity);
         }
     }
 
@@ -127,6 +126,6 @@ public class HearingEntity extends CreatedModifiedBaseEntity
     }
 
     public boolean containsMedia(MediaEntity mediaEntity) {
-        return mediaEntity.getId() != null && mediaList.stream().anyMatch(media -> mediaEntity.getId().equals(media.getId()));
+        return mediaEntity.getId() != null && medias.stream().anyMatch(media -> mediaEntity.getId().equals(media.getId()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
@@ -164,8 +164,8 @@ public class MediaEntity extends CreatedModifiedBaseEntity
     }
 
     public void addHearing(HearingEntity hearing) {
-        if (!hearingList.contains(hearing)) {
-            hearingList.add(hearing);
+        if (!hearings.contains(hearing)) {
+            hearings.add(hearing);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/MediaEntity.java
@@ -200,7 +200,7 @@ public class MediaEntity extends CreatedModifiedBaseEntity
      * This switch was needed to prevent data integirty issues when inserting/deleting values.
      * As when using a list spring will first delete all values on the mapping table. Then reinsert only the new ones.
      * Where as using a Set it will only add the new values and remove the old ones.
-     * A tech debt ticket has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
+     * A tech debt ticket (DMP-4972) has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
      *
      * @return the first hearing entity found within the set
      * @deprecated because this is not many to many safe. Implementation should account for multiple hearings

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectAdminActionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/ObjectAdminActionEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,7 +19,6 @@ import java.time.OffsetDateTime;
 @Table(name = "object_admin_action")
 @Getter
 @Setter
-@EqualsAndHashCode(callSuper = false)
 public class ObjectAdminActionEntity {
 
     @Id

--- a/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntity.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntity.java
@@ -235,7 +235,7 @@ public class TranscriptionEntity extends CreatedModifiedBaseEntity implements Ha
      * This switch was needed to prevent data integirty issues when inserting/deleting values.
      * As when using a list spring will first delete all values on the mapping table. Then reinsert only the new ones.
      * Where as using a Set it will only add the new values and remove the old ones.
-     * A tech debt ticket has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
+     * A tech debt ticket (DMP-4972) has be raised to refactor all the code that uses this method, to ensure it uses a many to many safe equivelent
      *
      * @return the first hearing entity found within the set
      * @deprecated because this is not many to many safe. Implementation should account for multiple hearings

--- a/src/main/java/uk/gov/hmcts/darts/common/mapper/TranscriptionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/mapper/TranscriptionMapper.java
@@ -24,6 +24,7 @@ public abstract class TranscriptionMapper<T extends TranscriptModel> {
         return response;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private T map(TranscriptionEntity transcriptionEntity) {
         T transcript = createNewTranscription();
         transcript.setTranscriptionId(transcriptionEntity.getId());

--- a/src/main/java/uk/gov/hmcts/darts/common/mapper/TranscriptionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/mapper/TranscriptionMapper.java
@@ -7,12 +7,14 @@ import uk.gov.hmcts.darts.common.model.TranscriptModel;
 import uk.gov.hmcts.darts.transcriptions.util.TranscriptionUtil;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 public abstract class TranscriptionMapper<T extends TranscriptModel> {
 
-    public List<T> mapResponse(List<TranscriptionEntity> transcriptionEntities) {
+    public List<T> mapResponse(Collection<TranscriptionEntity> transcriptionEntities) {
         List<T> response = new ArrayList<>();
         for (TranscriptionEntity transcriptionEntity : transcriptionEntities) {
             if (Boolean.TRUE.equals(transcriptionEntity.getIsCurrent())) {
@@ -25,13 +27,13 @@ public abstract class TranscriptionMapper<T extends TranscriptModel> {
     private T map(TranscriptionEntity transcriptionEntity) {
         T transcript = createNewTranscription();
         transcript.setTranscriptionId(transcriptionEntity.getId());
-        List<HearingEntity> hearings = transcriptionEntity.getHearings();
+        Set<HearingEntity> hearings = transcriptionEntity.getHearings();
         if (hearings.isEmpty()) {
             if (transcriptionEntity.getHearingDate() != null) {
                 transcript.setHearingDate(transcriptionEntity.getHearingDate());
             }
         } else {
-            HearingEntity hearing = hearings.getFirst();
+            HearingEntity hearing = transcriptionEntity.getHearing();
             transcript.setHearingId(hearing.getId());
             transcript.setHearingDate(hearing.getHearingDate());
         }

--- a/src/main/java/uk/gov/hmcts/darts/common/mapper/TranscriptionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/mapper/TranscriptionMapper.java
@@ -24,7 +24,7 @@ public abstract class TranscriptionMapper<T extends TranscriptModel> {
         return response;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     private T map(TranscriptionEntity transcriptionEntity) {
         T transcript = createNewTranscription();
         transcript.setTranscriptionId(transcriptionEntity.getId());

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/AnnotationRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/AnnotationRepository.java
@@ -17,7 +17,7 @@ public interface AnnotationRepository extends JpaRepository<AnnotationEntity, In
         SELECT ann
         FROM AnnotationEntity ann
          JOIN ann.annotationDocuments annDoc
-         JOIN ann.hearingList hearing
+         JOIN ann.hearings hearing
         WHERE hearing.id = :hearingId
         AND ann.deleted = false
         ORDER BY annDoc.uploadedDateTime DESC        
@@ -28,7 +28,7 @@ public interface AnnotationRepository extends JpaRepository<AnnotationEntity, In
         SELECT ann
         FROM AnnotationEntity ann
          JOIN ann.annotationDocuments annDoc
-         JOIN ann.hearingList hearing
+         JOIN ann.hearings hearing
         WHERE hearing.id = :hearingId
         AND ann.deleted = false
         AND ann.currentOwner = :userAccount
@@ -40,7 +40,7 @@ public interface AnnotationRepository extends JpaRepository<AnnotationEntity, In
         SELECT ann
         FROM AnnotationEntity ann
          JOIN ann.annotationDocuments annDoc
-         JOIN ann.hearingList hearing
+         JOIN ann.hearings hearing
         WHERE hearing.id in :hearingIds
         AND ann.deleted = false
         ORDER By hearing.hearingDate DESC        
@@ -51,7 +51,7 @@ public interface AnnotationRepository extends JpaRepository<AnnotationEntity, In
         SELECT ann
         FROM AnnotationEntity ann
          JOIN ann.annotationDocuments annDoc
-         JOIN ann.hearingList hearing
+         JOIN ann.hearings hearing
         WHERE hearing.id in :hearingIds
         AND ann.deleted = false
         AND ann.currentOwner = :userAccount

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
@@ -52,7 +52,7 @@ public interface HearingRepository extends JpaRepository<HearingEntity, Integer>
 
     @Query("""
         SELECT h FROM HearingEntity h
-        JOIN h.mediaList media
+        JOIN h.medias media
         WHERE media.id = :mediaId
         """
     )
@@ -108,7 +108,7 @@ public interface HearingRepository extends JpaRepository<HearingEntity, Integer>
     @Query("""
         SELECT hearing
         FROM HearingEntity hearing, CourtCaseEntity case
-        LEFT JOIN FETCH hearing.mediaList
+        LEFT JOIN FETCH hearing.medias
         WHERE case.id = :caseId
         AND hearing.courtCase = case
         """)

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
@@ -20,7 +20,7 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Integer>,
     @Query("""
            SELECT me
            FROM HearingEntity he
-           JOIN he.mediaList me
+           JOIN he.medias me
            WHERE he.id = :hearingId
            ORDER BY me.start
         """)
@@ -29,7 +29,7 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Integer>,
     @Query("""
            SELECT me
            FROM HearingEntity he
-           JOIN he.mediaList me
+           JOIN he.medias me
            WHERE he.id = :hearingId
            AND me.isCurrent = true
            ORDER BY me.start
@@ -40,7 +40,7 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Integer>,
            SELECT me
            FROM CourtCaseEntity ca
            JOIN ca.hearings he
-           JOIN he.mediaList me
+           JOIN he.medias me
            WHERE ca.id = :caseId
            ORDER BY me.start
         """)
@@ -49,7 +49,7 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Integer>,
     @Query("""
            SELECT me
            FROM HearingEntity he
-           JOIN he.mediaList me
+           JOIN he.medias me
            WHERE he.id = :hearingId
            AND me.channel = :channel
            AND me.isHidden = false
@@ -77,7 +77,7 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Integer>,
     @Query("""
         SELECT me
             FROM MediaEntity me
-            JOIN me.hearingList hearing
+            JOIN me.hearings hearing
         WHERE
             (:hearingIds IS NULL OR (:hearingIds IS NOT NULL AND hearing.id in (:hearingIds)))
             AND (cast(:endAt as TIMESTAMP) IS NULL OR (me.end <= :endAt))
@@ -122,7 +122,7 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Integer>,
     @Query("""
         SELECT distinct media
         FROM MediaEntity media
-        JOIN media.hearingList hearing
+        JOIN media.hearings hearing
         WHERE hearing.courtCase.id = :caseId
         """)
     List<MediaEntity> findByCaseIdWithMediaList(Integer caseId);

--- a/src/main/java/uk/gov/hmcts/darts/common/service/impl/HearingCommonServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/service/impl/HearingCommonServiceImpl.java
@@ -62,7 +62,7 @@ public class HearingCommonServiceImpl implements HearingCommonService {
         hearing.setCreatedBy(userAccount);
         hearing.setLastModifiedBy(userAccount);
         if (mediaEntity != null) {
-            hearing.getMediaList().add(mediaEntity);
+            hearing.getMedias().add(mediaEntity);
         }
         return hearingRepository.saveAndFlush(hearing);
     }

--- a/src/main/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingMapper.java
@@ -17,6 +17,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -81,7 +82,7 @@ public final class AdminHearingMapper {
     }
 
 
-    public static <R, P> List<R> asList(List<P> data, Function<P, R> mapperFunction) {
+    public static <R, P> List<R> asList(Collection<P> data, Function<P, R> mapperFunction) {
         if (data == null) {
             return new ArrayList<>();
         }

--- a/src/main/java/uk/gov/hmcts/darts/hearings/mapper/GetAnnotationsResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/mapper/GetAnnotationsResponseMapper.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.hearings.model.Annotation;
 import uk.gov.hmcts.darts.hearings.model.AnnotationDocument;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,14 +28,14 @@ public class GetAnnotationsResponseMapper {
         annotation.setAnnotationId(annotationEntity.getId());
         annotation.setAnnotationTs(annotationEntity.getTimestamp());
         annotation.setAnnotationText(annotationEntity.getText());
-        HearingEntity hearingEntity = findHearingInList(annotationEntity.getHearingList(), hearingId);
+        HearingEntity hearingEntity = findHearingInCollection(annotationEntity.getHearings(), hearingId);
         annotation.setHearingId(hearingEntity.getId());
         annotation.setHearingDate(hearingEntity.getHearingDate());
         annotation.setAnnotationDocuments(mapToAnnotationDocuments(annotationEntity.getAnnotationDocuments()));
         return annotation;
     }
 
-    private HearingEntity findHearingInList(List<HearingEntity> hearingEntities, Integer hearingId) {
+    private HearingEntity findHearingInCollection(Collection<HearingEntity> hearingEntities, Integer hearingId) {
         return hearingEntities
             .stream()
             .filter(hearing -> hearing.getId().equals(hearingId))

--- a/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImpl.java
@@ -32,6 +32,7 @@ import uk.gov.hmcts.darts.hearings.service.HearingsService;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -129,7 +130,7 @@ public class HearingsServiceImpl implements HearingsService {
                 return false;
             })
             .forEach(media -> {
-                List<HearingEntity> hearingEntities = media.getHearingList();
+                Set<HearingEntity> hearingEntities = media.getHearings();
                 hearingEntities.forEach(media::removeHearing);
                 mediaRepository.save(media);
                 hearingRepository.saveAll(hearingEntities);

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriptionRequestDetailsValidator.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriptionRequestDetailsValidator.java
@@ -53,7 +53,7 @@ public class TranscriptionRequestDetailsValidator implements Validator<Transcrip
     }
 
     private void checkAudioFileExistsAndTimesValid(TranscriptionRequestDetails transcriptionRequestDetails, HearingEntity hearing) {
-        if (isEmpty(hearing.getMediaList())) {
+        if (isEmpty(hearing.getMedias())) {
             log.error(
                 "Transcription could not be requested. No audio found for hearing id {}",
                 transcriptionRequestDetails.getHearingId()

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -161,7 +161,7 @@ public class TranscriptionResponseMapper {
         return Comparator.comparing(workflow -> ObjectUtils.defaultIfNull(workflow.getWorkflowTs(), OffsetDateTime.MIN));
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     public GetTranscriptionByIdResponse mapToTranscriptionResponse(TranscriptionEntity transcriptionEntity) {
         CourtCaseEntity courtCase = transcriptionEntity.getCourtCase();
         if (isNull(courtCase)) {
@@ -293,7 +293,7 @@ public class TranscriptionResponseMapper {
         return reportingRestriction;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     public GetTranscriptionDetailAdminResponse mapTransactionEntityToTransactionDetails(TranscriptionEntity transcriptionEntity) {
         GetTranscriptionDetailAdminResponse details = new GetTranscriptionDetailAdminResponse();
 
@@ -461,7 +461,7 @@ public class TranscriptionResponseMapper {
         return adminActionResponse;
     }
 
-    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
+    @SuppressWarnings("java:S1874")//Ticket (DMP-4972) has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     public AdminMarkedForDeletionResponseItem mapTranscriptionDocumentMarkedForDeletion(TranscriptionDocumentEntity transcriptionDocumentEntity) {
         TranscriptionEntity transcription = transcriptionDocumentEntity.getTranscription();
         HearingEntity hearingEntity = transcription.getHearing();

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -161,6 +161,7 @@ public class TranscriptionResponseMapper {
         return Comparator.comparing(workflow -> ObjectUtils.defaultIfNull(workflow.getWorkflowTs(), OffsetDateTime.MIN));
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     public GetTranscriptionByIdResponse mapToTranscriptionResponse(TranscriptionEntity transcriptionEntity) {
         CourtCaseEntity courtCase = transcriptionEntity.getCourtCase();
         if (isNull(courtCase)) {
@@ -292,6 +293,7 @@ public class TranscriptionResponseMapper {
         return reportingRestriction;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     public GetTranscriptionDetailAdminResponse mapTransactionEntityToTransactionDetails(TranscriptionEntity transcriptionEntity) {
         GetTranscriptionDetailAdminResponse details = new GetTranscriptionDetailAdminResponse();
 
@@ -459,6 +461,7 @@ public class TranscriptionResponseMapper {
         return adminActionResponse;
     }
 
+    @SuppressWarnings("java:S1874")//Ticket has been raised to remove instances where ManyToMany mappings are being treated as ManyToOne
     public AdminMarkedForDeletionResponseItem mapTranscriptionDocumentMarkedForDeletion(TranscriptionDocumentEntity transcriptionDocumentEntity) {
         TranscriptionEntity transcription = transcriptionDocumentEntity.getTranscription();
         HearingEntity hearingEntity = transcription.getHearing();

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -208,7 +208,7 @@ public class TranscriptionResponseMapper {
             transcriptionDocumentEntity -> transcriptionResponse.setTranscriptFileName(transcriptionDocumentEntity.getFileName()));
 
         if (CollectionUtils.isNotEmpty(transcriptionEntity.getHearings())) {
-            HearingEntity hearing = transcriptionEntity.getHearings().getFirst();
+            HearingEntity hearing = transcriptionEntity.getHearing();
             transcriptionResponse.setHearingId(hearing.getId());
             transcriptionResponse.setHearingDate(hearing.getHearingDate());
         } else {

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionDownloader.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionDownloader.java
@@ -38,13 +38,14 @@ public class TranscriptionDownloader {
     public DownloadTranscriptResponse downloadTranscript(Integer transcriptionId) {
         var userAccountEntity = getUserAccount();
         var userIsSuperAdmin = this.userIdentity.userHasGlobalAccess(Set.of(SUPER_ADMIN));
+        System.out.println("TMP: here 1");
         var transcriptionEntity = transcriptionRepository.findById(transcriptionId)
             // Only SUPER_ADMIN users are allowed to download hidden documents
             .filter(transcription -> userIsSuperAdmin
                 || transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcription.getId()).isEmpty()
             )
             .orElseThrow(() -> new DartsApiException(TRANSCRIPTION_NOT_FOUND));
-
+        System.out.println("TMP: here 2");
         // if the document is hidden and now deleted, this will successfully fail and not return the document
         var latestTranscriptionDocument = transcriptionEntity.getTranscriptionDocumentEntities()
             .stream()

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionDownloader.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionDownloader.java
@@ -38,14 +38,12 @@ public class TranscriptionDownloader {
     public DownloadTranscriptResponse downloadTranscript(Integer transcriptionId) {
         var userAccountEntity = getUserAccount();
         var userIsSuperAdmin = this.userIdentity.userHasGlobalAccess(Set.of(SUPER_ADMIN));
-        System.out.println("TMP: here 1");
         var transcriptionEntity = transcriptionRepository.findById(transcriptionId)
             // Only SUPER_ADMIN users are allowed to download hidden documents
             .filter(transcription -> userIsSuperAdmin
                 || transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcription.getId()).isEmpty()
             )
             .orElseThrow(() -> new DartsApiException(TRANSCRIPTION_NOT_FOUND));
-        System.out.println("TMP: here 2");
         // if the document is hidden and now deleted, this will successfully fail and not return the document
         var latestTranscriptionDocument = transcriptionEntity.getTranscriptionDocumentEntities()
             .stream()

--- a/src/test/java/uk/gov/hmcts/darts/arm/mapper/impl/AnnotationArchiveRecordMapperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/mapper/impl/AnnotationArchiveRecordMapperImplTest.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -54,7 +55,7 @@ class AnnotationArchiveRecordMapperImplTest {
 
         HearingEntity hearing = CommonTestDataUtil.createHearing("1001", LocalDate.of(2020, 10, 10));
 
-        annotationEntity.setHearingList(List.of(hearing));
+        annotationEntity.setHearings(Set.of(hearing));
         annotationEntity.setTimestamp(OffsetDateTime.of(2020, 10, 10, 10, 0, 0, 0, ZoneOffset.UTC));
         annotationEntity.setText("annotationText");
         annotationDocument = createAnnotationDocumentEntity(11);

--- a/src/test/java/uk/gov/hmcts/darts/arm/mapper/impl/TranscriptionArchiveRecordMapperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/mapper/impl/TranscriptionArchiveRecordMapperImplTest.java
@@ -19,7 +19,7 @@ import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
 import uk.gov.hmcts.darts.test.common.data.builder.TestExternalObjectDirectoryEntity;
 
 import java.time.OffsetDateTime;
-import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -95,7 +95,7 @@ class TranscriptionArchiveRecordMapperImplTest {
         CourtCaseEntity courtCase = new CourtCaseEntity();
         courtCase.setCourthouse(courthouse);
         TranscriptionEntity transcriptionEntity2 = new TranscriptionEntity();
-        transcriptionEntity2.setCourtCases(List.of(courtCase));
+        transcriptionEntity2.setCourtCases(Set.of(courtCase));
         TranscriptionDocumentEntity transcriptionDocumentEntity2 = new TranscriptionDocumentEntity();
         transcriptionDocumentEntity2.setTranscription(transcriptionEntity2);
         ExternalObjectDirectoryEntity externalObjectDirectory2 = new ExternalObjectDirectoryEntity();

--- a/src/test/java/uk/gov/hmcts/darts/audio/mapper/PostAdminMediaSearchResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/mapper/PostAdminMediaSearchResponseMapperTest.java
@@ -27,9 +27,9 @@ class PostAdminMediaSearchResponseMapperTest {
     @Test
     void multipleEntities() throws IOException {
         MediaEntity media = CommonTestDataUtil.createMedia("caseNumber1");
-        MediaEntity media2 = CommonTestDataUtil.createMedia(media.getHearingList().getFirst());
+        MediaEntity media2 = CommonTestDataUtil.createMedia(media.getHearing());
         media2.setStart(media2.getStart().plusMinutes(1));
-        MediaEntity media3 = CommonTestDataUtil.createMedia(media.getHearingList().getFirst());
+        MediaEntity media3 = CommonTestDataUtil.createMedia(media.getHearing());
         media3.setStart(media3.getStart().plusMinutes(2));
         List<PostAdminMediasSearchResponseItem> responseItemList = PostAdminMediaSearchResponseMapper.createResponseItemList(List.of(media, media2, media3));
 

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AdminMediaServiceImplTest.java
@@ -547,7 +547,7 @@ class AdminMediaServiceImplTest {
         mediaEntity.setStart(startDateTime);
         mediaEntity.setEnd(endDateTime);
 
-        mediaEntity.getHearingList().add(hearing);
+        mediaEntity.getHearings().add(hearing);
 
         when(mediaRepository.findMediaByDetails(List.of(hearing.getId()), null, null))
             .thenReturn(List.of(mediaEntity));
@@ -569,7 +569,7 @@ class AdminMediaServiceImplTest {
         mediaEntity.setChannel(6);
         mediaEntity.setStart(startDateTime);
         mediaEntity.setEnd(endDateTime);
-        mediaEntity.getHearingList().addAll(List.of(hearing, hearing2));
+        mediaEntity.getHearings().addAll(List.of(hearing, hearing2));
 
         when(mediaRepository.findMediaByDetails(List.of(hearing.getId(), hearing2.getId()), startDateTime, endDateTime))
             .thenReturn(List.of(mediaEntity));

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioAsyncServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioAsyncServiceImplTest.java
@@ -80,7 +80,7 @@ class AudioAsyncServiceImplTest {
 
         audioAsyncService.linkAudioToHearingByEvent(addAudioMetadataRequest, mediaEntity, userAccount);
         verify(hearingRepository, times(0)).saveAndFlush(any());
-        assertEquals(0, hearing.getMediaList().size());
+        assertEquals(0, hearing.getMedias().size());
     }
 
     @Test
@@ -104,7 +104,7 @@ class AudioAsyncServiceImplTest {
 
         audioAsyncService.linkAudioToHearingByEvent(addAudioMetadataRequest, mediaEntity, userAccount);
         verify(hearingRepository, times(1)).saveAndFlush(any());
-        assertEquals(1, hearing.getMediaList().size());
+        assertEquals(1, hearing.getMedias().size());
         verify(mediaLinkedCaseHelper).linkMediaToCase(mediaEntity, courtCase, MediaLinkedCaseSourceType.ADD_AUDIO_EVENT_LINKING, userAccount);
     }
 
@@ -130,7 +130,7 @@ class AudioAsyncServiceImplTest {
 
         audioAsyncService.linkAudioToHearingByEvent(addAudioMetadataRequest, mediaEntity, userAccount);
         verify(hearingRepository, times(1)).saveAndFlush(any());
-        assertEquals(1, hearing.getMediaList().size());
+        assertEquals(1, hearing.getMedias().size());
         verify(mediaLinkedCaseHelper).linkMediaToCase(mediaEntity, courtCase, MediaLinkedCaseSourceType.ADD_AUDIO_EVENT_LINKING, userAccount);
     }
 
@@ -160,7 +160,7 @@ class AudioAsyncServiceImplTest {
 
         // then
         verify(hearingRepository, times(1)).saveAndFlush(any());
-        assertEquals(1, hearing.getMediaList().size());
+        assertEquals(1, hearing.getMedias().size());
         verify(mediaLinkedCaseHelper).linkMediaToCase(mediaEntity, courtCase, MediaLinkedCaseSourceType.ADD_AUDIO_EVENT_LINKING, userAccount);
     }
 
@@ -183,7 +183,7 @@ class AudioAsyncServiceImplTest {
 
         audioAsyncService.linkAudioToHearingByEvent(addAudioMetadataRequest, mediaEntity, userAccount);
         verify(hearingRepository, times(1)).saveAndFlush(any());
-        assertEquals(1, hearing.getMediaList().size());
+        assertEquals(1, hearing.getMedias().size());
         assertTrue(hearing.getHearingIsActual());
     }
 
@@ -210,7 +210,7 @@ class AudioAsyncServiceImplTest {
 
         audioAsyncService.linkAudioToHearingByEvent(addAudioMetadataRequest, mediaEntity, userAccount);
         verify(hearingRepository, times(1)).saveAndFlush(any());
-        assertEquals(1, hearing.getMediaList().size());
+        assertEquals(1, hearing.getMedias().size());
     }
 
     private MediaEntity createMediaEntity(OffsetDateTime startedAt, OffsetDateTime endedAt) {

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioUploadServiceImplTest.java
@@ -182,9 +182,9 @@ class AudioUploadServiceImplTest {
         )).thenReturn(hearing3);
         audioService.linkAudioToHearingInMetadata(addAudioMetadataRequest, mediaEntity);
         verify(hearingRepository, times(3)).saveAndFlush(any());
-        assertEquals(1, hearing1.getMediaList().size());
-        assertEquals(1, hearing2.getMediaList().size());
-        assertEquals(1, hearing3.getMediaList().size());
+        assertEquals(1, hearing1.getMedias().size());
+        assertEquals(1, hearing2.getMedias().size());
+        assertEquals(1, hearing3.getMedias().size());
     }
 
     @Test
@@ -221,9 +221,9 @@ class AudioUploadServiceImplTest {
         )).thenReturn(hearing3);
         audioService.linkAudioToHearingInMetadata(addAudioMetadataRequest, mediaEntity);
         verify(hearingRepository, times(3)).saveAndFlush(any());
-        assertEquals(1, hearing1.getMediaList().size());
-        assertEquals(1, hearing2.getMediaList().size());
-        assertEquals(1, hearing3.getMediaList().size());
+        assertEquals(1, hearing1.getMedias().size());
+        assertEquals(1, hearing2.getMedias().size());
+        assertEquals(1, hearing3.getMedias().size());
         assertTrue(hearing2.getHearingIsActual());
     }
 
@@ -449,8 +449,8 @@ class AudioUploadServiceImplTest {
 
         audioService.addAudio(blobId, addAudioMetadataRequest);
         verify(hearingRepository, times(2)).saveAndFlush(any());
-        assertEquals(1, hearing1.getMediaList().size());
-        assertEquals(1, hearing2.getMediaList().size());
+        assertEquals(1, hearing1.getMedias().size());
+        assertEquals(1, hearing2.getMedias().size());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearingTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearingTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionDocumentEntity;
 import uk.gov.hmcts.darts.common.repository.TranscriptionDocumentRepository;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -63,7 +64,7 @@ class HearingEntityToCaseHearingTest {
             "Tests/cases/HearingEntityToCaseHearingTest/testWithSingleHearing/expectedResponse.json");
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
 
-        var transcriptionId = hearings.getFirst().getTranscriptions().getFirst().getId();
+        var transcriptionId = TestUtils.getFirst(hearings.getFirst().getTranscriptions()).getId();
         verify(transcriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionId);
     }
 
@@ -85,9 +86,9 @@ class HearingEntityToCaseHearingTest {
     @Test
     void testMappingToHearingsWithAutomatedTranscripts() {
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(1);
-        var hearingTranscripts = hearings.getFirst().getTranscriptions();
-        hearingTranscripts.getFirst().setIsManualTranscription(false);
-        hearingTranscripts.getFirst().setLegacyObjectId(null);
+        var hearingTranscript = TestUtils.getFirst(hearings.getFirst().getTranscriptions());
+        hearingTranscript.setIsManualTranscription(false);
+        hearingTranscript.setLegacyObjectId(null);
 
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
@@ -98,8 +99,8 @@ class HearingEntityToCaseHearingTest {
     @Test
     void testMappingToHearingsWithLegacyTranscripts() {
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(5);
-        var hearingTranscripts = hearings.getFirst().getTranscriptions();
-        hearingTranscripts.getFirst().setLegacyObjectId("something");
+        var hearingTranscript = TestUtils.getFirst(hearings.getFirst().getTranscriptions());
+        hearingTranscript.setLegacyObjectId("something");
 
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
@@ -110,9 +111,9 @@ class HearingEntityToCaseHearingTest {
     @Test
     void testMappingToHearingsWithLegacyAutomatedTranscripts() {
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(5);
-        var hearingTranscripts = hearings.getFirst().getTranscriptions();
-        hearingTranscripts.getFirst().setIsManualTranscription(false);
-        hearingTranscripts.getFirst().setLegacyObjectId("something");
+        var hearingTranscript = TestUtils.getFirst(hearings.getFirst().getTranscriptions());
+        hearingTranscript.setIsManualTranscription(false);
+        hearingTranscript.setLegacyObjectId("something");
 
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
@@ -127,13 +128,13 @@ class HearingEntityToCaseHearingTest {
 
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(1);
         var hearingTranscripts = hearings.getFirst().getTranscriptions();
-        var transcriptDocs = hearingTranscripts.getFirst().getTranscriptionDocumentEntities();
+        var transcriptDocs = TestUtils.getOrderedByCreatedByAndId(hearingTranscripts).getFirst().getTranscriptionDocumentEntities();
         transcriptDocs.getFirst().setHidden(true);
 
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(0, hearingList.getFirst().getTranscriptCount());
-        var transcriptionId = hearings.getFirst().getTranscriptions().getFirst().getId();
+        var transcriptionId = TestUtils.getOrderedByCreatedByAndId(hearings.getFirst().getTranscriptions()).getFirst().getId();
         verify(transcriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionId);
     }
 
@@ -144,7 +145,7 @@ class HearingEntityToCaseHearingTest {
 
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(1);
         var hearingTranscripts = hearings.getFirst().getTranscriptions();
-        var transcriptDocs = hearingTranscripts.getFirst().getTranscriptionDocumentEntities();
+        var transcriptDocs = TestUtils.getFirst(hearingTranscripts).getTranscriptionDocumentEntities();
         var transcriptionDocumentEntity = new TranscriptionDocumentEntity();
         transcriptionDocumentEntity.setFileName("test2.doc");
         transcriptionDocumentEntity.setHidden(true);
@@ -153,14 +154,14 @@ class HearingEntityToCaseHearingTest {
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
 
         assertEquals(0, hearingList.getFirst().getTranscriptCount());
-        var transcriptionId = hearings.getFirst().getTranscriptions().getFirst().getId();
+        var transcriptionId = TestUtils.getFirst(hearings.getFirst().getTranscriptions()).getId();
         verify(transcriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionId);
     }
 
     @Test
     void mapToHearingList_shouldNotIncludeNonCurrentTranscriptions() {
         List<HearingEntity> hearings = CommonTestDataUtil.createHearings(1);
-        hearings.getFirst().getTranscriptions().getFirst().setIsCurrent(false);
+        TestUtils.getFirst(hearings.getFirst().getTranscriptions()).setIsCurrent(false);
 
         List<Hearing> hearingList = HearingEntityToCaseHearing.mapToHearingList(hearings, transcriptionDocumentRepository);
         assertEquals(1, hearingList.size());

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearingTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearingTest.java
@@ -61,7 +61,7 @@ class HearingEntityToCaseHearingTest {
 
         String expectedResponse = getContentsFromFile(
             "Tests/cases/HearingEntityToCaseHearingTest/testWithSingleHearing/expectedResponse.json");
-        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
 
         var transcriptionId = hearings.getFirst().getTranscriptions().getFirst().getId();
         verify(transcriptionDocumentRepository).findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionId);
@@ -77,7 +77,7 @@ class HearingEntityToCaseHearingTest {
 
         String expectedResponse = getContentsFromFile(
             "Tests/cases/HearingEntityToCaseHearingTest/testWithMultipleHearings/expectedResponse.json");
-        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.STRICT);
+        JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
 
         verify(transcriptionDocumentRepository, times(hearings.size())).findByTranscriptionIdAndHiddenTrueIncludeDeleted(anyInt());
     }

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/TranscriptionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/TranscriptionMapperTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionTypeEntity;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum;
 import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionTypeEnum;
 
@@ -17,6 +18,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -33,7 +35,7 @@ class TranscriptionMapperTest {
     @Test
     void happyPath() {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, true, true);
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, true, true);
 
         List<Transcript> transcripts = caseTranscriptionMapper.getTranscriptList(caseTranscriptionMapper.mapResponse(transcriptionList));
         Transcript transcript = transcripts.getFirst();
@@ -78,9 +80,9 @@ class TranscriptionMapperTest {
     @Test
     void happyPathDoNotIncludeTranscriptionsIsCurrentFalse() {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1);
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1);
 
-        transcriptionList.getFirst().setIsCurrent(false);
+        TestUtils.getFirst(transcriptionList).setIsCurrent(false);
 
         List<Transcript> transcripts = caseTranscriptionMapper.getTranscriptList(caseTranscriptionMapper.mapResponse(transcriptionList));
         assertEquals(0, transcripts.size());

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/HearingEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/HearingEntityTest.java
@@ -3,8 +3,9 @@ package uk.gov.hmcts.darts.common.entity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,14 +14,14 @@ class HearingEntityTest {
     @Test
     void positiveContainsMedia() {
         HearingEntity hearing = new HearingEntity();
-        hearing.setMediaList(List.of(createMedia(1), createMedia(2), createMedia(3)));
+        hearing.setMedias(Set.of(createMedia(1), createMedia(2), createMedia(3)));
         Assertions.assertTrue(hearing.containsMedia(createMedia(1)));
     }
 
     @Test
     void negativeContainsHearing() {
         HearingEntity hearing = new HearingEntity();
-        hearing.setMediaList(List.of(createMedia(1), createMedia(2), createMedia(3)));
+        hearing.setMedias(Set.of(createMedia(1), createMedia(2), createMedia(3)));
         Assertions.assertFalse(hearing.containsMedia(createMedia(4)));
 
     }
@@ -28,23 +29,24 @@ class HearingEntityTest {
     @Test
     void addMedia() {
         HearingEntity hearing = new HearingEntity();
-        hearing.setMediaList(new ArrayList<>(List.of(createMedia(1), createMedia(2), createMedia(3))));
+        hearing.setMedias(new HashSet<>(List.of(createMedia(1), createMedia(2), createMedia(3))));
 
-        assertThat(hearing.getMediaList()).hasSize(3);
-        List<MediaEntity> mediaEntities = hearing.getMediaList();
-        assertThat(mediaEntities.getFirst().getId()).isEqualTo(1);
-        assertThat(mediaEntities.get(1).getId()).isEqualTo(2);
-        assertThat(mediaEntities.get(2).getId()).isEqualTo(3);
+        assertThat(hearing.getMedias()).hasSize(3);
+        assertThat(hearing.getMedias()
+                       .stream()
+                       .map(mediaEntity -> mediaEntity.getId())
+                       .toList())
+            .containsExactlyInAnyOrder(1, 2, 3);
 
         MediaEntity media = createMedia(4);
         hearing.addMedia(media);
-        assertThat(hearing.getMediaList()).hasSize(4);
+        assertThat(hearing.getMedias()).hasSize(4);
 
-        mediaEntities = hearing.getMediaList();
-        assertThat(mediaEntities.getFirst().getId()).isEqualTo(1);
-        assertThat(mediaEntities.get(1).getId()).isEqualTo(2);
-        assertThat(mediaEntities.get(2).getId()).isEqualTo(3);
-        assertThat(mediaEntities.get(3).getId()).isEqualTo(4);
+        assertThat(hearing.getMedias()
+                       .stream()
+                       .map(mediaEntity -> mediaEntity.getId())
+                       .toList())
+            .containsExactlyInAnyOrder(1, 2, 3, 4);
     }
 
     private MediaEntity createMedia(int id) {

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/MediaEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/MediaEntityTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -106,10 +107,10 @@ class MediaEntityTest {
     void addHearing_shouldAddHearing_whenMediaDoesNotContainHearing() {
         MediaEntity media = new MediaEntity();
         HearingEntity hearing = mock(HearingEntity.class);
-        assertThat(media.getHearingList()).isEmpty();
+        assertThat(media.getHearings()).isEmpty();
 
         media.addHearing(hearing);
-        assertThat(media.getHearingList())
+        assertThat(media.getHearings())
             .hasSize(1)
             .contains(hearing);
     }
@@ -118,12 +119,12 @@ class MediaEntityTest {
     void addHearing_shouldNotAddHearing_whenMediaAlreadyContainsHearing() {
         MediaEntity media = new MediaEntity();
         HearingEntity hearing = mock(HearingEntity.class);
-        media.setHearingList(List.of(hearing));
-        assertThat(media.getHearingList())
+        media.setHearings(Set.of(hearing));
+        assertThat(media.getHearings())
             .hasSize(1)
             .contains(hearing);
         media.addHearing(hearing);
-        assertThat(media.getHearingList())
+        assertThat(media.getHearings())
             .hasSize(1)
             .contains(hearing);
         verify(hearing, never()).addMedia(any());

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/TranscriptionEntityTest.java
@@ -2,7 +2,8 @@ package uk.gov.hmcts.darts.common.entity;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.time.OffsetDateTime;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -15,10 +16,10 @@ class TranscriptionEntityTest {
         var courtCase = new CourtCaseEntity();
         var hearingCourtCase = new CourtCaseEntity();
         var transcription = new TranscriptionEntity();
-        transcription.setCourtCases(List.of(courtCase));
+        transcription.setCourtCases(Set.of(courtCase));
         var hearing = new HearingEntity();
         hearing.setCourtCase(hearingCourtCase);
-        transcription.setHearings(List.of(hearing));
+        transcription.setHearings(Set.of(hearing));
         assertEquals(hearingCourtCase, transcription.getCourtCase());
     }
 
@@ -26,14 +27,23 @@ class TranscriptionEntityTest {
     void testGetCourtCaseViaHearingMultiple() {
         var courtCase = new CourtCaseEntity();
         var hearingCourtCase1 = new CourtCaseEntity();
+        hearingCourtCase1.setId(1);
+        hearingCourtCase1.setCreatedDateTime(OffsetDateTime.now());
         var hearingCourtCase2 = new CourtCaseEntity();
+        hearingCourtCase2.setId(2);
+        hearingCourtCase2.setCreatedDateTime(OffsetDateTime.now());
         var transcription = new TranscriptionEntity();
-        transcription.setCourtCases(List.of(courtCase));
+        transcription.setCourtCases(Set.of(courtCase));
         var hearing1 = new HearingEntity();
+        hearing1.setId(1);
+        hearing1.setCreatedDateTime(OffsetDateTime.now());
         var hearing2 = new HearingEntity();
+        hearing2.setId(2);
+        hearing2.setCreatedDateTime(OffsetDateTime.now());
+
         hearing1.setCourtCase(hearingCourtCase1);
         hearing2.setCourtCase(hearingCourtCase2);
-        transcription.setHearings(List.of(hearing1, hearing2));
+        transcription.setHearings(Set.of(hearing1, hearing2));
         assertEquals(hearingCourtCase1, transcription.getCourtCase());
     }
 
@@ -41,16 +51,20 @@ class TranscriptionEntityTest {
     void testGetCourtCaseDirect() {
         var courtCase = new CourtCaseEntity();
         var transcription = new TranscriptionEntity();
-        transcription.setCourtCases(List.of(courtCase));
+        transcription.setCourtCases(Set.of(courtCase));
         assertEquals(courtCase, transcription.getCourtCase());
     }
 
     @Test
     void testGetCourtCaseDirectMultiple() {
         var courtCase1 = new CourtCaseEntity();
+        courtCase1.setId(1);
+        courtCase1.setCreatedDateTime(OffsetDateTime.now());
         var courtCase2 = new CourtCaseEntity();
+        courtCase2.setId(2);
+        courtCase2.setCreatedDateTime(OffsetDateTime.now());
         var transcription = new TranscriptionEntity();
-        transcription.setCourtCases(List.of(courtCase1, courtCase2));
+        transcription.setCourtCases(Set.of(courtCase1, courtCase2));
         assertEquals(courtCase1, transcription.getCourtCase());
     }
 
@@ -66,21 +80,26 @@ class TranscriptionEntityTest {
         var transcription = new TranscriptionEntity();
         var hearing = new HearingEntity();
         hearing.setCourtroom(courtRoom);
-        transcription.setHearings(List.of(hearing));
+        transcription.setHearings(Set.of(hearing));
         assertEquals(courtRoom, transcription.getCourtroom());
     }
 
     @Test
     void testGetCourtRoomViaHearingMultipleWithSetHearing() {
-        var transcription = new TranscriptionEntity();
-        var courtRoom1 = new CourtroomEntity();
-        var courtRoom2 = new CourtroomEntity();
-        var hearing1 = new HearingEntity();
-        var hearing2 = new HearingEntity();
+        final var transcription = new TranscriptionEntity();
+        final var courtRoom1 = new CourtroomEntity();
+        final var courtRoom2 = new CourtroomEntity();
+        final var hearing1 = new HearingEntity();
+        hearing1.setId(1);
+        hearing1.setCreatedDateTime(OffsetDateTime.now());
+        final var hearing2 = new HearingEntity();
+        hearing2.setId(2);
+        hearing2.setCreatedDateTime(OffsetDateTime.now());
+
         hearing1.setCourtroom(courtRoom1);
         hearing2.setCourtroom(courtRoom2);
-        transcription.setHearings(List.of(hearing2, hearing1));
-        assertEquals(courtRoom2, transcription.getCourtroom());
+        transcription.setHearings(Set.of(hearing2, hearing1));
+        assertEquals(courtRoom1, transcription.getCourtroom());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/service/impl/DataAnonymisationServiceImplTest.java
@@ -329,7 +329,7 @@ class DataAnonymisationServiceImplTest {
 
         TranscriptionEntity transcriptionEntity1 = mock(TranscriptionEntity.class);
         TranscriptionEntity transcriptionEntity2 = mock(TranscriptionEntity.class);
-        hearingEntity.setTranscriptions(List.of(transcriptionEntity1, transcriptionEntity2));
+        hearingEntity.setTranscriptions(Set.of(transcriptionEntity1, transcriptionEntity2));
 
         EventEntity entityEntity1 = mock(EventEntity.class);
         EventEntity entityEntity2 = mock(EventEntity.class);
@@ -410,15 +410,15 @@ class DataAnonymisationServiceImplTest {
         MediaRequestEntity hearing1MediaRequestEntity1 = new MediaRequestEntity();
         MediaRequestEntity hearing1MediaRequestEntity2 = new MediaRequestEntity();
         MediaRequestEntity hearing1MediaRequestEntity3 = new MediaRequestEntity();
-        hearingEntity1.setMediaRequests(List.of(hearing1MediaRequestEntity1, hearing1MediaRequestEntity2, hearing1MediaRequestEntity3));
+        hearingEntity1.setMediaRequests(Set.of(hearing1MediaRequestEntity1, hearing1MediaRequestEntity2, hearing1MediaRequestEntity3));
 
         MediaRequestEntity hearing2MediaRequestEntity1 = new MediaRequestEntity();
         MediaRequestEntity hearing2MediaRequestEntity2 = new MediaRequestEntity();
         MediaRequestEntity hearing2MediaRequestEntity3 = new MediaRequestEntity();
-        hearingEntity2.setMediaRequests(List.of(hearing2MediaRequestEntity1, hearing2MediaRequestEntity2, hearing2MediaRequestEntity3));
+        hearingEntity2.setMediaRequests(Set.of(hearing2MediaRequestEntity1, hearing2MediaRequestEntity2, hearing2MediaRequestEntity3));
 
         MediaRequestEntity hearing3MediaRequestEntity1 = new MediaRequestEntity();
-        hearingEntity3.setMediaRequests(List.of(hearing3MediaRequestEntity1, hearing1MediaRequestEntity1, hearing2MediaRequestEntity2));
+        hearingEntity3.setMediaRequests(Set.of(hearing3MediaRequestEntity1, hearing1MediaRequestEntity1, hearing2MediaRequestEntity2));
 
         doNothing().when(dataAnonymisationService).expiredMediaRequest(any(), any());
         doNothing().when(dataAnonymisationService).deleteTransformedMediaEntity(any());

--- a/src/test/java/uk/gov/hmcts/darts/common/service/impl/HearingServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/service/impl/HearingServiceImplTest.java
@@ -155,7 +155,7 @@ class HearingServiceImplTest {
             .thenReturn(Optional.empty());
 
         assertThat(hearingService.linkAudioToHearings(courtCase, media)).isFalse();
-        assertThat(hearing.getMediaList()).isEmpty();
+        assertThat(hearing.getMedias()).isEmpty();
         verify(hearingRepository, never()).saveAndFlush(any());
         verify(hearingRepository).findHearing(
             courtCase,
@@ -178,7 +178,7 @@ class HearingServiceImplTest {
 
         assertThat(hearingService.linkAudioToHearings(courtCase, media)).isTrue();
 
-        assertThat(hearing.getMediaList())
+        assertThat(hearing.getMedias())
             .hasSize(1)
             .contains(media);
         assertThat(hearing.getHearingIsActual()).isTrue();

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -41,6 +41,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -427,8 +428,8 @@ public class CommonTestDataUtil {
         return userAccount;
     }
 
-    public List<JudgeEntity> createJudges(int numOfJudges) {
-        List<JudgeEntity> returnList = new ArrayList<>();
+    public Set<JudgeEntity> createJudges(int numOfJudges) {
+        Set<JudgeEntity> returnList = new HashSet<>();
         for (int counter = 1; counter <= numOfJudges; counter++) {
             returnList.add(createJudge("Judge_" + counter));
         }

--- a/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/util/CommonTestDataUtil.java
@@ -257,7 +257,7 @@ public class CommonTestDataUtil {
         hearing1.setHearingDate(date);
         hearing1.setScheduledStartTime(time);
         hearing1.setId(102);
-        hearing1.setTranscriptions(createTranscriptionList(hearing1));
+        hearing1.setTranscriptions(createTranscriptions(hearing1));
         hearing1.addJudges(createJudges(2));
         return hearing1;
     }
@@ -269,7 +269,7 @@ public class CommonTestDataUtil {
         mediaEntity.setStart(startTime);
         mediaEntity.setEnd(startTime.plusHours(1));
         mediaEntity.setChannel(1);
-        mediaEntity.setHearingList(new ArrayList<>(List.of(hearing)));
+        mediaEntity.setHearings(new HashSet<>(List.of(hearing)));
         mediaEntity.setCourtroom(hearing.getCourtroom());
         mediaEntity.setId(getStringId("MEDIA_ID" + caseNumber));
         return mediaEntity;
@@ -280,40 +280,42 @@ public class CommonTestDataUtil {
         return createMedia(hearing);
     }
 
-    public MediaEntity createMedia(List<HearingEntity> hearings, int mediaId) {
-        var hearing = hearings.getFirst();
+    public MediaEntity createMedia(Set<HearingEntity> hearings, int mediaId) {
+        var hearing = hearings.stream()
+            .sorted((o1, o2) -> o2.getCreatedDateTime().compareTo(o1.getCreatedDateTime()))
+            .findFirst().get();
         MediaEntity mediaEntity = new MediaEntity();
         OffsetDateTime startTime = OffsetDateTime.of(hearing.getHearingDate(), hearing.getScheduledStartTime(), UTC);
         mediaEntity.setStart(startTime);
         mediaEntity.setEnd(startTime.plusHours(1));
         mediaEntity.setChannel(1);
-        mediaEntity.setHearingList(hearings);
+        mediaEntity.setHearings(hearings);
         mediaEntity.setCourtroom(hearing.getCourtroom());
         mediaEntity.setId(mediaId);
         return mediaEntity;
     }
 
-    public List<TranscriptionEntity> createTranscriptionList(HearingEntity hearing) {
-        return createTranscriptionList(hearing, true, true, true, null);
+    public Set<TranscriptionEntity> createTranscriptions(HearingEntity hearing) {
+        return createTranscriptions(hearing, true, true, true, null);
     }
 
-    public List<TranscriptionEntity> createTranscriptionList(HearingEntity hearing, boolean generateStatus) {
-        return createTranscriptionList(hearing, generateStatus, true, false, null);
+    public Set<TranscriptionEntity> createTranscriptions(HearingEntity hearing, boolean generateStatus) {
+        return createTranscriptions(hearing, generateStatus, true, false, null);
     }
 
-    public List<TranscriptionEntity> createTranscriptionList(HearingEntity hearing, boolean generateStatus, boolean excludeWorkflow) {
-        return createTranscriptionList(hearing, generateStatus, excludeWorkflow, false, null);
+    public Set<TranscriptionEntity> createTranscriptions(HearingEntity hearing, boolean generateStatus, boolean excludeWorkflow) {
+        return createTranscriptions(hearing, generateStatus, excludeWorkflow, false, null);
     }
 
-    public List<TranscriptionEntity> createTranscriptionList(
+    public Set<TranscriptionEntity> createTranscriptions(
         HearingEntity hearing,
         boolean generateStatus,
         boolean excludeWorkflow,
         boolean generateRequestor) {
-        return createTranscriptionList(hearing, generateStatus, excludeWorkflow, generateRequestor, null);
+        return createTranscriptions(hearing, generateStatus, excludeWorkflow, generateRequestor, null);
     }
 
-    public List<TranscriptionEntity> createTranscriptionList(
+    public Set<TranscriptionEntity> createTranscriptions(
         HearingEntity hearing,
         boolean generateStatus,
         boolean excludeWorkflow,
@@ -357,7 +359,7 @@ public class CommonTestDataUtil {
             transcription.setTranscriptionStatus(transcriptionStatus);
         }
 
-        return List.of(transcription);
+        return Set.of(transcription);
     }
 
     private static List<TranscriptionDocumentEntity> createTranscriptionDocuments() {

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingMapperTest.java
@@ -24,6 +24,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -67,7 +68,7 @@ class AdminHearingMapperTest {
         hearingEntity.setCourtCase(courtCaseEntity);
         CourtroomEntity courtroomEntity = mock(CourtroomEntity.class);
         hearingEntity.setCourtroom(courtroomEntity);
-        hearingEntity.setJudges(List.of(
+        hearingEntity.setJudges(Set.of(
             craeteJudges("judges1"),
             craeteJudges("judges2"),
             craeteJudges("judges3")
@@ -89,7 +90,7 @@ class AdminHearingMapperTest {
         assertThat(hearingsResponse.getHearingIsActual()).isTrue();
         assertThat(hearingsResponse.getCase()).isEqualTo(hearingsResponseCase);
         assertThat(hearingsResponse.getCourtroom()).isEqualTo(hearingsResponseCourtroom);
-        assertThat(hearingsResponse.getJudges()).hasSize(3).containsExactly("judges1", "judges2", "judges3");
+        assertThat(hearingsResponse.getJudges()).hasSize(3).containsExactlyInAnyOrder("judges1", "judges2", "judges3");
         assertThat(hearingsResponse.getCreatedAt()).isEqualTo(cratedDate);
         assertThat(hearingsResponse.getCreatedBy()).isEqualTo(3);
         assertThat(hearingsResponse.getLastModifiedAt()).isEqualTo(updatedDate);
@@ -124,7 +125,7 @@ class AdminHearingMapperTest {
             craeteDefenders("efenders2"),
             craeteDefenders("efenders3")
         ));
-        courtCaseEntity.setJudges(List.of(
+        courtCaseEntity.setJudges(Set.of(
             craeteJudges("judges1"),
             craeteJudges("judges2"),
             craeteJudges("judges3")
@@ -141,7 +142,7 @@ class AdminHearingMapperTest {
         assertThat(hearingsResponseCase.getDefendants()).hasSize(3).containsExactly("defendant1", "defendant2", "defendant3");
         assertThat(hearingsResponseCase.getProsecutors()).hasSize(3).containsExactly("prosecutors1", "prosecutors2", "prosecutors3");
         assertThat(hearingsResponseCase.getDefenders()).hasSize(3).containsExactly("efenders1", "efenders2", "efenders3");
-        assertThat(hearingsResponseCase.getJudges()).hasSize(3).containsExactly("judges1", "judges2", "judges3");
+        assertThat(hearingsResponseCase.getJudges()).hasSize(3).containsExactlyInAnyOrder("judges1", "judges2", "judges3");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/GetAnnotationsResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/GetAnnotationsResponseMapperTest.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,7 +27,7 @@ class GetAnnotationsResponseMapperTest {
 
         HearingEntity hearing = CommonTestDataUtil.createHearing("1001", LocalDate.of(2020, 10, 10));
 
-        annotationEntity1.setHearingList(List.of(hearing));
+        annotationEntity1.setHearings(Set.of(hearing));
         annotationEntity1.setTimestamp(OffsetDateTime.of(2020, 10, 10, 10, 0, 0, 0, ZoneOffset.UTC));
         annotationEntity1.setText("annotationText");
         AnnotationDocumentEntity annotationDoc1a = createAnnotationDocumentEntity(11);
@@ -39,7 +40,7 @@ class GetAnnotationsResponseMapperTest {
         annotationEntity2.setId(1002);
         annotationEntity2.setCurrentOwner(userAccount);
 
-        annotationEntity2.setHearingList(List.of(hearing));
+        annotationEntity2.setHearings(Set.of(hearing));
         annotationEntity2.setTimestamp(OffsetDateTime.of(2020, 10, 10, 10, 0, 0, 0, ZoneOffset.UTC));
         annotationEntity2.setText("annotationText");
         AnnotationDocumentEntity annotationDoc2a = createAnnotationDocumentEntity(21);

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/GetHearingResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/GetHearingResponseMapperTest.java
@@ -15,8 +15,8 @@ import uk.gov.hmcts.darts.hearings.model.GetHearingResponse;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Collections;
-import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,7 +46,8 @@ class GetHearingResponseMapperTest {
         assertEquals(response.getHearingDate(), LocalDate.of(2023, 6, 20));
         assertEquals(response.getCaseNumber(), "TestCase");
         assertEquals(response.getCaseId(), 101);
-        assertEquals(response.getJudges(), List.of("Judge_1", "Judge_2"));
+        assertThat(response.getJudges())
+            .containsExactlyInAnyOrder("Judge_1", "Judge_2");
         assertEquals(response.getTranscriptionCount(), 1);
         assertEquals(0, response.getCaseReportingRestrictions().size());
     }

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/GetHearingResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/GetHearingResponseMapperTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.repository.HearingReportingRestrictionsRepository;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
 import uk.gov.hmcts.darts.hearings.model.GetHearingResponse;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -55,7 +56,7 @@ class GetHearingResponseMapperTest {
     @Test
     void getHearingResponseMapper_shouldNotIncludeNonCurrentTranscriptions() {
         HearingEntity hearing = CommonTestDataUtil.createHearing("TestCase", LocalTime.of(10, 0, 0));
-        hearing.getTranscriptions().getFirst().setIsCurrent(false);
+        TestUtils.getFirst(hearing.getTranscriptions()).setIsCurrent(false);
 
         GetHearingResponse response = getHearingResponseMapper.map(hearing);
         assertEquals(response.getTranscriptionCount(), 0);

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/TranscriptionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/TranscriptionMapperTest.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionTypeEntity;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
 import uk.gov.hmcts.darts.hearings.model.Transcript;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum;
 import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionTypeEnum;
 
@@ -16,6 +17,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -31,7 +33,7 @@ class TranscriptionMapperTest {
     @Test
     void happyPath() {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1);
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1);
 
         List<Transcript> transcripts = hearingTranscriptionMapper.getTranscriptList(hearingTranscriptionMapper.mapResponse(transcriptionList));
         Transcript transcript = transcripts.getFirst();
@@ -77,9 +79,9 @@ class TranscriptionMapperTest {
     @Test
     void happyPathDoNotIncludeTranscriptionsIsCurrentFalse() {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1);
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1);
 
-        transcriptionList.getFirst().setIsCurrent(false);
+        TestUtils.getFirst(transcriptionList).setIsCurrent(false);
 
         List<Transcript> transcripts = hearingTranscriptionMapper.getTranscriptList(hearingTranscriptionMapper.mapResponse(transcriptionList));
         assertEquals(0, transcripts.size());

--- a/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/service/impl/HearingsServiceImplTest.java
@@ -29,9 +29,10 @@ import uk.gov.hmcts.darts.hearings.mapper.HearingTranscriptionMapper;
 import uk.gov.hmcts.darts.hearings.model.EventResponse;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -162,8 +163,8 @@ class HearingsServiceImplTest {
     @Test
     void removeMediaLinkToHearing_shouldRemoveLinkToHearing_whenAllAssociatedCasesAreAnonymised() {
         MediaEntity mediaEntity = CommonTestDataUtil.createMedia("T1234");
-        HearingEntity hearingEntity = mediaEntity.getHearingList().getFirst();
-        hearingEntity.setMediaList(new ArrayList<>(List.of(mediaEntity)));
+        HearingEntity hearingEntity = mediaEntity.getHearing();
+        hearingEntity.setMedias(new HashSet<>(List.of(mediaEntity)));
 
         when(mediaRepository.findByCaseIdWithMediaList(hearingEntity.getCourtCase().getId())).thenReturn(List.of(mediaEntity));
         when(mediaLinkedCaseRepository.areAllAssociatedCasesAnonymised(any())).thenReturn(true);
@@ -175,8 +176,8 @@ class HearingsServiceImplTest {
     @Test
     void removeMediaLinkToHearing_shouldNotRemoveLinkToHearing_whenAllAssociatedCasesAreNotAnonymised() {
         MediaEntity mediaEntity = CommonTestDataUtil.createMedia("T1234");
-        HearingEntity hearingEntity = mediaEntity.getHearingList().getFirst();
-        hearingEntity.setMediaList(List.of(mediaEntity));
+        HearingEntity hearingEntity = mediaEntity.getHearing();
+        hearingEntity.setMedias(Set.of(mediaEntity));
 
         when(mediaRepository.findByCaseIdWithMediaList(hearingEntity.getCourtCase().getId())).thenReturn(List.of(mediaEntity));
         when(mediaLinkedCaseRepository.areAllAssociatedCasesAnonymised(any())).thenReturn(false);
@@ -188,7 +189,7 @@ class HearingsServiceImplTest {
     @Test
     void removeMediaLinkToHearing_shouldDoNothing_whenHearingsWithNoMediaExistsToUnlink() {
         MediaEntity mediaEntity = CommonTestDataUtil.createMedia("T1234");
-        HearingEntity hearingEntity = mediaEntity.getHearingList().getFirst();
+        HearingEntity hearingEntity = mediaEntity.getHearing();
 
         when(mediaRepository.findByCaseIdWithMediaList(hearingEntity.getCourtCase().getId())).thenReturn(List.of(mediaEntity));
 

--- a/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest.java
@@ -37,6 +37,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.time.ZoneOffset.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -394,8 +395,8 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         // given
         var annotationA1 = CommonTestDataUtil.createAnnotationEntity(111);
         var annotationB1 = CommonTestDataUtil.createAnnotationEntity(222);
-        annotationA1.setHearingList(List.of(case1PerfectlyClosed.getHearings().getFirst()));
-        annotationB1.setHearingList(List.of(case1PerfectlyClosed.getHearings().getFirst(),
+        annotationA1.setHearings(Set.of(case1PerfectlyClosed.getHearings().getFirst()));
+        annotationB1.setHearings(Set.of(case1PerfectlyClosed.getHearings().getFirst(),
                                             case4NotPerfectlyClosed.getHearings().getFirst()));
 
         var annotationDocumentA1 = annotationA1.getAnnotationDocuments().getFirst();

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriptionRequestDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriptionRequestDetailsValidatorTest.java
@@ -22,8 +22,7 @@ import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionUrgencyEnum;
 import uk.gov.hmcts.darts.transcriptions.model.TranscriptionRequestDetails;
 
 import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -71,10 +70,10 @@ class TranscriptionRequestDetailsValidatorTest {
     @ParameterizedTest
     @NullSource
     @EmptySource
-    void validateShouldThrowExceptionWhenProvidedHearingHasNoAudio(List<MediaEntity> mediaEntityList) {
+    void validateShouldThrowExceptionWhenProvidedHearingHasNoAudio(Set<MediaEntity> mediaEntityList) {
         // Given
         var hearingEntity = new HearingEntity();
-        hearingEntity.setMediaList(mediaEntityList);
+        hearingEntity.setMedias(mediaEntityList);
 
         Mockito.when(hearingsServiceMock.getHearingByIdWithValidation(DUMMY_HEARING_ID))
             .thenReturn(hearingEntity);
@@ -142,7 +141,7 @@ class TranscriptionRequestDetailsValidatorTest {
     void validateShouldSucceedWhenRequestHasHearingIdAndValidDates() {
         // Given
         var hearingEntity = new HearingEntity();
-        hearingEntity.setMediaList(createMediaList());
+        hearingEntity.setMedias(createMedias());
         Mockito.when(hearingsServiceMock.getHearingByIdWithValidation(DUMMY_HEARING_ID))
             .thenReturn(hearingEntity);
 
@@ -154,8 +153,8 @@ class TranscriptionRequestDetailsValidatorTest {
         assertDoesNotThrow(() -> validator.validate(requestDetails));
     }
 
-    private List<MediaEntity> createMediaList() {
-        return Arrays.asList(
+    private Set<MediaEntity> createMedias() {
+        return Set.of(
             createMediaEntity(MEDIA_1_START_TIME, MEDIA_1_END_TIME),
             createMediaEntity(MEDIA_2_START_TIME, MEDIA_2_END_TIME)
         );

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.HearingReportingRestrictionsRepository;
 import uk.gov.hmcts.darts.common.util.CommonTestDataUtil;
 import uk.gov.hmcts.darts.common.util.TranscriptionUrgencyEnum;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
 import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum;
 import uk.gov.hmcts.darts.transcriptions.enums.TranscriptionTypeEnum;
@@ -54,8 +55,9 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -147,8 +149,8 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponseWithNoStatus() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, false, true, true);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, false, true, true);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
 
         GetTranscriptionByIdResponse transcriptionResponse =
             transcriptionResponseMapper.mapToTranscriptionResponse(transcriptionEntity);
@@ -165,11 +167,11 @@ class TranscriptionResponseMapperTest {
         CourtroomEntity courtroomEntity = new CourtroomEntity();
         courtroomEntity.setName(courtName);
 
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(null, true, false, true, courtroomEntity);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
-        transcriptionEntity.setHearings(new ArrayList<>());
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(null, true, false, true, courtroomEntity);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
+        transcriptionEntity.setHearings(new HashSet<>());
         transcriptionEntity.setHearingDate(LocalDate.of(2023, 6, 20));
-        transcriptionEntity.setCourtCases(List.of(CommonTestDataUtil.createCase("case1")));
+        transcriptionEntity.setCourtCases(Set.of(CommonTestDataUtil.createCase("case1")));
         transcriptionEntity.setCourtroom(CommonTestDataUtil.createCourtroom("1"));
         GetTranscriptionByIdResponse transcriptionResponse =
             transcriptionResponseMapper.mapToTranscriptionResponse(transcriptionEntity);
@@ -182,11 +184,11 @@ class TranscriptionResponseMapperTest {
 
     @Test
     void mapToTranscriptionResponseWithCourtroom() throws Exception {
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(null, true, false, true, null);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
-        transcriptionEntity.setHearings(new ArrayList<>());
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(null, true, false, true, null);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
+        transcriptionEntity.setHearings(new HashSet<>());
         transcriptionEntity.setHearingDate(LocalDate.of(2023, 6, 20));
-        transcriptionEntity.setCourtCases(List.of(CommonTestDataUtil.createCase("case1")));
+        transcriptionEntity.setCourtCases(Set.of(CommonTestDataUtil.createCase("case1")));
         GetTranscriptionByIdResponse transcriptionResponse =
             transcriptionResponseMapper.mapToTranscriptionResponse(transcriptionEntity);
         String actualResponse = objectMapper.writeValueAsString(transcriptionResponse);
@@ -199,9 +201,9 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponseWithNoHearingsAndNoValidCourtCaseShouldFail() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
-        transcriptionEntity.setHearings(new ArrayList<>());
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, false);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
+        transcriptionEntity.setHearings(new HashSet<>());
         transcriptionEntity.setHearingDate(LocalDate.of(2023, 6, 20));
 
         var exception = assertThrows(
@@ -216,8 +218,8 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponseWithWorkflow() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
 
         GetTranscriptionByIdResponse transcriptionResponse =
             transcriptionResponseMapper.mapToTranscriptionResponse(transcriptionEntity);
@@ -231,8 +233,8 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponse() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
 
         GetTranscriptionByIdResponse transcriptionResponse =
             transcriptionResponseMapper.mapToTranscriptionResponse(transcriptionEntity);
@@ -246,8 +248,8 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponseWithOutLegacyComments() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
 
         transcriptionEntity.getTranscriptionCommentEntities()
             .forEach(transcriptionCommentEntity -> {
@@ -267,8 +269,8 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponseIsAutomated() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
         transcriptionEntity.setIsManualTranscription(false);
 
         GetTranscriptionByIdResponse transcriptionResponse =
@@ -284,8 +286,8 @@ class TranscriptionResponseMapperTest {
     void mapToTranscriptionResponseInternalServerError() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
         hearing1.setCourtCase(null);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
 
 
         var exception = assertThrows(
@@ -299,8 +301,8 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponseWithRequestor() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
 
         GetTranscriptionByIdResponse transcriptionResponse =
             transcriptionResponseMapper.mapToTranscriptionResponse(transcriptionEntity);
@@ -314,8 +316,8 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponseWithHideFromRequestor() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
         transcriptionEntity.setHideRequestFromRequestor(true);
 
         GetTranscriptionByIdResponse transcriptionResponse =
@@ -346,13 +348,13 @@ class TranscriptionResponseMapperTest {
         CourtCaseEntity caseEntity = new CourtCaseEntity();
         caseEntity.setCaseNumber(caseNumber);
 
-        List<HearingEntity> hearingEntityList = new ArrayList<>();
+        Set<HearingEntity> hearingEntitys = new HashSet<>();
 
         // create the transaction to be mapped
         Integer transactionId = 200;
         TranscriptionEntity transcriptionEntity = new TranscriptionEntity();
         transcriptionEntity.setId(transactionId);
-        transcriptionEntity.setHearings(hearingEntityList);
+        transcriptionEntity.setHearings(hearingEntitys);
         transcriptionEntity.setTranscriptionStatus(transcriptionStatus);
         transcriptionEntity.setIsManualTranscription(false);
         hearingEntity.setCourtCase(caseEntity);
@@ -386,13 +388,13 @@ class TranscriptionResponseMapperTest {
         caseEntity.setCaseNumber(caseNumber);
         caseEntity.setCourthouse(courthouseEntity);
 
-        List<HearingEntity> hearingEntityList = new ArrayList<>();
+        Set<HearingEntity> hearingEntitys = new HashSet<>();
 
         // create the transaction to be mapped
         Integer transactionId = 200;
         TranscriptionEntity transcriptionEntity = new TranscriptionEntity();
         transcriptionEntity.setId(transactionId);
-        transcriptionEntity.setHearings(hearingEntityList);
+        transcriptionEntity.setHearings(hearingEntitys);
         transcriptionEntity.setTranscriptionStatus(transcriptionStatus);
         transcriptionEntity.setIsManualTranscription(false);
         transcriptionEntity.getCourtCases().add(caseEntity);
@@ -425,13 +427,13 @@ class TranscriptionResponseMapperTest {
         TranscriptionStatusEntity transcriptionStatus = new TranscriptionStatusEntity();
         transcriptionStatus.setId(TranscriptionStatusEnum.COMPLETE.getId());
 
-        List<HearingEntity> hearingEntityList = new ArrayList<>();
+        Set<HearingEntity> hearingEntitys = new HashSet<>();
 
         // create the transaction to be mapped
         Integer transactionId = 200;
         TranscriptionEntity transcriptionEntity = new TranscriptionEntity();
         transcriptionEntity.setId(transactionId);
-        transcriptionEntity.setHearings(hearingEntityList);
+        transcriptionEntity.setHearings(hearingEntitys);
         transcriptionEntity.setTranscriptionStatus(transcriptionStatus);
         transcriptionEntity.setIsManualTranscription(false);
         transcriptionEntity.getHearings().add(hearingEntity);
@@ -836,7 +838,7 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionWorkflowsResponseWithLegacyComment() {
         HearingEntity hearing = CommonTestDataUtil.createHearing("1", LocalDate.of(2020, 10, 10));
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing);
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing);
 
         TranscriptionCommentEntity comment1a = new TranscriptionCommentEntity();
         comment1a.setComment("1a");
@@ -849,7 +851,7 @@ class TranscriptionResponseMapperTest {
 
         UserAccountEntity userAccount = CommonTestDataUtil.createUserAccount();
         TranscriptionWorkflowEntity transcriptionWorkflow1 = new TranscriptionWorkflowEntity();
-        transcriptionWorkflow1.setTranscription(transcriptionList.getFirst());
+        transcriptionWorkflow1.setTranscription(TestUtils.getFirst(transcriptionList));
         transcriptionWorkflow1.setTranscriptionStatus(CommonTestDataUtil.createTranscriptionStatusEntityFromEnum(TranscriptionStatusEnum.APPROVED));
         transcriptionWorkflow1.setId(1);
         transcriptionWorkflow1.setWorkflowTimestamp(OffsetDateTime.of(2020, 10, 10, 11, 0, 0, 0, ZoneOffset.UTC));
@@ -865,7 +867,7 @@ class TranscriptionResponseMapperTest {
         comment2b.setCommentTimestamp(OffsetDateTime.of(2020, 10, 10, 11, 1, 0, 0, ZoneOffset.UTC));
 
         TranscriptionWorkflowEntity transcriptionWorkflow2 = new TranscriptionWorkflowEntity();
-        transcriptionWorkflow2.setTranscription(transcriptionList.getFirst());
+        transcriptionWorkflow2.setTranscription(TestUtils.getFirst(transcriptionList));
         transcriptionWorkflow2.setTranscriptionStatus(CommonTestDataUtil.createTranscriptionStatusEntityFromEnum(TranscriptionStatusEnum.APPROVED));
         transcriptionWorkflow2.setId(2);
         transcriptionWorkflow2.setWorkflowTimestamp(OffsetDateTime.of(2020, 10, 11, 10, 0, 0, 0, ZoneOffset.UTC));
@@ -898,11 +900,11 @@ class TranscriptionResponseMapperTest {
     @Test
     void mapToTranscriptionResponseWithApprovedTimeStamp() throws Exception {
         HearingEntity hearing1 = CommonTestDataUtil.createHearing("case1", LocalTime.NOON);
-        List<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptionList(hearing1, true, false, true);
-        TranscriptionEntity transcriptionEntity = transcriptionList.getFirst();
+        Set<TranscriptionEntity> transcriptionList = CommonTestDataUtil.createTranscriptions(hearing1, true, false, true);
+        TranscriptionEntity transcriptionEntity = TestUtils.getFirst(transcriptionList);
 
         TranscriptionWorkflowEntity transcriptionWorkflow = new TranscriptionWorkflowEntity();
-        transcriptionWorkflow.setTranscription(transcriptionList.getFirst());
+        transcriptionWorkflow.setTranscription(TestUtils.getFirst(transcriptionList));
         transcriptionWorkflow.setTranscriptionStatus(CommonTestDataUtil.createTranscriptionStatusEntityFromEnum(TranscriptionStatusEnum.APPROVED));
         transcriptionWorkflow.setId(1);
         transcriptionWorkflow.setWorkflowTimestamp(OffsetDateTime.of(2020, 10, 10, 11, 0, 0, 0, ZoneOffset.UTC));
@@ -927,7 +929,7 @@ class TranscriptionResponseMapperTest {
 
         TranscriptionEntity transcription = new TranscriptionEntity();
         transcription.setHearings(null);
-        transcription.setCourtCases(List.of(courtCaseEntity));
+        transcription.setCourtCases(Set.of(courtCaseEntity));
         transcription.setCourtroom(courtroomEntity);
         TranscriptionDocumentEntity transcriptionDocumentEntity = new TranscriptionDocumentEntity();
         transcriptionDocumentEntity.setTranscription(transcription);
@@ -963,7 +965,7 @@ class TranscriptionResponseMapperTest {
 
         TranscriptionEntity transcription = new TranscriptionEntity();
         transcription.setHearings(null);
-        transcription.setCourtCases(List.of(courtCaseEntity));
+        transcription.setCourtCases(Set.of(courtCaseEntity));
         transcription.setCourtroom(courtroomEntity);
         TranscriptionDocumentEntity transcriptionDocumentEntity = new TranscriptionDocumentEntity();
         transcriptionDocumentEntity.setTranscription(transcription);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/TestUtils.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/TestUtils.java
@@ -43,7 +43,11 @@ import static java.lang.Character.toUpperCase;
 import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.CognitiveComplexity"})
+@SuppressWarnings({
+    "PMD.TestClassWithoutTestCases",
+    "PMD.CognitiveComplexity",
+    "PMD.GodClass"
+})
 @Slf4j
 public final class TestUtils {
 

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/TestUtils.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/TestUtils.java
@@ -230,4 +230,11 @@ public final class TestUtils {
             return true;
         }
     }
+
+    public static <T> T getFirst(Collection<T> data) {
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+        return data.iterator().next();
+    }
 }

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/AnnotationDocumentTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/AnnotationDocumentTestData.java
@@ -5,12 +5,10 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.test.common.data.builder.TestAnnotationDocumentEntity;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.RandomStringUtils.random;
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;
 

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/AnnotationDocumentTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/AnnotationDocumentTestData.java
@@ -6,6 +6,8 @@ import uk.gov.hmcts.darts.test.common.data.builder.TestAnnotationDocumentEntity;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
@@ -23,15 +25,15 @@ public final class AnnotationDocumentTestData implements Persistable<TestAnnotat
         return someMinimal();
     }
 
-    public AnnotationDocumentEntity createAnnotationDocumentForHearings(List<HearingEntity> hearingEntities) {
+    public AnnotationDocumentEntity createAnnotationDocumentForHearings(Set<HearingEntity> hearingEntities) {
         var annotationDocumentEntityRetrieve = someMinimalBuilder();
         AnnotationDocumentEntity annotationDocument = annotationDocumentEntityRetrieve.build().getEntity();
-        annotationDocument.getAnnotation().setHearingList(hearingEntities);
+        annotationDocument.getAnnotation().setHearings(hearingEntities);
         return annotationDocument;
     }
 
     public AnnotationDocumentEntity createAnnotationDocumentForHearings(HearingEntity... hearingEntities) {
-        return createAnnotationDocumentForHearings(stream(hearingEntities).collect(toList()));
+        return createAnnotationDocumentForHearings(stream(hearingEntities).collect(Collectors.toSet()));
     }
 
     @Override

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/AnnotationTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/AnnotationTestData.java
@@ -5,7 +5,6 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.test.common.data.builder.TestAnnotationEntity;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
 
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/AnnotationTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/AnnotationTestData.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.darts.test.common.data.builder.TestAnnotationEntity;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 
 import static uk.gov.hmcts.darts.test.common.data.UserAccountTestData.minimalUserAccount;
 
@@ -40,7 +41,7 @@ public final class AnnotationTestData implements Persistable<TestAnnotationEntit
             .createdById(0)
             .createdTimestamp(OffsetDateTime.now())
             .lastModifiedDateTime(OffsetDateTime.now())
-            .hearingList(new ArrayList<>());
+            .hearings(new HashSet<>());
         return retrieve;
     }
 }

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/PersistableFactory.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/PersistableFactory.java
@@ -1,5 +1,9 @@
 package uk.gov.hmcts.darts.test.common.data;
 
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
+
 public final class PersistableFactory {
 
     private PersistableFactory() {
@@ -80,5 +84,15 @@ public final class PersistableFactory {
 
     public static EventTestData getEventTestData() {
         return new EventTestData();
+    }
+
+    public static <T> T random(Class<T> clazz) {
+        EasyRandomParameters parameters = new EasyRandomParameters()
+            .randomize(Integer.class, new IntegerRangeRandomizer(1, 100))
+            .collectionSizeRange(1, 1)
+            .overrideDefaultInitialization(true);
+
+        EasyRandom generator = new EasyRandom(parameters);
+        return generator.nextObject(clazz);
     }
 }

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/TranscriptionTestData.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/TranscriptionTestData.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.darts.common.entity.TranscriptionStatusEntity;
 import uk.gov.hmcts.darts.common.entity.TranscriptionTypeEntity;
 import uk.gov.hmcts.darts.test.common.data.builder.TestTranscriptionEntity;
 
-import java.util.Arrays;
+import java.util.Set;
 
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.APPROVED;
 import static uk.gov.hmcts.darts.transcriptions.enums.TranscriptionStatusEnum.REQUESTED;
@@ -63,14 +63,14 @@ public final class TranscriptionTestData
     public TranscriptionEntity someTranscriptionForHearing(HearingEntity hearingEntity) {
         var transcription = minimalTranscription();
         transcription.addHearing(hearingEntity);
-        transcription.setCourtCases(Arrays.asList(hearingEntity.getCourtCase()));
+        transcription.setCourtCases(Set.of(hearingEntity.getCourtCase()));
         return transcription;
     }
 
     public TranscriptionEntity someApprovedTranscriptionForHearing(HearingEntity hearingEntity) {
         var transcription = minimalApprovedTranscription();
         transcription.addHearing(hearingEntity);
-        transcription.setCourtCases(Arrays.asList(hearingEntity.getCourtCase()));
+        transcription.setCourtCases(Set.of(hearingEntity.getCourtCase()));
         return transcription;
     }
 

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestAnnotationEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestAnnotationEntity.java
@@ -11,7 +11,10 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import java.lang.reflect.InvocationTargetException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.ConstructorCallsOverridableMethod"})
 @RequiredArgsConstructor
@@ -21,7 +24,7 @@ public class TestAnnotationEntity extends AnnotationEntity implements DbInsertab
     public TestAnnotationEntity(Integer id, String text, OffsetDateTime timestamp, String legacyObjectId,
                                 String legacyVersionLabel, UserAccountEntity currentOwner, boolean deleted,
                                 UserAccountEntity deletedBy, OffsetDateTime deletedTimestamp,
-                                List<AnnotationDocumentEntity> annotationDocuments, List<HearingEntity> hearingList,
+                                List<AnnotationDocumentEntity> annotationDocuments, Collection<HearingEntity> hearings,
                                 OffsetDateTime createdTimestamp,
                                 OffsetDateTime lastModifiedDateTime, Integer lastModifiedById, Integer createdById) {
         super();
@@ -35,7 +38,7 @@ public class TestAnnotationEntity extends AnnotationEntity implements DbInsertab
         setDeletedBy(deletedBy);
         setDeletedTimestamp(deletedTimestamp);
         setAnnotationDocuments(annotationDocuments != null ? annotationDocuments : new ArrayList<>());
-        setHearingList(hearingList);
+        setHearings(new HashSet<>(hearings));
         setCreatedDateTime(createdTimestamp);
         setCreatedById(lastModifiedById);
         setLastModifiedDateTime(lastModifiedDateTime);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestAnnotationEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestAnnotationEntity.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.ConstructorCallsOverridableMethod"})
 @RequiredArgsConstructor

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestCourtCaseEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestCourtCaseEntity.java
@@ -20,6 +20,8 @@ import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceScoreEnum;
 import java.lang.reflect.InvocationTargetException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.ConstructorCallsOverridableMethod"})
@@ -46,7 +48,7 @@ public class TestCourtCaseEntity extends CourtCaseEntity implements DbInsertable
         OffsetDateTime deletedTimestamp,
         List<HearingEntity> hearings,
         List<CaseRetentionEntity> caseRetentionEntities,
-        List<JudgeEntity> judges,
+        Collection<JudgeEntity> judges,
         List<MediaLinkedCaseEntity> mediaLinkedCaseList,
         Boolean dataAnonymised,
         Integer dataAnonymisedBy,
@@ -80,7 +82,7 @@ public class TestCourtCaseEntity extends CourtCaseEntity implements DbInsertable
         setDeletedTimestamp(deletedTimestamp);
         setHearings(hearings != null ? hearings : new ArrayList<>());
         setCaseRetentionEntities(caseRetentionEntities != null ? caseRetentionEntities : new ArrayList<>());
-        setJudges(judges != null ? judges : new ArrayList<>());
+        setJudges(judges != null ? new HashSet<>(judges) : new HashSet<>());
         setMediaLinkedCaseList(mediaLinkedCaseList != null ? mediaLinkedCaseList : new ArrayList<>());
         setDataAnonymised(dataAnonymised);
         setDataAnonymisedBy(dataAnonymisedBy);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestHearingEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestHearingEntity.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -33,7 +34,7 @@ public class TestHearingEntity extends HearingEntity implements DbInsertable<Hea
         LocalDate hearingDate,
         LocalTime scheduledStartTime,
         Boolean hearingIsActual,
-        List<JudgeEntity> judges,
+        Collection<JudgeEntity> judges,
         List<MediaEntity> mediaList,
         List<TranscriptionEntity> transcriptions,
         List<MediaRequestEntity> mediaRequests,
@@ -53,7 +54,7 @@ public class TestHearingEntity extends HearingEntity implements DbInsertable<Hea
         setHearingDate(hearingDate);
         setScheduledStartTime(scheduledStartTime);
         setHearingIsActual(hearingIsActual);
-        setJudges(judges != null ? judges : new ArrayList<>());
+        setJudges(judges != null ? new HashSet<>(judges) : new HashSet<>());
         setMediaList(mediaList != null ? mediaList : new ArrayList<>());
         setTranscriptions(transcriptions != null ? transcriptions : new ArrayList<>());
         setMediaRequests(mediaRequests != null ? mediaRequests : new ArrayList<>());

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestHearingEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestHearingEntity.java
@@ -17,11 +17,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.ConstructorCallsOverridableMethod"})
 @RequiredArgsConstructor
@@ -35,13 +32,13 @@ public class TestHearingEntity extends HearingEntity implements DbInsertable<Hea
         LocalTime scheduledStartTime,
         Boolean hearingIsActual,
         Collection<JudgeEntity> judges,
-        List<MediaEntity> mediaList,
-        List<TranscriptionEntity> transcriptions,
-        List<MediaRequestEntity> mediaRequests,
+        Collection<MediaEntity> mediaList,
+        Collection<TranscriptionEntity> transcriptions,
+        Collection<MediaRequestEntity> mediaRequests,
         boolean isNew,
-        List<EventEntity> eventList,
+        Collection<EventEntity> eventList,
         CourtCaseEntity courtCase,
-        List<AnnotationEntity> annotations,
+        Collection<AnnotationEntity> annotations,
         OffsetDateTime createdDateTime,
         Integer createdById,
         OffsetDateTime lastModifiedDateTime,
@@ -55,13 +52,13 @@ public class TestHearingEntity extends HearingEntity implements DbInsertable<Hea
         setScheduledStartTime(scheduledStartTime);
         setHearingIsActual(hearingIsActual);
         setJudges(judges != null ? new HashSet<>(judges) : new HashSet<>());
-        setMediaList(mediaList != null ? mediaList : new ArrayList<>());
-        setTranscriptions(transcriptions != null ? transcriptions : new ArrayList<>());
-        setMediaRequests(mediaRequests != null ? mediaRequests : new ArrayList<>());
+        setMedias(mediaList != null ? new HashSet<>(mediaList) : new HashSet<>());
+        setTranscriptions(transcriptions != null ? new HashSet<>(transcriptions) : new HashSet<>());
+        setMediaRequests(mediaRequests != null ? new HashSet<>(mediaRequests) : new HashSet<>());
         setNew(isNew);
-        setEvents(eventList != null ? Set.of(eventList.toArray(new EventEntity[0])) : new HashSet<>());
+        setEvents(eventList != null ? new HashSet<>(eventList) : new HashSet<>());
         setCourtCase(courtCase);
-        setAnnotations(annotations != null ? annotations : new ArrayList<>());
+        setAnnotations(annotations != null ? new HashSet<>(annotations) : new HashSet<>());
         setCreatedDateTime(createdDateTime);
         setCreatedById(createdById);
         setLastModifiedDateTime(lastModifiedDateTime);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestMediaEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestMediaEntity.java
@@ -14,6 +14,8 @@ import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceScoreEnum;
 import java.lang.reflect.InvocationTargetException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 @SuppressWarnings({"PMD.TestClassWithoutTestCases", "PMD.ConstructorCallsOverridableMethod"})
@@ -29,7 +31,7 @@ public class TestMediaEntity extends MediaEntity implements DbInsertable<MediaEn
                            String chronicleId, String antecedentId, boolean isHidden,
                            boolean isDeleted, Boolean isCurrent, UserAccountEntity deletedBy,
                            OffsetDateTime deletedTimestamp, String mediaStatus,
-                           List<HearingEntity> hearingList, OffsetDateTime retainUntilTs,
+                           Collection<HearingEntity> hearingList, OffsetDateTime retainUntilTs,
                            List<ObjectAdminActionEntity> objectAdminActions, RetentionConfidenceScoreEnum retConfScore,
                            String retConfReason, OffsetDateTime createdDateTime,
                            Integer createdById, OffsetDateTime lastModifiedDateTime,
@@ -59,7 +61,7 @@ public class TestMediaEntity extends MediaEntity implements DbInsertable<MediaEn
         setDeletedBy(deletedBy);
         setDeletedTimestamp(deletedTimestamp);
         setMediaStatus(mediaStatus);
-        setHearingList(hearingList != null ? hearingList : new ArrayList<>());
+        setHearings(hearingList != null ? new HashSet<>(hearingList) : new HashSet<>());
         setRetainUntilTs(retainUntilTs);
         setObjectAdminActions(objectAdminActions != null ? objectAdminActions : new ArrayList<>());
         setRetConfScore(retConfScore);

--- a/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestTranscriptionEntity.java
+++ b/src/testCommon/java/uk/gov/hmcts/darts/test/common/data/builder/TestTranscriptionEntity.java
@@ -19,6 +19,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,11 +28,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class TestTranscriptionEntity extends TranscriptionEntity implements DbInsertable<TranscriptionEntity> {
     @lombok.Builder
-    public TestTranscriptionEntity(Integer id, List<CourtCaseEntity> courtCases,
+    public TestTranscriptionEntity(Integer id, Collection<CourtCaseEntity> courtCases,
                                    TranscriptionTypeEntity transcriptionType,
                                    CourtroomEntity courtroom,
                                    TranscriptionUrgencyEntity transcriptionUrgency,
-                                   List<HearingEntity> hearings,
+                                   Collection<HearingEntity> hearings,
                                    TranscriptionStatusEntity transcriptionStatus,
                                    String legacyObjectId, UserAccountEntity requestedBy,
                                    LocalDate hearingDate, OffsetDateTime startTime,
@@ -48,11 +50,11 @@ public class TestTranscriptionEntity extends TranscriptionEntity implements DbIn
                                    Integer lastModifiedById) {
         super();
         setId(id);
-        setCourtCases(courtCases);
+        setCourtCases(courtCases != null ? new HashSet<>(courtCases) : new HashSet<>());
         setTranscriptionType(transcriptionType);
         setCourtroom(courtroom);
         setTranscriptionUrgency(transcriptionUrgency);
-        setHearings(hearings != null ? hearings : new ArrayList<>());
+        setHearings(hearings != null ? new HashSet<>(hearings) : new HashSet<>());
         setTranscriptionStatus(transcriptionStatus);
         setLegacyObjectId(legacyObjectId);
         setRequestedBy(requestedBy);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4969)


### Change description ###
# Summary of Git Diff

This Git diff highlights a significant update across multiple files in the codebase, primarily focusing on changing the data structure for managing many to many relationships from `List` to a `Set`. This change aims to enhance data integrity and prevent issues related to duplicate entries during insertions and deletions. The modifications involve updating method names, adjusting how hearings are saved and retrieved, and updating test cases to reflect these changes.

## Highlights

W.I.P

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
