### PR TITLE
DMP-5014: Aged cases closed by automated job are setting retention to a manual policy rather than default

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CloseOldCasesProcessorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/service/CloseOldCasesProcessorTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceReasonEnum;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceScoreEnum;
+import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
 import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
 import uk.gov.hmcts.darts.test.common.data.RetentionConfidenceCategoryMapperTestData;
 import uk.gov.hmcts.darts.test.common.data.builder.TestRetentionConfidenceCategoryMapperEntity;
@@ -145,11 +146,21 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertEquals(RetentionConfidenceScoreEnum.CASE_PERFECTLY_CLOSED, updatedCourtCaseEntity.getRetConfScore());
         assertEquals(RetentionConfidenceReasonEnum.AGED_CASE, updatedCourtCaseEntity.getRetConfReason());
         assertEquals(CURRENT_DATE_TIME, updatedCourtCaseEntity.getRetConfUpdatedTs());
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(courtCaseEntity.getId(), caseRetentionEntity.getCourtCase().getId());
         assertEquals(closeDate.plusYears(7).truncatedTo(ChronoUnit.DAYS), caseRetentionEntity.getRetainUntil());
         assertEquals(RetentionConfidenceCategoryEnum.AGED_CASE_CASE_CLOSED, caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
     }
+
+    private CaseRetentionEntity getCaseRetentionEagerLoaded() {
+        return dartsDatabase.getTransactionalUtil().executeInTransaction(() -> {
+            CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+            caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey();//Force entitty to load
+            return caseRetentionEntity;
+        });
+    }
+
 
     @Test
     void closeCases_shouldCloseCases_andUseDateAsClosedDate_andSetNullConfidenceReasonAndScore_whenNoConfidenceMappingExists() {
@@ -187,9 +198,9 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertNull(updatedCourtCaseEntity.getRetConfReason());
         assertEquals(CURRENT_DATE_TIME, updatedCourtCaseEntity.getRetConfUpdatedTs());
 
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository()
-            .findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(RetentionConfidenceCategoryEnum.AGED_CASE_MAX_EVENT_CLOSED, caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
     }
 
     @Test
@@ -221,9 +232,10 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertEquals(RetentionConfidenceScoreEnum.CASE_NOT_PERFECTLY_CLOSED, updatedCourtCaseEntity.getRetConfScore());
         assertEquals(RetentionConfidenceReasonEnum.MAX_EVENT_CLOSED, updatedCourtCaseEntity.getRetConfReason());
         assertEquals(CURRENT_DATE_TIME, updatedCourtCaseEntity.getRetConfUpdatedTs());
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(courtCaseEntity.getId(), caseRetentionEntity.getCourtCase().getId());
         assertEquals(RetentionConfidenceCategoryEnum.AGED_CASE_MAX_EVENT_CLOSED, caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
     }
 
     @Test
@@ -252,9 +264,10 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertEquals(RetentionConfidenceScoreEnum.CASE_NOT_PERFECTLY_CLOSED, updatedCourtCaseEntity.getRetConfScore());
         assertEquals(RetentionConfidenceReasonEnum.MAX_EVENT_CLOSED, updatedCourtCaseEntity.getRetConfReason());
         assertEquals(CURRENT_DATE_TIME, updatedCourtCaseEntity.getRetConfUpdatedTs());
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(courtCaseEntity.getId(), caseRetentionEntity.getCourtCase().getId());
         assertEquals(RetentionConfidenceCategoryEnum.AGED_CASE_MAX_EVENT_CLOSED, caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
     }
 
 
@@ -294,9 +307,10 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertEquals(RetentionConfidenceScoreEnum.CASE_NOT_PERFECTLY_CLOSED, updatedCourtCaseEntity.getRetConfScore());
         assertEquals(RetentionConfidenceReasonEnum.MAX_MEDIA_CLOSED, updatedCourtCaseEntity.getRetConfReason());
         assertEquals(CURRENT_DATE_TIME, updatedCourtCaseEntity.getRetConfUpdatedTs());
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(courtCaseEntity.getId(), caseRetentionEntity.getCourtCase().getId());
         assertEquals(RetentionConfidenceCategoryEnum.AGED_CASE_MAX_MEDIA_CLOSED, caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
     }
 
     @Test
@@ -322,9 +336,10 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertEquals(RetentionConfidenceScoreEnum.CASE_NOT_PERFECTLY_CLOSED, updatedCourtCaseEntity.getRetConfScore());
         assertEquals(RetentionConfidenceReasonEnum.MAX_HEARING_CLOSED, updatedCourtCaseEntity.getRetConfReason());
         assertEquals(CURRENT_DATE_TIME, updatedCourtCaseEntity.getRetConfUpdatedTs());
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(courtCaseEntity.getId(), caseRetentionEntity.getCourtCase().getId());
         assertEquals(RetentionConfidenceCategoryEnum.AGED_CASE_MAX_HEARING_CLOSED, caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
     }
 
     @Test
@@ -345,9 +360,10 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertEquals(RetentionConfidenceScoreEnum.CASE_NOT_PERFECTLY_CLOSED, updatedCourtCaseEntity.getRetConfScore());
         assertEquals(RetentionConfidenceReasonEnum.CASE_CREATION_CLOSED, updatedCourtCaseEntity.getRetConfReason());
         assertEquals(CURRENT_DATE_TIME, updatedCourtCaseEntity.getRetConfUpdatedTs());
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(courtCaseEntity.getId(), caseRetentionEntity.getCourtCase().getId());
         assertEquals(RetentionConfidenceCategoryEnum.AGED_CASE_CASE_CREATION_CLOSED, caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
     }
 
     @Test
@@ -384,9 +400,10 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertEquals(RetentionConfidenceScoreEnum.CASE_NOT_PERFECTLY_CLOSED, updatedCourtCaseEntity1.getRetConfScore());
         assertEquals(RetentionConfidenceReasonEnum.CASE_CREATION_CLOSED, updatedCourtCaseEntity1.getRetConfReason());
         assertEquals(CURRENT_DATE_TIME, updatedCourtCaseEntity1.getRetConfUpdatedTs());
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(courtCaseEntity1.getId(), caseRetentionEntity.getCourtCase().getId());
         assertEquals(RetentionConfidenceCategoryEnum.AGED_CASE_CASE_CREATION_CLOSED, caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
 
         CourtCaseEntity updatedCourtCaseEntity2 = dartsDatabase.getCaseRepository().findById(courtCaseEntity2.getId()).orElse(null);
         assert updatedCourtCaseEntity2 != null;
@@ -417,9 +434,10 @@ class CloseOldCasesProcessorTest extends IntegrationBase {
         assertNull(updatedCourtCaseEntity.getCaseClosedTimestamp());
         assertNull(updatedCourtCaseEntity.getRetConfScore());
         assertNull(updatedCourtCaseEntity.getRetConfReason());
-        CaseRetentionEntity caseRetentionEntity = dartsDatabase.getCaseRetentionRepository().findAll().getFirst();
+        CaseRetentionEntity caseRetentionEntity = getCaseRetentionEagerLoaded();
         assertEquals(courtCaseEntity.getId(), caseRetentionEntity.getCourtCase().getId());
         assertNull(caseRetentionEntity.getConfidenceCategory());
+        assertEquals(RetentionPolicyEnum.DEFAULT.getPolicyKey(), caseRetentionEntity.getRetentionPolicyType().getFixedPolicyKey());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CloseOldCasesProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CloseOldCasesProcessorImpl.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
 import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
 import uk.gov.hmcts.darts.retention.helper.RetentionDateHelper;
-import uk.gov.hmcts.darts.retentions.model.PostRetentionRequest;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -142,13 +141,9 @@ public class CloseOldCasesProcessorImpl implements CloseOldCasesProcessor {
             log.info("Closed court case id {}", courtCase.getId());
 
             LocalDate retentionDate = retentionDateHelper.getRetentionDateForPolicy(courtCase, RetentionPolicyEnum.DEFAULT);
-
-            PostRetentionRequest postRetentionRequest = new PostRetentionRequest();
-            postRetentionRequest.setComments(CLOSE_CASE_RETENTION_COMMENT);
-            postRetentionRequest.setRetentionDate(retentionDate);
-
-            CaseRetentionEntity retentionEntity = retentionApi.createRetention(postRetentionRequest, courtCase, retentionDate, userAccount,
-                                                                               CaseRetentionStatus.PENDING, retentionConfidenceCategory);
+            CaseRetentionEntity retentionEntity = retentionApi.createRetention(
+                RetentionPolicyEnum.DEFAULT, CLOSE_CASE_RETENTION_COMMENT, courtCase, retentionDate, userAccount,
+                CaseRetentionStatus.PENDING, retentionConfidenceCategory);
             caseRetentionRepository.save(retentionEntity);
             log.info("Set retention date {} and confidence category {} for case id {}", retentionDate, retentionConfidenceCategory,
                      courtCase.getId());

--- a/src/main/java/uk/gov/hmcts/darts/retention/api/RetentionApi.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/api/RetentionApi.java
@@ -6,14 +6,15 @@ import uk.gov.hmcts.darts.common.entity.RetentionPolicyTypeEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
-import uk.gov.hmcts.darts.retentions.model.PostRetentionRequest;
+import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
 
 import java.time.LocalDate;
 
 public interface RetentionApi {
     LocalDate applyPolicyStringToDate(LocalDate dateToAppend, String policyString, RetentionPolicyTypeEntity retentionPolicyType);
 
-    CaseRetentionEntity createRetention(PostRetentionRequest postRetentionRequest,
+    CaseRetentionEntity createRetention(RetentionPolicyEnum retentionPolicyEnum,
+                                        String comments,
                                         CourtCaseEntity courtCase,
                                         LocalDate newRetentionDate,
                                         UserAccountEntity userAccount,

--- a/src/main/java/uk/gov/hmcts/darts/retention/api/impl/RetentionApiImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/api/impl/RetentionApiImpl.java
@@ -9,10 +9,10 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.retention.api.RetentionApi;
 import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
+import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
 import uk.gov.hmcts.darts.retention.helper.RetentionDateHelper;
 import uk.gov.hmcts.darts.retention.service.RetentionPostService;
 import uk.gov.hmcts.darts.retention.service.RetentionService;
-import uk.gov.hmcts.darts.retentions.model.PostRetentionRequest;
 
 import java.time.LocalDate;
 
@@ -30,13 +30,15 @@ public class RetentionApiImpl implements RetentionApi {
     }
 
     @Override
-    public CaseRetentionEntity createRetention(PostRetentionRequest postRetentionRequest,
+    public CaseRetentionEntity createRetention(RetentionPolicyEnum retentionPolicyEnum,
+                                               String comments,
                                                CourtCaseEntity courtCase,
                                                LocalDate newRetentionDate,
                                                UserAccountEntity userAccount,
                                                CaseRetentionStatus caseRetentionStatus,
                                                RetentionConfidenceCategoryEnum retentionConfidenceCategory) {
-        return retentionPostService.createNewCaseRetention(postRetentionRequest,
+        return retentionPostService.createNewCaseRetention(retentionPolicyEnum,
+                                                           comments,
                                                            courtCase,
                                                            newRetentionDate,
                                                            userAccount,

--- a/src/main/java/uk/gov/hmcts/darts/retention/service/RetentionPostService.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/service/RetentionPostService.java
@@ -5,6 +5,7 @@ import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
 import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
+import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
 import uk.gov.hmcts.darts.retentions.model.PostRetentionRequest;
 import uk.gov.hmcts.darts.retentions.model.PostRetentionResponse;
 
@@ -15,6 +16,14 @@ public interface RetentionPostService {
     PostRetentionResponse postRetention(Boolean validateOnly, PostRetentionRequest postRetentionRequest);
 
     CaseRetentionEntity createNewCaseRetention(PostRetentionRequest postRetentionRequest,
+                                               CourtCaseEntity courtCase,
+                                               LocalDate newRetentionDate,
+                                               UserAccountEntity userAccount,
+                                               CaseRetentionStatus caseRetentionStatus,
+                                               RetentionConfidenceCategoryEnum retentionConfidenceCategory);
+
+    CaseRetentionEntity createNewCaseRetention(RetentionPolicyEnum retentionPolicyEnum,
+                                               String comments,
                                                CourtCaseEntity courtCase,
                                                LocalDate newRetentionDate,
                                                UserAccountEntity userAccount,

--- a/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CloseOldCasesProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CloseOldCasesProcessorImplTest.java
@@ -92,7 +92,7 @@ class CloseOldCasesProcessorImplTest {
         when(caseService.getCourtCaseById(1)).thenReturn(courtCase);
 
         CaseRetentionEntity caseRetention = createRetentionEntity(courtCase, userAccountEntity);
-        when(retentionApi.createRetention(any(), any(), any(), any(), any(), any())).thenReturn(caseRetention);
+        when(retentionApi.createRetention(any(),any(), any(), any(), any(), any(), any())).thenReturn(caseRetention);
         assertFalse(courtCase.getClosed());
 
         when(retentionApi.updateCourtCaseConfidenceAttributesForRetention(any(), eq(RetentionConfidenceCategoryEnum.AGED_CASE_MAX_HEARING_CLOSED)))


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5014)


### Change description ###
# Summary of Git Diff

This Git Diff represents modifications made to the `CloseOldCasesProcessorTest.java` and related files in the DARTS project. The primary focus of the changes is the integration of `RetentionPolicyEnum` into various classes, which standardizes the handling of retention policies across the system. The test cases have been updated to assert the correct retention policy key, ensuring that the system behaves as expected in relation to case retention.

## Highlights

- **New Import**: Added import for `RetentionPolicyEnum` in `CloseOldCasesProcessorTest.java`.
  
- **Refactoring of Test Cases**:
  - Updated multiple test cases to use `getCaseRetentionEagerLoaded()` instead of directly retrieving the first case retention entity from the repository.
  - Each test case now includes assertions to check the retention policy key against `RetentionPolicyEnum.DEFAULT`.

- **Improvements in `CloseOldCasesProcessorImpl`**:
  - Simplified the `createRetention()` method signature in `RetentionApi` to accept `RetentionPolicyEnum` and associated parameters directly instead of a `PostRetentionRequest`.
  - Adjusted the logic in `createRetention()` to utilize `RetentionPolicyEnum` for determining the retention policy.

- **Changes in `RetentionApiImpl`**: 
  - Updated method signatures to align with the new structure, ensuring `RetentionPolicyEnum` is passed directly where applicable.

- **Modification in `RetentionPostService`**: 
  - Added a new method signature to handle retention creation using `RetentionPolicyEnum`.

- **Test Updates**: 
  - Updated mocking in `CloseOldCasesProcessorImplTest.java` to reflect the new method signature that includes `RetentionPolicyEnum`.

These changes enhance the clarity and maintainability of the code, ensuring that retention policies are treated consistently throughout the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
