### PR TITLE
DMP-4946: Paginate the court log tab

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,12 +75,15 @@ swaggerList.each {
                 REF_AS_PARENT_IN_ALLOF: "true"
         ]
         configOptions = [
-                dateLibrary           : "java8",
-                interfaceOnly         : "true",
-                useTags               : "true",
-                useSpringBoot3        : "true",
-                containerDefaultToNull: "true"
+                dateLibrary                         : "java8",
+                interfaceOnly                       : "true",
+                useTags                             : "true",
+                useSpringBoot3                      : "true",
+                containerDefaultToNull              : "true",
+                generatedConstructorWithRequiredArgs: "false",
+                additionalModelTypeAnnotations: "@lombok.AllArgsConstructor;@lombok.NoArgsConstructor"
         ]
+
     })
 }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/annotation/AnnotationPostTest.java
@@ -129,7 +129,7 @@ class AnnotationPostTest extends IntegrationBase {
     }
 
     private MockMultipartFile someAnnotationPostBodyFor(HearingEntity hearingEntity) throws JsonProcessingException {
-        var annotation = new Annotation(hearingEntity.getId());
+        var annotation = new Annotation(hearingEntity.getId(),null);
         annotation.setComment("some comment");
 
         return new MockMultipartFile(
@@ -141,7 +141,7 @@ class AnnotationPostTest extends IntegrationBase {
     }
 
     private MockMultipartFile someAnnotationPostBodyNullHearingId() throws JsonProcessingException {
-        var annotation = new Annotation(null);
+        var annotation = new Annotation(null,null);
         return new MockMultipartFile(
             "annotation",
             null,

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -254,7 +254,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
         }
 
         @Test
-        void casesGetEvents_usingPaginatedCrieria_WithCustomOrderHearingDate_shouldReturnPaginatedResultsUsingCustomOrder_10Resultslimit3Page1()
+        void casesGetEvents_usingPaginatedCrieria_WithCustomOrderHearingDateAsc_shouldReturnPaginatedResultsUsingCustomOrder_10Resultslimit3Page1()
             throws Exception {
             MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE))
                 .queryParam("page_number", "1")
@@ -274,6 +274,29 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                     eventEntityList4.get(0).getId(),
                     eventEntityList4.get(1).getId(),
                     eventEntityList2.get(1).getId());
+        }
+
+        @Test
+        void casesGetEvents_usingPaginatedCrieria_WithCustomOrderHearingDateDesc_shouldReturnPaginatedResultsUsingCustomOrder_10Resultslimit3Page1()
+            throws Exception {
+            MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE))
+                .queryParam("page_number", "1")
+                .queryParam("page_size", "3")
+                .queryParam("sort_order", "DESC")
+                .queryParam("sort_by", "hearingDate");
+
+            MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+            PaginatedList<Event> paginatedList = paginationTestSupport.getPaginatedList(mvcResult, Event.class);
+            paginationTestSupport.assertPaginationDetails(paginatedList, 1, 3, 4, 10);
+            assertThat(
+                paginatedList.getData()
+                    .stream().map(Event::getId)
+                    .toList())
+                .contains(
+                    eventEntityList5.get(1).getId(),
+                    eventEntityList5.get(0).getId(),
+                    eventEntityList3.get(1).getId());
         }
 
 

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
@@ -25,6 +25,7 @@ public class EventMapper {
             .collect(Collectors.toList());
     }
 
+
     @SuppressWarnings("java:S1874")//Required as we replaced getFirst with getHearingEntity(). A ticket will be raised clean this up across the app
     public Event mapToEvent(EventEntity eventEntity) {
         HearingEntity hearingEntity = eventEntity.getHearingEntity();

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -204,7 +204,7 @@ public class CaseServiceImpl implements CaseService {
 
         return paginationDto.toPaginatedList(
             pageable -> eventRepository.findAllByCaseIdPaginated(caseId, pageable),
-            EventMapper::mapToEvent,
+            event -> event,
             List.of(HearingEntity_.HEARING_DATE, EventEntity_.TIMESTAMP),
             List.of(Sort.Direction.DESC, Sort.Direction.DESC),
             Map.of("hearingDate", "he.hearingDate",

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.darts.cases.model.Event;
 import uk.gov.hmcts.darts.common.entity.EventEntity;
 import uk.gov.hmcts.darts.event.model.EventSearchResult;
 
@@ -42,13 +43,21 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
 
 
     @Query("""
-           SELECT ee
+           SELECT new uk.gov.hmcts.darts.cases.model.Event(
+                  ee.id,
+                  he.id,
+                  he.hearingDate,
+                  ee.timestamp,
+                  ee.eventType.eventName,
+                  ee.isDataAnonymised,
+                  ee.eventText
+           )
            FROM EventEntity ee
            JOIN ee.hearingEntities he
            LEFT JOIN ee.eventType et        
            WHERE he.courtCase.id = :caseId
         """)
-    Page<EventEntity> findAllByCaseIdPaginated(Integer caseId, Pageable pageable);
+    Page<Event> findAllByCaseIdPaginated(Integer caseId, Pageable pageable);
 
 
     @Query("""

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberViewSummaryRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberViewSummaryRowMapper.java
@@ -25,7 +25,9 @@ public class TranscriberViewSummaryRowMapper implements RowMapper<TranscriberVie
             rs.getString("status"),
             rs.getObject("requested_ts", OffsetDateTime.class),
             rs.getObject("state_change_ts", OffsetDateTime.class),
-            rs.getBoolean("is_manual")
+            rs.getBoolean("is_manual"),
+            null,
+            null
         );
 
         summary.setApprovedTs(rs.getObject("approved_ts", OffsetDateTime.class));

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/YourTranscriptsSummaryRequesterRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/YourTranscriptsSummaryRequesterRowMapper.java
@@ -22,7 +22,9 @@ public class YourTranscriptsSummaryRequesterRowMapper extends YourTranscriptsSum
             rs.getObject("hearing_date", LocalDate.class),
             rs.getString("transcription_type"),
             rs.getString("status"),
-            rs.getObject("requested_ts", OffsetDateTime.class)
+            rs.getObject("requested_ts", OffsetDateTime.class),
+            null,
+            null
         );
         summary.setApprovedTs(rs.getObject("approved_ts", OffsetDateTime.class));
 

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/YourTranscriptsSummaryRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/YourTranscriptsSummaryRowMapper.java
@@ -23,7 +23,9 @@ public class YourTranscriptsSummaryRowMapper implements RowMapper<YourTranscript
             rs.getObject("hearing_date", LocalDate.class),
             rs.getString("transcription_type"),
             rs.getString("status"),
-            rs.getObject("requested_ts", OffsetDateTime.class)
+            rs.getObject("requested_ts", OffsetDateTime.class),
+            null,
+            null
         );
 
         if (rs.getInt("transcription_urgency_id") != 0) {

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -436,7 +436,7 @@ public class TranscriptionServiceImpl implements TranscriptionService {
 
         transcriptFileValidator.validate(transcript);
 
-        final var updateTranscription = updateTranscription(transcriptionId, new UpdateTranscriptionRequest(COMPLETE.getId()), false);
+        final var updateTranscription = updateTranscription(transcriptionId, new UpdateTranscriptionRequest(COMPLETE.getId(), null), false);
 
         final BlobClient inboundBlobCLient;
         final BlobClient unstructuredBlobClient;

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
@@ -174,7 +174,7 @@ public class UserManagementServiceImpl implements UserManagementService {
         List<Integer> rolledBackTranscriptionsList = new ArrayList<>();
 
         if (userPatch.getEmailAddress() != null && !userPatch.getEmailAddress().equals(userAccountEntity.getEmailAddress())) {
-            userEmailValidator.validate(new User(userPatch.getFullName(), userPatch.getEmailAddress()));
+            userEmailValidator.validate(new User(userPatch.getFullName(), userPatch.getEmailAddress(), null, null, null));
             userAccountEntity.setEmailAddress(userPatch.getEmailAddress());
         }
 

--- a/src/test/java/uk/gov/hmcts/darts/audio/component/impl/AddAudioRequestMapperImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/component/impl/AddAudioRequestMapperImplTest.java
@@ -87,7 +87,9 @@ class AddAudioRequestMapperImplTest {
                 "test",
                 "courthouse",
                 "courtroom",
+                null,
                 1000L,
+                null,
                 List.of("case1", "case2")
             ), userAccount);
         Assertions.assertEquals(media.getStart(), result.getStart());

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/CasesMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/CasesMapperTest.java
@@ -129,7 +129,7 @@ class CasesMapperTest {
         caseEntity.setDefenceList(createDefenceList(caseEntity));
         caseEntity.setDefendantList(createDefendantList(caseEntity));
 
-        AddCaseRequest request = new AddCaseRequest(SWANSEA, "1");
+        AddCaseRequest request = new AddCaseRequest(SWANSEA, "1",null,null,null,null,null);
         request.setProsecutors(new ArrayList<>(List.of("New Prosecutor")));
         request.setDefenders(new ArrayList<>(List.of("New Defenders")));
         request.setDefendants(new ArrayList<>(List.of("New Defendants")));
@@ -155,7 +155,7 @@ class CasesMapperTest {
         caseEntity.setDefenceList(createDefenceList(caseEntity));
         caseEntity.setDefendantList(createDefendantList(caseEntity));
 
-        AddCaseRequest request = new AddCaseRequest(SWANSEA, "1");
+        AddCaseRequest request = new AddCaseRequest(SWANSEA, "1",null,null,null,null,null);
         request.setProsecutors(new ArrayList<>(List.of("prosecutor_casenumber1_1")));
         request.setDefenders(new ArrayList<>(List.of("defence_casenumber1_1")));
         request.setDefendants(new ArrayList<>(List.of("defendant_casenumber1_1")));
@@ -173,7 +173,7 @@ class CasesMapperTest {
     void testDefendantNameMatchingUnallocatedCaseNumberFormat() {
         CourtCaseEntity existingCourtCaseEntity = new CourtCaseEntity();
         existingCourtCaseEntity.setCaseNumber(CASE_NUMBER);
-        AddCaseRequest request = new AddCaseRequest(SWANSEA, CASE_NUMBER);
+        AddCaseRequest request = new AddCaseRequest(SWANSEA, CASE_NUMBER,null,null,null,null,null);
         var unallocatedCaseNumber = "U20240603-103622, U20240603-03622";
         request.setDefendants(new ArrayList<>(List.of(unallocatedCaseNumber, "Mr Defendant")));
 

--- a/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
@@ -628,7 +628,7 @@ class CaseServiceImplTest {
         assertThat(pageArgumentCapturor.getValue()).isNotNull();
 
         Pageable pageable = mock(Pageable.class);
-        Page<EventEntity> page = mock(Page.class);
+        Page<Event> page = mock(Page.class);
         when(eventRepository.findAllByCaseIdPaginated(caseId, pageable)).thenReturn(page);
         assertThat(pageArgumentCapturor.getValue().apply(pageable))
             .isEqualTo(page);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4946)


### Change description ###
# Summary of Git Diff

This Git diff includes various modifications across multiple files in a project. The changes primarily focus on updating method parameters, enhancing test cases, and refining configurations in the Gradle build file. Notable changes include the addition of new parameters in constructors and the alterations to method signatures to accommodate these updates.

## Highlights

- **build.gradle**:
  - Added new configuration options:
    - `generatedConstructorWithRequiredArgs: "false"`
    - `additionalModelTypeAnnotations: "@lombok.AllArgsConstructor;@lombok.NoArgsConstructor"`

- **AnnotationPostTest.java**:
  - Updated the constructor for `Annotation` to accept an additional `null` parameter.
  
- **CaseControllerGetEventByCaseIdTest.java**:
  - Renamed test method for clarity: from `casesGetEvents_usingPaginatedCrieria_WithCustomOrderHearingDate_shouldReturnPaginatedResultsUsingCustomOrder_10Resultslimit3Page1` to `casesGetEvents_usingPaginatedCrieria_WithCustomOrderHearingDateAsc_shouldReturnPaginatedResultsUsingCustomOrder_10Resultslimit3Page1`.
  - Added a new test for descending order in pagination results.

- **EventRepository.java**:
  - Changed the return type of `findAllByCaseIdPaginated` from `Page<EventEntity>` to `Page<Event>`.

- **Transcriber View Mappers**:
  - Added `null` parameters in the constructors of various row mappers to accommodate new fields.

- **UserManagementServiceImpl.java**:
  - Updated user validation to include new parameters in the `User` object.

- **Test Cases**:
  - Updated various test cases to handle the new constructor signatures and validate new functionalities effectively. This includes adding `null` parameters to `AddCaseRequest` and other entities to ensure backward compatibility and proper handling of optional fields.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
