### PR TITLE
DMP-5016 Remove 90 day limit on transcription queries

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriberTranscriptsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetTranscriberTranscriptsIntTest.java
@@ -33,8 +33,7 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
     private static final String ASSIGNED_QUERY_PARAM = "assigned";
     private static final String PLACEHOLDER_URGENCY_ID = "$URGENCY";
     private static final String TODAYS_DATE = "$TODAYS_DATE";
-    private static final String MINUS_89_DAYS = "$MINUS_89_DAYS";
-    private static final String MINUS_90_DAYS = "$MINUS_90_DAYS";
+    private static final String MINUS_30_DAYS = "$MINUS_30_DAYS";
 
     @Autowired
     private MockMvc mockMvc;
@@ -46,14 +45,12 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
     private UserAccountRepository userAccountRepository;
 
     String todaysDate;
-    String dateMinus89Days;
-    String dateMinus90Days;
+    String dateMinus30Days;
 
     @BeforeEach
     void beforeAll() {
         todaysDate = todaysDateMinusDaysFormattedForSql(0);
-        dateMinus89Days = todaysDateMinusDaysFormattedForSql(89);
-        dateMinus90Days = todaysDateMinusDaysFormattedForSql(90);
+        dateMinus30Days = todaysDateMinusDaysFormattedForSql(30);
         setupDataWithUrgency();
     }
 
@@ -150,7 +147,7 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
             )
             .queryParam(ASSIGNED_QUERY_PARAM, FALSE.toString());
 
-        String expectedStateChangeTs = convertSqlDateTimeToLocalDateTime(dateMinus89Days);
+        String expectedStateChangeTs = convertSqlDateTimeToLocalDateTime(dateMinus30Days);
 
         final MvcResult mvcResult = mockMvc.perform(requestBuilder)
             .andExpect(status().isOk())
@@ -216,7 +213,7 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
             )
             .queryParam(ASSIGNED_QUERY_PARAM, FALSE.toString());
 
-        String expectedStateChangeTs = convertSqlDateTimeToLocalDateTime(dateMinus89Days);
+        String expectedStateChangeTs = convertSqlDateTimeToLocalDateTime(dateMinus30Days);
 
         final MvcResult mvcResult = mockMvc.perform(requestBuilder)
             .andExpect(status().isOk())
@@ -257,7 +254,7 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
             )
             .queryParam(ASSIGNED_QUERY_PARAM, TRUE.toString());
 
-        String expectedStateChangeTs = convertSqlDateTimeToLocalDateTime(dateMinus89Days);
+        String expectedStateChangeTs = convertSqlDateTimeToLocalDateTime(dateMinus30Days);
         String expectedStateChangeTodayTs = convertSqlDateTimeToLocalDateTime(todaysDate);
 
         final MvcResult mvcResult = mockMvc.perform(requestBuilder)
@@ -382,18 +379,7 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
                     VALUES (44, 41, 5, -410, '2023-11-23 16:30:00.0+00');
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (45, 41, 3, -410, '$MINUS_89_DAYS');
-                
-                    -- Add transcript request to test transcriptions do not show after 90 days
-                    INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
-                    created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
-                    is_manual_transcription, hide_request_from_requestor, is_current)
-                    VALUES (602, NULL, 9, NULL, NULL, '2023-11-23 09:00:00+00', '2023-11-23 09:30:00+00', '2023-11-23 16:25:55.297666+00',
-                    '2023-11-23 16:26:20.451054+00', -410, -410, $URGENCY, 3, NULL, true, false, true);
-                    INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (602,-1);
-                    INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (602,-1);
-                    INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (100, 602, 1, -410, '$MINUS_90_DAYS');
+                    VALUES (45, 41, 3, -410, '$MINUS_30_DAYS');
                 
                     -- Your work > To do: With Transcriber
                     INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
@@ -404,30 +390,13 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                     INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (81,-1);
                     INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (81,-1);
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (81, 81, 1, -410, '$MINUS_89_DAYS');
+                    VALUES (81, 81, 1, -410, '$MINUS_30_DAYS');
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (82, 81, 2, -410, '$MINUS_89_DAYS');
+                    VALUES (82, 81, 2, -410, '$MINUS_30_DAYS');
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (101, 81, 3, -410, '$MINUS_89_DAYS');
+                    VALUES (101, 81, 3, -410, '$MINUS_30_DAYS');
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (102, 81, 5, -410, '$MINUS_89_DAYS');
-                
-                    -- Add additional Your work transcription to test transcriptions do not show after 90 days
-                    INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
-                    created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
-                    is_manual_transcription, hide_request_from_requestor, is_current)
-                    VALUES (601, NULL, 9, NULL, NULL, '2023-11-23 09:20:00+00', '2024-07-01 09:30:00+00', '2024-07-01 17:45:14.938855+00',
-                    '2024-07-01 17:45:51.1549+00', -410, -410, $URGENCY, 5, NULL, true, false, true);
-                    INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (601,-1);
-                    INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (601,-1);
-                    INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (103, 601, 1, -410, '$MINUS_90_DAYS');
-                    INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (104, 601, 2, -410, '$MINUS_90_DAYS');
-                    INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (105, 601, 3, -410, '$MINUS_90_DAYS');
-                    INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (106, 601, 5, -410, '$MINUS_90_DAYS');
+                    VALUES (102, 81, 5, -410, '$MINUS_30_DAYS');
                 
                     -- This transcription would be hidden from Your work > Completed today (transcriber-view?assigned=true)
                     INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
@@ -484,7 +453,7 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
                     VALUES (244, 150, 5, -410, '2023-11-23 16:30:00.0+00');
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (245, 150, 3, -410, '$MINUS_89_DAYS');
+                    VALUES (245, 150, 3, -410, '$MINUS_30_DAYS');
                 
                     INSERT INTO darts.transcription (tra_id, ctr_id, trt_id, transcription_object_id, requested_by, start_ts, end_ts,
                     created_ts, last_modified_ts, last_modified_by, created_by, tru_id, trs_id, hearing_date,
@@ -494,18 +463,17 @@ class TranscriptionControllerGetTranscriberTranscriptsIntTest extends Integratio
                     INSERT INTO darts.case_transcription_ae (tra_id, cas_id) VALUES (151,-1);
                     INSERT INTO darts.hearing_transcription_ae (tra_id, hea_id) VALUES (151,-1);
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (246, 151, 1, -410, '$MINUS_89_DAYS');
+                    VALUES (246, 151, 1, -410, '$MINUS_30_DAYS');
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (247, 151, 2, -410, '$MINUS_89_DAYS');
+                    VALUES (247, 151, 2, -410, '$MINUS_30_DAYS');
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (248, 151, 3, -410, '$MINUS_89_DAYS');
+                    VALUES (248, 151, 3, -410, '$MINUS_30_DAYS');
                     INSERT INTO darts.transcription_workflow (trw_id, tra_id, trs_id, workflow_actor, workflow_ts)
-                    VALUES (249, 151, 5, -410, '$MINUS_89_DAYS');
+                    VALUES (249, 151, 5, -410, '$MINUS_30_DAYS');
                 
                 """.replace(PLACEHOLDER_URGENCY_ID, generatedUrgency ? "1" : "NULL")
                 .replace(TODAYS_DATE, todaysDate)
-                .replace(MINUS_89_DAYS, dateMinus89Days)
-                .replace(MINUS_90_DAYS, dateMinus90Days)
+                .replace(MINUS_30_DAYS, dateMinus30Days)
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetYourTranscriptsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerGetYourTranscriptsIntTest.java
@@ -224,27 +224,6 @@ class TranscriptionControllerGetYourTranscriptsIntTest extends IntegrationBase {
     }
 
     @Test
-    void getYourTranscriptsApproverOver90DaysShouldNotReturn() throws Exception {
-        var courtCase = authorisationStub.getCourtCaseEntity();
-        dartsDatabase.getTranscriptionStub()
-            .createAndSaveAwaitingAuthorisationTranscription(
-                systemUser,
-                courtCase,
-                authorisationStub.getHearingEntity(), MINUS_90_DAYS
-            );
-
-        MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URI)
-            .header(
-                "user_id",
-                testUser.getId()
-            );
-
-        mockMvc.perform(requestBuilder)
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.approver_transcriptions").isEmpty());
-    }
-
-    @Test
     void getYourTranscriptsRequesterShouldNotReturnHidden() throws Exception {
         var courtCase = authorisationStub.getCourtCaseEntity();
         var hearing = authorisationStub.getHearingEntity();

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/YourTranscriptsQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/YourTranscriptsQueryImpl.java
@@ -7,10 +7,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.transcriptions.component.YourTranscriptsQuery;
 import uk.gov.hmcts.darts.transcriptions.model.YourTranscriptsSummary;
-import uk.gov.hmcts.darts.transcriptions.util.TranscriptionUtil;
 
 import java.math.BigInteger;
-import java.time.Duration;
 import java.util.List;
 
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
@@ -28,11 +26,7 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
     private static final String ROL_ID = "rol_id";
     private static final String TRANSCRIPTION_STATUS_ID = "trs_id";
     private static final String INCLUDE_HIDDEN_FROM_REQUESTOR = "include_hidden_from_requester";
-    private static final String DATE_LIMIT = "date_limit";
     private static final String MAX_RESULT_SIZE = "max_result_size";
-
-    @Value("${darts.transcription.search.date-limit}")
-    private final Duration dateLimit;
 
     @Value("${darts.transcription.search.max-result-size}")
     private final BigInteger maxResultSize;
@@ -83,7 +77,6 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
                         WHERE trd.tra_id = tra.tra_id
                     )
                 )
-                AND trw.workflow_ts >= :date_limit
                 AND tra.is_current = true
                 UNION
                 -- Migrated "requester_transcriptions"
@@ -131,7 +124,6 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
                         WHERE trd.tra_id = tra.tra_id
                     )
                 )
-                AND trw.workflow_ts >= :date_limit
                 AND tra.is_current = true
                 ORDER BY requested_ts DESC
                 LIMIT :max_result_size
@@ -139,7 +131,6 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
             new MapSqlParameterSource()
                 .addValue(USR_ID, userId)
                 .addValue(INCLUDE_HIDDEN_FROM_REQUESTOR, includeHiddenFromRequester)
-                .addValue(DATE_LIMIT, TranscriptionUtil.getDateToLimitResults(dateLimit))
                 .addValue(MAX_RESULT_SIZE, maxResultSize),
             yourTranscriptsSummaryRequesterRowMapper
         );
@@ -198,7 +189,6 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
                         WHERE trd.tra_id = tra.tra_id
                     )
                 )
-                AND trw.workflow_ts >= :date_limit
                 AND tra.is_current = true
                 
                 UNION
@@ -255,7 +245,6 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
                         WHERE trd.tra_id = tra.tra_id
                     )
                 )
-                AND trw.workflow_ts >= :date_limit
                 AND tra.is_current = true
                 ORDER BY requested_ts DESC
                 LIMIT :max_result_size
@@ -263,7 +252,6 @@ public class YourTranscriptsQueryImpl implements YourTranscriptsQuery {
             new MapSqlParameterSource("usr_id", userId)
                 .addValue(ROL_ID, APPROVER.getId())
                 .addValue(TRANSCRIPTION_STATUS_ID, AWAITING_AUTHORISATION.getId())
-                .addValue(DATE_LIMIT, TranscriptionUtil.getDateToLimitResults(dateLimit))
                 .addValue(MAX_RESULT_SIZE, maxResultSize),
             yourTranscriptsSummaryRowMapper
         );

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -328,7 +328,6 @@ darts:
       - "application/msword"
     max-created-by-duration: 30d
     search:
-      date-limit: 90d
       max-result-size: 500
   portal:
     url: ${DARTS_PORTAL_URL:https://darts.staging.apps.hmcts.net}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-5016


### Change description ###
The 90 day limit on transcriptions has been superseded by the requirement to close transcriptions older than 30 days. This PR clears up this redundant code. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
