### PR TITLE
DMP-3379: Get events for case on admin portal

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -378,7 +378,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                 .queryParam("page_number", "1")
                 .queryParam("page_size", "3")
                 .queryParam("sort_order", "ASC,ASC")
-                .queryParam("sort_by", "event,timestamp");
+                .queryParam("sort_by", "eventName,timestamp");
 
             MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -116,7 +116,8 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
             "timestamp":"2023-01-01T12:01:00Z",
             "name":"Section 11 of the Contempt of Court Act 1981",
             "text":"some-event-text-2023-01-01T12:01",
-            "is_data_anonymised": false
+            "is_data_anonymised": false,
+            "courtroom":"TESTCOURTROOM"
             }]
             """;
 
@@ -166,7 +167,8 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                 "timestamp": "2023-01-02T12:01:00Z",
                 "name": "Section 11 of the Contempt of Court Act 1981",
                 "is_data_anonymised": false,
-                "text": "some-event-text-2023-01-01T12:01"
+                "text": "some-event-text-2023-01-01T12:01",
+                "courtroom":"TESTCOURTROOM"
               },
               {
                 "id": 1,
@@ -175,7 +177,8 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                 "timestamp": "2023-01-01T12:01:00Z",
                 "name": "Section 11 of the Contempt of Court Act 1981",
                 "is_data_anonymised": false,
-                "text": "some-event-text-2023-01-01T12:01"
+                "text": "some-event-text-2023-01-01T12:01",
+                "courtroom":"TESTCOURTROOM"
               }
             ]
             """;

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -378,7 +378,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                 .queryParam("page_number", "1")
                 .queryParam("page_size", "3")
                 .queryParam("sort_order", "ASC,ASC")
-                .queryParam("sort_by", "event,time");
+                .queryParam("sort_by", "event,timestamp");
 
             MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -355,7 +355,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                 .queryParam("page_number", "1")
                 .queryParam("page_size", "3")
                 .queryParam("sort_order", "DESC")
-                .queryParam("sort_by", "time");
+                .queryParam("sort_by", "timestamp");
 
             MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.util.DateConverterUtil;
 import uk.gov.hmcts.darts.test.common.PaginationTestSupport;
+import uk.gov.hmcts.darts.test.common.TestUtils;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.util.pagination.PaginatedList;
 
@@ -251,6 +252,50 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                     eventEntityList5.get(1).getId(),
                     eventEntityList5.get(0).getId(),
                     eventEntityList3.get(1).getId());
+
+            JSONAssert.assertEquals(
+                """
+                    {
+                      "current_page": 1,
+                      "total_pages": 4,
+                      "page_size": 3,
+                      "total_items": 10,
+                      "data": [
+                        {
+                          "id": 11,
+                          "hearing_id": 3,
+                          "hearing_date": "2020-01-01",
+                          "timestamp": "2020-01-01T14:02:00Z",
+                          "name": "Section 39 of the Children and Young Persons Act 1933",
+                          "is_data_anonymised": false,
+                          "text": "some-event-text-2020-01-01T14:02",
+                          "courtroom": "TESTCOURTROOM"
+                        },
+                        {
+                          "id": 10,
+                          "hearing_id": 3,
+                          "hearing_date": "2020-01-01",
+                          "timestamp": "2020-01-01T14:01:00Z",
+                          "name": "Section 39 of the Children and Young Persons Act 1933",
+                          "is_data_anonymised": false,
+                          "text": "some-event-text-2020-01-01T14:01",
+                          "courtroom": "TESTCOURTROOM"
+                        },
+                        {
+                          "id": 7,
+                          "hearing_id": 3,
+                          "hearing_date": "2020-01-01",
+                          "timestamp": "2020-01-01T13:02:00Z",
+                          "name": "Section 11 of the Contempt of Court Act 1981",
+                          "is_data_anonymised": false,
+                          "text": "some-event-text-2020-01-01T13:02",
+                          "courtroom": "TESTCOURTROOM"
+                        }
+                      ]
+                    }
+                    """,
+                TestUtils.writeAsString(paginatedList),
+                JSONCompareMode.STRICT);
         }
 
         @Test
@@ -307,7 +352,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                 .queryParam("page_number", "1")
                 .queryParam("page_size", "3")
                 .queryParam("sort_order", "DESC")
-                .queryParam("sort_by", "timestamp");
+                .queryParam("sort_by", "time");
 
             MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
@@ -330,7 +375,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
                 .queryParam("page_number", "1")
                 .queryParam("page_size", "3")
                 .queryParam("sort_order", "ASC,ASC")
-                .queryParam("sort_by", "eventName,timestamp");
+                .queryParam("sort_by", "event,time");
 
             MvcResult mvcResult = mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/EventMapper.java
@@ -38,6 +38,7 @@ public class EventMapper {
         event.setName(eventEntity.getEventType().getEventName());
         event.setText(eventEntity.getEventText());
         event.isDataAnonymised(eventEntity.isDataAnonymised());
+        event.courtroom(eventEntity.getCourtroom().getName());
 
         return event;
     }

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -209,7 +209,7 @@ public class CaseServiceImpl implements CaseService {
             List.of(Sort.Direction.DESC, Sort.Direction.DESC),
             Map.of("eventId", "ee.id",
                    "hearingDate", "he.hearingDate",
-                   "time", "ee.timestamp",
+                   "timestamp", "ee.timestamp",
                    "event", "et.eventName",
                    "courtroom", "ee.courtroom",
                    "text", "ee.eventText")

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -210,7 +210,7 @@ public class CaseServiceImpl implements CaseService {
             Map.of("eventId", "ee.id",
                    "hearingDate", "he.hearingDate",
                    "timestamp", "ee.timestamp",
-                   "event", "et.eventName",
+                   "eventName", "et.eventName",
                    "courtroom", "ee.courtroom",
                    "text", "ee.eventText")
         );

--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImpl.java
@@ -207,9 +207,12 @@ public class CaseServiceImpl implements CaseService {
             event -> event,
             List.of(HearingEntity_.HEARING_DATE, EventEntity_.TIMESTAMP),
             List.of(Sort.Direction.DESC, Sort.Direction.DESC),
-            Map.of("hearingDate", "he.hearingDate",
-                   "timestamp", "ee.timestamp",
-                   "eventName", "et.eventName")
+            Map.of("eventId", "ee.id",
+                   "hearingDate", "he.hearingDate",
+                   "time", "ee.timestamp",
+                   "event", "et.eventName",
+                   "courtroom", "ee.courtroom",
+                   "text", "ee.eventText")
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -50,7 +50,8 @@ public interface EventRepository extends JpaRepository<EventEntity, Integer> {
                   ee.timestamp,
                   ee.eventType.eventName,
                   ee.isDataAnonymised,
-                  ee.eventText
+                  ee.eventText,
+                  ee.courtroom.name
            )
            FROM EventEntity ee
            JOIN ee.hearingEntities he

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -293,9 +293,12 @@ paths:
             items:
               type: string
               enum:
+                - "eventId"
                 - "hearingDate"
-                - "timestamp"
-                - "eventName"
+                - "time"
+                - "event"
+                - "courtroom"
+                - "text"
         - in: query
           name: sort_order
           schema:
@@ -820,6 +823,9 @@ components:
         text:
           type: string
           example: "Record:New Case"
+        courtroom:
+          type: string
+          example: "1"
     transcripts:
       type: array
       items:

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -296,7 +296,7 @@ paths:
                 - "eventId"
                 - "hearingDate"
                 - "timestamp"
-                - "event"
+                - "eventName"
                 - "courtroom"
                 - "text"
         - in: query

--- a/src/main/resources/openapi/cases.yaml
+++ b/src/main/resources/openapi/cases.yaml
@@ -295,7 +295,7 @@ paths:
               enum:
                 - "eventId"
                 - "hearingDate"
-                - "time"
+                - "timestamp"
                 - "event"
                 - "courtroom"
                 - "text"

--- a/src/test/java/uk/gov/hmcts/darts/cases/mapper/EventMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/mapper/EventMapperTest.java
@@ -25,6 +25,7 @@ class EventMapperTest {
         OffsetDateTime hearingDate = OffsetDateTime.parse("2024-07-01T12:00Z");
         HearingEntity hearing = CommonTestDataUtil.createHearing("case1", hearingDate.toLocalDate());
         EventEntity eventEntity = createEventWith("eventName", "event text", hearing, hearingDate);
+        eventEntity.setCourtroom(CommonTestDataUtil.createCourtroom("some-courtroom"));
         if (isAnonymised) {
             eventEntity.setDataAnonymised(true);
         }
@@ -38,7 +39,7 @@ class EventMapperTest {
         assertEquals("event text", event.getText());
         assertEquals(hearingDate, event.getTimestamp());
         assertEquals(isAnonymised, event.getIsDataAnonymised());
-
+        assertEquals("SOME-COURTROOM", event.getCourtroom());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
@@ -622,7 +622,7 @@ class CaseServiceImplTest {
                 eq(List.of(Sort.Direction.DESC, Sort.Direction.DESC)),
                 eq(Map.of("eventId", "ee.id",
                           "hearingDate", "he.hearingDate",
-                          "time", "ee.timestamp",
+                          "timestamp", "ee.timestamp",
                           "event", "et.eventName",
                           "courtroom", "ee.courtroom",
                           "text", "ee.eventText"))

--- a/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
@@ -623,7 +623,7 @@ class CaseServiceImplTest {
                 eq(Map.of("eventId", "ee.id",
                           "hearingDate", "he.hearingDate",
                           "timestamp", "ee.timestamp",
-                          "event", "et.eventName",
+                          "eventName", "et.eventName",
                           "courtroom", "ee.courtroom",
                           "text", "ee.eventText"))
             );

--- a/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseServiceImplTest.java
@@ -400,7 +400,6 @@ class CaseServiceImplTest {
         );
 
         List<EventEntity> events = Lists.newArrayList(createEventWith("eventName", "event", hearing, hearingDate));
-
         when(eventRepository.findAllByCaseId(courtCaseEntity.getId())).thenReturn(events);
         when(caseRepository.findById(courtCaseEntity.getId())).thenReturn(Optional.of(courtCaseEntity));
         List<Event> result = caseService.getEventsByCaseId(courtCaseEntity.getId());
@@ -621,9 +620,12 @@ class CaseServiceImplTest {
                 dataMapperArgumentCapturor.capture(),
                 eq(List.of(HearingEntity_.HEARING_DATE, EventEntity_.TIMESTAMP)),
                 eq(List.of(Sort.Direction.DESC, Sort.Direction.DESC)),
-                eq(Map.of("hearingDate", "he.hearingDate",
-                          "timestamp", "ee.timestamp",
-                          "eventName", "et.eventName"))
+                eq(Map.of("eventId", "ee.id",
+                          "hearingDate", "he.hearingDate",
+                          "time", "ee.timestamp",
+                          "event", "et.eventName",
+                          "courtroom", "ee.courtroom",
+                          "text", "ee.eventText"))
             );
         assertThat(pageArgumentCapturor.getValue()).isNotNull();
 

--- a/src/test/resources/Tests/cases/CaseServiceTest/testGetEventsByCase/expectedResponse.json
+++ b/src/test/resources/Tests/cases/CaseServiceTest/testGetEventsByCase/expectedResponse.json
@@ -6,6 +6,7 @@
     "timestamp": "2024-07-01T12:00:00Z",
     "name": "eventName",
     "text": "event",
-    "is_data_anonymised": false
+    "is_data_anonymised": false,
+    "courtroom": "1",
   }
 ]


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3379)


### Change description ###
# Summary of Git Diff

This Git diff introduces several enhancements and modifications to the case management system, primarily focusing on the handling of event data related to court cases. Key changes include the addition of courtroom information in various components, updates to sorting parameters, and enhancements to JSON response formats for better clarity and usability.

## Highlights

- **New Import**: Added `TestUtils` to the `CaseControllerGetEventByCaseIdTest` for improved testing capabilities.
- **JSON Response Update**: Enhanced the expected JSON response structure in the integration test to include fields such as `courtroom` and updated the naming of existing fields for consistency (e.g., `timestamp` to `time`).
- **Sorting Parameter Changes**: Updated sorting parameters in the query string from `sort_by` values of `timestamp` and `eventName` to `time` and `event`, respectively.
- **Event Mapper Update**: Modified the `EventMapper` to include `courtroom` information when mapping from `EventEntity` to `Event`.
- **Service Layer Enhancements**: Updated `CaseServiceImpl` to accommodate new mapping for courtroom data and adjusted sorting criteria in the event retrieval logic.
- **Repository Changes**: Altered the `EventRepository` to fetch `courtroom` names in addition to existing event attributes.
- **OpenAPI Specification**: Updated the OpenAPI definition to reflect new fields in the expected response, ensuring that the API documentation is in sync with the implemented changes.
- **Test Adjustments**: Adjusted unit tests in `EventMapperTest` and `CaseServiceImplTest` to validate the inclusion of `courtroom` data and reflect other changes made in the codebase.

These changes collectively aim to improve the functionality and clarity of the event management features within the system, enhancing both developer experience and user interface consistency.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
