### PR TITLE
DMP-5045: Can we point 2 services at a single Dev environment

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -14,8 +14,8 @@ jobs:
     steps:
       - name: Remove Internal AD callback URLs
         run: |
-          authCallbackUrl="https://darts-portal-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/internal/callback"
-          logoutUrl="https://darts-portal-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/internal/logout-callback"
+          authCallbackUrl="https://darts-portal-api-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/internal/callback"
+          logoutUrl="https://darts-portal-api-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/internal/logout-callback"
           targetAppName="darts-stg"
           appId="dec3be30-6325-4335-b898-eb01985d6c90"
 
@@ -47,8 +47,8 @@ jobs:
     steps:
       - name: Remove External AD B2C callback URLs
         run: |
-          authCallbackUrl="https://darts-portal-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/callback"
-          logoutUrl="https://darts-portal-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/logout-callback"
+          authCallbackUrl="https://darts-portal-api-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/callback"
+          logoutUrl="https://darts-portal-api-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/logout-callback"
           targetAppName="darts"
           appId="363c11cb-48b9-44bf-9d06-9a3973f6f413"
 

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - name: Set Internal AD callback URLs
         run: |
-          authCallbackUrl="https://darts-portal-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/internal/callback"
-          logoutUrl="https://darts-portal-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/internal/logout-callback"
+          authCallbackUrl="https://darts-portal-api-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/internal/callback"
+          logoutUrl="https://darts-portal-api-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/internal/logout-callback"
           targetAppName="darts-stg"
           appId="dec3be30-6325-4335-b898-eb01985d6c90"
 
@@ -53,8 +53,8 @@ jobs:
     steps:
       - name: Set External AD B2C callback URLs
         run: |
-          authCallbackUrl="https://darts-portal-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/callback"
-          logoutUrl="https://darts-portal-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/logout-callback"
+          authCallbackUrl="https://darts-portal-api-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/callback"
+          logoutUrl="https://darts-portal-api-pr-${PR_NUMBER}.dev.platform.hmcts.net/auth/logout-callback"
           targetAppName="darts"
           appId="363c11cb-48b9-44bf-9d06-9a3973f6f413"
 

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -21,6 +21,13 @@
     <editorconfig>
       <option name="ENABLED" value="false" />
     </editorconfig>
+    <codeStyleSettings language="Groovy">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
       <option name="CALL_PARAMETERS_WRAP" value="1" />

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -71,6 +71,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 def determineDevEnvironmentDeployment() {
     env.DEV_ENABLE_DARTS_PORTAL = false
     env.DEV_DARTS_PORTAL_URL = "https://darts.staging.apps.hmcts.net"
+    env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = "latest"
 
     echo "1 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
     echo "1 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
@@ -81,7 +82,12 @@ def determineDevEnvironmentDeployment() {
             if (label == "enable_darts_portal") {
                 env.DEV_ENABLE_DARTS_PORTAL = true
                 env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
-                echo "Deploying DARTS portal instance in PR environment"
+
+                if(label ==~ 'enable_darts_portal_PR.*') {
+                    env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal_", "")
+                    echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
+                }
+                echo "Deploying DARTS portal (${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}) instance in PR environment"
             }
         }
     }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -12,51 +12,51 @@ def component = "api"
 def branchesToSync = ['demo', 'perftest', 'ithc']
 
 def secrets = [
-    'darts-${env}': [
-        secret('GovukNotifyTestApiKey', 'GOVUK_NOTIFY_API_KEY'),
-        secret('app-insights-connection-string', 'app-insights-connection-string'),
-        secret('AzureAdB2CTenantId', 'AAD_B2C_TENANT_ID'),
-        secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
-        secret('AzureAdB2CClientSecret', 'AAD_B2C_CLIENT_SECRET'),
-        secret('AzureAdB2CFuncTestROPCUsername', 'FUNC_TEST_ROPC_USERNAME'),
-        secret('AzureAdB2CFuncTestROPCPassword', 'FUNC_TEST_ROPC_PASSWORD'),
-        secret('AzureAdB2CFuncTestROPCClientId', 'AAD_B2C_ROPC_CLIENT_ID'),
-        secret('AzureAdB2CFuncTestROPCClientSecret', 'AAD_B2C_ROPC_CLIENT_SECRET'),
-        secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
-        secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
-        secret('AzureADTenantId', 'AAD_TENANT_ID'),
-        secret('AzureADClientId', 'AAD_CLIENT_ID'),
-        secret('AzureADClientSecret', 'AAD_CLIENT_SECRET'),
-        secret('AzureADTenantIdJustice', 'AAD_TENANT_ID_JUSTICE'),
-        secret('AzureADClientIdJustice', 'AAD_CLIENT_ID_JUSTICE'),
-        secret('AzureADClientSecretJustice', 'AAD_CLIENT_SECRET_JUSTICE'),
-        secret('XhibitUserName', 'XHIBIT_USER_NAME'),
-        secret('XhibitPassword', 'XHIBIT_PASSWORD'),
-        secret('CppUserName', 'CPP_USER_NAME'),
-        secret('CppPassword', 'CPP_PASSWORD'),
-        secret('DarPcUserName', 'DARPC_USER_NAME'),
-        secret('DarPcPassword', 'DARPC_PASSWORD'),
-        secret('DarMidTierUserName', 'DAR_MIDTIER_USER_NAME'),
-        secret('DarMidTierPassword', 'DAR_MIDTIER_PASSWORD'),
-        secret('AzureADFunctionalTestUsername', 'AZURE_AD_FUNCTIONAL_TEST_USERNAME'),
-        secret('AzureADFunctionalTestPassword', 'AZURE_AD_FUNCTIONAL_TEST_PASSWORD'),
-        secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
-        secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
-        secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
-        secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT'),
-        secret('DETSSasURLEndpoint', 'DETS_SAS_URL_ENDPOINT'),
-        secret('DartsInboundStorageSasUrl', 'DARTS_INBOUND_STORAGE_SAS_URL'),
-        secret('DartsUnstructuredStorageSasUrl', 'DARTS_UNSTRUCTURED_STORAGE_SAS_URL'),
-        secret('ArmServiceEntitlement', 'ARM_SERVICE_ENTITLEMENT'),
-        secret('ArmStorageAccountName', 'ARM_STORAGE_ACCOUNT_NAME'),
-        // secrets for staging DB
-        secret('api-POSTGRES-HOST', 'STAGING_DB_HOST'),
-        secret('api-POSTGRES-USER', 'STAGING_DB_USER'),
-        secret('api-POSTGRES-PASS', 'STAGING_DB_PASS'),
-        secret('api-POSTGRES-PORT', 'STAGING_DB_PORT'),
-        secret('api-POSTGRES-SCHEMA', 'STAGING_DB_SCHEMA'),
-        secret('api-POSTGRES-DATABASE', 'STAGING_DB_DATABASE'),
-    ],
+        'darts-${env}': [
+                secret('GovukNotifyTestApiKey', 'GOVUK_NOTIFY_API_KEY'),
+                secret('app-insights-connection-string', 'app-insights-connection-string'),
+                secret('AzureAdB2CTenantId', 'AAD_B2C_TENANT_ID'),
+                secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+                secret('AzureAdB2CClientSecret', 'AAD_B2C_CLIENT_SECRET'),
+                secret('AzureAdB2CFuncTestROPCUsername', 'FUNC_TEST_ROPC_USERNAME'),
+                secret('AzureAdB2CFuncTestROPCPassword', 'FUNC_TEST_ROPC_PASSWORD'),
+                secret('AzureAdB2CFuncTestROPCClientId', 'AAD_B2C_ROPC_CLIENT_ID'),
+                secret('AzureAdB2CFuncTestROPCClientSecret', 'AAD_B2C_ROPC_CLIENT_SECRET'),
+                secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
+                secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
+                secret('AzureADTenantId', 'AAD_TENANT_ID'),
+                secret('AzureADClientId', 'AAD_CLIENT_ID'),
+                secret('AzureADClientSecret', 'AAD_CLIENT_SECRET'),
+                secret('AzureADTenantIdJustice', 'AAD_TENANT_ID_JUSTICE'),
+                secret('AzureADClientIdJustice', 'AAD_CLIENT_ID_JUSTICE'),
+                secret('AzureADClientSecretJustice', 'AAD_CLIENT_SECRET_JUSTICE'),
+                secret('XhibitUserName', 'XHIBIT_USER_NAME'),
+                secret('XhibitPassword', 'XHIBIT_PASSWORD'),
+                secret('CppUserName', 'CPP_USER_NAME'),
+                secret('CppPassword', 'CPP_PASSWORD'),
+                secret('DarPcUserName', 'DARPC_USER_NAME'),
+                secret('DarPcPassword', 'DARPC_PASSWORD'),
+                secret('DarMidTierUserName', 'DAR_MIDTIER_USER_NAME'),
+                secret('DarMidTierPassword', 'DAR_MIDTIER_PASSWORD'),
+                secret('AzureADFunctionalTestUsername', 'AZURE_AD_FUNCTIONAL_TEST_USERNAME'),
+                secret('AzureADFunctionalTestPassword', 'AZURE_AD_FUNCTIONAL_TEST_PASSWORD'),
+                secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
+                secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
+                secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
+                secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT'),
+                secret('DETSSasURLEndpoint', 'DETS_SAS_URL_ENDPOINT'),
+                secret('DartsInboundStorageSasUrl', 'DARTS_INBOUND_STORAGE_SAS_URL'),
+                secret('DartsUnstructuredStorageSasUrl', 'DARTS_UNSTRUCTURED_STORAGE_SAS_URL'),
+                secret('ArmServiceEntitlement', 'ARM_SERVICE_ENTITLEMENT'),
+                secret('ArmStorageAccountName', 'ARM_STORAGE_ACCOUNT_NAME'),
+                // secrets for staging DB
+                secret('api-POSTGRES-HOST', 'STAGING_DB_HOST'),
+                secret('api-POSTGRES-USER', 'STAGING_DB_USER'),
+                secret('api-POSTGRES-PASS', 'STAGING_DB_PASS'),
+                secret('api-POSTGRES-PORT', 'STAGING_DB_PORT'),
+                secret('api-POSTGRES-SCHEMA', 'STAGING_DB_SCHEMA'),
+                secret('api-POSTGRES-DATABASE', 'STAGING_DB_DATABASE'),
+        ],
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
@@ -78,12 +78,12 @@ def determineDevEnvironmentDeployment() {
 
     def githubApi = new GithubAPI(this)
     if (githubApi.checkForLabel(env.BRANCH_NAME, "enable_keep_helm")) {
-        for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable_darts_") ) {
+        for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable_darts_")) {
             if (label ==~ /enable_darts_portal.*/) {
                 env.DEV_ENABLE_DARTS_PORTAL = true
                 env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
-                if(label ==~ /enable_darts_portal:pr-.*/) {
+                if (label ==~ /enable_darts_portal:pr-.*/) {
                     env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal:", "")
                     echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
                 }
@@ -110,57 +110,59 @@ withPipeline(type, product, component) {
 
     }
 
-    afterAlways('test') {
-
+    before('test') {
         stageWithAgent('Darts Test 2', product) {
 
         }
+    }
+
+    afterAlways('test') {
 
         builder.gradle('jacocoTestReport')
 
         publishHTML target: [
-            allowMissing         : true,
-            alwaysLinkToLastBuild: true,
-            keepAll              : true,
-            reportDir            : "build/reports/checkstyle",
-            reportFiles          : "main.html",
-            reportName           : "Checkstyle Main Report"
+                allowMissing         : true,
+                alwaysLinkToLastBuild: true,
+                keepAll              : true,
+                reportDir            : "build/reports/checkstyle",
+                reportFiles          : "main.html",
+                reportName           : "Checkstyle Main Report"
         ]
 
         publishHTML target: [
-            allowMissing         : true,
-            alwaysLinkToLastBuild: true,
-            keepAll              : true,
-            reportDir            : "build/reports/checkstyle",
-            reportFiles          : "test.html",
-            reportName           : "Checkstyle Test Report"
+                allowMissing         : true,
+                alwaysLinkToLastBuild: true,
+                keepAll              : true,
+                reportDir            : "build/reports/checkstyle",
+                reportFiles          : "test.html",
+                reportName           : "Checkstyle Test Report"
         ]
 
         publishHTML target: [
-            allowMissing         : true,
-            alwaysLinkToLastBuild: true,
-            keepAll              : true,
-            reportDir            : "build/reports/checkstyle",
-            reportFiles          : "functionalTest.html",
-            reportName           : "Checkstyle Functional Test Report"
+                allowMissing         : true,
+                alwaysLinkToLastBuild: true,
+                keepAll              : true,
+                reportDir            : "build/reports/checkstyle",
+                reportFiles          : "functionalTest.html",
+                reportName           : "Checkstyle Functional Test Report"
         ]
 
         publishHTML target: [
-            allowMissing         : true,
-            alwaysLinkToLastBuild: true,
-            keepAll              : true,
-            reportDir            : "build/reports/checkstyle",
-            reportFiles          : "integrationTest.html",
-            reportName           : "Checkstyle Integration Test Report"
+                allowMissing         : true,
+                alwaysLinkToLastBuild: true,
+                keepAll              : true,
+                reportDir            : "build/reports/checkstyle",
+                reportFiles          : "integrationTest.html",
+                reportName           : "Checkstyle Integration Test Report"
         ]
 
         publishHTML target: [
-            allowMissing         : true,
-            alwaysLinkToLastBuild: true,
-            keepAll              : true,
-            reportDir            : "build/reports/tests/test",
-            reportFiles          : "index.html",
-            reportName           : "Unit Tests Report"
+                allowMissing         : true,
+                alwaysLinkToLastBuild: true,
+                keepAll              : true,
+                reportDir            : "build/reports/tests/test",
+                reportFiles          : "index.html",
+                reportName           : "Unit Tests Report"
         ]
 
         publishHTML target: [

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -106,11 +106,16 @@ withPipeline(type, product, component) {
     disableCleanupOfHelmReleaseOnFailure()
     env.INTEGRATION_TEST_LOGGING_LEVEL = "off"
 
-    stageWithAgent('Darts Test', product) {
+    stageWithAgent('Darts Test 1', product) {
 
     }
 
     afterAlways('test') {
+
+        stageWithAgent('Darts Test 2', product) {
+
+        }
+
         builder.gradle('jacocoTestReport')
 
         publishHTML target: [

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -60,177 +60,177 @@ def secrets = [
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
-  [$class     : 'AzureKeyVaultSecret',
-   secretType : 'Secret',
-   name       : secretName,
-   version    : '',
-   envVariable: envVar
-  ]
+    [$class     : 'AzureKeyVaultSecret',
+     secretType : 'Secret',
+     name       : secretName,
+     version    : '',
+     envVariable: envVar
+    ]
 }
 
 def determineDevEnvironmentDeployment() {
-  env.DEV_ENABLE_DARTS_PORTAL = false
-  env.DEV_DARTS_PORTAL_URL = "https://darts.staging.apps.hmcts.net"
-  env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = "latest"
+    env.DEV_ENABLE_DARTS_PORTAL = false
+    env.DEV_DARTS_PORTAL_URL = "https://darts.staging.apps.hmcts.net"
+    env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = "latest"
 
-  echo "1 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
-  echo "1 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
+    echo "1 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
+    echo "1 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
 
-  def githubApi = new GithubAPI(this)
-  if (githubApi.checkForLabel(env.BRANCH_NAME, "enable_keep_helm")) {
-    for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable_darts_")) {
-      if (label ==~ /enable_darts_portal.*/) {
-        env.DEV_ENABLE_DARTS_PORTAL = true
-        env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
+    def githubApi = new GithubAPI(this)
+    if (githubApi.checkForLabel(env.BRANCH_NAME, "enable_keep_helm")) {
+        for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable_darts_")) {
+            if (label ==~ /enable_darts_portal.*/) {
+                env.DEV_ENABLE_DARTS_PORTAL = true
+                env.DEV_DARTS_PORTAL_URL = "https://darts-portal-api-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
-        if (label ==~ /enable_darts_portal:pr-.*/) {
-          env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal:", "")
-          echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
+                if (label ==~ /enable_darts_portal:pr-.*/) {
+                    env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal:", "")
+                    echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
+                }
+                echo "Deploying DARTS portal (${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}) instance in PR environment"
+            }
         }
-        echo "Deploying DARTS portal (${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}) instance in PR environment"
-      }
     }
-  }
 
-  echo "2 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
-  echo "2 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
+    echo "2 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
+    echo "2 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
 }
 
 GradleBuilder builder = new GradleBuilder(this, product)
 
 withPipeline(type, product, component) {
-  enableDbMigration(product)
-  loadVaultSecrets(secrets)
-  enableSlackNotifications('#darts-builds')
-  syncBranchesWithMaster(branchesToSync)
-  disableCleanupOfHelmReleaseOnFailure()
-  env.INTEGRATION_TEST_LOGGING_LEVEL = "off"
+    enableDbMigration(product)
+    loadVaultSecrets(secrets)
+    enableSlackNotifications('#darts-builds')
+    syncBranchesWithMaster(branchesToSync)
+    disableCleanupOfHelmReleaseOnFailure()
+    env.INTEGRATION_TEST_LOGGING_LEVEL = "off"
 
-  afterAlways('test') {
+    afterAlways('test') {
 
-    builder.gradle('jacocoTestReport')
+        builder.gradle('jacocoTestReport')
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/checkstyle",
-        reportFiles          : "main.html",
-        reportName           : "Checkstyle Main Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/checkstyle",
+            reportFiles          : "main.html",
+            reportName           : "Checkstyle Main Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/checkstyle",
-        reportFiles          : "test.html",
-        reportName           : "Checkstyle Test Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/checkstyle",
+            reportFiles          : "test.html",
+            reportName           : "Checkstyle Test Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/checkstyle",
-        reportFiles          : "functionalTest.html",
-        reportName           : "Checkstyle Functional Test Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/checkstyle",
+            reportFiles          : "functionalTest.html",
+            reportName           : "Checkstyle Functional Test Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/checkstyle",
-        reportFiles          : "integrationTest.html",
-        reportName           : "Checkstyle Integration Test Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/checkstyle",
+            reportFiles          : "integrationTest.html",
+            reportName           : "Checkstyle Integration Test Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/tests/test",
-        reportFiles          : "index.html",
-        reportName           : "Unit Tests Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/tests/test",
+            reportFiles          : "index.html",
+            reportName           : "Unit Tests Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/tests/integration",
-        reportFiles          : "index.html",
-        reportName           : "Integration Tests Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/tests/integration",
+            reportFiles          : "index.html",
+            reportName           : "Integration Tests Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/pmd",
-        reportFiles          : "main.html",
-        reportName           : "PMD Main Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/pmd",
+            reportFiles          : "main.html",
+            reportName           : "PMD Main Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/pmd",
-        reportFiles          : "test.html",
-        reportName           : "PMD Test Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/pmd",
+            reportFiles          : "test.html",
+            reportName           : "PMD Test Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/pmd",
-        reportFiles          : "functionalTest.html",
-        reportName           : "PMD Functional Test Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/pmd",
+            reportFiles          : "functionalTest.html",
+            reportName           : "PMD Functional Test Report"
+        ]
 
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "build/reports/pmd",
-        reportFiles          : "integrationTest.html",
-        reportName           : "PMD Integration Test Report"
-    ]
+        publishHTML target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: true,
+            keepAll              : true,
+            reportDir            : "build/reports/pmd",
+            reportFiles          : "integrationTest.html",
+            reportName           : "PMD Integration Test Report"
+        ]
 
 
-  }
-
-  afterFailure('test') {
-    junit '**/test-results/integration/*.xml'
-  }
-
-  before('dbmigrate:demo') {
-    sh("./gradlew --no-daemon --init-script init.gradle assemble")
-  }
-
-  before('dbmigrate:test') {
-    sh("./gradlew --no-daemon --init-script init.gradle assemble")
-  }
-
-  before('dbmigrate:ithc') {
-    sh("./gradlew --no-daemon --init-script init.gradle assemble")
-  }
-
-  before('akschartsinstall') {
-    onPR {
-      determineDevEnvironmentDeployment()
     }
-  }
 
-  afterSuccess('akschartsinstall') {
-    onPR {
-      // restore the PR DB from staging
-      sh("./bin/ci/db-stg-to-pr.sh")
-      // run flyway migrate on PR DB
-      sh("./bin/ci/run-flyway-pr-db.sh")
+    afterFailure('test') {
+        junit '**/test-results/integration/*.xml'
     }
-  }
+
+    before('dbmigrate:demo') {
+        sh("./gradlew --no-daemon --init-script init.gradle assemble")
+    }
+
+    before('dbmigrate:test') {
+        sh("./gradlew --no-daemon --init-script init.gradle assemble")
+    }
+
+    before('dbmigrate:ithc') {
+        sh("./gradlew --no-daemon --init-script init.gradle assemble")
+    }
+
+    before('akschartsinstall') {
+        onPR {
+            determineDevEnvironmentDeployment()
+        }
+    }
+
+    afterSuccess('akschartsinstall') {
+        onPR {
+            // restore the PR DB from staging
+            sh("./bin/ci/db-stg-to-pr.sh")
+            // run flyway migrate on PR DB
+            sh("./bin/ci/run-flyway-pr-db.sh")
+        }
+    }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -79,7 +79,7 @@ def determineDevEnvironmentDeployment() {
     def githubApi = new GithubAPI(this)
     if (githubApi.checkForLabel(env.BRANCH_NAME, "enable_keep_helm")) {
         for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable_darts_") ) {
-            if (label == "enable_darts_portal") {
+            if (label ==~ "enable_darts_portal.*") {
                 env.DEV_ENABLE_DARTS_PORTAL = true
                 env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -12,235 +12,225 @@ def component = "api"
 def branchesToSync = ['demo', 'perftest', 'ithc']
 
 def secrets = [
-        'darts-${env}': [
-                secret('GovukNotifyTestApiKey', 'GOVUK_NOTIFY_API_KEY'),
-                secret('app-insights-connection-string', 'app-insights-connection-string'),
-                secret('AzureAdB2CTenantId', 'AAD_B2C_TENANT_ID'),
-                secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
-                secret('AzureAdB2CClientSecret', 'AAD_B2C_CLIENT_SECRET'),
-                secret('AzureAdB2CFuncTestROPCUsername', 'FUNC_TEST_ROPC_USERNAME'),
-                secret('AzureAdB2CFuncTestROPCPassword', 'FUNC_TEST_ROPC_PASSWORD'),
-                secret('AzureAdB2CFuncTestROPCClientId', 'AAD_B2C_ROPC_CLIENT_ID'),
-                secret('AzureAdB2CFuncTestROPCClientSecret', 'AAD_B2C_ROPC_CLIENT_SECRET'),
-                secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
-                secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
-                secret('AzureADTenantId', 'AAD_TENANT_ID'),
-                secret('AzureADClientId', 'AAD_CLIENT_ID'),
-                secret('AzureADClientSecret', 'AAD_CLIENT_SECRET'),
-                secret('AzureADTenantIdJustice', 'AAD_TENANT_ID_JUSTICE'),
-                secret('AzureADClientIdJustice', 'AAD_CLIENT_ID_JUSTICE'),
-                secret('AzureADClientSecretJustice', 'AAD_CLIENT_SECRET_JUSTICE'),
-                secret('XhibitUserName', 'XHIBIT_USER_NAME'),
-                secret('XhibitPassword', 'XHIBIT_PASSWORD'),
-                secret('CppUserName', 'CPP_USER_NAME'),
-                secret('CppPassword', 'CPP_PASSWORD'),
-                secret('DarPcUserName', 'DARPC_USER_NAME'),
-                secret('DarPcPassword', 'DARPC_PASSWORD'),
-                secret('DarMidTierUserName', 'DAR_MIDTIER_USER_NAME'),
-                secret('DarMidTierPassword', 'DAR_MIDTIER_PASSWORD'),
-                secret('AzureADFunctionalTestUsername', 'AZURE_AD_FUNCTIONAL_TEST_USERNAME'),
-                secret('AzureADFunctionalTestPassword', 'AZURE_AD_FUNCTIONAL_TEST_PASSWORD'),
-                secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
-                secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
-                secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
-                secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT'),
-                secret('DETSSasURLEndpoint', 'DETS_SAS_URL_ENDPOINT'),
-                secret('DartsInboundStorageSasUrl', 'DARTS_INBOUND_STORAGE_SAS_URL'),
-                secret('DartsUnstructuredStorageSasUrl', 'DARTS_UNSTRUCTURED_STORAGE_SAS_URL'),
-                secret('ArmServiceEntitlement', 'ARM_SERVICE_ENTITLEMENT'),
-                secret('ArmStorageAccountName', 'ARM_STORAGE_ACCOUNT_NAME'),
-                // secrets for staging DB
-                secret('api-POSTGRES-HOST', 'STAGING_DB_HOST'),
-                secret('api-POSTGRES-USER', 'STAGING_DB_USER'),
-                secret('api-POSTGRES-PASS', 'STAGING_DB_PASS'),
-                secret('api-POSTGRES-PORT', 'STAGING_DB_PORT'),
-                secret('api-POSTGRES-SCHEMA', 'STAGING_DB_SCHEMA'),
-                secret('api-POSTGRES-DATABASE', 'STAGING_DB_DATABASE'),
-        ],
+    'darts-${env}': [
+        secret('GovukNotifyTestApiKey', 'GOVUK_NOTIFY_API_KEY'),
+        secret('app-insights-connection-string', 'app-insights-connection-string'),
+        secret('AzureAdB2CTenantId', 'AAD_B2C_TENANT_ID'),
+        secret('AzureAdB2CClientId', 'AAD_B2C_CLIENT_ID'),
+        secret('AzureAdB2CClientSecret', 'AAD_B2C_CLIENT_SECRET'),
+        secret('AzureAdB2CFuncTestROPCUsername', 'FUNC_TEST_ROPC_USERNAME'),
+        secret('AzureAdB2CFuncTestROPCPassword', 'FUNC_TEST_ROPC_PASSWORD'),
+        secret('AzureAdB2CFuncTestROPCClientId', 'AAD_B2C_ROPC_CLIENT_ID'),
+        secret('AzureAdB2CFuncTestROPCClientSecret', 'AAD_B2C_ROPC_CLIENT_SECRET'),
+        secret('api-POSTGRES-SCHEMA', 'DARTS_API_DB_SCHEMA'),
+        secret('AzureStorageConnectionString', 'AZURE_STORAGE_CONNECTION_STRING'),
+        secret('AzureADTenantId', 'AAD_TENANT_ID'),
+        secret('AzureADClientId', 'AAD_CLIENT_ID'),
+        secret('AzureADClientSecret', 'AAD_CLIENT_SECRET'),
+        secret('AzureADTenantIdJustice', 'AAD_TENANT_ID_JUSTICE'),
+        secret('AzureADClientIdJustice', 'AAD_CLIENT_ID_JUSTICE'),
+        secret('AzureADClientSecretJustice', 'AAD_CLIENT_SECRET_JUSTICE'),
+        secret('XhibitUserName', 'XHIBIT_USER_NAME'),
+        secret('XhibitPassword', 'XHIBIT_PASSWORD'),
+        secret('CppUserName', 'CPP_USER_NAME'),
+        secret('CppPassword', 'CPP_PASSWORD'),
+        secret('DarPcUserName', 'DARPC_USER_NAME'),
+        secret('DarPcPassword', 'DARPC_PASSWORD'),
+        secret('DarMidTierUserName', 'DAR_MIDTIER_USER_NAME'),
+        secret('DarMidTierPassword', 'DAR_MIDTIER_PASSWORD'),
+        secret('AzureADFunctionalTestUsername', 'AZURE_AD_FUNCTIONAL_TEST_USERNAME'),
+        secret('AzureADFunctionalTestPassword', 'AZURE_AD_FUNCTIONAL_TEST_PASSWORD'),
+        secret('DartsSystemUserEmail', 'SYSTEM_USER_EMAIL'),
+        secret('AzureAdB2CFuncTestROPCGlobalUsername', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_USERNAME'),
+        secret('AzureAdB2CFuncTestROPCGlobalPassword', 'AZURE_AD_FUNCTIONAL_TEST_GLOBAL_PASSWORD'),
+        secret('ARMSasEndpoint', 'ARM_SAS_ENDPOINT'),
+        secret('DETSSasURLEndpoint', 'DETS_SAS_URL_ENDPOINT'),
+        secret('DartsInboundStorageSasUrl', 'DARTS_INBOUND_STORAGE_SAS_URL'),
+        secret('DartsUnstructuredStorageSasUrl', 'DARTS_UNSTRUCTURED_STORAGE_SAS_URL'),
+        secret('ArmServiceEntitlement', 'ARM_SERVICE_ENTITLEMENT'),
+        secret('ArmStorageAccountName', 'ARM_STORAGE_ACCOUNT_NAME'),
+        // secrets for staging DB
+        secret('api-POSTGRES-HOST', 'STAGING_DB_HOST'),
+        secret('api-POSTGRES-USER', 'STAGING_DB_USER'),
+        secret('api-POSTGRES-PASS', 'STAGING_DB_PASS'),
+        secret('api-POSTGRES-PORT', 'STAGING_DB_PORT'),
+        secret('api-POSTGRES-SCHEMA', 'STAGING_DB_SCHEMA'),
+        secret('api-POSTGRES-DATABASE', 'STAGING_DB_DATABASE'),
+    ],
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
-    [$class     : 'AzureKeyVaultSecret',
-     secretType : 'Secret',
-     name       : secretName,
-     version    : '',
-     envVariable: envVar
-    ]
+  [$class     : 'AzureKeyVaultSecret',
+   secretType : 'Secret',
+   name       : secretName,
+   version    : '',
+   envVariable: envVar
+  ]
 }
 
 def determineDevEnvironmentDeployment() {
-    env.DEV_ENABLE_DARTS_PORTAL = false
-    env.DEV_DARTS_PORTAL_URL = "https://darts.staging.apps.hmcts.net"
-    env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = "latest"
+  env.DEV_ENABLE_DARTS_PORTAL = false
+  env.DEV_DARTS_PORTAL_URL = "https://darts.staging.apps.hmcts.net"
+  env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = "latest"
 
-    echo "1 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
-    echo "1 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
+  echo "1 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
+  echo "1 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
 
-    def githubApi = new GithubAPI(this)
-    if (githubApi.checkForLabel(env.BRANCH_NAME, "enable_keep_helm")) {
-        for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable_darts_")) {
-            if (label ==~ /enable_darts_portal.*/) {
-                env.DEV_ENABLE_DARTS_PORTAL = true
-                env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
+  def githubApi = new GithubAPI(this)
+  if (githubApi.checkForLabel(env.BRANCH_NAME, "enable_keep_helm")) {
+    for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable_darts_")) {
+      if (label ==~ /enable_darts_portal.*/) {
+        env.DEV_ENABLE_DARTS_PORTAL = true
+        env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
-                if (label ==~ /enable_darts_portal:pr-.*/) {
-                    env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal:", "")
-                    echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
-                }
-                echo "Deploying DARTS portal (${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}) instance in PR environment"
-            }
+        if (label ==~ /enable_darts_portal:pr-.*/) {
+          env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal:", "")
+          echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
         }
+        echo "Deploying DARTS portal (${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}) instance in PR environment"
+      }
     }
+  }
 
-    echo "2 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
-    echo "2 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
+  echo "2 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
+  echo "2 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
 }
 
 GradleBuilder builder = new GradleBuilder(this, product)
 
 withPipeline(type, product, component) {
-    enableDbMigration(product)
-    loadVaultSecrets(secrets)
-    enableSlackNotifications('#darts-builds')
-    syncBranchesWithMaster(branchesToSync)
-    disableCleanupOfHelmReleaseOnFailure()
-    env.INTEGRATION_TEST_LOGGING_LEVEL = "off"
+  enableDbMigration(product)
+  loadVaultSecrets(secrets)
+  enableSlackNotifications('#darts-builds')
+  syncBranchesWithMaster(branchesToSync)
+  disableCleanupOfHelmReleaseOnFailure()
+  env.INTEGRATION_TEST_LOGGING_LEVEL = "off"
 
-    stageWithAgent('Darts Test 1', product) {
+  afterAlways('test') {
 
+    builder.gradle('jacocoTestReport')
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/checkstyle",
+        reportFiles          : "main.html",
+        reportName           : "Checkstyle Main Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/checkstyle",
+        reportFiles          : "test.html",
+        reportName           : "Checkstyle Test Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/checkstyle",
+        reportFiles          : "functionalTest.html",
+        reportName           : "Checkstyle Functional Test Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/checkstyle",
+        reportFiles          : "integrationTest.html",
+        reportName           : "Checkstyle Integration Test Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/tests/test",
+        reportFiles          : "index.html",
+        reportName           : "Unit Tests Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/tests/integration",
+        reportFiles          : "index.html",
+        reportName           : "Integration Tests Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/pmd",
+        reportFiles          : "main.html",
+        reportName           : "PMD Main Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/pmd",
+        reportFiles          : "test.html",
+        reportName           : "PMD Test Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/pmd",
+        reportFiles          : "functionalTest.html",
+        reportName           : "PMD Functional Test Report"
+    ]
+
+    publishHTML target: [
+        allowMissing         : true,
+        alwaysLinkToLastBuild: true,
+        keepAll              : true,
+        reportDir            : "build/reports/pmd",
+        reportFiles          : "integrationTest.html",
+        reportName           : "PMD Integration Test Report"
+    ]
+
+
+  }
+
+  afterFailure('test') {
+    junit '**/test-results/integration/*.xml'
+  }
+
+  before('dbmigrate:demo') {
+    sh("./gradlew --no-daemon --init-script init.gradle assemble")
+  }
+
+  before('dbmigrate:test') {
+    sh("./gradlew --no-daemon --init-script init.gradle assemble")
+  }
+
+  before('dbmigrate:ithc') {
+    sh("./gradlew --no-daemon --init-script init.gradle assemble")
+  }
+
+  before('akschartsinstall') {
+    onPR {
+      determineDevEnvironmentDeployment()
     }
+  }
 
-    before('test') {
-        stageWithAgent('Darts Test 2', product) {
-
-        }
+  afterSuccess('akschartsinstall') {
+    onPR {
+      // restore the PR DB from staging
+      sh("./bin/ci/db-stg-to-pr.sh")
+      // run flyway migrate on PR DB
+      sh("./bin/ci/run-flyway-pr-db.sh")
     }
-
-    afterAlways('test') {
-
-        builder.gradle('jacocoTestReport')
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/checkstyle",
-                reportFiles          : "main.html",
-                reportName           : "Checkstyle Main Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/checkstyle",
-                reportFiles          : "test.html",
-                reportName           : "Checkstyle Test Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/checkstyle",
-                reportFiles          : "functionalTest.html",
-                reportName           : "Checkstyle Functional Test Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/checkstyle",
-                reportFiles          : "integrationTest.html",
-                reportName           : "Checkstyle Integration Test Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/tests/test",
-                reportFiles          : "index.html",
-                reportName           : "Unit Tests Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/tests/integration",
-                reportFiles          : "index.html",
-                reportName           : "Integration Tests Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/pmd",
-                reportFiles          : "main.html",
-                reportName           : "PMD Main Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/pmd",
-                reportFiles          : "test.html",
-                reportName           : "PMD Test Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/pmd",
-                reportFiles          : "functionalTest.html",
-                reportName           : "PMD Functional Test Report"
-        ]
-
-        publishHTML target: [
-                allowMissing         : true,
-                alwaysLinkToLastBuild: true,
-                keepAll              : true,
-                reportDir            : "build/reports/pmd",
-                reportFiles          : "integrationTest.html",
-                reportName           : "PMD Integration Test Report"
-        ]
-
-
-    }
-
-    afterFailure('test') {
-        junit '**/test-results/integration/*.xml'
-    }
-
-    before('dbmigrate:demo') {
-        sh("./gradlew --no-daemon --init-script init.gradle assemble")
-    }
-
-    before('dbmigrate:test') {
-        sh("./gradlew --no-daemon --init-script init.gradle assemble")
-    }
-
-    before('dbmigrate:ithc') {
-        sh("./gradlew --no-daemon --init-script init.gradle assemble")
-    }
-
-    before('akschartsinstall') {
-        onPR {
-            determineDevEnvironmentDeployment()
-        }
-    }
-
-    afterSuccess('akschartsinstall') {
-        onPR {
-            // restore the PR DB from staging
-            sh("./bin/ci/db-stg-to-pr.sh")
-            // run flyway migrate on PR DB
-            sh("./bin/ci/run-flyway-pr-db.sh")
-        }
-    }
+  }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -79,11 +79,11 @@ def determineDevEnvironmentDeployment() {
     def githubApi = new GithubAPI(this)
     if (githubApi.checkForLabel(env.BRANCH_NAME, "enable_keep_helm")) {
         for (label in githubApi.getLabelsbyPattern(env.BRANCH_NAME, "enable_darts_") ) {
-            if (label ==~ "enable_darts_portal.*") {
+            if (label ==~ /enable_darts_portal.*/) {
                 env.DEV_ENABLE_DARTS_PORTAL = true
                 env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
-                if(label ==~ 'enable_darts_portal:pr-.*') {
+                if(label ==~ /enable_darts_portal:pr-.*/) {
                     env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal:", "")
                     echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
                 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -83,7 +83,7 @@ def determineDevEnvironmentDeployment() {
                 env.DEV_ENABLE_DARTS_PORTAL = true
                 env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
-                if(label ==~ 'enable_darts_portal_PR.*') {
+                if(label ==~ 'enable_darts_portal_pr-.*') {
                     env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal_", "")
                     echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
                 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -106,6 +106,10 @@ withPipeline(type, product, component) {
     disableCleanupOfHelmReleaseOnFailure()
     env.INTEGRATION_TEST_LOGGING_LEVEL = "off"
 
+    stageWithAgent('Darts Test', product) {
+
+    }
+
     afterAlways('test') {
         builder.gradle('jacocoTestReport')
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -83,8 +83,8 @@ def determineDevEnvironmentDeployment() {
                 env.DEV_ENABLE_DARTS_PORTAL = true
                 env.DEV_DARTS_PORTAL_URL = "https://darts-portal-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
-                if(label ==~ 'enable_darts_portal_pr-.*') {
-                    env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal_", "")
+                if(label ==~ 'enable_darts_portal:pr-.*') {
+                    env.DEV_DARTS_PORTAL_IMAGE_SUFFIX = label.replace("enable_darts_portal:", "")
                     echo "DARTS portal image suffix: ${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}"
                 }
                 echo "Deploying DARTS portal (${env.DEV_DARTS_PORTAL_IMAGE_SUFFIX}) instance in PR environment"

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -143,7 +143,7 @@ darts-portal:
           - darts-portal-session-secret
     environment:
       ALLOW_CONFIG_MUTATIONS: true
-      DARTS_PORTAL_URL: "https://darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
+      DARTS_PORTAL_URL: "https://darts-portal-api-pr-${CHANGE_ID}.dev.platform.hmcts.net"
       DARTS_API_URL: "https://darts-api-pr-${CHANGE_ID}.dev.platform.hmcts.net"
       DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsstgextid.b2clogin.com
       DARTS_AZUREAD_B2C_HOSTNAME: https://darts.staging.apps.hmcts.net

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -133,7 +133,7 @@ darts-portal:
   enabled: ${DEV_ENABLE_DARTS_PORTAL}
   nodejs:
     applicationPort: 3000
-    image: 'sdshmctspublic.azurecr.io/darts/portal:latest'
+    image: 'sdshmctspublic.azurecr.io/darts/portal:${DEV_DARTS_PORTAL_IMAGE_SUFFIX}'
     ingressHost: "darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
     aadIdentityName: darts
     keyVaults:

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -134,7 +134,7 @@ darts-portal:
   nodejs:
     applicationPort: 3000
     image: 'sdshmctspublic.azurecr.io/darts/portal:${DEV_DARTS_PORTAL_IMAGE_SUFFIX}'
-    ingressHost: "darts-portal-pr-${CHANGE_ID}.dev.platform.hmcts.net"
+    ingressHost: "darts-portal-api-pr-${CHANGE_ID}.dev.platform.hmcts.net"
     aadIdentityName: darts
     keyVaults:
       darts:


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5045)


### Change description ###
# Summary of Git Diff Changes

The recent changes to the `Jenkinsfile_CNP` and `values.dev.template.yaml` files introduce enhancements related to the DARTS portal deployment. A new environment variable for the DARTS portal image suffix has been added, allowing for more flexible image tagging during deployment in the development and pull request environments.

## Highlights

- **Added Environment Variable**: 
  - Introduced `env.DEV_DARTS_PORTAL_IMAGE_SUFFIX` in `Jenkinsfile_CNP`, defaulting to "latest".
  
- **Conditional Logic for PR Deployments**:
  - Added logic to set `DEV_DARTS_PORTAL_IMAGE_SUFFIX` based on the label when enabling the DARTS portal in pull request environments.
  - Updated the echo statement to reflect the chosen image suffix during deployment.
  
- **Updated Image Reference**:
  - Changed the image reference in `values.dev.template.yaml` to use the new `DEV_DARTS_PORTAL_IMAGE_SUFFIX` variable instead of a hardcoded "latest" tag. This allows for dynamic image tagging based on the environment configuration.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
