### PR TITLE
DMP-5055 Move from Jitpack to Azure Devops Artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -392,7 +392,7 @@ dependencyCheck {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url 'https://jitpack.io' }
+  maven { url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1' }
   maven { url 'https://repo.spring.io/milestone/' }
 }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-5055


### Change description ###
Move from Jitpack to Azure Devops Artifacts


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
