### PR TITLE
DMP-5094 Hearing transcription count fix for legacy automated transcriptions

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearing.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/HearingEntityToCaseHearing.java
@@ -40,7 +40,12 @@ public class HearingEntityToCaseHearing {
             .stream()
             .filter(transcriptionEntity -> BooleanUtils.isTrue(transcriptionEntity.getIsCurrent()))
             .filter(transcriptionEntity -> BooleanUtils.isTrue(transcriptionEntity.getIsManualTranscription())
-                || StringUtils.isNotBlank(transcriptionEntity.getLegacyObjectId())
+                ||
+                (
+                    StringUtils.isNotBlank(transcriptionEntity.getLegacyObjectId())
+                    &&
+                    !transcriptionEntity.getTranscriptionDocumentEntities().isEmpty()
+                )
             )
             .filter(transcriptionEntity ->
                 transcriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted(transcriptionEntity.getId()).isEmpty()

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentRepository.java
@@ -73,6 +73,6 @@ public interface TranscriptionDocumentRepository extends JpaRepository<Transcrip
     List<TranscriptionDocumentEntity> getMarkedForDeletion();
 
     // native query to bypass @SQLRestriction
-    @Query(value = "SELECT trd.* FROM darts.transcription_document trd WHERE trd.tra_id = :trdId AND trd.is_hidden = true", nativeQuery = true)
-    List<TranscriptionDocumentEntity> findByTranscriptionIdAndHiddenTrueIncludeDeleted(Long trdId);
+    @Query(value = "SELECT trd.* FROM darts.transcription_document trd WHERE trd.tra_id = :traId AND trd.is_hidden = true", nativeQuery = true)
+    List<TranscriptionDocumentEntity> findByTranscriptionIdAndHiddenTrueIncludeDeleted(Long traId);
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5094

### Change description ###

- exclude legacy automated transcriptions where no documents are associated
- fixing `TranscriptionDocumentRepository.findByTranscriptionIdAndHiddenTrueIncludeDeleted` parameters name to be clearer


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
