### PR TITLE
Fixing transcription documents search when tra.requested_by is null

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/TranscriptionDocumentRepository.java
@@ -30,6 +30,7 @@ public interface TranscriptionDocumentRepository extends JpaRepository<Transcrip
          tmd.isHidden)
               FROM TranscriptionDocumentEntity tmd
               JOIN tmd.transcription t
+              LEFT JOIN t.requestedBy
               LEFT JOIN t.hearings hearings
               LEFT JOIN t.courtCases courtCase
               LEFT JOIN hearings.courtCase hearingCase                 


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

To ensure we can see transcription documents even if the associated transcription requested by is null

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
