### PR TITLE
DMP-5092: Legacy Transcription associated through hearing and not case and is "Approved" or "With Transcriber" in workflow not being returned to Transcribers

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AuthorisationStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/AuthorisationStub.java
@@ -126,12 +126,12 @@ public class AuthorisationStub {
         dartsDatabaseStub.getUserAccountRepository().save(separateIntegrationUser);
 
         transcriptionEntity = dartsDatabaseStub.getTranscriptionStub()
-            .createAndSaveAwaitingAuthorisationTranscription(testUser, courtCaseEntity, hearingEntity, YESTERDAY);
+            .createAndSaveAwaitingAuthorisationTranscription(testUser, null, hearingEntity, YESTERDAY);
     }
 
     public TranscriptionEntity addNewTranscription() {
         return dartsDatabaseStub.getTranscriptionStub()
-            .createAndSaveAwaitingAuthorisationTranscription(separateIntegrationUser, courtCaseEntity, hearingEntity, YESTERDAY);
+            .createAndSaveAwaitingAuthorisationTranscription(separateIntegrationUser, null, hearingEntity, YESTERDAY);
     }
 
     private void createHearing() {

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberTranscriptsQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberTranscriptsQueryImpl.java
@@ -51,7 +51,8 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                 FROM darts.transcription tra
                 LEFT JOIN darts.hearing_transcription_ae hearing_transcription ON tra.tra_id = hearing_transcription.tra_id
                 LEFT JOIN darts.hearing hea ON hearing_transcription.hea_id = hea.hea_id
-                LEFT JOIN darts.case_transcription_ae case_transcription ON (case_transcription.cas_id != hea.cas_id and tra.tra_id = case_transcription.tra_id)
+                LEFT JOIN darts.case_transcription_ae case_transcription 
+                    ON ((hea.cas_id is null or case_transcription.cas_id != hea.cas_id) and tra.tra_id = case_transcription.tra_id)
                 JOIN darts.court_case cas ON ((case_transcription.cas_id = cas.cas_id) or (hea.cas_id = cas.cas_id))                        
                 JOIN darts.courthouse cth ON cas.cth_id = cth.cth_id
                 AND cth.cth_id IN (
@@ -104,7 +105,8 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                 FROM darts.transcription tra
                 LEFT JOIN darts.hearing_transcription_ae hearing_transcription ON tra.tra_id = hearing_transcription.tra_id
                 LEFT JOIN darts.hearing hea ON hearing_transcription.hea_id = hea.hea_id
-                LEFT JOIN darts.case_transcription_ae case_transcription ON (case_transcription.cas_id != hea.cas_id and tra.tra_id = case_transcription.tra_id)
+                LEFT JOIN darts.case_transcription_ae case_transcription 
+                    ON ((hea.cas_id is null or case_transcription.cas_id != hea.cas_id) and tra.tra_id = case_transcription.tra_id)
                 JOIN darts.court_case cas ON ((case_transcription.cas_id = cas.cas_id) or (hea.cas_id = cas.cas_id))                    
                 JOIN darts.courthouse cth ON cas.cth_id = cth.cth_id
                 AND cth.cth_id IN (
@@ -169,7 +171,8 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                 FROM darts.transcription tra
                 LEFT JOIN darts.hearing_transcription_ae hearing_transcription ON tra.tra_id = hearing_transcription.tra_id
                 LEFT JOIN darts.hearing hea ON hearing_transcription.hea_id = hea.hea_id
-                LEFT JOIN darts.case_transcription_ae case_transcription ON (tra.tra_id = case_transcription.tra_id AND case_transcription.cas_id != hea.cas_id)
+                LEFT JOIN darts.case_transcription_ae case_transcription 
+                    ON ((hea.cas_id is null or case_transcription.cas_id != hea.cas_id) and tra.tra_id = case_transcription.tra_id)
                 JOIN darts.court_case cas ON ((case_transcription.cas_id = cas.cas_id) or (hea.cas_id = cas.cas_id))
                 JOIN darts.courthouse cth ON cas.cth_id = cth.cth_id
                 AND cth.cth_id IN (
@@ -263,15 +266,15 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
             workflowSubQuery.append(" AND trw.workflow_actor = ").append(userId);
         }
         workflowSubQuery.append(" GROUP BY tra_id");
-        StringBuilder sql = new StringBuilder(433)
+        StringBuilder sql = new StringBuilder(744)
             .append(
                 """
                     SELECT count(*)
                     FROM darts.transcription transcription
-                    
                     LEFT JOIN darts.hearing_transcription_ae hearing_transcription ON transcription.tra_id = hearing_transcription.tra_id
                     LEFT JOIN darts.hearing hea ON hearing_transcription.hea_id = hea.hea_id
-                    LEFT JOIN darts.case_transcription_ae case_transcription ON (case_transcription.cas_id != hea.cas_id and transcription.tra_id = case_transcription.tra_id)
+                    LEFT JOIN darts.case_transcription_ae case_transcription ON 
+                         ((hea.cas_id is null or case_transcription.cas_id != hea.cas_id) and transcription.tra_id = case_transcription.tra_id)
                     JOIN darts.court_case court_case ON ((case_transcription.cas_id = court_case.cas_id) or (hea.cas_id = court_case.cas_id))
                     JOIN darts.courthouse courthouse ON courthouse.cth_id=court_case.cth_id
                     JOIN (""")


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5092)


### Change description ###
# Summary of Git Diff

This Git Diff reflects updates made to the `TranscriberTranscriptsQueryImpl.java` file in the `src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl` directory. The main changes include modifications to the SQL JOIN operations, switching from INNER JOINs to LEFT JOINs in several places, which impacts how data is retrieved related to transcription and court cases.

## Highlights

- **LEFT JOIN Changes**: 
  - Modified SQL queries to use `LEFT JOIN` instead of `JOIN` for `hearing_transcription_ae` and `hearing` tables, allowing for more inclusive data retrieval.
  
- **Conditional JOIN Logic**:
  - Adjusted conditions in the JOIN clauses to ensure that case IDs are correctly handled between transcriptions and hearings.

- **Query Consistency**:
  - Ensured that similar changes were consistently applied across multiple methods within the file, particularly in `getTranscriptRequests`, `getTranscriberTranscriptions`, and others.

- **Impact on Data Retrieval**:
  - The changes likely lead to a broader set of results being returned from the database, accommodating cases where relationships might not strictly exist (due to the use of LEFT JOIN). 

- **Maintained Original Structure**: 
  - Despite the changes, the overall structure of the SQL queries has been preserved, ensuring that the existing logic is still intact while improving data accessibility.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
