### PR TITLE
DMP-5101: Remove link to case_transcription_ae table for modernised transcriptions

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImpl.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
-import uk.gov.hmcts.darts.cases.service.CaseService;
 import uk.gov.hmcts.darts.common.datamanagement.enums.DatastoreContainerType;
 import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
@@ -138,7 +137,6 @@ public class TranscriptionServiceImpl implements TranscriptionService {
     private final TranscriptionNotifications transcriptionNotifications;
     private final DataManagementApi dataManagementApi;
 
-    private final CaseService caseService;
     private final HearingsService hearingsService;
     private final AuditApi auditApi;
 
@@ -294,7 +292,7 @@ public class TranscriptionServiceImpl implements TranscriptionService {
 
     @SuppressWarnings({"PMD.CyclomaticComplexity"})
     void validateUpdateTranscription(TranscriptionEntity transcription,
-                                             UpdateTranscriptionRequest updateTranscription, boolean allowSelfApprovalOrRejection, boolean isAdmin) {
+                                     UpdateTranscriptionRequest updateTranscription, boolean allowSelfApprovalOrRejection, boolean isAdmin) {
 
         TranscriptionStatusEnum desiredTargetTranscriptionStatus = TranscriptionStatusEnum.fromId(updateTranscription.getTranscriptionStatusId());
         UserAccountEntity transcriptionUser = userAccountRepository.getReferenceById(transcription.getCreatedById());
@@ -341,10 +339,6 @@ public class TranscriptionServiceImpl implements TranscriptionService {
         transcription.setHideRequestFromRequestor(false);
         transcription.setIsCurrent(true);
         transcription.setRequestedBy(userAccount);
-
-        if (nonNull(transcriptionRequestDetails.getCaseId())) {
-            transcription.addCase(caseService.getCourtCaseById(transcriptionRequestDetails.getCaseId()));
-        }
 
         if (nonNull(transcriptionRequestDetails.getHearingId())) {
             HearingEntity hearing = hearingsService.getHearingByIdWithValidation(transcriptionRequestDetails.getHearingId());

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/TranscriptionServiceImplTest.java
@@ -15,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.darts.audit.api.AuditApi;
 import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
-import uk.gov.hmcts.darts.cases.service.CaseService;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
@@ -110,9 +109,6 @@ class TranscriptionServiceImplTest {
 
     @Mock
     private TranscriptionWorkflowEntity mockTranscriptionWorkflowEntity;
-
-    @Mock
-    private CaseService mockCaseService;
     @Mock
     private HearingsService mockHearingsService;
     @Mock
@@ -214,9 +210,6 @@ class TranscriptionServiceImplTest {
         Integer hearingId = 1;
         when(mockHearingsService.getHearingByIdWithValidation(hearingId)).thenReturn(mockHearing);
 
-        Integer caseId = 1;
-        when(mockCaseService.getCourtCaseById(caseId)).thenReturn(mockCourtCase);
-
         TranscriptionUrgencyEnum transcriptionUrgencyEnum = TranscriptionUrgencyEnum.OVERNIGHT;
         when(mockTranscriptionUrgencyRepository.getReferenceById(transcriptionUrgencyEnum.getId()))
             .thenReturn(mockTranscriptionUrgency);
@@ -242,6 +235,7 @@ class TranscriptionServiceImplTest {
         OffsetDateTime startDateTime = CommonTestDataUtil.createOffsetDateTime(START_TIME);
         OffsetDateTime endDateTime = CommonTestDataUtil.createOffsetDateTime(END_TIME);
 
+        Integer caseId = 1;
         TranscriptionRequestDetails transcriptionRequestDetails = createTranscriptionRequestDetails(
             hearingId,
             caseId,
@@ -301,9 +295,6 @@ class TranscriptionServiceImplTest {
     void saveTranscriptionRequestWithValidValuesNullHearingAndCourtLogTypeReturnSuccess() {
         doNothing().when(duplicateRequestDetector).checkForDuplicate(any(TranscriptionRequestDetails.class), any(Boolean.class));
 
-        Integer caseId = 1;
-        when(mockCaseService.getCourtCaseById(caseId)).thenReturn(mockCourtCase);
-
         TranscriptionUrgencyEnum transcriptionUrgencyEnum = TranscriptionUrgencyEnum.OVERNIGHT;
         when(mockTranscriptionUrgencyRepository.getReferenceById(transcriptionUrgencyEnum.getId()))
             .thenReturn(mockTranscriptionUrgency);
@@ -330,6 +321,7 @@ class TranscriptionServiceImplTest {
         OffsetDateTime startDateTime = CommonTestDataUtil.createOffsetDateTime(START_TIME);
         OffsetDateTime endDateTime = CommonTestDataUtil.createOffsetDateTime(END_TIME);
 
+        Integer caseId = 1;
         TranscriptionRequestDetails transcriptionRequestDetails = createTranscriptionRequestDetails(
             hearingId,
             caseId,
@@ -346,7 +338,6 @@ class TranscriptionServiceImplTest {
 
         TranscriptionEntity transcriptionEntity = transcriptionEntityArgumentCaptor.getValue();
         assertThat(transcriptionEntity.getHearing()).isNull();
-        assertThat(transcriptionEntity.getCourtCase()).isNotNull();
         assertThat(transcriptionEntity.getCourtroom()).isNull();
         assertThat(transcriptionEntity.getTranscriptionUrgency()).isNotNull();
         assertThat(transcriptionEntity.getStartTime()).isEqualTo(startDateTime);
@@ -472,9 +463,6 @@ class TranscriptionServiceImplTest {
         Integer hearingId = 1;
         when(mockHearingsService.getHearingByIdWithValidation(hearingId)).thenReturn(mockHearing);
 
-        Integer caseId = 1;
-        when(mockCaseService.getCourtCaseById(caseId)).thenReturn(mockCourtCase);
-
         TranscriptionUrgencyEnum transcriptionUrgencyEnum = TranscriptionUrgencyEnum.OVERNIGHT;
         when(mockTranscriptionUrgencyRepository.getReferenceById(transcriptionUrgencyEnum.getId()))
             .thenReturn(mockTranscriptionUrgency);
@@ -500,6 +488,7 @@ class TranscriptionServiceImplTest {
         OffsetDateTime startDateTime = null;
         OffsetDateTime endDateTime = null;
 
+        Integer caseId = 1;
         TranscriptionRequestDetails transcriptionRequestDetails = createTranscriptionRequestDetails(
             hearingId,
             caseId,


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5101)


### Change description ###
# Summary of Git Diff

This diff introduces several modifications to the `TranscriptionServiceImpl` class and its corresponding test class, `TranscriptionServiceImplTest`. The primary change involves the removal of the `CaseService` dependency from both the implementation and test classes. As a result, references to case-related functionality have been eliminated, streamlining the code.

## Highlights

- **Removed CaseService Dependency**: 
  - The `CaseService` field was removed from `TranscriptionServiceImpl`.
  - Corresponding mock object and references in `TranscriptionServiceImplTest` were also deleted.

- **Code Cleanup**:
  - Unused code related to `CaseService` was eliminated from method implementations, particularly in the `saveTranscription` method and various test methods.
  
- **Minor Method Signature Change**:
  - Adjusted the method signature of `validateUpdateTranscription` to align with the removal of the `CaseService`.

- **Test Adjustments**:
  - Tests were updated to remove assertions and mock setups related to the case entity, ensuring that they focus solely on hearing and transcription-related functionalities. 

These changes enhance the clarity and maintainability of the code by removing unnecessary dependencies and focusing on relevant components.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
