### PR TITLE
DMP-5063: Transcription marked for deletion ts genrated with is marked for deletion flag false

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -457,6 +457,8 @@ public class TranscriptionResponseMapper {
             adminActionResponse.setIsMarkedForManualDeletion(objectAdminActionEntity.isMarkedForManualDeletion());
             adminActionResponse.setMarkedForManualDeletionById(objectAdminActionEntity.getMarkedForManualDelBy().getId());
             adminActionResponse.setMarkedForManualDeletionAt(objectAdminActionEntity.getMarkedForManualDelDateTime());
+        } else {
+            adminActionResponse.setIsMarkedForManualDeletion(false);
         }
         adminActionResponse.setTicketReference(objectAdminActionEntity.getTicketReference());
         adminActionResponse.setComments(objectAdminActionEntity.getComments());

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -453,9 +453,11 @@ public class TranscriptionResponseMapper {
         adminActionResponse.setReasonId(objectAdminActionEntity.getObjectHiddenReason().getId());
         adminActionResponse.setHiddenById(objectAdminActionEntity.getHiddenBy().getId());
         adminActionResponse.setHiddenAt(objectAdminActionEntity.getHiddenDateTime());
-        adminActionResponse.setIsMarkedForManualDeletion(objectAdminActionEntity.isMarkedForManualDeletion());
-        adminActionResponse.setMarkedForManualDeletionById(objectAdminActionEntity.getMarkedForManualDelBy().getId());
-        adminActionResponse.setMarkedForManualDeletionAt(objectAdminActionEntity.getMarkedForManualDelDateTime());
+        if (objectAdminActionEntity.isMarkedForManualDeletion()) {
+            adminActionResponse.setIsMarkedForManualDeletion(objectAdminActionEntity.isMarkedForManualDeletion());
+            adminActionResponse.setMarkedForManualDeletionById(objectAdminActionEntity.getMarkedForManualDelBy().getId());
+            adminActionResponse.setMarkedForManualDeletionAt(objectAdminActionEntity.getMarkedForManualDelDateTime());
+        }
         adminActionResponse.setTicketReference(objectAdminActionEntity.getTicketReference());
         adminActionResponse.setComments(objectAdminActionEntity.getComments());
 

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceImpl.java
@@ -207,18 +207,21 @@ public class AdminTranscriptionServiceImpl implements AdminTranscriptionService 
 
                 auditApi.record(HIDE_TRANSCRIPTION);
 
+                ObjectHiddenReasonEntity objectHiddenReason = objectHiddenReasonEntity.get();
+                UserAccountEntity currentUser = userIdentity.getUserAccount();
                 // on hiding add the relevant hide record
                 ObjectAdminActionEntity objectAdminActionEntity = new ObjectAdminActionEntity();
-                objectAdminActionEntity.setObjectHiddenReason(objectHiddenReasonEntity.get());
+                objectAdminActionEntity.setObjectHiddenReason(objectHiddenReason);
                 objectAdminActionEntity.setTicketReference(transcriptionDocumentHideRequest.getAdminAction().getTicketReference());
                 objectAdminActionEntity.setComments(transcriptionDocumentHideRequest.getAdminAction().getComments());
                 objectAdminActionEntity.setTranscriptionDocument(documentEntity);
-                objectAdminActionEntity.setHiddenBy(userIdentity.getUserAccount());
+                objectAdminActionEntity.setHiddenBy(currentUser);
                 objectAdminActionEntity.setHiddenDateTime(OffsetDateTime.now());
-                objectAdminActionEntity.setMarkedForManualDeletion(false);
-                objectAdminActionEntity.setMarkedForManualDelBy(userIdentity.getUserAccount());
-                objectAdminActionEntity.setMarkedForManualDelDateTime(OffsetDateTime.now());
-
+                if (objectHiddenReason.isMarkedForDeletion()) {
+                    objectAdminActionEntity.setMarkedForManualDeletion(true);
+                    objectAdminActionEntity.setMarkedForManualDelBy(currentUser);
+                    objectAdminActionEntity.setMarkedForManualDelDateTime(OffsetDateTime.now());
+                }
                 objectAdminActionEntity = objectAdminActionRepository.saveAndFlush(objectAdminActionEntity);
 
                 response = transcriptionMapper.mapHideOrShowResponse(documentEntity, objectAdminActionEntity);

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
@@ -61,6 +61,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -724,6 +725,53 @@ class TranscriptionResponseMapperTest {
 
         TranscriptionDocumentHideResponse response = transcriptionResponseMapper.mapHideOrShowResponse(documentEntity, objectAdminActionEntity);
 
+        assertEquals(documentEntity.getId(), response.getId());
+        assertEquals(documentEntity.isHidden(), response.getIsHidden());
+        assertEquals(objectAdminActionEntity.getObjectHiddenReason().getId(), response.getAdminAction().getReasonId());
+        assertEquals(objectAdminActionEntity.getComments(), response.getAdminAction().getComments());
+        assertEquals(objectAdminActionEntity.getTicketReference(), response.getAdminAction().getTicketReference());
+        assertEquals(objectAdminActionEntity.getId(), response.getAdminAction().getId());
+        assertEquals(objectAdminActionEntity.getHiddenDateTime(), response.getAdminAction().getHiddenAt());
+        assertEquals(objectAdminActionEntity.getHiddenBy().getId(), response.getAdminAction().getHiddenById());
+        assertEquals(userAccountEntity.getId(), response.getAdminAction().getHiddenById());
+        assertEquals(objectAdminActionEntity.getMarkedForManualDelBy().getId(), response.getAdminAction().getMarkedForManualDeletionById());
+        assertNull(response.getAdminAction().getMarkedForManualDeletionAt());
+        assertFalse(response.getAdminAction().getIsMarkedForManualDeletion());
+    }
+
+    @Test
+    void mapHideResponse_isMakredForDeletion_shouldMapMarkedForDeletionFields() {
+        Long documentId = 100L;
+        boolean hide = true;
+
+        TranscriptionDocumentEntity documentEntity = new TranscriptionDocumentEntity();
+        documentEntity.setId(documentId);
+        documentEntity.setHidden(hide);
+
+        Integer objectAdminActionId = 101;
+        String comments = "comments";
+        String reference = "reference";
+
+        UserAccountEntity userAccountEntity = new UserAccountEntity();
+
+        ObjectHiddenReasonEntity reasonEntity = mock(ObjectHiddenReasonEntity.class);
+        when(reasonEntity.getId()).thenReturn(2332);
+
+        OffsetDateTime creationDate = OffsetDateTime.now();
+        ObjectAdminActionEntity objectAdminActionEntity = new ObjectAdminActionEntity();
+        objectAdminActionEntity.setId(objectAdminActionId);
+        objectAdminActionEntity.setComments(comments);
+        objectAdminActionEntity.setTicketReference(reference);
+        objectAdminActionEntity.setId(objectAdminActionId);
+        objectAdminActionEntity.setHiddenBy(userAccountEntity);
+        objectAdminActionEntity.setHiddenDateTime(creationDate);
+        objectAdminActionEntity.setMarkedForManualDeletion(true);
+        objectAdminActionEntity.setMarkedForManualDelBy(userAccountEntity);
+        objectAdminActionEntity.setMarkedForManualDelDateTime(creationDate);
+        objectAdminActionEntity.setObjectHiddenReason(reasonEntity);
+
+        TranscriptionDocumentHideResponse response = transcriptionResponseMapper.mapHideOrShowResponse(documentEntity, objectAdminActionEntity);
+
         assertEquals(response.getId(), documentEntity.getId());
         assertEquals(response.getIsHidden(), documentEntity.isHidden());
         assertEquals(response.getAdminAction().getReasonId(), objectAdminActionEntity.getObjectHiddenReason().getId());
@@ -736,6 +784,53 @@ class TranscriptionResponseMapperTest {
         assertEquals(response.getAdminAction().getMarkedForManualDeletionById(), objectAdminActionEntity.getMarkedForManualDelBy().getId());
         assertEquals(response.getAdminAction().getMarkedForManualDeletionAt(), objectAdminActionEntity.getMarkedForManualDelDateTime());
         assertEquals(response.getAdminAction().getIsMarkedForManualDeletion(), objectAdminActionEntity.isMarkedForManualDeletion());
+    }
+
+    @Test
+    void mapHideResponse_isNotMakredForDeletion_shouldNotMapMarkedForDeletionFields() {
+        Long documentId = 100L;
+        boolean hide = true;
+
+        TranscriptionDocumentEntity documentEntity = new TranscriptionDocumentEntity();
+        documentEntity.setId(documentId);
+        documentEntity.setHidden(hide);
+
+        Integer objectAdminActionId = 101;
+        String comments = "comments";
+        String reference = "reference";
+
+        UserAccountEntity userAccountEntity = new UserAccountEntity();
+
+        ObjectHiddenReasonEntity reasonEntity = mock(ObjectHiddenReasonEntity.class);
+        when(reasonEntity.getId()).thenReturn(2332);
+
+        OffsetDateTime creationDate = OffsetDateTime.now();
+        ObjectAdminActionEntity objectAdminActionEntity = new ObjectAdminActionEntity();
+        objectAdminActionEntity.setId(objectAdminActionId);
+        objectAdminActionEntity.setComments(comments);
+        objectAdminActionEntity.setTicketReference(reference);
+        objectAdminActionEntity.setId(objectAdminActionId);
+        objectAdminActionEntity.setHiddenBy(userAccountEntity);
+        objectAdminActionEntity.setHiddenDateTime(creationDate);
+        objectAdminActionEntity.setMarkedForManualDeletion(false);
+        objectAdminActionEntity.setMarkedForManualDelBy(userAccountEntity);
+        objectAdminActionEntity.setMarkedForManualDelDateTime(creationDate);
+        objectAdminActionEntity.setObjectHiddenReason(reasonEntity);
+
+        TranscriptionDocumentHideResponse response = transcriptionResponseMapper.mapHideOrShowResponse(documentEntity, objectAdminActionEntity);
+
+        assertEquals(response.getId(), documentEntity.getId());
+        assertEquals(response.getIsHidden(), documentEntity.isHidden());
+        assertEquals(response.getAdminAction().getReasonId(), objectAdminActionEntity.getObjectHiddenReason().getId());
+        assertEquals(response.getAdminAction().getComments(), objectAdminActionEntity.getComments());
+        assertEquals(response.getAdminAction().getTicketReference(), objectAdminActionEntity.getTicketReference());
+        assertEquals(response.getAdminAction().getId(), objectAdminActionEntity.getId());
+        assertEquals(response.getAdminAction().getHiddenAt(), objectAdminActionEntity.getHiddenDateTime());
+        assertEquals(response.getAdminAction().getHiddenById(), objectAdminActionEntity.getHiddenBy().getId());
+        assertEquals(response.getAdminAction().getHiddenById(), userAccountEntity.getId());
+        assertEquals(objectAdminActionEntity.getMarkedForManualDelBy().getId(), response.getAdminAction().getMarkedForManualDeletionById());
+        assertNull(response.getAdminAction().getMarkedForManualDeletionAt());
+        assertFalse(response.getAdminAction().getIsMarkedForManualDeletion());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
@@ -49,7 +49,9 @@ import java.util.Optional;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -265,16 +267,26 @@ class AdminTranscriptionServiceTest {
     void testTranscriptionDocumentHide() {
         TranscriptionDocumentHideRequest request = new TranscriptionDocumentHideRequest();
         request.setIsHidden(true);
-        setupTestTranscriptionDocumentHide(request);
+        assertTestTranscriptionDocumentHide(request, false);
     }
 
     @Test
     void testTranscriptionDocumentHideDefaultIsHidden() {
         TranscriptionDocumentHideRequest request = new TranscriptionDocumentHideRequest();
-        setupTestTranscriptionDocumentHide(request);
+        assertTestTranscriptionDocumentHide(request, false);
     }
 
-    void setupTestTranscriptionDocumentHide(TranscriptionDocumentHideRequest request) {
+
+    @Test
+    void hideOrShowTranscriptionDocumentById_shouldSetMarkedForDeletion_whenObjectHiddenReasonIsMarkedForDeletion() {
+        assertTestTranscriptionDocumentHide(new TranscriptionDocumentHideRequest(), true);
+    }
+    @Test
+    void hideOrShowTranscriptionDocumentById_shouldNotSetMarkedForDeletion_whenObjectHiddenReasonNotIsMarkedForDeletion() {
+        assertTestTranscriptionDocumentHide(new TranscriptionDocumentHideRequest(), false);
+    }
+
+    void assertTestTranscriptionDocumentHide(TranscriptionDocumentHideRequest request, boolean isMarkedForDeleton) {
         Long hideOrShowTranscriptionDocument = 343L;
         Integer reasonId = 555;
 
@@ -297,6 +309,7 @@ class AdminTranscriptionServiceTest {
         when(transcriptionDocumentRepository.saveAndFlush(transcriptionDocumentEntityArgumentCaptor.capture())).thenReturn(transcriptionDocumentEntity);
         ObjectAdminActionEntity objectAdminActionEntity = new ObjectAdminActionEntity();
         ObjectHiddenReasonEntity objectHiddenReasonEntity = new ObjectHiddenReasonEntity();
+        objectHiddenReasonEntity.setMarkedForDeletion(isMarkedForDeleton);
         TranscriptionDocumentHideResponse expectedResponse = new TranscriptionDocumentHideResponse();
 
         when(objectHiddenReasonRepository.findById(reasonId)).thenReturn(Optional.of(objectHiddenReasonEntity));
@@ -311,15 +324,25 @@ class AdminTranscriptionServiceTest {
 
 
         // make the assertion
-        assertTrue(transcriptionDocumentEntityArgumentCaptor.getValue().isHidden());
+        TranscriptionDocumentEntity transcriptionDocument = transcriptionDocumentEntityArgumentCaptor.getValue();
+        ObjectAdminActionEntity objectAdminAction = objectAdminActionEntityArgumentCaptor.getValue();
+
+        assertTrue(transcriptionDocument.isHidden());
         assertEquals(expectedResponse, actualResponse);
-        assertEquals(request.getAdminAction().getComments(), objectAdminActionEntityArgumentCaptor.getValue().getComments());
-        assertEquals(request.getAdminAction().getReasonId(), reasonId);
-        Assertions.assertFalse(objectAdminActionEntityArgumentCaptor.getValue().isMarkedForManualDeletion());
-        assertNotNull(objectAdminActionEntityArgumentCaptor.getValue().getHiddenBy());
-        assertNotNull(objectAdminActionEntityArgumentCaptor.getValue().getHiddenDateTime());
-        assertNotNull(objectAdminActionEntityArgumentCaptor.getValue().getMarkedForManualDelBy());
-        assertNotNull(objectAdminActionEntityArgumentCaptor.getValue().getMarkedForManualDelDateTime());
+        assertEquals(objectAdminAction.getComments(), request.getAdminAction().getComments());
+        assertEquals(reasonId, request.getAdminAction().getReasonId());
+        Assertions.assertFalse(objectAdminAction.isMarkedForManualDeletion());
+        assertNotNull(objectAdminAction.getHiddenBy());
+        assertNotNull(objectAdminAction.getHiddenDateTime());
+        if (isMarkedForDeleton) {
+            assertTrue(objectAdminAction.isMarkedForManualDeletion());
+            assertNotNull(objectAdminAction.getMarkedForManualDelBy());
+            assertNotNull(objectAdminAction.getMarkedForManualDelDateTime());
+        } else {
+            assertNull(objectAdminAction.getMarkedForManualDelBy());
+            assertNull(objectAdminAction.getMarkedForManualDelDateTime());
+            assertFalse(objectAdminAction.isMarkedForManualDeletion());
+        }
         verify(auditApi).record(HIDE_TRANSCRIPTION);
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
@@ -331,7 +331,6 @@ class AdminTranscriptionServiceTest {
         assertEquals(expectedResponse, actualResponse);
         assertEquals(objectAdminAction.getComments(), request.getAdminAction().getComments());
         assertEquals(reasonId, request.getAdminAction().getReasonId());
-        Assertions.assertFalse(objectAdminAction.isMarkedForManualDeletion());
         assertNotNull(objectAdminAction.getHiddenBy());
         assertNotNull(objectAdminAction.getHiddenDateTime());
         if (isMarkedForDeleton) {

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.transcriptions.service.impl;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
@@ -281,6 +281,7 @@ class AdminTranscriptionServiceTest {
     void hideOrShowTranscriptionDocumentById_shouldSetMarkedForDeletion_whenObjectHiddenReasonIsMarkedForDeletion() {
         assertTestTranscriptionDocumentHide(new TranscriptionDocumentHideRequest(), true);
     }
+
     @Test
     void hideOrShowTranscriptionDocumentById_shouldNotSetMarkedForDeletion_whenObjectHiddenReasonNotIsMarkedForDeletion() {
         assertTestTranscriptionDocumentHide(new TranscriptionDocumentHideRequest(), false);
@@ -387,7 +388,7 @@ class AdminTranscriptionServiceTest {
             = adminTranscriptionService.hideOrShowTranscriptionDocumentById(hideOrShowTranscriptionDocument, request);
 
         // make the assertion
-        Assertions.assertFalse(transcriptionDocumentEntityArgumentCaptor.getValue().isHidden());
+        assertFalse(transcriptionDocumentEntityArgumentCaptor.getValue().isHidden());
         assertEquals(expectedResponse, actualResponse);
         verify(objectAdminActionRepository, times(1)).deleteById(objectAdminActionEntityId);
         verify(objectAdminActionRepository, times(1)).deleteById(objectAdminActionEntityId1);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5063)


### Change description ###
# Summary of Git Diff

This Git diff reflects changes made to the `AdminTranscriptionServiceImpl.java` and `AdminTranscriptionServiceTest.java` files in the transcription service of the HMCTS DARTS project. The modifications focus on the handling of transcription document hiding logic, particularly around the management of deletion markers and user accounts.

## Highlights

### Changes in `AdminTranscriptionServiceImpl.java`
- **User Account Handling**: 
  - Replaced direct calls to `userIdentity.getUserAccount()` with a stored variable `currentUser` for clarity and performance.
  
- **Object Admin Action Entity Modifications**:
  - The method now checks if the `objectHiddenReason` is marked for deletion before setting the `markedForManualDeletion` flag.
  - If marked for deletion, the fields for manual deletion are set using `currentUser`.

### Changes in `AdminTranscriptionServiceTest.java`
- **Test Method Enhancements**:
  - Introduced new test cases to verify the behavior of the `hideOrShowTranscriptionDocumentById` method regarding the deletion flag.
  - Modified the existing test cases to use an assertion method `assertTestTranscriptionDocumentHide`, which checks both the hidden state and the deletion status effectively.
  
- **Assertions on Object Admin Action**:
  - Improved assertions to check for null values and correctness of the manual deletion fields based on the `isMarkedForDeletion` parameter.

These changes enhance the robustness of the transcription document management by ensuring that the deletion logic is accurately reflected in both the service implementation and its associated tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
