### PR TITLE
DMP-5047: Can ATS Keda pods run on the Dev environment? 

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -83,11 +83,16 @@ def determineDevEnvironmentDeployment() {
   env.DEV_DARTS_GATEWAY_URL = "http://darts-gateway.staging.platform.hmcts.net"
   env.DEV_DARTS_GATEWAY_IMAGE_SUFFIX = "latest"
 
+
+  env.DEV_ENABLE_DARTS_KEDA = false
+
   echo "1 - env.DEV_ENABLE_DARTS_PORTAL: ${env.DEV_ENABLE_DARTS_PORTAL}"
   echo "1 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
 
   echo "1 - env.DEV_ENABLE_DARTS_GATEWAY: ${env.DEV_ENABLE_DARTS_GATEWAY}"
   echo "1 - env.DEV_DARTS_GATEWAY_URL: ${env.DEV_DARTS_GATEWAY_URL}"
+
+  echo "1 - env.DEV_ENABLE_DARTS_KEDA: ${env.DEV_ENABLE_DARTS_KEDA}"
 
 
   def githubApi = new GithubAPI(this)
@@ -117,6 +122,12 @@ def determineDevEnvironmentDeployment() {
         }
         echo "Deploying DARTS gateway (${env.DEV_DARTS_GATEWAY_IMAGE_SUFFIX}) instance in PR environment"
       }
+
+      //Gateway
+      if (label ==~ /enable_keda/) {
+        env.DEV_ENABLE_DARTS_KEDA = true
+        echo "DARTS KEDA enabled in PR environment"
+      }
     }
   }
 
@@ -124,6 +135,7 @@ def determineDevEnvironmentDeployment() {
   echo "2 - env.DEV_DARTS_PORTAL_URL: ${env.DEV_DARTS_PORTAL_URL}"
   echo "2 - env.DEV_ENABLE_DARTS_GATEWAY: ${env.DEV_ENABLE_DARTS_GATEWAY}"
   echo "2 - env.DEV_DARTS_GATEWAY_URL: ${env.DEV_DARTS_GATEWAY_URL}"
+  echo "2 - env.DEV_ENABLE_DARTS_KEDA: ${env.DEV_ENABLE_DARTS_KEDA}"
 }
 
 GradleBuilder builder = new GradleBuilder(this, product)

--- a/charts/darts-api/values.dev.template.yaml
+++ b/charts/darts-api/values.dev.template.yaml
@@ -207,72 +207,84 @@ darts-gateway:
       DARTS_API_URL: "https://darts-api-pr-${CHANGE_ID}.dev.platform.hmcts.net"
       TESTING_SUPPORT_ENDPOINTS_ENABLED: true
 
-# function:
-#   scaleType: Job
-#   image: ${IMAGE_NAME}
-#   aadIdentityName: darts
-#   pollingInterval: 300 # every 5 mins, but this should probably be configurable per env
-#   minReplicaCount: 0
-#   maxReplicaCount: 2
-#   scalingStrategy: accurate
-#   keyVaults:
-#     "darts":
-#       secrets:
-#         - name: GovukNotifyApiKey
-#           alias: GOVUK_NOTIFY_API_KEY
-#         - name: api-POSTGRES-USER
-#           alias: DARTS_API_DB_USERNAME
-#         - name: api-POSTGRES-PASS
-#           alias: DARTS_API_DB_PASSWORD
-#         - name: api-POSTGRES-HOST
-#           alias: DARTS_API_DB_HOST
-#         - name: api-POSTGRES-DATABASE
-#           alias: DARTS_API_DB_NAME
-#         - name: api-POSTGRES-SCHEMA
-#           alias: DARTS_API_DB_SCHEMA
-#         - name: AzureAdB2CTenantId
-#           alias: AAD_B2C_TENANT_ID
-#         - name: AzureAdB2CClientId
-#           alias: AAD_B2C_CLIENT_ID
-#         - name: AzureAdB2CClientSecret
-#           alias: AAD_B2C_CLIENT_SECRET
-#         - name: app-insights-connection-string
-#           alias: app-insights-connection-string
-#         - name: AzureAdB2CFuncTestROPCClientId
-#           alias: AAD_B2C_ROPC_CLIENT_ID
-#         - name: AzureAdB2CFuncTestROPCClientSecret
-#           alias: AAD_B2C_ROPC_CLIENT_SECRET
-#         - name: AzureStorageConnectionString
-#           alias: AZURE_STORAGE_CONNECTION_STRING
-#         - name: api-POSTGRES-CONNECTION-STRING
-#           alias: DARTS_API_DB_CONNECTION_STRING
-#         - name: AzureADTenantId
-#           alias: AAD_TENANT_ID
-#         - name: AzureADClientId
-#           alias: AAD_CLIENT_ID
-#         - name: AzureADClientSecret
-#           alias: AAD_CLIENT_SECRET
-#         - name: AzureADTenantIdJustice
-#           alias: AAD_TENANT_ID_JUSTICE
-#         - name: AzureADClientIdJustice
-#           alias: AAD_CLIENT_ID_JUSTICE
-#         - name: AzureADClientSecretJustice
-#           alias: AAD_CLIENT_SECRET_JUSTICE
-#   environment:
-#     ATS_MODE: true
-#     POSTGRES_SSL_MODE: require
-#     RUN_DB_MIGRATION_ON_STARTUP: false
-#     DARTS_GATEWAY_URL: https://darts-gateway.staging.platform.hmcts.net
-#   secrets:
-#     DARTS_API_DB_CONNECTION_STRING:
-#       secretRef: darts-api-{{ .Release.Name }}-postgresql
-#       key: connectionString
-#   job:
-#     activeDeadlineSeconds: 300
-#     parallelism: 1
-#     completions: 1
-#   triggers:
-#     - type: postgres
-#       connectionFromEnv: DARTS_API_DB_CONNECTION_STRING
-#       query: "SELECT count(*) FROM darts.media_request WHERE mer_id = ( SELECT mer_id FROM darts.media_request WHERE request_status = 'OPEN' ORDER BY created_ts LIMIT 1 )"
-#       targetQueryValue: "0.9"
+function:
+  enabled: ${DEV_ENABLE_DARTS_KEDA}
+  scaleType: Job
+  image: ${IMAGE_NAME}
+  aadIdentityName: darts
+  pollingInterval: 300 # every 5 mins, but this should probably be configurable per env
+  minReplicaCount: 0
+  maxReplicaCount: 2
+  scalingStrategy: accurate
+  global:
+    enableKeyVaults: true
+  keyVaults:
+    "darts":
+      secrets:
+        - name: GovukNotifyApiKey
+          alias: GOVUK_NOTIFY_API_KEY
+        - name: api-POSTGRES-USER
+          alias: DARTS_API_DB_USERNAME
+        - name: api-POSTGRES-PASS
+          alias: DARTS_API_DB_PASSWORD
+        - name: api-POSTGRES-HOST
+          alias: DARTS_API_DB_HOST
+        - name: api-POSTGRES-DATABASE
+          alias: DARTS_API_DB_NAME
+        - name: api-POSTGRES-SCHEMA
+          alias: DARTS_API_DB_SCHEMA
+        - name: AzureAdB2CTenantId
+          alias: AAD_B2C_TENANT_ID
+        - name: AzureAdB2CClientId
+          alias: AAD_B2C_CLIENT_ID
+        - name: AzureAdB2CClientSecret
+          alias: AAD_B2C_CLIENT_SECRET
+        - name: app-insights-connection-string
+          alias: app-insights-connection-string
+        - name: AzureAdB2CFuncTestROPCClientId
+          alias: AAD_B2C_ROPC_CLIENT_ID
+        - name: AzureAdB2CFuncTestROPCClientSecret
+          alias: AAD_B2C_ROPC_CLIENT_SECRET
+        - name: AzureStorageConnectionString
+          alias: AZURE_STORAGE_CONNECTION_STRING
+        - name: api-POSTGRES-CONNECTION-STRING
+          alias: DARTS_API_DB_CONNECTION_STRING
+        - name: AzureADTenantId
+          alias: AAD_TENANT_ID
+        - name: AzureADClientId
+          alias: AAD_CLIENT_ID
+        - name: AzureADClientSecret
+          alias: AAD_CLIENT_SECRET
+        - name: AzureADTenantIdJustice
+          alias: AAD_TENANT_ID_JUSTICE
+        - name: AzureADClientIdJustice
+          alias: AAD_CLIENT_ID_JUSTICE
+        - name: AzureADClientSecretJustice
+          alias: AAD_CLIENT_SECRET_JUSTICE
+  environment:
+    DARTS_API_DB_CONNECTION_STRING: jdbc:postgresql://${DARTS_API_DB_HOST}:5432/${DARTS_API_DB_NAME}${DARTS_API_DB_OPTIONS:}
+    ATS_MODE: true
+    API_MODE: false
+    NOTIFICATION_SCHEDULER_ENABLED: false
+    AUTOMATED_TASK_MODE: false
+    POSTGRES_SSL_MODE: require
+    RUN_DB_MIGRATION_ON_STARTUP: false
+    DARTS_GATEWAY_URL: "https://darts-gateway-api-pr-${CHANGE_ID}.dev.platform.hmcts.net"
+    ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsstgextid.b2clogin.com
+    ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
+    ARM_URL: http://darts-stub-services.{{ .Values.global.environment }}.platform.hmcts.net
+    FEIGN_LOG_LEVEL: none
+    IS_MOCK_ARM_RPO_DOWNLOAD_CSV: false
+    ARM_RPO_THREAD_SLEEP_DURATION: 60s
+    ARM_RPO_POLL_DURATION: 4h
+    AZCOPY_LOG_LEVEL: "--log-level=ERROR"
+    AZCOPY_OUTPUT_LEVEL: "--output-level=essential"
+  job:
+    activeDeadlineSeconds: 300
+    parallelism: 1
+    completions: 1
+  triggers:
+    - type: postgres
+      connectionFromEnv: DARTS_API_DB_CONNECTION_STRING
+      query: "SELECT count(*) FROM darts.media_request WHERE mer_id = ( SELECT mer_id FROM darts.media_request WHERE request_status = 'OPEN' ORDER BY created_ts LIMIT 1 )"
+      targetQueryValue: "0.9"


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5047)


### Change description ###
# Git Diff Summary

This Git diff introduces modifications to the `Jenkinsfile_CNP` and `values.dev.template.yaml` files, primarily adding support for enabling DARTS KEDA in the development environment.

## Highlights

### Jenkinsfile_CNP
- Added a new environment variable: `env.DEV_ENABLE_DARTS_KEDA` with a default value of `false`.
- Echo statements now include `env.DEV_ENABLE_DARTS_KEDA` to output its value during execution.
- A conditional statement checks for the `enable_keda` label and sets `env.DEV_ENABLE_DARTS_KEDA` to `true` if the label is present, indicating that DARTS KEDA should be enabled in the PR environment.

### values.dev.template.yaml
- Introduced the `function.enabled` parameter to control the DARTS KEDA functionality, allowing it to be set based on `DEV_ENABLE_DARTS_KEDA`.
- Updated the configuration for the function, including parameters like `scaleType`, `image`, `aadIdentityName`, and various secrets.
- Added additional environment variables related to DARTS API and Azure AD B2C settings.
- Configured a PostgreSQL trigger to monitor the media request table for specific conditions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
