### PR TITLE
DMP-5100 ARM Replay needs to reset input_upload_processed_ts

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoReplayServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoReplayServiceIntTest.java
@@ -16,6 +16,7 @@ import java.time.OffsetDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.lenient;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_RAW_DATA_FAILED;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_REPLAY;
@@ -81,6 +82,7 @@ class ArmRpoReplayServiceIntTest extends PostgresIntegrationBase {
         validEodResults.forEach(eod -> {
             assertEquals(ARM_RAW_DATA_FAILED.getId(), eod.getStatus().getId());
             assertEquals(0, eod.getTransferAttempts());
+            assertNull(eod.getInputUploadProcessedTs());
         });
 
         invalidEodResults.forEach(eod -> {

--- a/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoServiceIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/arm/service/ArmRpoServiceIntTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_REPLAY;
@@ -230,7 +230,7 @@ class ArmRpoServiceIntTest extends PostgresIntegrationBase {
         assertEquals(1, foundMediaList6.size());
         ExternalObjectDirectoryEntity foundMedia6 = foundMediaList6.getFirst();
         assertEquals(ARM_REPLAY.getId(), foundMedia6.getStatus().getId());
-        assertNull(foundMedia6.getInputUploadProcessedTs());
+        assertNotNull(foundMedia6.getInputUploadProcessedTs());
 
     }
 
@@ -332,7 +332,7 @@ class ArmRpoServiceIntTest extends PostgresIntegrationBase {
         assertEquals(1, foundMediaList.size());
         ExternalObjectDirectoryEntity foundMedia = foundMediaList.getFirst();
         assertEquals(ARM_REPLAY.getId(), foundMedia.getStatus().getId());
-        assertNull(foundMedia.getInputUploadProcessedTs());
+        assertNotNull(foundMedia.getInputUploadProcessedTs());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoReplayServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoReplayServiceImpl.java
@@ -36,7 +36,7 @@ public class ArmRpoReplayServiceImpl implements ArmRpoReplayService {
     public void replayArmRpo(int batchSize) {
         ArmAutomatedTaskEntity armAutomatedTaskEntity = automatedTaskService.getArmAutomatedTaskEntity(ARM_RPO_REPLAY_TASK_NAME);
 
-        List<Integer> eodIdsToBeUpdated = externalObjectDirectoryRepository.findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit(
+        List<Long> eodIdsToBeUpdated = externalObjectDirectoryRepository.findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit(
             EodHelper.armReplayStatus(),
             armAutomatedTaskEntity.getArmReplayStartTs(),
             armAutomatedTaskEntity.getArmReplayEndTs(),

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoServiceImpl.java
@@ -142,7 +142,6 @@ public class ArmRpoServiceImpl implements ArmRpoService {
                     externalObjectDirectoryEntity.setStatus(EodHelper.storedStatus());
                 } else {
                     externalObjectDirectoryEntity.setStatus(EodHelper.armReplayStatus());
-                    externalObjectDirectoryEntity.setInputUploadProcessedTs(null);
                 }
             }
         );

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -87,7 +87,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<Long> findMediaIdsByInMediaIdStatusAndType(List<Long> mediaIdList, ObjectRecordStatusEntity status,
-                                                       ExternalLocationTypeEntity... externalLocationTypes);
+                                                    ExternalLocationTypeEntity... externalLocationTypes);
 
 
     @Query(
@@ -134,9 +134,9 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<Long> findNotFinishedAndNotExceededRetryInStorageLocation(List<ObjectRecordStatusEntity> failedStatuses,
-                                                                      ExternalLocationTypeEntity type,
-                                                                      Integer transferAttempts,
-                                                                      Pageable pageable);
+                                                                   ExternalLocationTypeEntity type,
+                                                                   Integer transferAttempts,
+                                                                   Pageable pageable);
 
     @Query(
         """
@@ -148,9 +148,9 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<Long> findNotFinishedAndNotExceededRetryInStorageLocationForDets(List<ObjectRecordStatusEntity> failedStatuses,
-                                                                             ExternalLocationTypeEntity type,
-                                                                             Integer transferAttempts,
-                                                                             Limit limit);
+                                                                          ExternalLocationTypeEntity type,
+                                                                          Integer transferAttempts,
+                                                                          Limit limit);
 
 
     @Query(
@@ -218,12 +218,12 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<Long> findIdsIn2StorageLocationsBeforeTime(ObjectRecordStatusEntity status1,
-                                                       ObjectRecordStatusEntity status2,
-                                                       ExternalLocationTypeEntity location1,
-                                                       ExternalLocationTypeEntity location2,
-                                                       OffsetDateTime lastModifiedBefore,
-                                                       Integer externalObjectDirectoryQueryTypeEnumIndex,
-                                                       Limit limit);
+                                                    ObjectRecordStatusEntity status2,
+                                                    ExternalLocationTypeEntity location1,
+                                                    ExternalLocationTypeEntity location2,
+                                                    OffsetDateTime lastModifiedBefore,
+                                                    Integer externalObjectDirectoryQueryTypeEnumIndex,
+                                                    Limit limit);
 
     @Query(
         """
@@ -240,12 +240,12 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<Long> findIdsIn2StorageLocationsBeforeTime(ObjectRecordStatusEntity status1,
-                                                       ObjectRecordStatusEntity status2,
-                                                       ExternalLocationTypeEntity location1,
-                                                       ExternalLocationTypeEntity location2,
-                                                       OffsetDateTime lastModifiedBefore1,
-                                                       OffsetDateTime lastModifiedBefore2,
-                                                       Limit limit);
+                                                    ObjectRecordStatusEntity status2,
+                                                    ExternalLocationTypeEntity location1,
+                                                    ExternalLocationTypeEntity location2,
+                                                    OffsetDateTime lastModifiedBefore1,
+                                                    OffsetDateTime lastModifiedBefore2,
+                                                    Limit limit);
 
     @Query(
         """
@@ -260,10 +260,10 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<Long> findIdsForAudioToBeDeletedFromUnstructured(ObjectRecordStatusEntity storedStatus,
-                                                             ExternalLocationTypeEntity unstructuredLocation,
-                                                             ExternalLocationTypeEntity armLocation,
-                                                             OffsetDateTime unstructuredLastModifiedBefore,
-                                                             Limit limit);
+                                                          ExternalLocationTypeEntity unstructuredLocation,
+                                                          ExternalLocationTypeEntity armLocation,
+                                                          OffsetDateTime unstructuredLastModifiedBefore,
+                                                          Limit limit);
 
 
     @Query(
@@ -365,8 +365,8 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
 
 
     default List<Long> findEodsForTransfer(ObjectRecordStatusEntity status, ExternalLocationTypeEntity type,
-                                              ObjectRecordStatusEntity notExistsStatus, ExternalLocationTypeEntity notExistsType,
-                                              Integer maxTransferAttempts, Limit limit) {
+                                           ObjectRecordStatusEntity notExistsStatus, ExternalLocationTypeEntity notExistsType,
+                                           Integer maxTransferAttempts, Limit limit) {
         List<Long> results = new ArrayList<>();//Ensures no duplicates
         results.addAll(findEodsForTransferOnlyMedia(status.getId(), type.getId(), notExistsStatus.getId(),
                                                     notExistsType.getId(), maxTransferAttempts, limit.max()));
@@ -399,8 +399,8 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<Long> findEodsForTransferOnlyMedia(Integer status, Integer type,
-                                               Integer notExistsStatus, Integer notExistsType,
-                                               Integer maxTransferAttempts, Integer limit);
+                                            Integer notExistsStatus, Integer notExistsType,
+                                            Integer maxTransferAttempts, Integer limit);
 
     @Query(
         """
@@ -418,12 +418,12 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<Long> findEodsForTransferExcludingMedia(ObjectRecordStatusEntity status, ExternalLocationTypeEntity type,
-                                                    ObjectRecordStatusEntity notExistsStatus, ExternalLocationTypeEntity notExistsType,
-                                                    Integer maxTransferAttempts, Limit limit);
+                                                 ObjectRecordStatusEntity notExistsStatus, ExternalLocationTypeEntity notExistsType,
+                                                 Integer maxTransferAttempts, Limit limit);
 
 
     default List<Long> findEodsNotInOtherStorage(ObjectRecordStatusEntity status, ExternalLocationTypeEntity type,
-                                                    ExternalLocationTypeEntity notExistsLocation, Integer limitRecords) {
+                                                 ExternalLocationTypeEntity notExistsLocation, Integer limitRecords) {
         Set<Long> results = new HashSet<>();//Ensures no duplicates
         results.addAll(findEodsNotInOtherStorageOnlyMedia(status.getId(), type.getId(), notExistsLocation.getId(), limitRecords));
         if (results.size() < limitRecords) {
@@ -450,7 +450,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
         nativeQuery = true
     )
     List<Long> findEodsNotInOtherStorageOnlyMedia(Integer status, Integer type,
-                                                     Integer notExistsLocation, Integer limitRecords);
+                                                  Integer notExistsLocation, Integer limitRecords);
 
     @Query(
         value = """
@@ -474,7 +474,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
         nativeQuery = true
     )
     List<Long> findEodsNotInOtherStorageExcludingMedia(Integer status, Integer type,
-                                                          Integer notExistsLocation, Integer limitRecords);
+                                                       Integer notExistsLocation, Integer limitRecords);
 
     @Query(
         """
@@ -528,7 +528,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
         AND eod.updateRetention = :updateRetention
         """)
     List<Long> findByExternalLocationTypeAndUpdateRetention(ExternalLocationTypeEntity externalLocationTypeEntity,
-                                                               boolean updateRetention, Limit limit);
+                                                            boolean updateRetention, Limit limit);
 
     List<ExternalObjectDirectoryEntity> findByManifestFile(String manifestName);
 
@@ -635,12 +635,13 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             set eod.status = :newStatus,
                 eod.transferAttempts = :transferAttempts,
                 eod.lastModifiedById = :currentUser,
-                eod.lastModifiedDateTime = current_timestamp
+                eod.lastModifiedDateTime = current_timestamp,
+                eod.inputUploadProcessedTs = null
             where eod.id in :idsToUpdate
             """
     )
     void updateEodStatusAndTransferAttemptsWhereIdIn(ObjectRecordStatusEntity newStatus, Integer transferAttempts, Integer currentUser,
-                                                     List<Integer> idsToUpdate);
+                                                     List<Long> idsToUpdate);
 
 
     @Query(
@@ -672,11 +673,11 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
         AND eod.lastModifiedDateTime BETWEEN :startDateTime AND :endDateTime
         AND eod.externalLocationType = :locationType
         """)
-    List<Integer> findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit(@Param("status") ObjectRecordStatusEntity status,
-                                                                           @Param("startDateTime") OffsetDateTime startDateTime,
-                                                                           @Param("endDateTime") OffsetDateTime endDateTime,
-                                                                           @Param("locationType") ExternalLocationTypeEntity locationType,
-                                                                           Limit limit);
+    List<Long> findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit(@Param("status") ObjectRecordStatusEntity status,
+                                                                        @Param("startDateTime") OffsetDateTime startDateTime,
+                                                                        @Param("endDateTime") OffsetDateTime endDateTime,
+                                                                        @Param("locationType") ExternalLocationTypeEntity locationType,
+                                                                        Limit limit);
 
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoReplayServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/ArmRpoReplayServiceImplTest.java
@@ -74,7 +74,7 @@ class ArmRpoReplayServiceImplTest {
             .thenReturn(armAutomatedTaskEntity);
         when(externalObjectDirectoryRepository.findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit(
             any(), eq(startTs), eq(endTs), any(), any(Limit.class)
-        )).thenReturn(List.of(22, 14));
+        )).thenReturn(List.of(22L, 14L));
         UserAccountEntity userAccountEntity = mock(UserAccountEntity.class);
         int userId = 100;
         when(userAccountEntity.getId()).thenReturn(userId);
@@ -88,7 +88,7 @@ class ArmRpoReplayServiceImplTest {
             EodHelper.failedArmRawDataStatus(),
             0,
             userId,
-            List.of(22, 14)
+            List.of(22L, 14L)
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ArmRpoReplayAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/ArmRpoReplayAutomatedTaskTest.java
@@ -92,7 +92,7 @@ class ArmRpoReplayAutomatedTaskTest {
             endTs,
             EodHelper.armLocation(),
             Limit.of(0)
-        )).thenReturn(List.of(22, 14));
+        )).thenReturn(List.of(22L, 14L));
 
         UserAccountEntity userAccount = mock(UserAccountEntity.class);
         int userId = 123;
@@ -111,7 +111,7 @@ class ArmRpoReplayAutomatedTaskTest {
             EodHelper.failedArmRawDataStatus(),
             0,
             userId,
-            List.of(22, 14)
+            List.of(22L, 14L)
         );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5100

### Change description ###

Changed the location where the input_upload_processed_ts is reset to when the replay job is called. Moved the private methods below the tests. I also had to fix the issue where the ids are now longs not ints on the EOD records. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
