### PR TITLE
DMP-3411: Implement endpoint to make event current version

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerPatchAdminEventByIdIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/event/controller/EventsControllerPatchAdminEventByIdIntTest.java
@@ -86,13 +86,15 @@ class EventsControllerPatchAdminEventByIdIntTest extends IntegrationBase {
     }
 
     @Test
-    void shouldReturn422_whenIsCurrentIsSetToFalse() throws Exception {
+    void shouldReturn400_whenIsCurrentIsSetToFalse() throws Exception {
         given.anAuthenticatedUserWithGlobalAccessAndRole(SecurityRoleEnum.SUPER_ADMIN);
 
-        mockMvc.perform(patch(ENDPOINT.resolve("123456789"))
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(createPayload(false)))
-            .andExpect(status().isUnprocessableEntity());
+        MvcResult mvcResult = mockMvc.perform(patch(ENDPOINT.resolve("123456789"))
+                                                  .contentType(MediaType.APPLICATION_JSON)
+                                                  .content(createPayload(false)))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+        assertStandardErrorJsonResponse(mvcResult, CommonApiError.BAD_REQUEST, "is_current must be set to true");
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/CommonApiError.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/CommonApiError.java
@@ -30,6 +30,11 @@ public enum CommonApiError implements DartsApiError {
         HttpStatus.UNPROCESSABLE_ENTITY,
         CommonTitleErrors.INVALID_REQUEST.getValue()
     ),
+    BAD_REQUEST(
+        CommonErrorCode.INVALID_REQUEST.getValue(),
+        HttpStatus.BAD_REQUEST,
+        CommonTitleErrors.INVALID_REQUEST.getValue()
+    ),
     INTERNAL_SERVER_ERROR(
         CommonErrorCode.INTERNAL_SERVER_ERROR.getValue(),
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/main/java/uk/gov/hmcts/darts/event/exception/EventError.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/exception/EventError.java
@@ -60,6 +60,11 @@ public enum EventError implements DartsApiError {
         EventErrorCode.EVENT_ALREADY_CURRENT.getValue(),
         HttpStatus.CONFLICT,
         EventTitleErrors.EVENT_ALREADY_CURRENT.toString()
+    ),
+    CAN_NOT_UPDATE_EVENT_ID_0(
+        EventErrorCode.CAN_NOT_UPDATE_EVENT_ID_0.getValue(),
+        HttpStatus.UNPROCESSABLE_ENTITY,
+        EventTitleErrors.CAN_NOT_UPDATE_EVENT_ID_0.toString()
     );
 
     private static final String ERROR_TYPE_PREFIX = "EVENT";

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImpl.java
@@ -107,9 +107,12 @@ public class EventServiceImpl implements EventService {
     @Override
     public void patchEventById(Long eveId, PatchAdminEventByIdRequest patchAdminEventByIdRequest) {
         if (!Boolean.TRUE.equals(patchAdminEventByIdRequest.getIsCurrent())) {
-            throw new DartsApiException(CommonApiError.INVALID_REQUEST, "is_current must be set to true");
+            throw new DartsApiException(CommonApiError.BAD_REQUEST, "is_current must be set to true");
         }
         EventEntity eventEntityToUpdate = getEventByEveId(eveId);
+        if (eventEntityToUpdate.getEventId() == 0) {
+            throw new DartsApiException(EventError.CAN_NOT_UPDATE_EVENT_ID_0);
+        }
         if (eventEntityToUpdate.isCurrent()) {
             throw new DartsApiException(EventError.EVENT_ALREADY_CURRENT);
         }

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -1051,6 +1051,7 @@ components:
         - "EVENT_108"
         - "EVENT_109"
         - "EVENT_110"
+        - "EVENT_111"
       x-enum-varnames: [
         EVENT_DATA_NOT_FOUND,
         EVENT_HANDLER_NOT_FOUND_IN_DB,
@@ -1061,7 +1062,8 @@ components:
         MAPPING_IN_USE,
         TOO_MANY_RESULTS,
         EVENT_ID_NOT_FOUND,
-        EVENT_ALREADY_CURRENT
+        EVENT_ALREADY_CURRENT,
+        CAN_NOT_UPDATE_EVENT_ID_0
       ]
 
     EventTitleErrors:
@@ -1077,6 +1079,7 @@ components:
         - "The search resulted in too many results"
         - "Event id does not exist"
         - "Event already current"
+        - "Cannot update event id 0"
       x-enum-varnames: [
         EVENT_DATA_NOT_FOUND,
         EVENT_HANDLER_NOT_FOUND_IN_DB,
@@ -1087,5 +1090,6 @@ components:
         MAPPING_IN_USE,
         TOO_MANY_RESULTS,
         EVENT_ID_NOT_FOUND,
-        EVENT_ALREADY_CURRENT
+        EVENT_ALREADY_CURRENT,
+        CAN_NOT_UPDATE_EVENT_ID_0
       ]

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -230,7 +230,18 @@ class EventServiceImplTest {
         void shouldThrowException_whenIsCurrentIsTrue(Boolean isCurrent) {
             PatchAdminEventByIdRequest request = new PatchAdminEventByIdRequest(isCurrent);
             DartsApiException exception = assertThrows(DartsApiException.class, () -> eventService.patchEventById(1L, request));
-            assertThat(exception.getError()).isEqualTo(CommonApiError.INVALID_REQUEST);
+            assertThat(exception.getError()).isEqualTo(CommonApiError.BAD_REQUEST);
+            verifyNoInteractions(auditApi);
+        }
+
+        @Test
+        void shouldThrowException_whenEventIdIsZero() {
+            PatchAdminEventByIdRequest request = new PatchAdminEventByIdRequest(true);
+            EventEntity event = mock(EventEntity.class);
+            doReturn(event).when(eventService).getEventByEveId(123L);
+            when(event.getEventId()).thenReturn(0);
+            DartsApiException exception = assertThrows(DartsApiException.class, () -> eventService.patchEventById(123L, request));
+            assertThat(exception.getError()).isEqualTo(EventError.CAN_NOT_UPDATE_EVENT_ID_0);
             verifyNoInteractions(auditApi);
         }
 

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventServiceImplTest.java
@@ -250,6 +250,7 @@ class EventServiceImplTest {
             PatchAdminEventByIdRequest request = new PatchAdminEventByIdRequest(true);
             EventEntity event = mock(EventEntity.class);
             doReturn(event).when(eventService).getEventByEveId(123L);
+            when(event.getEventId()).thenReturn(3);
             when(event.isCurrent()).thenReturn(true);
             DartsApiException exception = assertThrows(DartsApiException.class, () -> eventService.patchEventById(123L, request));
             assertThat(exception.getError()).isEqualTo(EventError.EVENT_ALREADY_CURRENT);
@@ -264,6 +265,7 @@ class EventServiceImplTest {
             EventEntity event = new EventEntity();
             event.setIsCurrent(false);
             event.setId(123L);
+            event.setEventId(3);
             doReturn(event).when(eventService).getEventByEveId(123L);
 
             CourtCaseEntity courtCase1 = new CourtCaseEntity();


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-3411)


### Change description ###

This is needed to add an additional layer of protection such that event_id 0 that is_current = false (which should not happen) does cause catastrophic data issues by linking all event_ids = 0 and setting all other ones to false 


# Summary of Git Diff

The Git Diff reflects a series of changes made to the event management service in the codebase. Key changes include updating error handling for API requests, modifying test cases, and adding new error codes for specific scenarios.

## Highlights

- **Error Handling Update**: The error response for when `isCurrent` is set to `false` has been changed from HTTP status `422 Unprocessable Entity` to `400 Bad Request` in both the integration test and the event service implementation.
  
- **New Error Code**: Introduced a new error code `CAN_NOT_UPDATE_EVENT_ID_0` in the `EventError` enum to handle the specific case when an event ID is `0`.

- **Integration Test Updates**:
  - Updated the test case to expect a `400 Bad Request` status instead of `422` when `isCurrent` is set to `false`.
  - Added a new test case to check for the `CAN_NOT_UPDATE_EVENT_ID_0` error when trying to patch an event with an ID of `0`.

- **OpenAPI Update**: The OpenAPI specification has been updated to include the new error code `CAN_NOT_UPDATE_EVENT_ID_0`.

- **Consistent Error Responses**: The changes ensure that error responses are consistent across the API and the service layer, enhancing the robustness of error handling in the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
