### PR TITLE
DMP-5082: Transformed media with changed owner is not accessible to the new owner

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest.java
@@ -4,39 +4,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.audiorequests.model.AudioRequestType;
-import uk.gov.hmcts.darts.authorisation.component.Authorisation;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
-import uk.gov.hmcts.darts.common.exception.DartsApiException;
-import uk.gov.hmcts.darts.testutils.GivenBuilder;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
-import static org.skyscreamer.jsonassert.JSONAssert.assertNotEquals;
 import static org.skyscreamer.jsonassert.JSONCompareMode.NON_EXTENSIBLE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static uk.gov.hmcts.darts.audio.exception.AudioRequestsApiError.MEDIA_REQUEST_NOT_VALID_FOR_USER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.APPROVER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.REQUESTER;
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSCRIBER;
-import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.TRANSLATION_QA;
 
 @AutoConfigureMockMvc
 class AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest extends IntegrationBase {
@@ -85,7 +70,7 @@ class AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest 
     @Test
     void updateTransformedMediaLastAccessedTimestampShouldReturnForbiddenErrorWhenRequestorDifferentUser() throws Exception {
         UserAccountEntity userAccount = givenBuilder.anAuthenticatedUserWithRoles(mediaRequestEntity.getHearing().getCourtroom().getCourthouse(), TRANSCRIBER);
-        assertFalse(userAccount.getId() == mediaRequestEntity.getCurrentOwner().getId());
+        assertNotSame(userAccount.getId(), mediaRequestEntity.getCurrentOwner().getId());
 
         Integer transformedMediaId = transformedMediaEntity.getId();
 
@@ -110,6 +95,6 @@ class AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest 
         UserAccountEntity userAccount = givenBuilder.anAuthenticatedUserWithRoles(mediaRequestEntity.getHearing().getCourtroom().getCourthouse(), TRANSCRIBER);
         mediaRequestEntity.setCurrentOwner(userAccount);
         dartsDatabase.save(mediaRequestEntity);
-        assertTrue(userAccount.getId() == mediaRequestEntity.getCurrentOwner().getId());
+        assertSame(userAccount.getId(), mediaRequestEntity.getCurrentOwner().getId());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/GivenBuilder.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/GivenBuilder.java
@@ -7,12 +7,17 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.authentication.component.DartsJwt;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
+import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
+import uk.gov.hmcts.darts.common.entity.SecurityRoleEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.enums.SecurityRoleEnum;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.test.common.data.SecurityGroupTestData;
 import uk.gov.hmcts.darts.testutils.stubs.DartsDatabaseStub;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.JUDICIARY;
@@ -25,6 +30,41 @@ public class GivenBuilder {
 
     @Autowired
     private DartsDatabaseStub dartsDatabase;
+
+    public UserAccountEntity anAuthenticatedUserWithRoles(CourthouseEntity courthouse, SecurityRoleEnum... roles) {
+        return anAuthenticatedUserWithRoles(Set.of(courthouse), roles);
+    }
+
+    public UserAccountEntity anAuthenticatedUserWithRoles(Set<CourthouseEntity> courthouses, SecurityRoleEnum... roles) {
+        UUID userId = UUID.randomUUID();
+        var userEmail = userId + "@global.com";
+
+
+        var user = minimalUserAccount();
+        user.setEmailAddress(userEmail);
+        user = dartsDatabase.save(user);
+
+        for (SecurityRoleEnum role : roles) {
+            SecurityRoleEntity securityRole = dartsDatabase.getSecurityRoleRepository().findById(role.getId()).orElseThrow();
+            String groupName = "TEST_GROUP_WITH_ROLE_" + role.name();
+            Optional<SecurityGroupEntity> securityGroupOpt = dartsDatabase.getSecurityGroupRepository().findByGroupNameIgnoreCase(groupName);
+            SecurityGroupEntity securityGroupEntity;
+            if (securityGroupOpt.isEmpty()) {
+                securityGroupEntity = SecurityGroupTestData.minimalSecurityGroup(0);
+                securityGroupEntity.setGroupName(groupName);
+                securityGroupEntity.setSecurityRoleEntity(securityRole);
+                securityGroupEntity.getCourthouseEntities().addAll(courthouses);
+                dartsDatabase.save(securityGroupEntity);
+            } else {
+                securityGroupEntity = securityGroupOpt.get();
+                securityGroupEntity.getCourthouseEntities().addAll(courthouses);
+            }
+            dartsDatabase.addUserToGroup(user, securityGroupEntity);
+        }
+        anAuthenticatedUserFor(user);
+        return dartsDatabase.getDartsPersistence().refresh(user);
+    }
+
 
     public UserAccountEntity anAuthenticatedUserWithGlobalAccessAndRole(SecurityRoleEnum role) {
         var userEmail = role.name() + "@global.com";

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/TestBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/TestBase.java
@@ -35,6 +35,8 @@ public class TestBase {
     protected TransactionalUtil transactionalUtil;
     @Autowired
     protected ObjectMapper objectMapper;
+    @Autowired
+    protected GivenBuilder givenBuilder;
 
     @Autowired
     @Qualifier("inMemoryCacheManager")

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/component/impl/AuthorisationImpl.java
@@ -177,9 +177,8 @@ public class AuthorisationImpl implements Authorisation {
 
     private void checkMediaRequestIsRequestedByUser(MediaRequestEntity mediaRequest) {
         UserAccountEntity userAccount = userIdentity.getUserAccount();
-        if (!mediaRequest.getRequestor().getId().equals(userAccount.getId())) {
+        if (!mediaRequest.getCurrentOwner().getId().equals(userAccount.getId())) {
             throw new DartsApiException(MEDIA_REQUEST_NOT_VALID_FOR_USER);
         }
     }
-
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5082)


### Change description ###
# Summary of Git Diff

This Git diff introduces changes primarily focused on enhancing the integration test for the `AudioRequestsController`. Key modifications involve the removal of mock authorization checks, improvements to user authentication during tests, and adjustments to the way media requests are validated against user roles. The `GivenBuilder` utility has been updated to facilitate user role assignment more effectively.

## Highlights

- **Removed Mock Authorisation**: The previous mock authorization checks in the `AudioRequestsControllerUpdateTransformedMediaLastAccessedTimestampIntTest` class have been removed to streamline the test process.
  
- **Enhanced User Authentication**: A new method `authenticateValid()` has been introduced to handle user authentication by assigning roles directly from the `GivenBuilder`.

- **Updated `GivenBuilder` Class**: 
  - Added methods for creating authenticated users with specific roles and linking them to security groups.
  - Improved the process for saving users and their associated roles to the database.

- **Simplified Test Cases**:
  - The tests for updating the media timestamp have been simplified, focusing more on the interaction rather than detailed authorization verifications.
  - The test cases now utilize the new user authentication method to ensure proper role assignment and ownership checks.

- **Code Cleanup**: General cleanup and refactoring for better readability and maintainability, including the removal of unused imports and redundant code. 

These changes aim to improve the effectiveness and clarity of integration tests related to audio requests while ensuring that user role management is handled more robustly.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
