### PR TITLE
DMP-5092: Legacy Transcription performance fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberTranscriptsQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberTranscriptsQueryImpl.java
@@ -53,7 +53,7 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                 LEFT JOIN darts.hearing hea ON hearing_transcription.hea_id = hea.hea_id
                 LEFT JOIN darts.case_transcription_ae case_transcription 
                     ON ((hea.cas_id is null or case_transcription.cas_id != hea.cas_id) and tra.tra_id = case_transcription.tra_id)
-                JOIN darts.court_case cas ON ((case_transcription.cas_id = cas.cas_id) or (hea.cas_id = cas.cas_id))                        
+                JOIN darts.court_case cas ON cas.cas_id = COALESCE(hea.cas_id, case_transcription.cas_id)                       
                 JOIN darts.courthouse cth ON cas.cth_id = cth.cth_id
                 AND cth.cth_id IN (
                     SELECT DISTINCT(grc.cth_id)
@@ -107,7 +107,7 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                 LEFT JOIN darts.hearing hea ON hearing_transcription.hea_id = hea.hea_id
                 LEFT JOIN darts.case_transcription_ae case_transcription 
                     ON ((hea.cas_id is null or case_transcription.cas_id != hea.cas_id) and tra.tra_id = case_transcription.tra_id)
-                JOIN darts.court_case cas ON ((case_transcription.cas_id = cas.cas_id) or (hea.cas_id = cas.cas_id))                    
+                JOIN darts.court_case cas ON cas.cas_id = COALESCE(hea.cas_id, case_transcription.cas_id)                    
                 JOIN darts.courthouse cth ON cas.cth_id = cth.cth_id
                 AND cth.cth_id IN (
                     SELECT DISTINCT(grc.cth_id)
@@ -173,7 +173,7 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                 LEFT JOIN darts.hearing hea ON hearing_transcription.hea_id = hea.hea_id
                 LEFT JOIN darts.case_transcription_ae case_transcription 
                     ON ((hea.cas_id is null or case_transcription.cas_id != hea.cas_id) and tra.tra_id = case_transcription.tra_id)
-                JOIN darts.court_case cas ON ((case_transcription.cas_id = cas.cas_id) or (hea.cas_id = cas.cas_id))
+                JOIN darts.court_case cas ON cas.cas_id = COALESCE(hea.cas_id, case_transcription.cas_id)
                 JOIN darts.courthouse cth ON cas.cth_id = cth.cth_id
                 AND cth.cth_id IN (
                     SELECT DISTINCT(grc.cth_id)
@@ -275,7 +275,7 @@ public class TranscriberTranscriptsQueryImpl implements TranscriberTranscriptsQu
                     LEFT JOIN darts.hearing hea ON hearing_transcription.hea_id = hea.hea_id
                     LEFT JOIN darts.case_transcription_ae case_transcription ON 
                          ((hea.cas_id is null or case_transcription.cas_id != hea.cas_id) and transcription.tra_id = case_transcription.tra_id)
-                    JOIN darts.court_case court_case ON ((case_transcription.cas_id = court_case.cas_id) or (hea.cas_id = court_case.cas_id))
+                    JOIN darts.court_case court_case ON court_case.cas_id = COALESCE(hea.cas_id, case_transcription.cas_id)
                     JOIN darts.courthouse courthouse ON courthouse.cth_id=court_case.cth_id
                     JOIN (""")
             .append(workflowSubQuery)


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5092)


### Change description ###

Fixed performance of some transcription queries as using or in the joins bypasses some indexes which significantly degraded performance of the API (95 percentile was well over 5 minutes for the call)

# Summary of Git Diff

The diff shows modifications made to the `TranscriberTranscriptsQueryImpl.java` file, specifically changing the way `JOIN` operations are constructed in SQL queries. The changes involve replacing a complex conditional join with a more succinct use of the `COALESCE` function.

## Highlights
- **Code Changes**:
  - Replaced complex join conditions with `COALESCE` in SQL queries to improve clarity and maintainability.
  - The affected SQL joins are located in multiple methods: `getTranscriptRequests`, `getTranscriberTranscriptions`, and a count query.
  
- **Impact**:
  - The new join condition reduces redundancy in the SQL statements and is expected to enhance performance and readability.
  
- **File Affected**:
  - `src/main/java/uk/gov/hmcts/darts/transcriptions/component/impl/TranscriberTranscriptsQueryImpl.java`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
