### PR TITLE
DMP-5086: ApplyRetentionCaseAssociatedObjects -> Fails if media_linked_case has a cas_id that is null

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl.java
@@ -95,7 +95,7 @@ public class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl implemen
             mediaLinkedCaseRepository.findByMedia(media).stream()
                 .map(MediaLinkedCaseEntity::getCourtCase)
                 .filter(Objects::nonNull)
-                .forEach(courtCaseEntity -> cases.add(courtCaseEntity));
+                .forEach(cases::add);
 
             var allCases = io.vavr.collection.List.ofAll(cases).distinctBy(CourtCaseEntity::getId).toJavaList();
             if (allClosed(allCases)) {

--- a/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest.java
@@ -282,8 +282,9 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         when(mediaRepository.findAllLinkedByMediaLinkedCaseByCaseId(case1PerfectlyClosed.getId())).thenReturn(List.of(mediaC1));
 
         var mediaC1LinkedToCase1 = createMediaLinkedCase(mediaC1, case5PerfectlyClosed);
+        var mediaLinkedToNullCase = createMediaLinkedCase(mediaC1, null);//Should exclude this one as it is not linked to a case
 
-        when(mediaLinkedCaseRepository.findByMedia(mediaA1)).thenReturn(List.of(mediaC1LinkedToCase1));
+        when(mediaLinkedCaseRepository.findByMedia(mediaA1)).thenReturn(List.of(mediaC1LinkedToCase1, mediaLinkedToNullCase));
 
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case1PerfectlyClosed)).thenReturn(Optional.of(caseRetentionA1));
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case2PerfectlyClosed)).thenReturn(Optional.of(caseRetentionB1));

--- a/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest.java
@@ -282,8 +282,9 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         when(mediaRepository.findAllLinkedByMediaLinkedCaseByCaseId(case1PerfectlyClosed.getId())).thenReturn(List.of(mediaC1));
 
         var mediaC1LinkedToCase1 = createMediaLinkedCase(mediaC1, case5PerfectlyClosed);
-        var mediaLinkedToNullCase = createMediaLinkedCase(mediaC1, null);//Should exclude this one as it is not linked to a case
-
+        //Adding mediaLinkedWithNull case (refering legacy data that has courtroom/casenumber but could not be linked to a case correctly)
+        //Previously this would cause a nullpointer this should not happen anymore
+        var mediaLinkedToNullCase = createMediaLinkedCase(mediaC1, null);
         when(mediaLinkedCaseRepository.findByMedia(mediaA1)).thenReturn(List.of(mediaC1LinkedToCase1, mediaLinkedToNullCase));
 
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case1PerfectlyClosed)).thenReturn(Optional.of(caseRetentionA1));


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5086)


### Change description ###
# Summary of Git Diff

This Git diff introduces enhancements to the `ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl` class by adding a new import and modifying the logic for handling media linked to court cases. It enhances the retrieval of cases associated with media by ensuring that only non-null linked cases are considered. Additionally, the test file for this implementation has been updated to accommodate these changes.

## Highlights

- **New Import Added**: 
  - `MediaLinkedCaseEntity` is now imported to facilitate handling media linked to court cases.

- **Code Modifications**: 
  - The method `applyRetentionToMedias` was updated to utilize a stream for retrieving court cases linked to media, filtering out any null cases.
  - Code now uses `Objects::nonNull` to ensure only valid court cases are added.

- **Test Enhancements**: 
  - Updated test cases in `ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest` to include a scenario where a media is linked to a null case, ensuring such cases are excluded from processing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
