### PR TITLE
DMP-5061: Need to return user email address in /userstate endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/controller/AuthorisationControllerIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/controller/AuthorisationControllerIntTest.java
@@ -76,15 +76,17 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
             .andReturn();
 
         // Then
-        JSONAssert.assertEquals("""
-                                    {
-                                       "userId": 15000,
-                                       "userName": "Test UserFullName",
-                                       "roles": [],
-                                       "isActive": true
-                                    }""",
-                                mvcResult.getResponse().getContentAsString(),
-                                JSONCompareMode.NON_EXTENSIBLE
+        JSONAssert.assertEquals(
+            """
+                {
+                   "userId": 15000,
+                   "userName": "Test UserFullName",
+                   "email_address": "test@test.com",
+                   "roles": [],
+                   "isActive": true
+                }""",
+            mvcResult.getResponse().getContentAsString(),
+            JSONCompareMode.NON_EXTENSIBLE
         );
     }
 
@@ -104,36 +106,38 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
             .andReturn();
 
         // Then
-        JSONAssert.assertEquals("""
-                                    {
-                                      "userId": 15000,
-                                      "userName": "Test UserFullName",
-                                      "roles": [
-                                        {
-                                          "roleId": 1,
-                                          "roleName": "JUDICIARY",
-                                          "globalAccess": true,
-                                          "courthouseIds": [],
-                                          "permissions": [
-                                            "VIEW_MY_TRANSCRIPTIONS",
-                                            "SEARCH_CASES",
-                                            "VIEW_MY_AUDIOS",
-                                            "READ_JUDGES_NOTES",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_TRANSCRIPTION",
-                                            "REQUEST_AUDIO",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK",
-                                            "RETENTION_ADMINISTRATION",
-                                            "UPLOAD_JUDGES_NOTES"
-                                          ]
-                                        }
-                                      ],
-                                      "isActive": true
-                                    }""",
-                                mvcResult.getResponse().getContentAsString(),
-                                JSONCompareMode.NON_EXTENSIBLE
+        JSONAssert.assertEquals(
+            """
+                {
+                  "userId": 15000,
+                  "userName": "Test UserFullName",
+                  "email_address": "test@test.com",
+                  "roles": [
+                    {
+                      "roleId": 1,
+                      "roleName": "JUDICIARY",
+                      "globalAccess": true,
+                      "courthouseIds": [],
+                      "permissions": [
+                        "VIEW_MY_TRANSCRIPTIONS",
+                        "SEARCH_CASES",
+                        "VIEW_MY_AUDIOS",
+                        "READ_JUDGES_NOTES",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_TRANSCRIPTION",
+                        "REQUEST_AUDIO",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK",
+                        "RETENTION_ADMINISTRATION",
+                        "UPLOAD_JUDGES_NOTES"
+                      ]
+                    }
+                  ],
+                  "isActive": true
+                }""",
+            mvcResult.getResponse().getContentAsString(),
+            JSONCompareMode.NON_EXTENSIBLE
         );
     }
 
@@ -154,36 +158,38 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
             .andReturn();
 
         // Then
-        JSONAssert.assertEquals("""
-                                    {
-                                      "userId": 15000,
-                                      "userName": "Test UserFullName",
-                                      "roles": [
-                                        {
-                                          "roleId": 1,
-                                          "roleName": "JUDICIARY",
-                                          "globalAccess": true,
-                                          "courthouseIds": [],
-                                          "permissions": [
-                                            "VIEW_MY_TRANSCRIPTIONS",
-                                            "SEARCH_CASES",
-                                            "VIEW_MY_AUDIOS",
-                                            "READ_JUDGES_NOTES",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_TRANSCRIPTION",
-                                            "REQUEST_AUDIO",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK",
-                                            "RETENTION_ADMINISTRATION",
-                                            "UPLOAD_JUDGES_NOTES"
-                                          ]
-                                        }
-                                      ],
-                                      "isActive": true
-                                    }""",
-                                mvcResult.getResponse().getContentAsString(),
-                                JSONCompareMode.NON_EXTENSIBLE
+        JSONAssert.assertEquals(
+            """
+                {
+                  "userId": 15000,
+                  "userName": "Test UserFullName",
+                  "email_address": "test@test.com",
+                  "roles": [
+                    {
+                      "roleId": 1,
+                      "roleName": "JUDICIARY",
+                      "globalAccess": true,
+                      "courthouseIds": [],
+                      "permissions": [
+                        "VIEW_MY_TRANSCRIPTIONS",
+                        "SEARCH_CASES",
+                        "VIEW_MY_AUDIOS",
+                        "READ_JUDGES_NOTES",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_TRANSCRIPTION",
+                        "REQUEST_AUDIO",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK",
+                        "RETENTION_ADMINISTRATION",
+                        "UPLOAD_JUDGES_NOTES"
+                      ]
+                    }
+                  ],
+                  "isActive": true
+                }""",
+            mvcResult.getResponse().getContentAsString(),
+            JSONCompareMode.NON_EXTENSIBLE
         );
     }
 
@@ -211,38 +217,40 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
             .andReturn();
 
         // Then
-        JSONAssert.assertEquals("""
-                                    {
-                                      "userId": 15000,
-                                      "userName": "Test UserFullName",
-                                      "roles": [
-                                        {
-                                          "roleId": 1,
-                                          "roleName": "JUDICIARY",
-                                          "globalAccess": true,
-                                          "courthouseIds": [
-                                            1
-                                          ],
-                                          "permissions": [
-                                            "VIEW_MY_TRANSCRIPTIONS",
-                                            "SEARCH_CASES",
-                                            "VIEW_MY_AUDIOS",
-                                            "READ_JUDGES_NOTES",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_AUDIO",
-                                            "REQUEST_TRANSCRIPTION",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK",
-                                            "RETENTION_ADMINISTRATION",
-                                            "UPLOAD_JUDGES_NOTES"
-                                          ]
-                                        }
-                                      ],
-                                      "isActive": true
-                                    }""",
-                                mvcResult.getResponse().getContentAsString(),
-                                JSONCompareMode.NON_EXTENSIBLE
+        JSONAssert.assertEquals(
+            """
+                {
+                  "userId": 15000,
+                  "userName": "Test UserFullName",
+                  "email_address": "test@test.com",
+                  "roles": [
+                    {
+                      "roleId": 1,
+                      "roleName": "JUDICIARY",
+                      "globalAccess": true,
+                      "courthouseIds": [
+                        1
+                      ],
+                      "permissions": [
+                        "VIEW_MY_TRANSCRIPTIONS",
+                        "SEARCH_CASES",
+                        "VIEW_MY_AUDIOS",
+                        "READ_JUDGES_NOTES",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_AUDIO",
+                        "REQUEST_TRANSCRIPTION",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK",
+                        "RETENTION_ADMINISTRATION",
+                        "UPLOAD_JUDGES_NOTES"
+                      ]
+                    }
+                  ],
+                  "isActive": true
+                }""",
+            mvcResult.getResponse().getContentAsString(),
+            JSONCompareMode.NON_EXTENSIBLE
         );
     }
 
@@ -264,56 +272,58 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
             .andReturn();
 
         // Then
-        JSONAssert.assertEquals("""
-                                    {
-                                      "userId": 15000,
-                                      "userName": "Test UserFullName",
-                                      "roles": [
-                                        {
-                                          "roleId": 3,
-                                          "roleName": "APPROVER",
-                                          "globalAccess": false,
-                                          "courthouseIds": [],
-                                          "permissions": [
-                                            "VIEW_MY_TRANSCRIPTIONS",
-                                            "APPROVE_REJECT_TRANSCRIPTION_REQUEST",
-                                            "SEARCH_CASES",
-                                            "VIEW_MY_AUDIOS",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_TRANSCRIPTION",
-                                            "REQUEST_AUDIO",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK",
-                                            "RETENTION_ADMINISTRATION"
-                                          ]
-                                        },
-                                        {
-                                          "roleId": 1,
-                                          "roleName": "JUDICIARY",
-                                          "globalAccess": true,
-                                          "courthouseIds": [],
-                                          "permissions": [
-                                            "VIEW_MY_TRANSCRIPTIONS",
-                                            "SEARCH_CASES",
-                                            "VIEW_MY_AUDIOS",
-                                            "READ_JUDGES_NOTES",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_TRANSCRIPTION",
-                                            "REQUEST_AUDIO",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK",
-                                            "UPLOAD_JUDGES_NOTES",
-                                            "RETENTION_ADMINISTRATION"
-                                          ]
-                                        }
-                                      ],
-                                      "isActive": true
-                                    }
-                                    """,
-                                mvcResult.getResponse().getContentAsString(),
-                                JSONCompareMode.NON_EXTENSIBLE
+        JSONAssert.assertEquals(
+            """
+                {
+                  "userId": 15000,
+                  "userName": "Test UserFullName",
+                  "email_address": "test@test.com",
+                  "roles": [
+                    {
+                      "roleId": 3,
+                      "roleName": "APPROVER",
+                      "globalAccess": false,
+                      "courthouseIds": [],
+                      "permissions": [
+                        "VIEW_MY_TRANSCRIPTIONS",
+                        "APPROVE_REJECT_TRANSCRIPTION_REQUEST",
+                        "SEARCH_CASES",
+                        "VIEW_MY_AUDIOS",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_TRANSCRIPTION",
+                        "REQUEST_AUDIO",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK",
+                        "RETENTION_ADMINISTRATION"
+                      ]
+                    },
+                    {
+                      "roleId": 1,
+                      "roleName": "JUDICIARY",
+                      "globalAccess": true,
+                      "courthouseIds": [],
+                      "permissions": [
+                        "VIEW_MY_TRANSCRIPTIONS",
+                        "SEARCH_CASES",
+                        "VIEW_MY_AUDIOS",
+                        "READ_JUDGES_NOTES",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_TRANSCRIPTION",
+                        "REQUEST_AUDIO",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK",
+                        "UPLOAD_JUDGES_NOTES",
+                        "RETENTION_ADMINISTRATION"
+                      ]
+                    }
+                  ],
+                  "isActive": true
+                }
+                """,
+            mvcResult.getResponse().getContentAsString(),
+            JSONCompareMode.NON_EXTENSIBLE
         );
     }
 
@@ -354,100 +364,102 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
             .andReturn();
 
         // Then
-        JSONAssert.assertEquals("""
-                                    {
-                                      "userId": 15000,
-                                      "userName": "Test UserFullName",
-                                      "roles": [
-                                        {
-                                          "roleId": 2,
-                                          "roleName": "REQUESTER",
-                                          "globalAccess": false,
-                                          "courthouseIds": [
-                                            1
-                                          ],
-                                          "permissions": [
-                                            "VIEW_MY_TRANSCRIPTIONS",
-                                            "SEARCH_CASES",
-                                            "VIEW_MY_AUDIOS",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_TRANSCRIPTION",
-                                            "REQUEST_AUDIO",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK",
-                                            "RETENTION_ADMINISTRATION"
-                                          ]
-                                        },
-                                        {
-                                          "roleId": 5,
-                                          "roleName": "TRANSLATION_QA",
-                                          "globalAccess": false,
-                                          "courthouseIds": [
-                                            1,
-                                            2
-                                          ],
-                                          "permissions": [
-                                            "SEARCH_CASES",
-                                            "VIEW_MY_AUDIOS",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_AUDIO",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK"
-                                          ]
-                                        },
-                                        {
-                                          "roleId": 3,
-                                          "roleName": "APPROVER",
-                                          "globalAccess": false,
-                                          "courthouseIds": [
-                                            1,
-                                            2
-                                          ],
-                                          "permissions": [
-                                            "VIEW_MY_TRANSCRIPTIONS",
-                                            "SEARCH_CASES",
-                                            "APPROVE_REJECT_TRANSCRIPTION_REQUEST",
-                                            "VIEW_MY_AUDIOS",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_TRANSCRIPTION",
-                                            "REQUEST_AUDIO",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK",
-                                            "RETENTION_ADMINISTRATION"
-                                          ]
-                                        },
-                                        {
-                                          "roleId": 1,
-                                          "roleName": "JUDICIARY",
-                                          "globalAccess": true,
-                                          "courthouseIds": [
-                                            1,
-                                            2,
-                                            3
-                                          ],
-                                          "permissions": [
-                                            "VIEW_MY_TRANSCRIPTIONS",
-                                            "SEARCH_CASES",
-                                            "VIEW_MY_AUDIOS",
-                                            "READ_JUDGES_NOTES",
-                                            "EXPORT_PROCESSED_PLAYBACK_AUDIO",
-                                            "REQUEST_AUDIO",
-                                            "REQUEST_TRANSCRIPTION",
-                                            "VIEW_DARTS_INBOX",
-                                            "READ_TRANSCRIBED_DOCUMENT",
-                                            "LISTEN_TO_AUDIO_FOR_PLAYBACK",
-                                            "UPLOAD_JUDGES_NOTES",
-                                            "RETENTION_ADMINISTRATION"
-                                          ]
-                                        }
-                                      ],
-                                      "isActive": true
-                                    }""",
-                                mvcResult.getResponse().getContentAsString(),
-                                JSONCompareMode.NON_EXTENSIBLE
+        JSONAssert.assertEquals(
+            """
+                {
+                  "userId": 15000,
+                  "userName": "Test UserFullName",
+                  "email_address": "test@test.com",
+                  "roles": [
+                    {
+                      "roleId": 2,
+                      "roleName": "REQUESTER",
+                      "globalAccess": false,
+                      "courthouseIds": [
+                        1
+                      ],
+                      "permissions": [
+                        "VIEW_MY_TRANSCRIPTIONS",
+                        "SEARCH_CASES",
+                        "VIEW_MY_AUDIOS",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_TRANSCRIPTION",
+                        "REQUEST_AUDIO",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK",
+                        "RETENTION_ADMINISTRATION"
+                      ]
+                    },
+                    {
+                      "roleId": 5,
+                      "roleName": "TRANSLATION_QA",
+                      "globalAccess": false,
+                      "courthouseIds": [
+                        1,
+                        2
+                      ],
+                      "permissions": [
+                        "SEARCH_CASES",
+                        "VIEW_MY_AUDIOS",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_AUDIO",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK"
+                      ]
+                    },
+                    {
+                      "roleId": 3,
+                      "roleName": "APPROVER",
+                      "globalAccess": false,
+                      "courthouseIds": [
+                        1,
+                        2
+                      ],
+                      "permissions": [
+                        "VIEW_MY_TRANSCRIPTIONS",
+                        "SEARCH_CASES",
+                        "APPROVE_REJECT_TRANSCRIPTION_REQUEST",
+                        "VIEW_MY_AUDIOS",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_TRANSCRIPTION",
+                        "REQUEST_AUDIO",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK",
+                        "RETENTION_ADMINISTRATION"
+                      ]
+                    },
+                    {
+                      "roleId": 1,
+                      "roleName": "JUDICIARY",
+                      "globalAccess": true,
+                      "courthouseIds": [
+                        1,
+                        2,
+                        3
+                      ],
+                      "permissions": [
+                        "VIEW_MY_TRANSCRIPTIONS",
+                        "SEARCH_CASES",
+                        "VIEW_MY_AUDIOS",
+                        "READ_JUDGES_NOTES",
+                        "EXPORT_PROCESSED_PLAYBACK_AUDIO",
+                        "REQUEST_AUDIO",
+                        "REQUEST_TRANSCRIPTION",
+                        "VIEW_DARTS_INBOX",
+                        "READ_TRANSCRIBED_DOCUMENT",
+                        "LISTEN_TO_AUDIO_FOR_PLAYBACK",
+                        "UPLOAD_JUDGES_NOTES",
+                        "RETENTION_ADMINISTRATION"
+                      ]
+                    }
+                  ],
+                  "isActive": true
+                }""",
+            mvcResult.getResponse().getContentAsString(),
+            JSONCompareMode.NON_EXTENSIBLE
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/service/AuthorisationServiceTest.java
@@ -177,6 +177,8 @@ class AuthorisationServiceTest extends IntegrationBase {
 
         Set<String> judgePermissions = judgeRole.getPermissions();
         assertEquals(0, judgePermissions.size());
+
+        assertEquals(TEST_JUDGE_EMAIL, judgeUserState.getEmailAddress());
     }
 
     @Test
@@ -199,6 +201,8 @@ class AuthorisationServiceTest extends IntegrationBase {
 
         Set<String> judgePermissions = judgeRole.getPermissions();
         assertEquals(0, judgePermissions.size());
+
+        assertEquals(TEST_JUDGE_GLOBAL_EMAIL, judgeUserState.getEmailAddress());
     }
 
     @Test
@@ -219,6 +223,7 @@ class AuthorisationServiceTest extends IntegrationBase {
         assertEquals(APPROVER.getId(), requesterRole.getRoleId());
         Set<String> requesterPermissions = requesterRole.getPermissions();
         assertEquals(0, requesterPermissions.size());
+        assertEquals("test.bristol@example.com", userState.getEmailAddress());
     }
 
     @Test
@@ -228,6 +233,7 @@ class AuthorisationServiceTest extends IntegrationBase {
         assertTrue(userState.getUserId() > 0);
         assertEquals("Test New", userState.getUserName());
         assertEquals(0, userState.getRoles().size());
+        assertEquals(TEST_NEW_EMAIL, userState.getEmailAddress());
     }
 
     @Test
@@ -237,6 +243,7 @@ class AuthorisationServiceTest extends IntegrationBase {
         assertTrue(userState.getUserId() > 0);
         assertEquals("Test Multiple User 1", userState.getUserName());
         assertEquals(0, userState.getRoles().size());
+        assertEquals(TEST_MULTIPLE_USER_EMAIL, TEST_MULTIPLE_USER_EMAIL);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/model/UserState.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/model/UserState.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.darts.authorisation.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -21,4 +22,6 @@ public class UserState {
     @NonNull
     private Boolean isActive;
 
+    @JsonProperty("email_address")
+    private String emailAddress;
 }

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/service/impl/AuthorisationServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/service/impl/AuthorisationServiceImpl.java
@@ -120,12 +120,13 @@ public class AuthorisationServiceImpl implements AuthorisationService {
         return userAccountEntityEntityGraph;
     }
 
-    private UserState getUserState(UserAccountEntity userAccountEntity) {
+    UserState getUserState(UserAccountEntity userAccountEntity) {
         return UserState.builder()
             .userId(userAccountEntity.getId())
             .userName(userAccountEntity.getUserFullName())
             .isActive(userAccountEntity.isActive())
             .roles(mapRoles(userAccountEntity.getSecurityGroupEntities()))
+            .emailAddress(userAccountEntity.getEmailAddress())
             .build();
     }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5061)


### Change description ###
# Summary of the Git Diff

The changes in this Git Diff primarily involve the addition of an `email_address` field to the `UserState` model and its associated tests. This enhancement allows the system to return user email addresses in various user state responses, ensuring consistency in the data being handled.

## Highlights

- **Integration Tests Updated**:
  - Added `email_address` field to the assertions in the tests located in `AuthorisationControllerIntTest.java`.
  - The email address is now included in the expected JSON responses for various user states.

- **Service Tests Updated**:
  - The `AuthorisationServiceTest.java` includes assertions for the `email_address` for multiple test cases, ensuring the email is correctly retrieved and asserted for different user roles.

- **UserState Model Modified**:
  - Introduced a new property `emailAddress` in the `UserState` class with the appropriate JSON annotation (`@JsonProperty("email_address")`), enabling the serialization of the email address field in the output.

- **Service Implementation Change**:
  - The `getUserState` method in `AuthorisationServiceImpl.java` has been updated to set the `emailAddress` field when creating `UserState` objects from `UserAccountEntity`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
