### PR TITLE
DMP-5081: Manually updating the URL to an event mapping that is inactive allows the user to see the update screen

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AnnotationXmlGeneratorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/component/impl/AnnotationXmlGeneratorImpl.java
@@ -63,7 +63,6 @@ public class AnnotationXmlGeneratorImpl extends AbstractDocumentGenerator {
         // Root element
         Element root = document.createElement(ANNOTATION_ROOT_ELEMENT_NAME);
         document.appendChild(root);
-
         // Annotation element
         Element annotations = document.createElement(ANNOTATION_ANNOTATION_ELEMENT_NAME);
         root.appendChild(annotations);

--- a/src/main/java/uk/gov/hmcts/darts/event/exception/EventError.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/exception/EventError.java
@@ -37,10 +37,16 @@ public enum EventError implements DartsApiError {
         HttpStatus.UNPROCESSABLE_ENTITY,
         EventTitleErrors.INVALID_HANDLER_MAPPING_NAME.toString()
     ),
-    EVENT_HANDLER_MAPPING_INACTIVE(
+    EVENT_HANDLER_MAPPING_INACTIVE_DELETED(
         EventErrorCode.MAPPING_INACTIVE.getValue(),
         HttpStatus.CONFLICT,
-        EventTitleErrors.MAPPING_INACTIVE.toString(),
+        EventTitleErrors.MAPPING_INACTIVE_DELETED.toString(),
+        false
+    ),
+    EVENT_HANDLER_MAPPING_INACTIVE_UPDATED(
+        EventErrorCode.MAPPING_INACTIVE.getValue(),
+        HttpStatus.CONFLICT,
+        EventTitleErrors.MAPPING_INACTIVE_UPDATED.toString(),
         false
     ),
     EVENT_HANDLER_MAPPING_IN_USE(

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
@@ -62,16 +62,17 @@ public class EventMappingServiceImpl implements EventMappingService {
                     format(HANDLER_DOES_NOT_EXIST_MESSAGE, eventMapping.getType(), eventMapping.getSubType())
                 );
             }
+            if (eventMapping.getId() != null) {
+                Optional<EventHandlerEntity> mappingBeingUpdated = activeMappings.stream()
+                    .filter(eventHandlerEntity -> eventHandlerEntity.getId().equals(eventMapping.getId()))
+                    .findAny();
 
-            Optional<EventHandlerEntity> mappingBeingUpdated = activeMappings.stream()
-                .filter(eventHandlerEntity -> eventHandlerEntity.getId().equals(eventMapping.getId()))
-                .findAny();
-
-            if (mappingBeingUpdated.isEmpty()) {
-                throw new DartsApiException(
-                    EVENT_HANDLER_MAPPING_INACTIVE,
-                    format(MAPPING_IS_INACTIVE_MESSAGE_UPDATE, eventMapping.getId())
-                );
+                if (mappingBeingUpdated.isEmpty()) {
+                    throw new DartsApiException(
+                        EVENT_HANDLER_MAPPING_INACTIVE,
+                        format(MAPPING_IS_INACTIVE_MESSAGE_UPDATE, eventMapping.getId())
+                    );
+                }
             }
         }
         if (!isRevision && doesActiveEventMappingExist(activeMappings)) {

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
@@ -9,12 +9,10 @@ import uk.gov.hmcts.darts.audit.api.AuditApi;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity_;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
-import uk.gov.hmcts.darts.common.exception.DartsException;
 import uk.gov.hmcts.darts.common.repository.EventHandlerRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.event.mapper.EventHandlerMapper;
 import uk.gov.hmcts.darts.event.model.EventMapping;
-import uk.gov.hmcts.darts.event.service.EventHandler;
 import uk.gov.hmcts.darts.event.service.EventMappingService;
 import uk.gov.hmcts.darts.event.service.handler.EventHandlerEnumerator;
 

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
@@ -21,7 +21,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static uk.gov.hmcts.darts.event.exception.EventError.EVENT_HANDLER_MAPPING_INACTIVE;
+import static uk.gov.hmcts.darts.event.exception.EventError.EVENT_HANDLER_MAPPING_INACTIVE_DELETED;
+import static uk.gov.hmcts.darts.event.exception.EventError.EVENT_HANDLER_MAPPING_INACTIVE_UPDATED;
 import static uk.gov.hmcts.darts.event.exception.EventError.EVENT_HANDLER_MAPPING_IN_USE;
 import static uk.gov.hmcts.darts.event.exception.EventError.EVENT_HANDLER_NAME_DOES_NOT_EXIST;
 import static uk.gov.hmcts.darts.event.exception.EventError.EVENT_HANDLER_NOT_FOUND_IN_DB;
@@ -71,7 +72,7 @@ public class EventMappingServiceImpl implements EventMappingService {
                 .findAny().isEmpty()) {
 
                 throw new DartsApiException(
-                    EVENT_HANDLER_MAPPING_INACTIVE,
+                    EVENT_HANDLER_MAPPING_INACTIVE_UPDATED,
                     format(MAPPING_IS_INACTIVE_MESSAGE_UPDATE, eventMapping.getId())
                 );
             }
@@ -175,7 +176,7 @@ public class EventMappingServiceImpl implements EventMappingService {
             String errorMessage = MessageFormat.format(MAPPING_IS_INACTIVE_MESSAGE, id);
             log.warn(errorMessage);
             throw new DartsApiException(
-                EVENT_HANDLER_MAPPING_INACTIVE,
+                EVENT_HANDLER_MAPPING_INACTIVE_DELETED,
                 errorMessage
             );
         }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
@@ -62,7 +62,7 @@ public class EventMappingServiceImpl implements EventMappingService {
                     format(HANDLER_DOES_NOT_EXIST_MESSAGE, eventMapping.getType(), eventMapping.getSubType())
                 );
             }
-            //Skip the check for inactive mappings if the event handler id is null as we can not vierfy which mapping is inactive
+            //Skip the check for inactive mappings if the event handler id is null as we can not verify which mapping is inactive
             if (eventMapping.getId() != null
                 //Check if the event handler id is not returned it means it is inactive
                 && activeMappings.stream()
@@ -74,8 +74,7 @@ public class EventMappingServiceImpl implements EventMappingService {
                     format(MAPPING_IS_INACTIVE_MESSAGE_UPDATE, eventMapping.getId())
                 );
             }
-        }
-        if (!isRevision && doesActiveEventMappingExist(activeMappings)) {
+        } else if (doesActiveEventMappingExist(activeMappings)) {
             throw new DartsApiException(
                 EVENT_MAPPING_DUPLICATE_IN_DB,
                 format(HANDLER_ALREADY_EXISTS_MESSAGE, eventMapping.getType(), eventMapping.getSubType())

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImpl.java
@@ -62,17 +62,17 @@ public class EventMappingServiceImpl implements EventMappingService {
                     format(HANDLER_DOES_NOT_EXIST_MESSAGE, eventMapping.getType(), eventMapping.getSubType())
                 );
             }
-            if (eventMapping.getId() != null) {
-                Optional<EventHandlerEntity> mappingBeingUpdated = activeMappings.stream()
-                    .filter(eventHandlerEntity -> eventHandlerEntity.getId().equals(eventMapping.getId()))
-                    .findAny();
+            //Skip the check for inactive mappings if the event handler id is null as we can not vierfy which mapping is inactive
+            if (eventMapping.getId() != null
+                //Check if the event handler id is not returned it means it is inactive
+                && activeMappings.stream()
+                .filter(eventHandlerEntity -> eventHandlerEntity.getId().equals(eventMapping.getId()))
+                .findAny().isEmpty()) {
 
-                if (mappingBeingUpdated.isEmpty()) {
-                    throw new DartsApiException(
-                        EVENT_HANDLER_MAPPING_INACTIVE,
-                        format(MAPPING_IS_INACTIVE_MESSAGE_UPDATE, eventMapping.getId())
-                    );
-                }
+                throw new DartsApiException(
+                    EVENT_HANDLER_MAPPING_INACTIVE,
+                    format(MAPPING_IS_INACTIVE_MESSAGE_UPDATE, eventMapping.getId())
+                );
             }
         }
         if (!isRevision && doesActiveEventMappingExist(activeMappings)) {

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -1075,6 +1075,7 @@ components:
         - "Event mapping not found in database"
         - "Handler name does not exist"
         - "The mapping is inactive, so cannot be deleted"
+        - "The mapping is inactive, so cannot be updated"
         - "The mapping has already processed events, so cannot be deleted"
         - "The search resulted in too many results"
         - "Event id does not exist"
@@ -1086,7 +1087,8 @@ components:
         DUPLICATE_EVENT_MAPPING,
         NO_EVENT_MAPPING,
         INVALID_HANDLER_MAPPING_NAME,
-        MAPPING_INACTIVE,
+        MAPPING_INACTIVE_DELETED,
+        MAPPING_INACTIVE_UPDATED,
         MAPPING_IN_USE,
         TOO_MANY_RESULTS,
         EVENT_ID_NOT_FOUND,

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImplTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
 import uk.gov.hmcts.darts.common.repository.EventHandlerRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
+import uk.gov.hmcts.darts.event.exception.EventError;
 import uk.gov.hmcts.darts.event.mapper.EventHandlerMapper;
 import uk.gov.hmcts.darts.event.model.EventMapping;
 import uk.gov.hmcts.darts.event.service.handler.EventHandlerEnumerator;
@@ -186,6 +187,7 @@ class EventMappingServiceImplTest {
             "Event handler mapping " + EVENT_HANDLER_ID + " cannot be updated because it is inactive.",
             exception.getDetail()
         );
+        assertEquals(EventError.EVENT_HANDLER_MAPPING_INACTIVE_UPDATED, exception.getError());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventMappingServiceImplTest.java
@@ -146,7 +146,9 @@ class EventMappingServiceImplTest {
 
     @Test
     void handleRequestToSaveEventMappingForHandlerMappingThatAlreadyExistsAndIsRevisionFalse() {
+        setupHandlers();
         when(eventHandlerRepository.findActiveMappingsForTypeAndSubtype(anyString(), anyString())).thenReturn(List.of(eventHandlerEntity));
+        when(eventHandlerMapper.mapFromEventMappingAndMakeActive(any())).thenReturn(eventHandlerEntity);
 
         var exception = assertThrows(DartsApiException.class, () -> eventMappingServiceImpl.postEventMapping(eventMapping, false));
 
@@ -158,7 +160,9 @@ class EventMappingServiceImplTest {
 
     @Test
     void handleRequestToSaveEventMappingForHandlerMappingThatDoesNotAlreadyExistsAndIsRevisionTrue() {
+        setupHandlers();
         when(eventHandlerRepository.findActiveMappingsForTypeAndSubtype(anyString(), anyString())).thenReturn(null);
+        when(eventHandlerMapper.mapFromEventMappingAndMakeActive(any())).thenReturn(eventHandlerEntity);
 
         var exception = assertThrows(DartsApiException.class, () -> eventMappingServiceImpl.postEventMapping(eventMapping, true));
 
@@ -170,9 +174,11 @@ class EventMappingServiceImplTest {
 
     @Test
     void postEventMapping_shouldError_whenEventHandlerIsInactive() {
+        setupHandlers();
         eventHandlerEntity.setId(EVENT_HANDLER_ID + 1);
         eventMapping.setId(EVENT_HANDLER_ID);//Have a different ID to the active mapping
         when(eventHandlerRepository.findActiveMappingsForTypeAndSubtype(anyString(), anyString())).thenReturn(List.of(eventHandlerEntity));
+        when(eventHandlerMapper.mapFromEventMappingAndMakeActive(any())).thenReturn(eventHandlerEntity);
 
         var exception = assertThrows(DartsApiException.class, () -> eventMappingServiceImpl.postEventMapping(eventMapping, true));
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5081)


### Change description ###
# Summary of Changes in EventMappingServiceImpl

The recent updates to the `EventMappingServiceImpl` class primarily focus on improving the error handling during event mapping updates, specifically related to inactive event handlers. These changes enhance the robustness of the service by ensuring that attempts to update inactive mappings are appropriately handled with informative exceptions.

## Highlights

- **New Exception Handling**:
  - Introduced a new constant message `MAPPING_IS_INACTIVE_MESSAGE_UPDATE` for better clarity when an update is attempted on an inactive event handler mapping.
  
- **Refactored Logic**:
  - The conditional logic for handling revisions has been reorganized to improve readability and maintainability. The check for whether a mapping exists has been broken down into clearer steps.
  
- **Error Checking**:
  - Added checks to throw `DartsApiException` when trying to update an inactive event handler mapping, providing a more descriptive error message.
  
- **Test Enhancements**:
  - New unit tests have been added to ensure that the new error handling works correctly when an inactive event handler is involved. 
  - The test case `postEventMapping_shouldError_whenEventHandlerIsInactive` verifies that the expected exception is thrown when an inactive mapping is updated.

These changes contribute to enhancing the functionality and reliability of the event mapping service in the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
