### PR TITLE
DMP-4910 Always set case closed date on case closed event

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/event/service/handler/StopAndCloseHandler.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/handler/StopAndCloseHandler.java
@@ -1,61 +1,32 @@
 package uk.gov.hmcts.darts.event.service.handler;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.BooleanUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
-import uk.gov.hmcts.darts.common.entity.CaseManagementRetentionEntity;
-import uk.gov.hmcts.darts.common.entity.CaseRetentionEntity;
-import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
-import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.repository.CaseRepository;
-import uk.gov.hmcts.darts.common.repository.CaseRetentionRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
 import uk.gov.hmcts.darts.common.service.RetrieveCoreObjectService;
 import uk.gov.hmcts.darts.event.exception.DarNotifyError;
-import uk.gov.hmcts.darts.event.model.CreatedHearingAndEvent;
 import uk.gov.hmcts.darts.event.model.DarNotifyApplicationEvent;
 import uk.gov.hmcts.darts.event.model.DartsEvent;
-import uk.gov.hmcts.darts.event.model.DartsEventRetentionPolicy;
-import uk.gov.hmcts.darts.event.model.stopandclosehandler.PendingRetention;
-import uk.gov.hmcts.darts.event.service.CaseManagementRetentionService;
 import uk.gov.hmcts.darts.event.service.EventPersistenceService;
 import uk.gov.hmcts.darts.event.service.handler.base.EventHandlerBase;
 import uk.gov.hmcts.darts.event.service.impl.DarNotifyServiceImpl;
 import uk.gov.hmcts.darts.log.api.LogApi;
-import uk.gov.hmcts.darts.retention.api.RetentionApi;
-import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
-import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
-import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
+import uk.gov.hmcts.darts.retention.service.impl.CloseCaseWithRetentionServiceImpl;
 import uk.gov.hmcts.darts.util.DataUtil;
 
-import java.time.LocalDate;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-import java.util.List;
-import java.util.Optional;
-
-import static java.lang.Boolean.TRUE;
 import static uk.gov.hmcts.darts.event.enums.DarNotifyType.STOP_RECORDING;
 
 @Service
 @Slf4j
-@SuppressWarnings("PMD.CouplingBetweenObjects")//TODO - refactor to reduce coupling when this class is next edited
 public class StopAndCloseHandler extends EventHandlerBase {
 
     private final DarNotifyServiceImpl darNotifyService;
-    private final CaseRetentionRepository caseRetentionRepository;
-    private final RetentionApi retentionApi;
-    private final CaseManagementRetentionService caseManagementRetentionService;
-    private final AuthorisationApi authorisationApi;
-
-    @Value("${darts.retention.overridable-fixed-policy-keys}")
-    List<String> overridableFixedPolicyKeys;
+    private final CloseCaseWithRetentionServiceImpl closeCaseWithRetentionServiceImpl;
 
     @SuppressWarnings({"PMD.ExcessiveParameterList"})
     public StopAndCloseHandler(RetrieveCoreObjectService retrieveCoreObjectService,
@@ -64,18 +35,12 @@ public class StopAndCloseHandler extends EventHandlerBase {
                                CaseRepository caseRepository,
                                ApplicationEventPublisher eventPublisher,
                                DarNotifyServiceImpl darNotifyService,
-                               CaseRetentionRepository caseRetentionRepository,
-                               RetentionApi retentionApi,
-                               AuthorisationApi authorisationApi,
+                               CloseCaseWithRetentionServiceImpl closeCaseWithRetentionServiceImpl,
                                LogApi logApi,
-                               CaseManagementRetentionService caseManagementRetentionService,
                                EventPersistenceService eventPersistenceService) {
         super(retrieveCoreObjectService, eventRepository, hearingRepository, caseRepository, eventPublisher, logApi, eventPersistenceService);
         this.darNotifyService = darNotifyService;
-        this.caseRetentionRepository = caseRetentionRepository;
-        this.caseManagementRetentionService = caseManagementRetentionService;
-        this.retentionApi = retentionApi;
-        this.authorisationApi = authorisationApi;
+        this.closeCaseWithRetentionServiceImpl = closeCaseWithRetentionServiceImpl;
     }
 
     @Override
@@ -93,109 +58,6 @@ public class StopAndCloseHandler extends EventHandlerBase {
             // if DAR notify fails, continue processing the event
         }
 
-        setDefaultPolicyIfNotDefined(dartsEvent);
-
-        CaseManagementRetentionEntity caseManagementRetentionEntity = caseManagementRetentionService.createCaseManagementRetention(
-            hearingAndEvent.getEventEntity(),
-            hearingAndEvent.getHearingEntity().getCourtCase(),
-            dartsEvent.getRetentionPolicy());
-
-        Optional<CaseRetentionEntity> latestCompletedManualRetention = caseRetentionRepository.findLatestCompletedManualRetention(courtCase);
-        if (latestCompletedManualRetention.isPresent()) {
-            log.info("Ignoring retention for event with id {} because there is an existing manual retention for caseId {}.",
-                     dartsEvent.getEventId(), courtCase.getId());
-            return;
-        }
-
-        // ignore the caseTotalSentence if it's not an overridable policy
-        if (dartsEvent.getRetentionPolicy().getCaseTotalSentence() != null && !overridableFixedPolicyKeys.contains(
-            dartsEvent.getRetentionPolicy().getCaseRetentionFixedPolicy())) {
-            dartsEvent.getRetentionPolicy().setCaseTotalSentence(null);
-        }
-
-        Optional<PendingRetention> latestPendingRetentionOpt = caseRetentionRepository.findLatestPendingRetention(courtCase);
-        if (latestPendingRetentionOpt.isEmpty()) {
-            closeCase(dartsEvent, courtCase);
-            createRetention(caseManagementRetentionEntity, hearingAndEvent, dartsEvent);
-        } else {
-            PendingRetention latestPendingRetention = latestPendingRetentionOpt.get();
-            if (dartsEvent.getDateTime().isAfter(latestPendingRetention.getEventTimestamp())) {
-                closeCase(dartsEvent, courtCase);
-                updateExistingRetention(caseManagementRetentionEntity, latestPendingRetention.getCaseRetention(), dartsEvent);
-            } else {
-                log.info("Ignoring event with id {} because its event time {} is not after the latest pending entry {} for caseId {}.", dartsEvent.getEventId(),
-                         dartsEvent.getDateTime(), latestPendingRetention.getEventTimestamp(), courtCase.getId());
-            }
-        }
+        closeCaseWithRetentionServiceImpl.closeCaseAndSetRetention(dartsEvent, hearingAndEvent, courtCase);
     }
-
-    private void setDefaultPolicyIfNotDefined(DartsEvent dartsEvent) {
-        if (dartsEvent.getRetentionPolicy() == null) {
-            DartsEventRetentionPolicy defaultRetentionPolicy = new DartsEventRetentionPolicy();
-            defaultRetentionPolicy.setCaseRetentionFixedPolicy(RetentionPolicyEnum.DEFAULT.getPolicyKey());
-            dartsEvent.setRetentionPolicy(defaultRetentionPolicy);
-        }
-    }
-
-    private void closeCase(DartsEvent dartsEvent, CourtCaseEntity courtCase) {
-        if (BooleanUtils.isNotTrue(courtCase.getClosed()) || courtCase.getCaseClosedTimestamp() == null) {
-            //setting the case to closed after notifying DAR Pc to ensure notification is sent.
-            courtCase.setClosed(TRUE);
-            courtCase.setCaseClosedTimestamp(dartsEvent.getDateTime());
-            courtCase.setLastModifiedBy(authorisationApi.getCurrentUser());
-            caseRepository.saveAndFlush(
-                retentionApi.updateCourtCaseConfidenceAttributesForRetention(courtCase, RetentionConfidenceCategoryEnum.CASE_CLOSED)
-            );
-        }
-    }
-
-    private void updateExistingRetention(CaseManagementRetentionEntity caseManagementRetentionEntity, CaseRetentionEntity existingCaseRetention,
-                                         DartsEvent dartsEvent) {
-        DartsEventRetentionPolicy dartsEventRetentionPolicy = dartsEvent.getRetentionPolicy();
-        existingCaseRetention.setRetentionPolicyType(caseManagementRetentionEntity.getRetentionPolicyTypeEntity());
-        existingCaseRetention.setTotalSentence(dartsEventRetentionPolicy.getCaseTotalSentence());
-
-        OffsetDateTime eventTimestamp = dartsEvent.getDateTime();
-        LocalDate eventDate = eventTimestamp.toLocalDate();
-        LocalDate retentionDate = retentionApi.applyPolicyStringToDate(eventDate,
-                                                                       dartsEventRetentionPolicy.getCaseTotalSentence(),
-                                                                       caseManagementRetentionEntity.getRetentionPolicyTypeEntity());
-
-        existingCaseRetention.setRetainUntil(retentionDate.atStartOfDay().atOffset(ZoneOffset.UTC));
-        existingCaseRetention.setCaseManagementRetention(caseManagementRetentionEntity);
-        UserAccountEntity currentUser = authorisationApi.getCurrentUser();
-        existingCaseRetention.setSubmittedBy(currentUser);
-        existingCaseRetention.setCreatedBy(currentUser);
-        existingCaseRetention.setLastModifiedBy(currentUser);
-        existingCaseRetention.setConfidenceCategory(RetentionConfidenceCategoryEnum.CASE_CLOSED);
-        caseRetentionRepository.save(existingCaseRetention);
-    }
-
-    private void createRetention(CaseManagementRetentionEntity caseManagementRetentionEntity,
-                                 CreatedHearingAndEvent hearingAndEvent,
-                                 DartsEvent dartsEvent) {
-        DartsEventRetentionPolicy dartsEventRetentionPolicy = dartsEvent.getRetentionPolicy();
-        CourtCaseEntity courtCase = hearingAndEvent.getHearingEntity().getCourtCase();
-
-        CaseRetentionEntity caseRetentionEntity = new CaseRetentionEntity();
-        caseRetentionEntity.setCourtCase(courtCase);
-        caseRetentionEntity.setRetentionPolicyType(caseManagementRetentionEntity.getRetentionPolicyTypeEntity());
-        caseRetentionEntity.setCaseManagementRetention(caseManagementRetentionEntity);
-        caseRetentionEntity.setTotalSentence(dartsEventRetentionPolicy.getCaseTotalSentence());
-        caseRetentionEntity.setConfidenceCategory(RetentionConfidenceCategoryEnum.CASE_CLOSED);
-        OffsetDateTime eventTimestamp = dartsEvent.getDateTime();
-        LocalDate eventDate = eventTimestamp.toLocalDate();
-        LocalDate retentionDate = retentionApi.applyPolicyStringToDate(eventDate,
-                                                                       dartsEventRetentionPolicy.getCaseTotalSentence(),
-                                                                       caseManagementRetentionEntity.getRetentionPolicyTypeEntity());
-
-        caseRetentionEntity.setRetainUntil(retentionDate.atStartOfDay().atOffset(ZoneOffset.UTC));
-        caseRetentionEntity.setCurrentState(CaseRetentionStatus.PENDING.name());
-        UserAccountEntity currentUser = authorisationApi.getCurrentUser();
-        caseRetentionEntity.setSubmittedBy(currentUser);
-        caseRetentionEntity.setCreatedBy(currentUser);
-        caseRetentionEntity.setLastModifiedBy(currentUser);
-        caseRetentionRepository.save(caseRetentionEntity);
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/darts/retention/service/CloseCaseWithRetentionService.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/service/CloseCaseWithRetentionService.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.darts.retention.service;
+
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.event.model.CreatedHearingAndEvent;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+
+@FunctionalInterface
+public interface CloseCaseWithRetentionService {
+
+    void closeCaseAndSetRetention(DartsEvent dartsEvent, CreatedHearingAndEvent hearingAndEvent, CourtCaseEntity courtCase);
+}

--- a/src/main/java/uk/gov/hmcts/darts/retention/service/impl/CloseCaseWithRetentionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/service/impl/CloseCaseWithRetentionServiceImpl.java
@@ -1,0 +1,151 @@
+package uk.gov.hmcts.darts.retention.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.common.entity.CaseManagementRetentionEntity;
+import uk.gov.hmcts.darts.common.entity.CaseRetentionEntity;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.repository.CaseRepository;
+import uk.gov.hmcts.darts.common.repository.CaseRetentionRepository;
+import uk.gov.hmcts.darts.event.model.CreatedHearingAndEvent;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+import uk.gov.hmcts.darts.event.model.DartsEventRetentionPolicy;
+import uk.gov.hmcts.darts.event.model.stopandclosehandler.PendingRetention;
+import uk.gov.hmcts.darts.event.service.CaseManagementRetentionService;
+import uk.gov.hmcts.darts.retention.api.RetentionApi;
+import uk.gov.hmcts.darts.retention.enums.CaseRetentionStatus;
+import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
+import uk.gov.hmcts.darts.retention.enums.RetentionPolicyEnum;
+import uk.gov.hmcts.darts.retention.service.CloseCaseWithRetentionService;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.Boolean.TRUE;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CloseCaseWithRetentionServiceImpl implements CloseCaseWithRetentionService {
+
+    private final CaseRetentionRepository caseRetentionRepository;
+    private final CaseManagementRetentionService caseManagementRetentionService;
+    private final AuthorisationApi authorisationApi;
+    private final RetentionApi retentionApi;
+    private final CaseRepository caseRepository;
+
+    @Value("${darts.retention.overridable-fixed-policy-keys}")
+    List<String> overridableFixedPolicyKeys;
+
+    @Override
+    public void closeCaseAndSetRetention(DartsEvent dartsEvent, CreatedHearingAndEvent hearingAndEvent, CourtCaseEntity courtCase) {
+        setDefaultPolicyIfNotDefined(dartsEvent);
+
+        CaseManagementRetentionEntity caseManagementRetentionEntity = caseManagementRetentionService.createCaseManagementRetention(
+            hearingAndEvent.getEventEntity(),
+            hearingAndEvent.getHearingEntity().getCourtCase(),
+            dartsEvent.getRetentionPolicy());
+
+        Optional<CaseRetentionEntity> latestCompletedManualRetention = caseRetentionRepository.findLatestCompletedManualRetention(courtCase);
+        if (latestCompletedManualRetention.isPresent()) {
+            log.info("Ignoring retention for event with id {} because there is an existing manual retention for caseId {}.",
+                     dartsEvent.getEventId(), courtCase.getId());
+            return;
+        }
+
+        // ignore the caseTotalSentence if it's not an overridable policy
+        if (dartsEvent.getRetentionPolicy().getCaseTotalSentence() != null && !overridableFixedPolicyKeys.contains(
+            dartsEvent.getRetentionPolicy().getCaseRetentionFixedPolicy())) {
+            dartsEvent.getRetentionPolicy().setCaseTotalSentence(null);
+        }
+
+        closeCase(dartsEvent, courtCase);
+
+        Optional<PendingRetention> latestPendingRetentionOpt = caseRetentionRepository.findLatestPendingRetention(courtCase);
+        if (latestPendingRetentionOpt.isEmpty()) {
+            createRetention(caseManagementRetentionEntity, hearingAndEvent, dartsEvent);
+        } else {
+            PendingRetention latestPendingRetention = latestPendingRetentionOpt.get();
+            if (dartsEvent.getDateTime().isAfter(latestPendingRetention.getEventTimestamp())) {
+                updateExistingRetention(caseManagementRetentionEntity, latestPendingRetention.getCaseRetention(), dartsEvent);
+            } else {
+                log.info("Ignoring event with id {} because its event time {} is not after the latest pending entry {} for caseId {}.", dartsEvent.getEventId(),
+                         dartsEvent.getDateTime(), latestPendingRetention.getEventTimestamp(), courtCase.getId());
+            }
+        }
+    }
+
+
+    private void setDefaultPolicyIfNotDefined(DartsEvent dartsEvent) {
+        if (dartsEvent.getRetentionPolicy() == null) {
+            DartsEventRetentionPolicy defaultRetentionPolicy = new DartsEventRetentionPolicy();
+            defaultRetentionPolicy.setCaseRetentionFixedPolicy(RetentionPolicyEnum.DEFAULT.getPolicyKey());
+            dartsEvent.setRetentionPolicy(defaultRetentionPolicy);
+        }
+    }
+
+    private void closeCase(DartsEvent dartsEvent, CourtCaseEntity courtCase) {
+        courtCase.setClosed(TRUE);
+        courtCase.setCaseClosedTimestamp(dartsEvent.getDateTime());
+        caseRepository.saveAndFlush(
+            retentionApi.updateCourtCaseConfidenceAttributesForRetention(courtCase, RetentionConfidenceCategoryEnum.CASE_CLOSED)
+        );
+    }
+
+    private void updateExistingRetention(CaseManagementRetentionEntity caseManagementRetentionEntity, CaseRetentionEntity existingCaseRetention,
+                                         DartsEvent dartsEvent) {
+        DartsEventRetentionPolicy dartsEventRetentionPolicy = dartsEvent.getRetentionPolicy();
+        existingCaseRetention.setRetentionPolicyType(caseManagementRetentionEntity.getRetentionPolicyTypeEntity());
+        existingCaseRetention.setTotalSentence(dartsEventRetentionPolicy.getCaseTotalSentence());
+
+        OffsetDateTime eventTimestamp = dartsEvent.getDateTime();
+        LocalDate eventDate = eventTimestamp.toLocalDate();
+        LocalDate retentionDate = retentionApi.applyPolicyStringToDate(eventDate,
+                                                                       dartsEventRetentionPolicy.getCaseTotalSentence(),
+                                                                       caseManagementRetentionEntity.getRetentionPolicyTypeEntity());
+
+        existingCaseRetention.setRetainUntil(retentionDate.atStartOfDay().atOffset(ZoneOffset.UTC));
+        existingCaseRetention.setCaseManagementRetention(caseManagementRetentionEntity);
+        UserAccountEntity currentUser = authorisationApi.getCurrentUser();
+        existingCaseRetention.setSubmittedBy(currentUser);
+        existingCaseRetention.setCreatedBy(currentUser);
+        existingCaseRetention.setLastModifiedBy(currentUser);
+        existingCaseRetention.setConfidenceCategory(RetentionConfidenceCategoryEnum.CASE_CLOSED);
+        caseRetentionRepository.save(existingCaseRetention);
+    }
+
+    private void createRetention(CaseManagementRetentionEntity caseManagementRetentionEntity,
+                                 CreatedHearingAndEvent hearingAndEvent,
+                                 DartsEvent dartsEvent) {
+        DartsEventRetentionPolicy dartsEventRetentionPolicy = dartsEvent.getRetentionPolicy();
+        CourtCaseEntity courtCase = hearingAndEvent.getHearingEntity().getCourtCase();
+
+        CaseRetentionEntity caseRetentionEntity = new CaseRetentionEntity();
+        caseRetentionEntity.setCourtCase(courtCase);
+        caseRetentionEntity.setRetentionPolicyType(caseManagementRetentionEntity.getRetentionPolicyTypeEntity());
+        caseRetentionEntity.setCaseManagementRetention(caseManagementRetentionEntity);
+        caseRetentionEntity.setTotalSentence(dartsEventRetentionPolicy.getCaseTotalSentence());
+        caseRetentionEntity.setConfidenceCategory(RetentionConfidenceCategoryEnum.CASE_CLOSED);
+        OffsetDateTime eventTimestamp = dartsEvent.getDateTime();
+        LocalDate eventDate = eventTimestamp.toLocalDate();
+        LocalDate retentionDate = retentionApi.applyPolicyStringToDate(eventDate,
+                                                                       dartsEventRetentionPolicy.getCaseTotalSentence(),
+                                                                       caseManagementRetentionEntity.getRetentionPolicyTypeEntity());
+
+        caseRetentionEntity.setRetainUntil(retentionDate.atStartOfDay().atOffset(ZoneOffset.UTC));
+        caseRetentionEntity.setCurrentState(CaseRetentionStatus.PENDING.name());
+        UserAccountEntity currentUser = authorisationApi.getCurrentUser();
+        caseRetentionEntity.setSubmittedBy(currentUser);
+        caseRetentionEntity.setCreatedBy(currentUser);
+        caseRetentionEntity.setLastModifiedBy(currentUser);
+        caseRetentionRepository.save(caseRetentionEntity);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/darts/retention/service/impl/CloseCaseWithRetentionServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/retention/service/impl/CloseCaseWithRetentionServiceImplTest.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.darts.retention.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.authorisation.api.AuthorisationApi;
+import uk.gov.hmcts.darts.common.entity.CaseManagementRetentionEntity;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
+import uk.gov.hmcts.darts.common.entity.RetentionPolicyTypeEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.repository.CaseRepository;
+import uk.gov.hmcts.darts.common.repository.CaseRetentionRepository;
+import uk.gov.hmcts.darts.event.model.CreatedHearingAndEvent;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+import uk.gov.hmcts.darts.event.model.DartsEventRetentionPolicy;
+import uk.gov.hmcts.darts.event.service.CaseManagementRetentionService;
+import uk.gov.hmcts.darts.retention.api.RetentionApi;
+import uk.gov.hmcts.darts.retention.enums.RetentionConfidenceCategoryEnum;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CloseCaseWithRetentionServiceImplTest {
+
+    @Mock
+    private CaseRetentionRepository caseRetentionRepository;
+
+    @Mock
+    private CaseManagementRetentionService caseManagementRetentionService;
+
+    @Mock
+    private RetentionApi retentionApi;
+
+    @Mock
+    private CaseRepository caseRepository;
+
+    @Mock
+    private AuthorisationApi authorisationApi;
+
+    @InjectMocks
+    private CloseCaseWithRetentionServiceImpl service;
+
+    // Note, the main test scenarios for this class are covered in the integration StopAndCloseHandlerTest
+    @Test
+    void closeCaseAndSetRetention_shouldCloseAndSetRetentionOnCase() {
+        DartsEvent dartsEvent = new DartsEvent();
+        dartsEvent.setDateTime(OffsetDateTime.now());
+        DartsEventRetentionPolicy retentionPolicy = new DartsEventRetentionPolicy();
+        retentionPolicy.setCaseRetentionFixedPolicy("DEFAULT");
+        dartsEvent.setRetentionPolicy(retentionPolicy);
+
+        CreatedHearingAndEvent hearingAndEvent = mock(CreatedHearingAndEvent.class);
+        HearingEntity hearingEntity = mock(HearingEntity.class);
+        when(hearingAndEvent.getHearingEntity()).thenReturn(hearingEntity);
+
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        when(hearingEntity.getCourtCase()).thenReturn(new CourtCaseEntity());
+
+        CaseManagementRetentionEntity caseManagementRetentionEntity = mock(CaseManagementRetentionEntity.class);
+
+        when(caseManagementRetentionService.createCaseManagementRetention(
+            hearingAndEvent.getEventEntity(),
+            hearingEntity.getCourtCase(),
+            retentionPolicy))
+            .thenReturn(caseManagementRetentionEntity);
+        when(caseManagementRetentionEntity.getRetentionPolicyTypeEntity())
+            .thenReturn(mock(RetentionPolicyTypeEntity.class));
+
+        when(retentionApi.applyPolicyStringToDate(any(), eq(null), any(RetentionPolicyTypeEntity.class)))
+            .thenReturn(LocalDate.now());
+        when(caseRetentionRepository.findLatestCompletedManualRetention(courtCase))
+            .thenReturn(Optional.empty());
+        when(caseRetentionRepository.findLatestPendingRetention(courtCase))
+            .thenReturn(Optional.empty());
+        when(retentionApi.updateCourtCaseConfidenceAttributesForRetention(courtCase, RetentionConfidenceCategoryEnum.CASE_CLOSED))
+            .thenReturn(courtCase);
+        when(authorisationApi.getCurrentUser()).thenReturn(mock(UserAccountEntity.class));
+
+        service.closeCaseAndSetRetention(dartsEvent, hearingAndEvent, courtCase);
+
+        verify(caseRepository).saveAndFlush(any(CourtCaseEntity.class));
+        verify(caseRetentionRepository).save(any());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-4910


### Change description ###
Always set the case closed date on a case, even if the event date is before a previously received one. This aligns with legacy behaviour.
This change also includes a refactor to remove the PMD warning about coupling between objects in this class. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
