### PR TITLE
DMP-5063 Fixes for requesting transcription document deletion

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminPostTranscriptionIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAdminPostTranscriptionIntTest.java
@@ -197,13 +197,9 @@ class TranscriptionControllerAdminPostTranscriptionIntTest extends IntegrationBa
         assertEquals(objectAdminActionEntity.getFirst().getHiddenDateTime().truncatedTo(ChronoUnit.SECONDS),
                      transcriptionResponse.getAdminAction().getHiddenAt().truncatedTo(ChronoUnit.SECONDS));
 
-        assertTrue(objectAdminActionEntity.getFirst().isMarkedForManualDeletion());
-
-        assertEquals(objectAdminActionEntity.getFirst().getMarkedForManualDelBy().getId(),
-                     transcriptionResponse.getAdminAction().getMarkedForManualDeletionById());
-        assertEquals(objectAdminActionEntity.getFirst().getMarkedForManualDelDateTime()
-                         .truncatedTo(ChronoUnit.SECONDS), transcriptionResponse.getAdminAction()
-                         .getMarkedForManualDeletionAt().truncatedTo(ChronoUnit.SECONDS));
+        assertFalse(objectAdminActionEntity.getFirst().isMarkedForManualDeletion());
+        assertNull(objectAdminActionEntity.getFirst().getMarkedForManualDelBy());
+        assertNull(objectAdminActionEntity.getFirst().getMarkedForManualDelDateTime());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapper.java
@@ -417,7 +417,7 @@ public class TranscriptionResponseMapper {
             .isMarkedForManualDeletion(action.isMarkedForManualDeletion())
             .markedForManualDeletionAt(action.getMarkedForManualDelDateTime())
             .ticketReference(action.getTicketReference())
-            .markedForManualDeletionById(action.getMarkedForManualDelBy().getId());
+            .markedForManualDeletionById(action.getMarkedForManualDelBy() == null ? null : action.getMarkedForManualDelBy().getId());
 
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceImpl.java
@@ -217,11 +217,6 @@ public class AdminTranscriptionServiceImpl implements AdminTranscriptionService 
                 objectAdminActionEntity.setTranscriptionDocument(documentEntity);
                 objectAdminActionEntity.setHiddenBy(currentUser);
                 objectAdminActionEntity.setHiddenDateTime(OffsetDateTime.now());
-                if (objectHiddenReason.isMarkedForDeletion()) {
-                    objectAdminActionEntity.setMarkedForManualDeletion(true);
-                    objectAdminActionEntity.setMarkedForManualDelBy(currentUser);
-                    objectAdminActionEntity.setMarkedForManualDelDateTime(OffsetDateTime.now());
-                }
                 objectAdminActionEntity = objectAdminActionRepository.saveAndFlush(objectAdminActionEntity);
 
                 response = transcriptionMapper.mapHideOrShowResponse(documentEntity, objectAdminActionEntity);

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/mapper/TranscriptionResponseMapperTest.java
@@ -740,7 +740,7 @@ class TranscriptionResponseMapperTest {
     }
 
     @Test
-    void mapHideResponse_isMakredForDeletion_shouldMapMarkedForDeletionFields() {
+    void mapHideResponse_isMarkedForDeletion_shouldMapMarkedForDeletionFields() {
         Long documentId = 100L;
         boolean hide = true;
 
@@ -787,7 +787,7 @@ class TranscriptionResponseMapperTest {
     }
 
     @Test
-    void mapHideResponse_isNotMakredForDeletion_shouldNotMapMarkedForDeletionFields() {
+    void mapHideResponse_isNotMarkedForDeletion_shouldNotMapMarkedForDeletionFields() {
         Long documentId = 100L;
         boolean hide = true;
 

--- a/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/transcriptions/service/impl/AdminTranscriptionServiceTest.java
@@ -277,16 +277,16 @@ class AdminTranscriptionServiceTest {
 
 
     @Test
-    void hideOrShowTranscriptionDocumentById_shouldSetMarkedForDeletion_whenObjectHiddenReasonIsMarkedForDeletion() {
+    void hideOrShowTranscriptionDocumentById_shouldNotSetMarkedForDeletion_whenObjectHiddenReasonIsMarkedForDeletion() {
         assertTestTranscriptionDocumentHide(new TranscriptionDocumentHideRequest(), true);
     }
 
     @Test
-    void hideOrShowTranscriptionDocumentById_shouldNotSetMarkedForDeletion_whenObjectHiddenReasonNotIsMarkedForDeletion() {
+    void hideOrShowTranscriptionDocumentById_shouldNotSetMarkedForDeletion_whenObjectHiddenReasonIsNotMarkedForDeletion() {
         assertTestTranscriptionDocumentHide(new TranscriptionDocumentHideRequest(), false);
     }
 
-    void assertTestTranscriptionDocumentHide(TranscriptionDocumentHideRequest request, boolean isMarkedForDeleton) {
+    void assertTestTranscriptionDocumentHide(TranscriptionDocumentHideRequest request, boolean isMarkedForDeletion) {
         Long hideOrShowTranscriptionDocument = 343L;
         Integer reasonId = 555;
 
@@ -309,7 +309,7 @@ class AdminTranscriptionServiceTest {
         when(transcriptionDocumentRepository.saveAndFlush(transcriptionDocumentEntityArgumentCaptor.capture())).thenReturn(transcriptionDocumentEntity);
         ObjectAdminActionEntity objectAdminActionEntity = new ObjectAdminActionEntity();
         ObjectHiddenReasonEntity objectHiddenReasonEntity = new ObjectHiddenReasonEntity();
-        objectHiddenReasonEntity.setMarkedForDeletion(isMarkedForDeleton);
+        objectHiddenReasonEntity.setMarkedForDeletion(isMarkedForDeletion);
         TranscriptionDocumentHideResponse expectedResponse = new TranscriptionDocumentHideResponse();
 
         when(objectHiddenReasonRepository.findById(reasonId)).thenReturn(Optional.of(objectHiddenReasonEntity));
@@ -333,15 +333,9 @@ class AdminTranscriptionServiceTest {
         assertEquals(reasonId, request.getAdminAction().getReasonId());
         assertNotNull(objectAdminAction.getHiddenBy());
         assertNotNull(objectAdminAction.getHiddenDateTime());
-        if (isMarkedForDeleton) {
-            assertTrue(objectAdminAction.isMarkedForManualDeletion());
-            assertNotNull(objectAdminAction.getMarkedForManualDelBy());
-            assertNotNull(objectAdminAction.getMarkedForManualDelDateTime());
-        } else {
-            assertNull(objectAdminAction.getMarkedForManualDelBy());
-            assertNull(objectAdminAction.getMarkedForManualDelDateTime());
-            assertFalse(objectAdminAction.isMarkedForManualDeletion());
-        }
+        assertNull(objectAdminAction.getMarkedForManualDelBy());
+        assertNull(objectAdminAction.getMarkedForManualDelDateTime());
+        assertFalse(objectAdminAction.isMarkedForManualDeletion());
         verify(auditApi).record(HIDE_TRANSCRIPTION);
     }
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5063

### Change description ###

- the "marked_for_manual_deletion", "marked_for_manual_del_by" and "marked_for_manual_del_ts" columns should not be set when the deletion is first requested
- these should be thought of as "approved for manual deletion" columns, which are set when the deletion is approved by the second admin, and this is already implemented

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
