### PR TITLE
Dmp 5054 amend admin portal search default sort order

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/repository/CaseRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/repository/CaseRepositoryIntTest.java
@@ -359,7 +359,10 @@ class CaseRepositoryIntTest extends IntegrationBase {
         CourtCaseEntity case1 = dartsDatabase.createCase(SOME_COURTHOUSE, SOME_CASE_NUMBER_1);
         dartsDatabase.createCase(SOME_COURTHOUSE, SOME_CASE_NUMBER_2);
         CourtCaseEntity case3 = dartsDatabase.createCase(SOME_COURTHOUSE, "SOME_CASE_NUMBER_3");
-        CourtCaseEntity case4 = dartsDatabase.createCase(SOME_COURTHOUSE, "SOME_CASE_NUMBER_0");
+        CourtCaseEntity case4 = dartsDatabase.createCase("SOME OTHER COURTHOUSE", "SOME_CASE_NUMBER_0");
+
+        dartsDatabase.getHearingStub().createHearing("SOME OTHER COURTHOUSE", SOME_ROOM, "SOME_CASE_NUMBER_0",
+                                                     DateConverterUtil.toLocalDateTime(testTime));
 
         // when
         List<CourtCaseEntity> returnedCourtCases = caseRepository.findAllWithIdMatchingOneOf(List.of(
@@ -368,8 +371,8 @@ class CaseRepositoryIntTest extends IntegrationBase {
 
         // then
         assertThat(returnedCourtCases).hasSize(3);
-        assertThat(returnedCourtCases.getFirst().getId()).isEqualTo(case3.getId());
-        assertThat(returnedCourtCases.get(1).getId()).isEqualTo(case4.getId());
-        assertThat(returnedCourtCases.get(2).getId()).isEqualTo(case1.getId());
+        assertThat(returnedCourtCases.getFirst().getId()).isEqualTo(case4.getId());
+        assertThat(returnedCourtCases.get(1).getId()).isEqualTo(case1.getId());
+        assertThat(returnedCourtCases.get(2).getId()).isEqualTo(case3.getId());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryIntTest.java
@@ -380,13 +380,14 @@ class EventRepositoryIntTest extends PostgresIntegrationBase {
         HearingEntity hearing2 = PersistableFactory.getHearingTestData().someMinimal();
         HearingEntity hearing3 = PersistableFactory.getHearingTestData().someMinimal();
 
-        hearing1.setCourtroom(courtroom1);
-        hearing2.setCourtroom(courtroom2);
-        hearing3.setCourtroom(courtroom3);
-
         dartsDatabase.save(hearing1);
         dartsDatabase.save(hearing2);
         dartsDatabase.save(hearing3);
+
+        hearing1.setCourtroom(courtroom1);
+        hearing2.setCourtroom(courtroom2);
+        hearing3.setCourtroom(courtroom3);
+        dartsDatabase.saveAll(hearing1, hearing2, hearing3);
 
         // Create and save events linked to courtrooms and hearings
         EventEntity event1 = EventTestData.someMinimalEvent();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/HearingRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/HearingRepositoryIntTest.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.darts.testutils.stubs.HearingStub;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,6 +30,7 @@ import static uk.gov.hmcts.darts.test.common.data.JudgeTestData.createListOfJudg
 import static uk.gov.hmcts.darts.test.common.data.ProsecutorTestData.createListOfProsecutor;
 
 @Slf4j
+@Transactional
 class HearingRepositoryIntTest extends PostgresIntegrationBase {
 
     // generation count. Should always be an even number
@@ -51,36 +54,43 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetAllHearingNoSearchCriteria() {
-        generatedHearingEntities.sort((he1, he2) -> he2.getHearingDate().compareTo(he1.getHearingDate()));
+    void findHearingDetails_ReturnsAllHearings_WithNoSearchCriteria() {
+        var mutablePersistedHearings = new ArrayList<>(generatedHearingEntities);
+        mutablePersistedHearings.sort((event1, event2) -> event1.getCourtroom().getCourthouse().getCourthouseName().compareTo(
+            event2.getCourtroom().getCourthouse().getCourthouseName()));
+
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null, null,
                                                                                      null, null,
                                                                                      null, RESULT_LIMIT);
-        assertEquals(generatedHearingEntities.size(), hearingEntityList.size());
-        for (int i = 0; i < generatedHearingEntities.size(); i++) {
-            assertEquals(generatedHearingEntities.get(i).getId(), hearingEntityList.get(i).getId());
-        }
+        assertEquals(mutablePersistedHearings.size(), hearingEntityList.size());
+        assertThat(hearingEntityList)
+            .extracting(hearing1 -> hearing1.getCourtroom().getCourthouse().getCourthouseName())
+            .isEqualTo(mutablePersistedHearings.stream()
+                           .map(hearing2 -> hearing2.getCourtroom().getCourthouse().getCourthouseName())
+                           .toList());
     }
 
     @Test
-    void testGetHearingWithLimit() {
-        generatedHearingEntities.sort((he1, he2) -> he2.getHearingDate().compareTo(he1.getHearingDate()));
+    void findHearingDetails_ReturnsHearings_UsingLimit() {
+        var mutablePersistedHearings = new ArrayList<>(generatedHearingEntities);
+        mutablePersistedHearings.sort((event1, event2) -> event1.getCourtroom().getCourthouse().getCourthouseName().compareTo(
+            event2.getCourtroom().getCourthouse().getCourthouseName()));
+        var expectedHearingEntities = mutablePersistedHearings.subList(0, 2);
+
         int resultLimit = 2;
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null, null,
                                                                                      null, null,
                                                                                      null, resultLimit);
-        assertEquals(resultLimit, hearingEntityList.size());
-        for (int i = 0; i < generatedHearingEntities.size(); i++) {
-            if (i < resultLimit) {
-                assertEquals(generatedHearingEntities.get(i).getId(), hearingEntityList.get(i).getId());
-            } else {
-                break;
-            }
-        }
+        assertEquals(expectedHearingEntities.size(), hearingEntityList.size());
+        assertThat(hearingEntityList)
+            .extracting(hearing1 -> hearing1.getCourtroom().getCourthouse().getCourthouseName())
+            .isEqualTo(expectedHearingEntities.stream()
+                           .map(hearing2 -> hearing2.getCourtroom().getCourthouse().getCourthouseName())
+                           .toList());
     }
 
     @Test
-    void testGetHearingUsingAllSearchCriteria() {
+    void findHearingDetails_ReturnsHearing_UsingAllSearchCriteria() {
         int recordIndexToFind = GENERATION_COUNT / 2;
         List<HearingEntity> hearingEntityList = hearingRepository
             .findHearingDetails(List.of(generatedHearingEntities
@@ -99,10 +109,15 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetHearingForCourthouseIds() {
+    void findHearingDetails_ReturnsHearings_ForCourthouseIds() {
         generatedHearingEntities.sort((he1, he2) -> he2.getHearingDate().compareTo(he1.getHearingDate()));
         int recordIndexToFind = GENERATION_COUNT / 2;
         int recordIndexToFindNext = (GENERATION_COUNT / 2) + 1;
+        generatedHearingEntities.subList(recordIndexToFind, recordIndexToFindNext);
+        var mutablePersistedHearings = generatedHearingEntities.subList(recordIndexToFind, recordIndexToFindNext + 1);
+
+        mutablePersistedHearings.sort((event1, event2) -> event1.getCourtroom().getCourthouse().getCourthouseName().compareTo(
+            event2.getCourtroom().getCourthouse().getCourthouseName()));
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(List.of(generatedHearingEntities
                                                                                                  .get(recordIndexToFind)
@@ -114,13 +129,17 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
                                                                                      null,
                                                                                      null,
                                                                                      null, RESULT_LIMIT);
-        assertEquals(2, hearingEntityList.size());
-        assertEquals(generatedHearingEntities.get(recordIndexToFind).getId(), hearingEntityList.getFirst().getId());
-        assertEquals(generatedHearingEntities.get(recordIndexToFindNext).getId(), hearingEntityList.get(1).getId());
+
+        assertEquals(mutablePersistedHearings.size(), hearingEntityList.size());
+        assertThat(hearingEntityList)
+            .extracting(hearing1 -> hearing1.getCourtroom().getCourthouse().getCourthouseName())
+            .isEqualTo(mutablePersistedHearings.stream()
+                           .map(hearing2 -> hearing2.getCourtroom().getCourthouse().getCourthouseName())
+                           .toList());
     }
 
     @Test
-    void testGetHearingsForCaseNumber() {
+    void findHearingDetails_ReturnsHearings_ForCaseNumber() {
         int recordIndexToFind = GENERATION_COUNT / 2;
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null,
@@ -134,7 +153,7 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetHearingsForPrefixCaseInsensitiveCaseNumber() {
+    void findHearingDetails_ReturnsHearings_ForPrefixCaseInsensitiveCaseNumber() {
         Integer recordIndexToFind = GENERATION_COUNT / 2;
 
         List<HearingEntity> hearingEntityList = hearingRepository
@@ -149,7 +168,7 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetHearingsForPostfixCaseInsensitiveCaseNumber() {
+    void findHearingDetails_ReturnsHearings_ForPostfixCaseInsensitiveCaseNumber() {
         Integer recordIndexToFind = GENERATION_COUNT / 2;
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null,
@@ -163,7 +182,7 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetHearingsForCourtroomName() {
+    void findHearingDetails_ReturnsHearings_ForCourtroomName() {
         int recordIndexToFind = GENERATION_COUNT / 2;
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null,
@@ -177,7 +196,7 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetHearingsForPrefixCourtroomCaseInsensitiveCourtroomName() {
+    void findHearingDetails_ReturnsHearings_ForPrefixCourtroomCaseInsensitiveCourtroomName() {
         Integer recordIndexToFind = GENERATION_COUNT / 2;
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null,
@@ -191,7 +210,7 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetHearingsForPostfixCourtroomCaseInsensitiveCourtroomName() {
+    void findHearingDetails_ReturnsHearings_ForPostfixCourtroomCaseInsensitiveCourtroomName() {
         Integer recordIndexToFind = GENERATION_COUNT / 2;
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null,
@@ -205,9 +224,13 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetHearingsForHearingStartDate() {
+    void findHearingDetails_ReturnsHearings_ForHearingStartDate() {
         generatedHearingEntities.sort((he1, he2) -> he2.getHearingDate().compareTo(he1.getHearingDate()));
         Integer recordIndexToFindFrom = GENERATION_COUNT / 2;
+        List<HearingEntity> expectedHearings = generatedHearingEntities.subList(0, recordIndexToFindFrom + 1);
+        var mutablePersistedHearings = new ArrayList<>(expectedHearings);
+        mutablePersistedHearings.sort((event1, event2) -> event1.getCourtroom().getCourthouse().getCourthouseName().compareTo(
+            event2.getCourtroom().getCourthouse().getCourthouseName()));
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null,
                                                                                      null,
@@ -215,18 +238,22 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
                                                                                      generatedHearingEntities.get(recordIndexToFindFrom).getHearingDate(),
                                                                                      null, RESULT_LIMIT);
 
-        List<HearingEntity> expectedHearings = generatedHearingEntities.subList(0, recordIndexToFindFrom + 1);
-        assertEquals(expectedHearings.size(), hearingEntityList.size());
-
-        for (int i = 0; i < expectedHearings.size(); i++) {
-            assertEquals(expectedHearings.get(i).getId(), hearingEntityList.get(i).getId());
-        }
+        assertEquals(mutablePersistedHearings.size(), hearingEntityList.size());
+        assertThat(hearingEntityList)
+            .extracting(hearing1 -> hearing1.getCourtroom().getCourthouse().getCourthouseName())
+            .isEqualTo(mutablePersistedHearings.stream()
+                           .map(hearing2 -> hearing2.getCourtroom().getCourthouse().getCourthouseName())
+                           .toList());
     }
 
     @Test
-    void testGetHearingsForHearingAfterDate() {
+    void findHearingDetails_ReturnsHearings_ForHearingAfterDate() {
         Integer recordIndexToFindTo = GENERATION_COUNT / 2;
         generatedHearingEntities.sort((he1, he2) -> he2.getHearingDate().compareTo(he1.getHearingDate()));
+        List<HearingEntity> expectedHearings = generatedHearingEntities.subList(recordIndexToFindTo, generatedHearingEntities.size());
+        var mutablePersistedHearings = new ArrayList<>(expectedHearings);
+        mutablePersistedHearings.sort((event1, event2) -> event1.getCourtroom().getCourthouse().getCourthouseName().compareTo(
+            event2.getCourtroom().getCourthouse().getCourthouseName()));
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null,
                                                                                      null,
@@ -235,20 +262,27 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
                                                                                      generatedHearingEntities.get(recordIndexToFindTo).getHearingDate(),
                                                                                      RESULT_LIMIT);
 
-        List<HearingEntity> expectedHearings = generatedHearingEntities.subList(recordIndexToFindTo, generatedHearingEntities.size());
-        assertEquals(expectedHearings.size(), hearingEntityList.size());
-
-        for (int i = 0; i < expectedHearings.size(); i++) {
-            assertEquals(expectedHearings.get(i).getId(), hearingEntityList.get(i).getId());
-        }
+        assertEquals(mutablePersistedHearings.size(), hearingEntityList.size());
+        assertThat(hearingEntityList)
+            .extracting(hearing1 -> hearing1.getCourtroom().getCourthouse().getCourthouseName())
+            .isEqualTo(mutablePersistedHearings.stream()
+                           .map(hearing2 -> hearing2.getCourtroom().getCourthouse().getCourthouseName())
+                           .toList());
     }
 
     @Test
-    void testGetHearingsForHearingBetweenBeforeAndAfterDate() {
+    void findHearingDetails_ReturnsHearings_ForHearingBetweenBeforeAndAfterDate() {
         generatedHearingEntities.sort((he1, he2) -> he2.getHearingDate().compareTo(he1.getHearingDate()));
         Integer recordToOffset = 2;
         Integer recordIndexToFindFrom = (GENERATION_COUNT / 2) - 1;
         Integer recordIndexToFindTo = (GENERATION_COUNT / 2) + recordToOffset - 1;
+
+        List<HearingEntity> expectedHearings = generatedHearingEntities.subList(recordIndexToFindFrom, recordIndexToFindTo + 1);
+        assertEquals(expectedHearings.size(), expectedHearings.size());
+
+        var mutablePersistedHearings = new ArrayList<>(expectedHearings);
+        mutablePersistedHearings.sort((event1, event2) -> event1.getCourtroom().getCourthouse().getCourthouseName().compareTo(
+            event2.getCourtroom().getCourthouse().getCourthouseName()));
 
         List<HearingEntity> hearingEntityList = hearingRepository.findHearingDetails(null,
                                                                                      null,
@@ -256,16 +290,17 @@ class HearingRepositoryIntTest extends PostgresIntegrationBase {
                                                                                      generatedHearingEntities.get(recordIndexToFindTo).getHearingDate(),
                                                                                      generatedHearingEntities.get(recordIndexToFindFrom).getHearingDate(),
                                                                                      RESULT_LIMIT);
-        List<HearingEntity> expectedHearings = generatedHearingEntities.subList(recordIndexToFindFrom, recordIndexToFindTo + 1);
-        assertEquals(expectedHearings.size(), hearingEntityList.size());
 
-        for (int i = 0; i < expectedHearings.size(); i++) {
-            assertEquals(expectedHearings.get(i).getId(), hearingEntityList.get(i).getId());
-        }
+        assertEquals(mutablePersistedHearings.size(), hearingEntityList.size());
+        assertThat(hearingEntityList)
+            .extracting(hearing1 -> hearing1.getCourtroom().getCourthouse().getCourthouseName())
+            .isEqualTo(mutablePersistedHearings.stream()
+                           .map(hearing2 -> hearing2.getCourtroom().getCourthouse().getCourthouseName())
+                           .toList());
     }
 
     @Test
-    void testFindHearingIdsByEventId() {
+    void findHearingIdsByEventId_ReturnsHearingIds() {
         EventEntity event = dartsDatabase.getEventStub().createEvent(generatedHearingEntities.getFirst());
 
         List<Integer> hearingIdList = hearingRepository.findHearingIdsByEventId(event.getId());

--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/PostAdminMediasSearchHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/PostAdminMediasSearchHelper.java
@@ -55,7 +55,9 @@ public class PostAdminMediasSearchHelper {
         Path<MediaEntity> namePath = mediaRoot;
         criteriaQuery.select(namePath).distinct(true);
         criteriaQuery.where(finalAndPredicate);
-        criteriaQuery.orderBy(criteriaBuilder.desc(mediaRoot.get(MediaEntity_.ID)));
+
+        criteriaQuery.orderBy(criteriaBuilder.asc(mediaRoot.get(MediaEntity_.START)),
+                              criteriaBuilder.asc(mediaRoot.get(MediaEntity_.CHANNEL)));
 
         TypedQuery<MediaEntity> query = entityManager.createQuery(criteriaQuery);
         query.setMaxResults(maxResults + 1);

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdminCasesSearchResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdminCasesSearchResponseMapper.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
 import uk.gov.hmcts.darts.common.entity.HearingEntity;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Slf4j
@@ -46,9 +47,9 @@ public class AdminCasesSearchResponseMapper {
         return responseCourthouse;
     }
 
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")//TODO - refactor to avoid instantiating objects in loops when this is next edited
     private List<CourtroomResponseObject> createCourtroomList(List<HearingEntity> hearings) {
-        List<CourtroomEntity> courtroomEntityList = hearings.stream().map(HearingEntity::getCourtroom).distinct().toList();
+        List<CourtroomEntity> courtroomEntityList = new ArrayList<>(hearings.stream().map(HearingEntity::getCourtroom).distinct().toList());
+        courtroomEntityList.sort(Comparator.comparing(CourtroomEntity::getName));
         List<CourtroomResponseObject> responseList = new ArrayList<>();
         for (CourtroomEntity courtroomEntity : courtroomEntityList) {
             CourtroomResponseObject courtroomResponseObject = new CourtroomResponseObject();

--- a/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdminCasesSearchResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/mapper/AdminCasesSearchResponseMapper.java
@@ -52,12 +52,16 @@ public class AdminCasesSearchResponseMapper {
         courtroomEntityList.sort(Comparator.comparing(CourtroomEntity::getName));
         List<CourtroomResponseObject> responseList = new ArrayList<>();
         for (CourtroomEntity courtroomEntity : courtroomEntityList) {
-            CourtroomResponseObject courtroomResponseObject = new CourtroomResponseObject();
-            courtroomResponseObject.setId(courtroomEntity.getId());
-            courtroomResponseObject.setName(courtroomEntity.getName());
-            responseList.add(courtroomResponseObject);
+            responseList.add(createCourtroomResponseObject(courtroomEntity));
         }
         return responseList;
+    }
+
+    private static CourtroomResponseObject createCourtroomResponseObject(CourtroomEntity courtroomEntity) {
+        CourtroomResponseObject courtroomResponseObject = new CourtroomResponseObject();
+        courtroomResponseObject.setId(courtroomEntity.getId());
+        courtroomResponseObject.setName(courtroomEntity.getName());
+        return courtroomResponseObject;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRepository.java
@@ -118,8 +118,9 @@ public interface CaseRepository
     @Query("""
         SELECT cc
         FROM CourtCaseEntity cc
-        WHERE cc.id in :ids
-        ORDER BY cc.caseNumber DESC
+        WHERE cc.id IN :ids
+        ORDER BY cc.courthouse.courthouseName ASC,
+            cc.caseNumber ASC
         """)
     List<CourtCaseEntity> findAllWithIdMatchingOneOf(List<Integer> ids);
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -86,7 +86,7 @@ public interface EventRepository extends JpaRepository<EventEntity, Long> {
              AND (cast(:hearingStartDate as LocalDate) IS NULL OR h.hearingDate >= :hearingStartDate)
              AND (cast(:hearingEndDate as LocalDate) IS NULL OR h.hearingDate <= :hearingEndDate)
              AND e.isCurrent = true
-        ORDER BY e.id DESC
+        ORDER BY ch.displayName ASC, c.name ASC, e.timestamp ASC
         """)
     List<EventSearchResult> searchEventsFilteringOn(
         List<Integer> courthouseIds,

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/HearingRepository.java
@@ -98,7 +98,8 @@ public interface HearingRepository extends JpaRepository<HearingEntity, Integer>
             AND (:courtroomName IS NULL OR hearing.courtroom.name ILIKE CONCAT('%', cast(:courtroomName as text), '%'))
             AND (cast(:startDate as LocalDate) IS NULL OR hearing.hearingDate >= :startDate)
             AND (cast(:endDate as LocalDate) IS NULL OR hearing.hearingDate <= :endDate)
-            ORDER BY hearing.hearingDate DESC
+            ORDER BY hearing.courtroom.courthouse.courthouseName ASC, hearing.courtroom.name ASC, 
+                hearing.hearingDate ASC, hearing.courtCase.caseNumber ASC
             LIMIT :numberOfRecords
         """)
     List<HearingEntity> findHearingDetails(List<Integer> courthouseIds, String caseNumber,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5054

### Change description ###

Amended the default sort order for admin portal search results, returned from the API, as follows

Cases

courthouse_name ASC, case_number ASC

Hearings

courthouse display_name ASC, courtroom_name ASC, hearing_date ASC, case_number ASC

Events

courthouse_name ASC, courtroom_name ASC, event_ts ASC

Audio

start_ts ASC, channel ASC

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
