### PR TITLE
DMP-5113 ARM Batch Processor is not using the correct value for getting IU files

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
@@ -101,9 +101,9 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
             // Iterate through the continuation token until no more data is found. First time round continuation token is null
             // which sets up the session and when there are no more results the result from listResponseBlobsUsingMarker will be null
             for (int pageSize = 0; pageSize < batchSize; pageSize += maxContinuationBatchSize) {
-
+                int listBatchSize = Math.min(maxContinuationBatchSize, batchSize);
                 ContinuationTokenBlobs continuationTokenData =
-                    armDataManagementApi.listResponseBlobsUsingMarker(prefix, maxContinuationBatchSize, continuationToken);
+                    armDataManagementApi.listResponseBlobsUsingMarker(prefix, listBatchSize, continuationToken);
                 if (nonNull(continuationTokenData)) {
                     inputUploadResponseFiles.addAll(continuationTokenData.getBlobNamesAndPaths());
                     continuationToken = continuationTokenData.getContinuationToken();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5113

### Change description ###

Added fix so that the correct no of IU files is retrieved between the batch size and the continuation token max size


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
