### PR TITLE
DMP-5129: Improve duplicate case check query for eventId = 0

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/EventRepositoryIntTest.java
@@ -157,7 +157,7 @@ class EventRepositoryIntTest extends PostgresIntegrationBase {
         updateCreatedBy(event2, createdTime.plusMinutes(2));
         updateCreatedBy(event4, createdTime.plusMinutes(3));
 
-        List<Long> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId());
+        List<Long> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId(), event1.getMessageId(), event1.getEventText());
 
         assertThat(duplicates)
             .hasSize(3)
@@ -188,7 +188,7 @@ class EventRepositoryIntTest extends PostgresIntegrationBase {
         updateCreatedBy(event3, createdTime.plusMinutes(2));
         updateCreatedBy(event4, createdTime.plusMinutes(3));
 
-        List<Long> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId());
+        List<Long> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId(), event1.getMessageId(), event1.getEventText());
         assertThat(duplicates).isEmpty();
     }
 
@@ -214,7 +214,7 @@ class EventRepositoryIntTest extends PostgresIntegrationBase {
         updateCreatedBy(event3, createdTime.plusMinutes(2));
         updateCreatedBy(event4, createdTime.plusMinutes(3));
 
-        List<Long> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId());
+        List<Long> duplicates = eventRepository.findDuplicateEventIds(event1.getEventId(), event1.getMessageId(), event1.getEventText());
         assertThat(duplicates).isEmpty();
     }
 

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/EventRepository.java
@@ -128,18 +128,12 @@ public interface EventRepository extends JpaRepository<EventEntity, Long> {
     List<Long> findAllByEventStatusAndNotCourtrooms(Integer statusNumber, List<String> courtroomNumbers, Limit limit);
 
     @Query("""
-                        SELECT e3.id from EventEntity e3
-                        JOIN (                        
-                            SELECT e.eventId as eventId, e.messageId as messageId, e.eventText as eventText
-                            FROM EventEntity e
-                            WHERE e.eventId IS NOT NULL and e.messageId IS NOT NULL and e.eventId = :eventId
-                            GROUP BY e.eventId, e.messageId, e.eventText
-                            HAVING COUNT(e) > 1) e2
-                         ON e2.eventId = e3.eventId and e2.messageId = e3.messageId and e2.eventText = e3.eventText
-                         WHERE e3.eventId >= :eventId
-                         ORDER BY e3.createdDateTime ASC  
+        SELECT e3.id from EventEntity e3
+        WHERE e3.eventId = :eventId and e3.messageId = :messageId and e3.eventText = :eventText
+        ORDER BY e3.createdDateTime ASC  
         """)
-    List<Long> findDuplicateEventIds(Integer eventId);
+    List<Long> findDuplicateEventIds(Integer eventId, String messageId, String eventText);
+
 
     @Query("""
            SELECT ee FROM EventEntity ee

--- a/src/main/java/uk/gov/hmcts/darts/event/service/RemoveDuplicateEventsProcessor.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/RemoveDuplicateEventsProcessor.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.darts.event.service;
 
+import uk.gov.hmcts.darts.event.model.DartsEvent;
+
 @FunctionalInterface
 public interface RemoveDuplicateEventsProcessor {
-    boolean findAndRemoveDuplicateEvent(Integer eventId);
+    boolean findAndRemoveDuplicateEvent(DartsEvent event);
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/AsyncEventProcessor.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/AsyncEventProcessor.java
@@ -1,8 +1,10 @@
 package uk.gov.hmcts.darts.event.service.impl;
 
 import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.service.CleanupCurrentFlagEventProcessor;
 
 @Service
@@ -13,9 +15,9 @@ public class AsyncEventProcessor {
 
 
     @Async("eventTaskExecutor")
-    public void processEvent(Integer eventId) {
-        if (!removeDuplicateEventsProcessor.findAndRemoveDuplicateEvent(eventId)) {
-            cleanupCurrentFlagEventProcessor.processEvent(eventId);
+    public void processEvent(DartsEvent event) {
+        if (!removeDuplicateEventsProcessor.findAndRemoveDuplicateEvent(event)) {
+            cleanupCurrentFlagEventProcessor.processEvent(NumberUtils.createInteger(event.getEventId()));
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventDispatcherImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventDispatcherImpl.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.darts.event.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.darts.common.entity.EventHandlerEntity;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventDispatcherImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/EventDispatcherImpl.java
@@ -44,7 +44,7 @@ public class EventDispatcherImpl implements EventDispatcher {
         if (foundHandler.isPresent()) {
             logEvent(event, foundHandler.get());
             foundHandler.get().handle(event, foundHandlerEntity);
-            asyncEventProcessor.processEvent(NumberUtils.createInteger(event.getEventId()));
+            asyncEventProcessor.processEvent(event);
         } else {
             // Event registered in DB, but no handler defined...just log and return OK.
             log.warn(format(HANDLER_NOT_FOUND_MESSAGE, event.getMessageId(), event.getType(), event.getSubType()));

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
@@ -2,12 +2,14 @@ package uk.gov.hmcts.darts.event.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.darts.common.repository.CaseManagementRetentionRepository;
 import uk.gov.hmcts.darts.common.repository.CaseRetentionRepository;
 import uk.gov.hmcts.darts.common.repository.EventLinkedCaseRepository;
 import uk.gov.hmcts.darts.common.repository.EventRepository;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.service.RemoveDuplicateEventsProcessor;
 
 import java.util.List;
@@ -23,8 +25,13 @@ public class RemoveDuplicateEventsProcessorImpl implements RemoveDuplicateEvents
 
     @Override
     @Transactional
-    public boolean findAndRemoveDuplicateEvent(Integer eventId) {
-        List<Long> eventEntitiesIds = eventRepository.findDuplicateEventIds(eventId);
+    public boolean findAndRemoveDuplicateEvent(DartsEvent event) {
+        List<Long> eventEntitiesIds = eventRepository.findDuplicateEventIds(
+            NumberUtils.createInteger(event.getEventId()),
+            event.getMessageId(),
+            event.getEventText()
+        );
+
         if (eventEntitiesIds.isEmpty() || eventEntitiesIds.size() == 1) {
             //No need to continue if there are no duplicates
             return false;
@@ -43,7 +50,8 @@ public class RemoveDuplicateEventsProcessorImpl implements RemoveDuplicateEvents
         eventRepository.deleteAllById(eventEntitiesIdsToDelete);
         eventRepository.flush();
 
-        log.info("Duplicate events found. Removing the following events {}", eventEntitiesIdsToDelete);
+        log.info("Duplicate events found for event_id='{}', message_id='{}', event_text='{}'. Removing the following events {}",
+                 event.getEventId(), event.getMessageId(), event.getEventText(), eventEntitiesIdsToDelete);
         return true;
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/service/impl/RemoveDuplicateEventsProcessorImpl.java
@@ -26,6 +26,9 @@ public class RemoveDuplicateEventsProcessorImpl implements RemoveDuplicateEvents
     @Override
     @Transactional
     public boolean findAndRemoveDuplicateEvent(DartsEvent event) {
+        if (event.getEventId() == null || event.getMessageId() == null) {
+            return false;
+        }
         List<Long> eventEntitiesIds = eventRepository.findDuplicateEventIds(
             NumberUtils.createInteger(event.getEventId()),
             event.getMessageId(),

--- a/src/main/resources/db/migration/common/V1_476__new_index.sql
+++ b/src/main/resources/db/migration/common/V1_476__new_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX event_event_id_idx ON darts."event" (event_id,message_id,event_text);

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/AsyncEventProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/AsyncEventProcessorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.event.model.DartsEvent;
 import uk.gov.hmcts.darts.event.service.CleanupCurrentFlagEventProcessor;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,10 +28,11 @@ class AsyncEventProcessorTest {
     void processEvent_hasDuplicates() {
         when(removeDuplicateEventsProcessor.findAndRemoveDuplicateEvent(any()))
             .thenReturn(true);
+        DartsEvent dartsEvent = new DartsEvent();
+        dartsEvent.setEventId("1");
+        asyncEventProcessor.processEvent(dartsEvent);
 
-        asyncEventProcessor.processEvent(1);
-
-        verify(removeDuplicateEventsProcessor).findAndRemoveDuplicateEvent(1);
+        verify(removeDuplicateEventsProcessor).findAndRemoveDuplicateEvent(dartsEvent);
         verify(cleanupCurrentFlagEventProcessor, never()).processEvent(any());
     }
 
@@ -39,9 +41,11 @@ class AsyncEventProcessorTest {
         when(removeDuplicateEventsProcessor.findAndRemoveDuplicateEvent(any()))
             .thenReturn(false);
 
-        asyncEventProcessor.processEvent(1);
+        DartsEvent dartsEvent = new DartsEvent();
+        dartsEvent.setEventId("1");
+        asyncEventProcessor.processEvent(dartsEvent);
 
-        verify(removeDuplicateEventsProcessor).findAndRemoveDuplicateEvent(1);
+        verify(removeDuplicateEventsProcessor).findAndRemoveDuplicateEvent(dartsEvent);
         verify(cleanupCurrentFlagEventProcessor).processEvent(1);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventDispatcherImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/service/impl/EventDispatcherImplTest.java
@@ -80,7 +80,7 @@ class EventDispatcherImplTest {
 
         verify(mockEventHandler).handle(any(), any());
         verify(logApi, times(1)).eventReceived(event);
-        verify(asyncEventProcessor, times(1)).processEvent(123);
+        verify(asyncEventProcessor, times(1)).processEvent(event);
     }
 
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5129)


### Change description ###
An edge case has been observed on production where an event with eventId = 0 has been incorrectly deleted.

Here is a summary of the issue:

At 14:37:24 an event with event id zero was received that took more than 30 seconds to be processed. The request timed out and an error was returned back to XHIBIT at 14:37:54, causing them to retry that event, which was received at 14:38:01. However, the original request was actually processed and saved to the database after 30 seconds at 14:37:58. This meant that this retried event was a duplicate. However, there was an issue with the duplicate check query in that if an unrelated request with event id zero was received before the duplicate had been cleaned up, what actually happened was this unrelated request grouped all duplicate event id zero's and removed them. Therefore, what we have seen is that for the request highlighted above, both the original and duplicate were removed. Therefore, as things stand there is a risk of a loss of data with this query for event id's zero.

 

DARTS should not be deleting events that have the same event id if the message id and event text are different. 
h4. Prerequisites:
 # Multiple events exist with event id = 0, with message id and event text set to the same values for each of these events (For testing, inject these via SQL into the database, not through Postman otherwise the duplicate logic will kick in)  e.g.

 
||No.||Event ID||Message ID||Event Text||
|1|0|ABC123|Test 1|
|2|0|ABC123|Test 1|
|3|0|ZYX987|Test 2|

Ensure the 3 above have slightly different created dates, in ascending order from 1 - 3. 

 
h4. Steps to reproduce:
 # Send an event in with the following detail:

||Event ID||Message ID||Event Text||
|0|ZYX987|Test 2|
h4. Expected results:
 # The newly inserted event with messageId ZYX987 is deleted
 # A log message with the event id, message id and event text is printed with the details of the event that has been deleted

||No.||Event ID||Message ID||Event Text||
|1|0|ABC123|Test 1|
|2|0|ABC123|Test 1|
|3|0|ZYX987|Test 2|
h4. Actual results:
 # The 2 events with message id ZYX987 and 1 of the ABC123 events are incorrectly deleted

||No.||Event ID||Message ID||Event Text||
|1|0|ABC123|Test 1|
h4. Impact:
 # Loss of data

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
