### PR TITLE
DMP-5130 : arm response processing failing for end of line character

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/MediaStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/stubs/MediaStub.java
@@ -67,8 +67,8 @@ public class MediaStub {
     @Transactional
     public List<MediaEntity> createAndSaveSomeMedias() {
         return List.of(
-            createMediaEntity("testCourthouse", "testCourtroom", MEDIA_1_START_TIME, MEDIA_1_END_TIME, 1),
-            createMediaEntity("testCourthouse", "testCourtroom", MEDIA_1_START_TIME, MEDIA_1_END_TIME, 2),
+            createMediaEntity("testCourthouse\\1", "testCourtroom", MEDIA_1_START_TIME, MEDIA_1_END_TIME, 1),
+            createMediaEntity("testCourthouse1\ntestCourthouse2", "testCourtroom", MEDIA_1_START_TIME, MEDIA_1_END_TIME, 2),
             createMediaEntity("testCourthouse", "testCourtroom", MEDIA_1_START_TIME, MEDIA_1_END_TIME, 3),
             createMediaEntity("testCourthouse", "testCourtroom", MEDIA_1_START_TIME, MEDIA_1_END_TIME, 4),
             createMediaEntity("testCourthouse", "testCourtroom", MEDIA_2_START_TIME, MEDIA_2_END_TIME, 1),

--- a/src/integrationTest/resources/tests/arm/service/ArmBatchResponseFilesProcessorTest/ValidResponses/CreateRecordBackSlash.rsp
+++ b/src/integrationTest/resources/tests/arm/service/ArmBatchResponseFilesProcessorTest/ValidResponses/CreateRecordBackSlash.rsp
@@ -1,0 +1,11 @@
+{
+  "operation": "create_record",
+  "transaction_id": "02b54347-bf86-7098-b836-41af570e6502",
+  "relation_id": "<EODID>",
+  "a360_record_id": "29d8089f-7294-785f-add0-01588bd56d50",
+  "process_time": "2023-07-11T11:39:26.085000+00:00",
+  "status": 1,
+  "input": "{\"operation\":\"create_record\",\"relation_id\":\"<EODID>\",\"record_metadata\":{\"record_class\":\"DARTS\",\"publisher\":\"DARTS\",\"region\":\"GBR\",\"recordDate\":\"2025-05-27T22:13:59.361Z\",\"event_date\":\"2025-05-27T17:05:14.292Z\",\"title\":\"Test User - Test Model Court - Sentencing Remarks - 20200723 Anon.doc\",\"client_identifier\":\"<EODID>\",\"contributor\":\"Guildford & 2\",\"bf_001\":\"Transcription\",\"bf_002\":\"T20202020\",\"bf_003\":\"application/msword\",\"bf_004\":\"2020-07-23T00:00:00.000Z\",\"bf_005\":\"4062456f27d1ab69545027761a6fb244\",\"bf_006\":\"Manual\",\"bf_007\":\"Sentencing remarks\",\"bf_008\":\"Up to 12 working days\",\"bf_009\":\"Test Line 1. \\\\ Test Line 2\\n\",\"bf_010\":\"2025-05-27T17:05:14.292Z\",\"bf_012\":17325,\"bf_013\":58929,\"bf_016\":\"4608\",\"bf_019\":\"Guildford\",\"bf_020\":\"2\"}}",
+  "exception_description": null,
+  "error_status": null
+}

--- a/src/integrationTest/resources/tests/arm/service/ArmBatchResponseFilesProcessorTest/ValidResponses/CreateRecordEndOfLine.rsp
+++ b/src/integrationTest/resources/tests/arm/service/ArmBatchResponseFilesProcessorTest/ValidResponses/CreateRecordEndOfLine.rsp
@@ -1,0 +1,11 @@
+{
+  "operation": "create_record",
+  "transaction_id": "02b54347-bf86-7098-b836-41af570e6502",
+  "relation_id": "<EODID>",
+  "a360_record_id": "29d8089f-7294-785f-add0-01588bd56d50",
+  "process_time": "2023-07-11T11:39:26.085000+00:00",
+  "status": 1,
+  "input": "{\"operation\":\"create_record\",\"relation_id\":\"<EODID>\",\"record_metadata\":{\"record_class\":\"DARTS\",\"publisher\":\"DARTS\",\"region\":\"GBR\",\"recordDate\":\"2025-05-27T22:13:59.361Z\",\"event_date\":\"2025-05-27T17:05:14.292Z\",\"title\":\"Test User - Test Model Court - Sentencing Remarks - 20200723 Anon.doc\",\"client_identifier\":\"<EODID>\",\"contributor\":\"Guildford & 2\",\"bf_001\":\"Transcription\",\"bf_002\":\"T20202020\",\"bf_003\":\"application/msword\",\"bf_004\":\"2020-07-23T00:00:00.000Z\",\"bf_005\":\"4062456f27d1ab69545027761a6fb244\",\"bf_006\":\"Manual\",\"bf_007\":\"Sentencing remarks\",\"bf_008\":\"Up to 12 working days\",\"bf_009\":\"Test Line 1.\\nTest Line 2\\n\",\"bf_010\":\"2025-05-27T17:05:14.292Z\",\"bf_012\":17325,\"bf_013\":58929,\"bf_016\":\"4608\",\"bf_019\":\"Guildford\",\"bf_020\":\"2\"}}",
+  "exception_description": null,
+  "error_status": null
+}

--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
 import uk.gov.hmcts.darts.arm.api.ArmDataManagementApi;
 import uk.gov.hmcts.darts.arm.config.ArmDataManagementConfiguration;
 import uk.gov.hmcts.darts.arm.model.ResponseFilenames;
@@ -680,9 +679,8 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
     private UploadNewFileRecord readInputJson(String input) {
         UploadNewFileRecord uploadNewFileRecord = null;
         if (StringUtils.isNotEmpty(input)) {
-            String unescapedJson = StringEscapeUtils.unescapeJson(input);
             try {
-                uploadNewFileRecord = objectMapper.readValue(unescapedJson, UploadNewFileRecord.class);
+                uploadNewFileRecord = objectMapper.readValue(input, UploadNewFileRecord.class);
             } catch (Exception e) {
                 log.error("Failed to parse the input field {}", input, e);
             }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
DMP-5130


### Change description ###
DARTS application pushes raw data alongwith a manifest file containing the metadata of the object.
In return, ARM produces the response file which DARTS ingest every hour.
If the response files contains end of line characters e.g. \n, ARM is escaping it with a backslash so a '\n' looks like '\\n' in the response file.
In DARTS while parsing the response we have an additional unescaping logic using StringEscapeUtils.unescapeJson which is failing the parsing process as \n gets transformed into a new line.

We donot need the additioanl unescaping logic as Spring handles it for the application.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
