### PR TITLE
DMP-4974: Users endpoints to include system users and "is_system_user" property

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerSearchIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/controller/UserControllerSearchIntTest.java
@@ -227,7 +227,7 @@ class UserControllerSearchIntTest extends IntegrationBase {
         superAdminUserStub.givenUserIsAuthorised(userIdentity);
         UserAccountEntity nonSystemUser1 = createUser("test_search_nonSystemUser1", false);
         UserAccountEntity nonSystemUser2 = createUser("test_search_nonSystemUser2", false);
-        UserAccountEntity systemUser1 = createUser("test_search_systemUser1", true);
+        createUser("test_search_systemUser1", true);
 
         UserSearch userSearch = new UserSearch();
         userSearch.fullName("test_search_");
@@ -251,7 +251,7 @@ class UserControllerSearchIntTest extends IntegrationBase {
         superAdminUserStub.givenUserIsAuthorised(userIdentity);
         UserAccountEntity nonSystemUser1 = createUser("test_search_nonSystemUser1", false);
         UserAccountEntity nonSystemUser2 = createUser("test_search_nonSystemUser2", false);
-        UserAccountEntity systemUser1 = createUser("test_search_systemUser1", true);
+        createUser("test_search_systemUser1", true);
 
         UserSearch userSearch = new UserSearch();
         userSearch.fullName("test_search_");

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserQueryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserQueryTest.java
@@ -29,6 +29,7 @@ class UserQueryTest extends IntegrationBase {
         assertThat(users).extracting("id")
             .isEqualTo(userIdsDesc(user1, user2, user3));
     }
+
     @Test
     void searchWithOnlyEmailSpecified() {
         UserAccountEntity user1 = minimalUserAccount();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserQueryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/usermanagement/service/UserQueryTest.java
@@ -24,12 +24,11 @@ class UserQueryTest extends IntegrationBase {
         UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
-        var users = userManagementQuery.getUsers(null, null);
+        var users = userManagementQuery.getUsers(false, null, null);
 
         assertThat(users).extracting("id")
             .isEqualTo(userIdsDesc(user1, user2, user3));
     }
-
     @Test
     void searchWithOnlyEmailSpecified() {
         UserAccountEntity user1 = minimalUserAccount();
@@ -38,7 +37,7 @@ class UserQueryTest extends IntegrationBase {
         UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
-        var users = userManagementQuery.getUsers(user1.getEmailAddress(), null);
+        var users = userManagementQuery.getUsers(false, user1.getEmailAddress(), null);
 
         assertThat(users).extracting("id").containsExactly(user1.getId());
     }
@@ -50,7 +49,7 @@ class UserQueryTest extends IntegrationBase {
         UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
-        var users = userManagementQuery.getUsers(null, List.of(user1.getId()));
+        var users = userManagementQuery.getUsers(false, null, List.of(user1.getId()));
 
         assertThat(users).extracting("id").containsExactly(user1.getId());
     }
@@ -62,7 +61,7 @@ class UserQueryTest extends IntegrationBase {
         UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
-        var users = userManagementQuery.getUsers(null, List.of(user1.getId(), user3.getId()));
+        var users = userManagementQuery.getUsers(false, null, List.of(user1.getId(), user3.getId()));
 
         assertThat(users).extracting("id")
             .isEqualTo(userIdsDesc(user1, user3));
@@ -76,9 +75,38 @@ class UserQueryTest extends IntegrationBase {
         UserAccountEntity user3 = minimalUserAccount();
         dartsDatabase.saveAll(user1, user2, user3);
 
-        var users = userManagementQuery.getUsers(user1.getEmailAddress(), List.of(user3.getId()));
+        var users = userManagementQuery.getUsers(false, user1.getEmailAddress(), List.of(user3.getId()));
 
         assertThat(users).isEmpty();
+    }
+
+
+    @Test
+    void getUsers_shouldIncludeSystemUsers_whenIncludeSystemUsersIsTrue() {
+        UserAccountEntity user1 = minimalUserAccount();
+        user1.setIsSystemUser(true);
+        UserAccountEntity user2 = minimalUserAccount();
+        UserAccountEntity user3 = minimalUserAccount();
+        dartsDatabase.saveAll(user1, user2, user3);
+
+        var users = userManagementQuery.getUsers(true, null, List.of(user1.getId(), user3.getId()));
+
+        assertThat(users).extracting("id")
+            .isEqualTo(userIdsDesc(user1, user3));
+    }
+
+    @Test
+    void getUsers_shouldIncludeSystemUsers_whenIncludeSystemUsersIsFalse() {
+        UserAccountEntity user1 = minimalUserAccount();
+        user1.setIsSystemUser(true);
+        UserAccountEntity user2 = minimalUserAccount();
+        UserAccountEntity user3 = minimalUserAccount();
+        dartsDatabase.saveAll(user1, user2, user3);
+
+        var users = userManagementQuery.getUsers(false, null, List.of(user1.getId(), user3.getId()));
+
+        assertThat(users).extracting("id")
+            .isEqualTo(userIdsDesc(user3));
     }
 
     private static List<Integer> userIdsDesc(UserAccountEntity... users) {

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/component/UserManagementQuery.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/component/UserManagementQuery.java
@@ -7,6 +7,6 @@ import java.util.List;
 @FunctionalInterface
 public interface UserManagementQuery {
 
-    List<UserAccountEntity> getUsers(String emailAddress, List<Integer> userIds);
+    List<UserAccountEntity> getUsers(boolean includeSystemUSers, String emailAddress, List<Integer> userIds);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/component/UserSearchQuery.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/component/UserSearchQuery.java
@@ -7,6 +7,6 @@ import java.util.List;
 @FunctionalInterface
 public interface UserSearchQuery {
 
-    List<UserAccountEntity> getUsers(String fullName, String emailAddress, Boolean active);
+    List<UserAccountEntity> getUsers(boolean includeSystemUsers, String fullName, String emailAddress, Boolean active);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserManagementQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserManagementQueryImpl.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.darts.usermanagement.component.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
 import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
@@ -22,11 +23,11 @@ public class UserManagementQueryImpl implements UserManagementQuery {
     private final UserAccountRepository userAccountRepository;
 
     @Override
-    public List<UserAccountEntity> getUsers(String emailAddress, List<Integer> userIds) {
-        return userAccountRepository.findAll(
-            where(notSystemUser())
-                .and(hasEmailAddress(emailAddress))
-                .and(isInIds(userIds)),
-            Sort.by(DESC, "id"));
+    public List<UserAccountEntity> getUsers(boolean includeSystemUSers, String emailAddress, List<Integer> userIds) {
+        Specification<UserAccountEntity> spec = where(hasEmailAddress(emailAddress)).and(isInIds(userIds));
+        if (!includeSystemUSers) {
+            spec = spec.and(notSystemUser());
+        }
+        return userAccountRepository.findAll(spec, Sort.by(DESC, "id"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserSearchQueryImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/component/impl/UserSearchQueryImpl.java
@@ -29,7 +29,7 @@ public class UserSearchQueryImpl implements UserSearchQuery {
     private final EntityManager em;
 
     @Override
-    public List<UserAccountEntity> getUsers(String fullName, String emailAddress, Boolean active) {
+    public List<UserAccountEntity> getUsers(boolean includeSystemUsers, String fullName, String emailAddress, Boolean active) {
         CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
         CriteriaQuery<UserAccountEntity> criteriaQuery = criteriaBuilder.createQuery(UserAccountEntity.class);
 
@@ -37,7 +37,9 @@ public class UserSearchQueryImpl implements UserSearchQuery {
         criteriaQuery.select(root);
 
         List<Predicate> wherePredicates = new ArrayList<>();
-        wherePredicates.add(criteriaBuilder.isFalse(root.get(UserAccountEntity_.isSystemUser)));
+        if (!includeSystemUsers) {
+            wherePredicates.add(criteriaBuilder.isFalse(root.get(UserAccountEntity_.isSystemUser)));
+        }
         ParameterExpression<String> paramEmailAddress = criteriaBuilder.parameter(String.class);
         ParameterExpression<String> paramFullName = criteriaBuilder.parameter(String.class);
         ParameterExpression<Boolean> paramActive = criteriaBuilder.parameter(Boolean.class);

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/controller/UserController.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.darts.usermanagement.model.UserSearch;
 import uk.gov.hmcts.darts.usermanagement.model.UserWithId;
 import uk.gov.hmcts.darts.usermanagement.model.UserWithIdAndTimestamps;
 import uk.gov.hmcts.darts.usermanagement.service.UserManagementService;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.util.List;
 
@@ -32,8 +33,8 @@ public class UserController implements UserApi {
     @Override
     @SecurityRequirement(name = SECURITY_SCHEMES_BEARER_AUTH)
     @Authorisation(contextId = ANY_ENTITY_ID, globalAccessSecurityRoles = {SUPER_ADMIN, SUPER_USER})
-    public ResponseEntity<List<UserWithIdAndTimestamps>> getUsers(List<Integer> userIds, String emailAddress) {
-        return ResponseEntity.ok(userManagementService.getUsers(emailAddress, userIds));
+    public ResponseEntity<List<UserWithIdAndTimestamps>> getUsers(Boolean includeSystemUsers, List<Integer> userIds, String emailAddress) {
+        return ResponseEntity.ok(userManagementService.getUsers(DataUtil.toBoolean(includeSystemUsers), emailAddress, userIds));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/mapper/impl/UserAccountMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/mapper/impl/UserAccountMapper.java
@@ -27,6 +27,7 @@ public interface UserAccountMapper {
     String CREATED_AT = "createdAt";
     String CREATED_DATE_TIME = "createdDateTime";
     String ID = "id";
+    String IS_SYSTEM_USER = "isSystemUser";
 
     @Mappings({
         @Mapping(source = FULL_NAME, target = USER_FULL_NAME),
@@ -53,7 +54,8 @@ public interface UserAccountMapper {
         @Mapping(source = ACTIVE, target = ACTIVE),
         @Mapping(source = LAST_LOGIN_TIME, target = LAST_LOGIN_AT),
         @Mapping(source = LAST_MODIFIED_DATE_TIME, target = LAST_MODIFIED_AT),
-        @Mapping(source = CREATED_DATE_TIME, target = CREATED_AT)
+        @Mapping(source = CREATED_DATE_TIME, target = CREATED_AT),
+        @Mapping(source = IS_SYSTEM_USER, target = IS_SYSTEM_USER)
     })
     UserWithIdAndTimestamps mapToUserWithIdAndLastLoginModel(UserAccountEntity userAccountEntity);
 

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementService.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/UserManagementService.java
@@ -16,7 +16,7 @@ public interface UserManagementService {
 
     List<UserWithIdAndTimestamps> search(UserSearch userSearch);
 
-    List<UserWithIdAndTimestamps> getUsers(String emailAddress, List<Integer> userIds);
+    List<UserWithIdAndTimestamps> getUsers(boolean includeSystemUsers, String emailAddress, List<Integer> userIds);
 
     UserWithIdAndTimestamps getUserById(Integer userId);
 

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/UserManagementServiceImpl.java
@@ -31,6 +31,7 @@ import uk.gov.hmcts.darts.usermanagement.service.validation.UserTypeValidator;
 import uk.gov.hmcts.darts.usermanagement.validator.AuthorisedUserPermissionsValidator;
 import uk.gov.hmcts.darts.usermanagement.validator.UserActivateValidator;
 import uk.gov.hmcts.darts.usermanagement.validator.UserDeactivateNotLastInSuperAdminGroupValidator;
+import uk.gov.hmcts.darts.util.DataUtil;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -127,8 +128,10 @@ public class UserManagementServiceImpl implements UserManagementService {
     @Override
     public List<UserWithIdAndTimestamps> search(UserSearch userSearch) {
         List<UserWithIdAndTimestamps> userWithIdAndLastLoginList = new ArrayList<>();
-
-        userSearchQuery.getUsers(userSearch.getFullName(), userSearch.getEmailAddress(), userSearch.getActive())
+        userSearchQuery.getUsers(DataUtil.toBoolean(userSearch.getIncludeSystemUsers()),
+                                 userSearch.getFullName(),
+                                 userSearch.getEmailAddress(),
+                                 userSearch.getActive())
             .forEach(userAccountEntity -> {
                 UserWithIdAndTimestamps userWithIdAndLastLogin = userAccountMapper.mapToUserWithIdAndUserFullName(userAccountEntity);
                 userWithIdAndLastLogin.setSecurityGroupIds(securityGroupIdMapper.mapSecurityGroupEntitiesToIds(userAccountEntity.getSecurityGroupEntities()));
@@ -138,10 +141,9 @@ public class UserManagementServiceImpl implements UserManagementService {
         return userWithIdAndLastLoginList;
     }
 
-    @SuppressWarnings("Convert2MethodRef")
     @Override
-    public List<UserWithIdAndTimestamps> getUsers(String emailAddress, List<Integer> userIds) {
-        return userManagementQuery.getUsers(emailAddress, userIds).stream()
+    public List<UserWithIdAndTimestamps> getUsers(boolean includeSystemUSers, String emailAddress, List<Integer> userIds) {
+        return userManagementQuery.getUsers(includeSystemUSers, emailAddress, userIds).stream()
             .map(this::toUserWithIdAndTimestamps)
             .toList();
     }

--- a/src/main/java/uk/gov/hmcts/darts/util/DataUtil.java
+++ b/src/main/java/uk/gov/hmcts/darts/util/DataUtil.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import static java.util.Objects.isNull;
 
 
+@SuppressWarnings("PMD.TooManyMethods")//Utility class with many small methods
 public final class DataUtil {
     private DataUtil() {
 
@@ -115,5 +116,13 @@ public final class DataUtil {
         }
         throw new DartsApiException(CommonApiError.INTERNAL_SERVER_ERROR,
                                     "Cannot compare ids of type " + id.getClass().getName() + " and " + id1.getClass().getName());
+    }
+
+    public static boolean toBoolean(Boolean value) {
+        return toBoolean(value, false);
+    }
+
+    public static boolean toBoolean(Boolean value, boolean defaultValue) {
+        return Optional.ofNullable(value).orElse(defaultValue);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,7 +82,7 @@ spring:
       maximum-pool-size: ${DARTS_API_DB_POOL_SIZE:50}
   jpa:
     database: postgresql
-    show-sql: false
+    show-sql: true
     hibernate:
       ddl-auto: none
     properties:

--- a/src/main/resources/openapi/usermanagement.yaml
+++ b/src/main/resources/openapi/usermanagement.yaml
@@ -18,6 +18,12 @@ paths:
       operationId: getUsers
       parameters:
         - in: query
+          name: include_system_users
+          description: Optional - If set to true, will return system users. If set to false or not set will exclude system users
+          schema:
+            type: boolean
+            default: false
+        - in: query
           name: user_ids
           required: false
           style: form
@@ -50,7 +56,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           $ref: '#/components/responses/BadUserRequest'
   /admin/users/{user_id}:
@@ -83,7 +89,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           $ref: '#/components/responses/BadUserPatchRequest'
         '404':
@@ -105,7 +111,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request Error
           content:
@@ -155,7 +161,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           description: Bad Request Error
           content:
@@ -213,7 +219,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           $ref: '#/components/responses/SecurityGroupBadRequest'
         '401':
@@ -303,7 +309,7 @@ paths:
           content:
             application/json+problem:
               schema:
-                $ref: './problem.yaml' 
+                $ref: './problem.yaml'
         '400':
           $ref: '#/components/responses/SecurityGroupBadRequest'
 
@@ -592,6 +598,9 @@ components:
           $ref: '#/components/schemas/UserEmailAddress'
         active:
           $ref: '#/components/schemas/UserActive'
+        include_system_users:
+          type: boolean
+          default: false
     UserWithId:
       type: object
       properties:
@@ -610,6 +619,8 @@ components:
         last_modified_at:
           type: string
           format: date-time
+        is_system_user:
+          type: boolean
         created_at:
           type: string
           format: date-time

--- a/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/usermanagement/service/UserManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/usermanagement/service/UserManagementServiceImplTest.java
@@ -119,9 +119,24 @@ class UserManagementServiceImplTest {
     void testGetUser() throws IOException {
         List<UserAccountEntity> userAccountEntities = Collections.singletonList(createUserAccount(1, EXISTING_EMAIL_ADDRESS));
 
-        when(userManagementQuery.getUsers(EXISTING_EMAIL_ADDRESS, null)).thenReturn(userAccountEntities);
+        when(userManagementQuery.getUsers(false, EXISTING_EMAIL_ADDRESS, null)).thenReturn(userAccountEntities);
 
-        List<UserWithIdAndTimestamps> resultList = service.getUsers(EXISTING_EMAIL_ADDRESS, null);
+        List<UserWithIdAndTimestamps> resultList = service.getUsers(false, EXISTING_EMAIL_ADDRESS, null);
+
+        assertEquals(userAccountEntities.getFirst().getUserFullName(), resultList.getFirst().getFullName());
+        assertEquals(userAccountEntities.getFirst().getEmailAddress(), resultList.getFirst().getEmailAddress());
+        assertEquals(userAccountEntities.getFirst().getLastLoginTime(), resultList.getFirst().getLastLoginAt());
+        assertEquals(userAccountEntities.getFirst().getLastModifiedDateTime(), resultList.getFirst().getLastModifiedAt());
+        assertEquals(userAccountEntities.getFirst().getCreatedDateTime(), resultList.getFirst().getCreatedAt());
+    }
+
+    @Test
+    void testGetUserWithIncludeSystemUser() throws IOException {
+        List<UserAccountEntity> userAccountEntities = Collections.singletonList(createUserAccount(1, EXISTING_EMAIL_ADDRESS));
+
+        when(userManagementQuery.getUsers(true, EXISTING_EMAIL_ADDRESS, null)).thenReturn(userAccountEntities);
+
+        List<UserWithIdAndTimestamps> resultList = service.getUsers(true, EXISTING_EMAIL_ADDRESS, null);
 
         assertEquals(userAccountEntities.getFirst().getUserFullName(), resultList.getFirst().getFullName());
         assertEquals(userAccountEntities.getFirst().getEmailAddress(), resultList.getFirst().getEmailAddress());

--- a/src/test/java/uk/gov/hmcts/darts/util/DataUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/DataUtilTest.java
@@ -280,4 +280,19 @@ class DataUtilTest {
             return hearingEntity;
         }
     }
+
+    @Test
+    void toBooleanNoDefaultValue_shouldDefaultToFalse(){
+        assertThat(DataUtil.toBoolean(null)).isFalse();
+        assertThat(DataUtil.toBoolean(true)).isTrue();
+        assertThat(DataUtil.toBoolean(false)).isFalse();
+    }
+
+    @Test
+    void toBooleanWithDefaultValue_shouldDefaultToValueSpecified(){
+        assertThat(DataUtil.toBoolean(null, false)).isFalse();
+        assertThat(DataUtil.toBoolean(null, true)).isTrue();
+        assertThat(DataUtil.toBoolean(true)).isTrue();
+        assertThat(DataUtil.toBoolean(false)).isFalse();
+    }
 }

--- a/src/test/java/uk/gov/hmcts/darts/util/DataUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/util/DataUtilTest.java
@@ -282,14 +282,14 @@ class DataUtilTest {
     }
 
     @Test
-    void toBooleanNoDefaultValue_shouldDefaultToFalse(){
+    void toBooleanNoDefaultValue_shouldDefaultToFalse() {
         assertThat(DataUtil.toBoolean(null)).isFalse();
         assertThat(DataUtil.toBoolean(true)).isTrue();
         assertThat(DataUtil.toBoolean(false)).isFalse();
     }
 
     @Test
-    void toBooleanWithDefaultValue_shouldDefaultToValueSpecified(){
+    void toBooleanWithDefaultValue_shouldDefaultToValueSpecified() {
         assertThat(DataUtil.toBoolean(null, false)).isFalse();
         assertThat(DataUtil.toBoolean(null, true)).isTrue();
         assertThat(DataUtil.toBoolean(true)).isTrue();


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4974)


### Change description ###
# Summary of Git Diff

This diff introduces enhancements to the user management functionality within the application by adding support for including system users in user queries and search operations. It modifies several test classes, service implementations, and the API contract to accommodate this new functionality.

## Highlights

### Changes in UserControllerGetUsersIntTest
- **New Test Cases**:
  - Added tests to handle scenarios for fetching users based on the `include_system_users` query parameter.
    - **When `include_system_users` is true**: Both system and non-system users are returned.
    - **When `include_system_users` is false**: Only non-system users are returned.
    - **When `include_system_users` is not provided**: Defaults to excluding system users.

### Changes in UserControllerSearchIntTest
- **New Test Cases**:
  - Added tests similar to the ones in `UserControllerGetUsersIntTest` to validate the behavior of user search based on the `include_system_users` parameter.

### Changes in UserManagementQuery
- **Method Signature Update**:
  - Updated the `getUsers` method to take a boolean parameter `includeSystemUsers` to control the inclusion of system users in the query.

### Changes in UserSearchQuery
- **Method Signature Update**:
  - Similar to `UserManagementQuery`, updated the method to include `includeSystemUsers`.

### Changes in UserManagementService
- **Method Signature Update**:
  - Modified the `getUsers` method to accept the new `includeSystemUsers` parameter, propagating this through the service layer.

### Changes in UserManagementQueryImpl
- **Query Logic Update**:
  - The query now selectively includes or excludes system users based on the `includeSystemUsers` parameter.

### Changes in UserSearchQueryImpl
- **Predicate Logic Update**:
  - The query logic now respects the `includeSystemUsers` flag when constructing the criteria for fetching users.

### OpenAPI Specification Update
- Added a new query parameter `include_system_users` to the OpenAPI specification to document the new functionality.

### DataUtil Class Update
- Introduced utility methods to convert Boolean values, providing default values as needed.

### Tests Update
- **UserManagementService Tests**: Updated to validate the new functionality, ensuring that the service correctly includes/excludes system users based on the flag passed.

This diff enhances the user management capabilities, making it more flexible and robust in terms of user querying.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
