### PR TITLE
DMP-5140: When running the OutboundAudioDeleterProcessorImpl the Job fails due to LazyLoad errors

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/service/OutboundAudioDeleterProcessorSingleElement.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/OutboundAudioDeleterProcessorSingleElement.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.darts.audio.service;
 
-import uk.gov.hmcts.darts.audio.entity.MediaRequestEntity;
 import uk.gov.hmcts.darts.common.entity.TransformedMediaEntity;
 import uk.gov.hmcts.darts.common.entity.TransientObjectDirectoryEntity;
 
@@ -10,5 +9,5 @@ public interface OutboundAudioDeleterProcessorSingleElement {
 
     List<TransientObjectDirectoryEntity> markForDeletion(TransformedMediaEntity transformedMedia);
 
-    void markMediaRequestAsExpired(MediaRequestEntity mediaRequest);
+    void markMediaRequestAsExpired(int mediaRequestId);
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5140)

NOTE: No new tests have been added apart of this ticket as Lazy loading errors in this instance can not be detected apart of the integration tests. I have tried a few things but I can not seem to replicate the issue (but I am open to ideas :))

I have however, manually replicated the issue with darts-portal -> darts-api, in which the old code throw a lazy load error and following this fix it did not.


### Change description ###
# Summary of Git Diff

This Git diff outlines several modifications made to the `OutboundAudioDeleterProcessorSingleElement` interface and its implementation classes. The primary change involves updating the `markMediaRequestAsExpired` method to accept a media request ID instead of a `MediaRequestEntity` object, streamlining the deletion process for transformed media.

## Highlights

- **Method Signature Change**: 
  - The `markMediaRequestAsExpired` method in the `OutboundAudioDeleterProcessorSingleElement` interface has been updated to take an `int mediaRequestId` instead of `MediaRequestEntity mediaRequest`.

- **Implementation Updates**:
  - In the implementation class `OutboundAudioDeleterProcessorImpl`, the method signature for the `process` function was updated to return an `Integer` (the media request ID) rather than a `MediaRequestEntity`.
  - The use of `Set<Integer>` instead of `Set<MediaRequestEntity>` in the deletion logic, promoting better performance and reducing unnecessary object creation.
  - Debug logs were added to improve traceability during the deletion process.

- **Documentation and Testing Note**:
  - Comments were added to emphasize the importance of manual testing when editing the class due to potential lazy loading errors not being caught in integration tests.

These changes are aimed at improving the efficiency of the audio deletion process while ensuring that the code remains clean and maintainable.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
