### PR TITLE
DMP-5112: New Index to resolve ProcessDETSToArmResponse automated task performance issues

### DIFF
--- a/src/main/resources/db/migration/common/V1_477__new_index.sql
+++ b/src/main/resources/db/migration/common/V1_477__new_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS osr_arm_eod_id_idx ON darts.object_state_record (arm_eod_id);
+
+

--- a/src/main/resources/db/migration/common/V1_477__new_index.sql
+++ b/src/main/resources/db/migration/common/V1_477__new_index.sql
@@ -1,3 +1,1 @@
 CREATE INDEX IF NOT EXISTS osr_arm_eod_id_idx ON darts.object_state_record (arm_eod_id);
-
-


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5112)


NOTE: it is recommended to manually run this index in production with the concurrently flag. To avoid locking the table

'CREATE INDEX CONCURRENTLY IF NOT EXISTS osr_arm_eod_id_idx ON darts.object_state_record (arm_eod_id);'
### Change description ###
# Summary of Git Diff

A new SQL migration file, `V1_477__new_index.sql`, has been added to the project. This file creates an index on the `object_state_record` table.

## Highlights
- **File Added**: `src/main/resources/db/migration/common/V1_477__new_index.sql`
- **Index Created**: `osr_arm_eod_id_idx`
- **Table**: `darts.object_state_record`
- **Column Indexed**: `arm_eod_id`
- **Condition**: The index will only be created if it does not already exist (`IF NOT EXISTS`).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
