### PR TITLE
DMP-5076 Use retention date from latest retention record if multiple exist

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CaseRepository.java
@@ -109,11 +109,18 @@ public interface CaseRepository
     @Query("""
         select cc.id from CourtCaseEntity cc
         join CaseRetentionEntity cr
-        on cr.courtCase.id = cc.id and cr.currentState = 'COMPLETE'
-        where cc.isDataAnonymised = false
+        on cr.courtCase.id = cc.id
+        where cr.currentState = 'COMPLETE'
+        and cr.createdDateTime = (
+            select MAX(sub_cr.createdDateTime) from CaseRetentionEntity sub_cr
+            where sub_cr.courtCase.id = cc.id
+            and sub_cr.currentState = 'COMPLETE'
+        )
+        and cc.isDataAnonymised = false
         and cr.retainUntil < :maxRetentionDate
         """)
     List<Integer> findCaseIdsToBeAnonymised(OffsetDateTime maxRetentionDate, Limit limit);
+
 
     @Query("""
         SELECT cc


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-5076


### Change description ###
When anonymising case data, a query is run to find all 'Complete' retention records where the retention date exceeds the current date/time. This PR ensures only the latest 'Complete' record is chosen, preventing a case from being anonymised prematurely.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
