### PR TITLE
DMP-5116: ApplyRetentionCaseAssociatedObjects do not stop running after the max lock time

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsProcessorImpl.java
@@ -23,6 +23,9 @@ public class ApplyRetentionCaseAssociatedObjectsProcessorImpl implements ApplyRe
     private final CaseRepository caseRepository;
     private final ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl singleCaseProcessor;
 
+
+    //Required to prevent duplicate logic with generic exception handling
+    @SuppressWarnings("PMD.AvoidInstanceofChecksInCatchClause")
     @Override
     public void processApplyRetentionToCaseAssociatedObjects(Integer batchSize) {
 
@@ -44,6 +47,9 @@ public class ApplyRetentionCaseAssociatedObjectsProcessorImpl implements ApplyRe
                 courtCase.setRetentionRetries(courtCase.getRetentionRetries() + 1);
                 courtCase.setRetentionUpdated(true);
                 caseRepository.saveAndFlush(courtCase);
+                if (exc instanceof InterruptedException) {
+                    return;
+                }
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/AbstractLockableAutomatedTask.java
@@ -289,7 +289,9 @@ public abstract class AbstractLockableAutomatedTask<T extends AbstractAutomatedT
                 } catch (TimeoutException e) {
                     setAutomatedTaskStatus(FAILED);
                     log.error("Task: {} timed out after {}ms", getTaskName(), getLockAtMostFor().toMillis());
-                    future.cancel(true);
+                    if (!future.cancel(true)) {
+                        log.error("Failed to cancel task: {}.", getTaskName());
+                    }
                 } catch (ExecutionException e) {
                     setAutomatedTaskStatus(FAILED);
                     log.error("Task: {} execution exception", getTaskName(), e);

--- a/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsProcessorImplTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.darts.retention.service.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.common.repository.CaseRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class ApplyRetentionCaseAssociatedObjectsProcessorImplTest {
+
+    @Mock
+    private CaseRepository caseRepository;
+    @Mock
+    private ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl singleCaseProcessor;
+    @InjectMocks
+    private ApplyRetentionCaseAssociatedObjectsProcessorImpl applyRetentionCaseAssociatedObjectsProcessor;
+
+    @Test
+    void processApplyRetentionToCaseAssociatedObjects_onInterruptedException_shouldStopProcessingAndReturn() {
+        doReturn(List.of(1, 2, 3, 4)).when(caseRepository).findIdsByIsRetentionUpdatedTrueAndRetentionRetriesLessThan(anyInt(), any());
+        CourtCaseEntity caseEntity1 = mock(CourtCaseEntity.class);
+        CourtCaseEntity caseEntity2 = mock(CourtCaseEntity.class);
+
+        doReturn(Optional.ofNullable(caseEntity1)).when(caseRepository).findById(1);
+        doReturn(1).when(caseEntity1).getId();
+        doReturn(Optional.ofNullable(caseEntity2)).when(caseRepository).findById(2);
+        doReturn(2).when(caseEntity2).getId();
+        doReturn(1).when(caseEntity2).getRetentionRetries();
+
+        doAnswer(invocation -> {
+            throw new InterruptedException("Simulated interruption");
+        }).when(singleCaseProcessor).processApplyRetentionToCaseAssociatedObjects(2);
+
+        applyRetentionCaseAssociatedObjectsProcessor.processApplyRetentionToCaseAssociatedObjects(10);
+
+        verify(singleCaseProcessor).processApplyRetentionToCaseAssociatedObjects(1);
+        verify(singleCaseProcessor).processApplyRetentionToCaseAssociatedObjects(2);
+        //Check to ensure that the processor stops processing after the InterruptedException
+        verifyNoMoreInteractions(singleCaseProcessor);
+
+        verify(caseEntity2).setRetentionRetries(2);
+        verify(caseEntity2).setRetentionUpdated(true);
+    }
+}


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5116)


### Change description ###
# Summary of Git Diff

This diff introduces modifications to the `ApplyRetentionCaseAssociatedObjectsProcessorImpl` class and the `AbstractLockableAutomatedTask` class, along with the addition of a new test class for the processor implementation. Key changes include improved exception handling and the addition of a unit test to verify the behavior when an `InterruptedException` occurs.

## Highlights

### Changes in `ApplyRetentionCaseAssociatedObjectsProcessorImpl.java`
- Added a suppression warning for duplicate logic in exception handling.
- Included a check for `InterruptedException` to stop processing if such an exception is thrown.

### Changes in `AbstractLockableAutomatedTask.java`
- Enhanced error logging when failing to cancel a future task, providing clearer insights into task failures.

### New Test Class `ApplyRetentionCaseAssociatedObjectsProcessorImplTest.java`
- Introduced unit tests using JUnit and Mockito.
- Added a test case to validate that processing stops upon encountering an `InterruptedException`, ensuring that no further processing occurs after the exception.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
