### PR TITLE
DMP-5154 : reset failed ARM objects

### DIFF
--- a/src/main/resources/db/reference/manual-data-fixes/003_reset_failed_arm_objects/reset_failed_arm_objects.sql
+++ b/src/main/resources/db/reference/manual-data-fixes/003_reset_failed_arm_objects/reset_failed_arm_objects.sql
@@ -1,0 +1,21 @@
+begin;
+savepoint dmp5154;
+
+--
+-- pre-check list of EOD records to be updated to set status to 14 (ARM_RAW_DATA_FAILED) and transfer_attempts to 1 (expect 1414)
+--
+SELECT count(*) FROM darts.external_object_directory
+WHERE ors_id = 17;
+
+--
+--
+--
+UPDATE darts.external_object_directory
+SET ors_id = 14,
+last_modified_ts = now(),
+transfer_attempts=1
+WHERE ors_id = 17;
+
+-- script is currently configured to rollback, if run end-to-end
+rollback to dmp5154;
+--commit;

--- a/src/main/resources/db/reference/manual-data-fixes/README.md
+++ b/src/main/resources/db/reference/manual-data-fixes/README.md
@@ -29,6 +29,14 @@ This manual data fix applies to failed ARM objects so that they can be pushed ag
 
 Scripts available under following location [reset_status_for_failed_arm_objects.sql](../manual-data-fixes/002_failed_arm_jobs_reset_status/reset_status_for_failed_arm_objects.sql)
 
+## 003 - Reset failed ARM objects status
+This manual data fix applies to failed ARM objects so that they can be pushed again in next execution. This is done by updating the status to 14(ARM_RAW_DATA_FAILED_ and transfer_attempts to 1.
+During the CI/CD deployment to PROD, which restarted the pods, few of the ARM objects were moved to stale status as the execution stopped abruptly.
+
+**Fix applied date:**
+
+Scripts available under following location [reset_failed_arm_objects.sql](../manual-data-fixes/003_reset_failed_arm_objects/reset_failed_arm_objects.sql)
+
 
 
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DMP-5154


### Change description ###
Due to the last CI/CD release, which restarted the pods, few of the ARM objects were moved to stale status which will require resetting those status back so that it can replayed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
