### PR TITLE
DMP-4998: Deviation between legacy and modernised when only channel 4 audio is available

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetMetadataIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioControllerGetMetadataIntTest.java
@@ -144,11 +144,11 @@ class AudioControllerGetMetadataIntTest extends IntegrationBase {
                 }
               ]
             """.formatted(
-                mediaChannel4.getId(),
-                mediaChannel5.getId(),
-                mediaChannel2.getId(),
-                mediaChannel3.getId(),
-                mediaChannel1.getId()
+            mediaChannel4.getId(),
+            mediaChannel5.getId(),
+            mediaChannel2.getId(),
+            mediaChannel3.getId(),
+            mediaChannel1.getId()
         );
         JSONAssert.assertEquals(expectedJson, actualJson, JSONCompareMode.STRICT);
     }
@@ -184,7 +184,7 @@ class AudioControllerGetMetadataIntTest extends IntegrationBase {
     }
 
     @Test
-    void getAudioMetadataGetShouldNotReturnHiddenMediaChannel1() throws Exception {
+    void getAudioMetadata_shouldReturnChannel2IfHiddenMediaChannel1() throws Exception {
         var courtroomEntity = someMinimalCourtRoom();
         var mediaChannel1 = getMediaTestData().createMediaWith(courtroomEntity, MEDIA_START_TIME, MEDIA_END_TIME, 1);
         mediaChannel1.setIsCurrent(false);
@@ -207,7 +207,18 @@ class AudioControllerGetMetadataIntTest extends IntegrationBase {
             .andReturn();
 
         String actualJson = mvcResult.getResponse().getContentAsString();
-        JSONAssert.assertEquals("[]", actualJson, JSONCompareMode.NON_EXTENSIBLE);
+        JSONAssert.assertEquals(
+            """
+                [
+                  {
+                    "id": %s,
+                    "media_start_timestamp": "2023-01-01T12:00:00Z",
+                    "media_end_timestamp": "2023-01-01T13:00:00Z",
+                    "is_archived": false,
+                    "is_available": false
+                  }
+                ]
+                """.formatted(mediaChannel2.getId()), actualJson, JSONCompareMode.NON_EXTENSIBLE);
     }
 
     private HearingEntity hearingWithMedias(MediaEntity... mediaEntities) {

--- a/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/controller/AudioController.java
@@ -87,7 +87,7 @@ public class AudioController implements AudioApi {
         securityRoles = {JUDICIARY, REQUESTER, APPROVER, TRANSCRIBER, TRANSLATION_QA},
         globalAccessSecurityRoles = {JUDICIARY, SUPER_ADMIN, SUPER_USER, RCJ_APPEALS, TRANSLATION_QA, DARTS})
     public ResponseEntity<List<AudioMetadata>> getAudioMetadata(Integer hearingId) {
-        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndChannel(hearingId, 1);
+        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(hearingId);
         List<AudioMetadata> audioMetadata = audioResponseMapper.mapToAudioMetadata(mediaEntities);
         audioService.setIsArchived(audioMetadata, hearingId);
         audioService.setIsAvailable(audioMetadata);

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/AudioService.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/AudioService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface AudioService {
 
-    List<MediaEntity> getMediaEntitiesByHearingAndChannel(Integer hearingId, Integer channel);
+    List<MediaEntity> getMediaEntitiesByHearingAndLowestChannel(Integer hearingId);
 
     BinaryData encode(Long mediaId);
 

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
@@ -55,7 +55,7 @@ public class AudioServiceImpl implements AudioService {
 
     @Override
     public List<MediaEntity> getMediaEntitiesByHearingAndLowestChannel(Integer hearingId) {
-        return mediaRepository.findAllByHearingIdAndIsCurrentTrue(hearingId);
+        return mediaRepository.findAllByHearingIdAndMinimumChannelAndIsCurrentTrue(hearingId);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
@@ -23,13 +23,9 @@ import uk.gov.hmcts.darts.common.util.EodHelper;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 
@@ -59,35 +55,7 @@ public class AudioServiceImpl implements AudioService {
 
     @Override
     public List<MediaEntity> getMediaEntitiesByHearingAndLowestChannel(Integer hearingId) {
-        List<MediaEntity> mediaEntities = mediaRepository.findAllByHearingIdAndIsCurrentTrue(hearingId);
-
-
-        //Create a function to group MediaEntity by courtroom, start time, end time, and total channels
-        Function<MediaEntity, String> getGroupByKey = mediaEntity ->
-            mediaEntity.getCourtroom().getId()
-                + "-" + mediaEntity.getStart().toEpochSecond()
-                + "-" + mediaEntity.getEnd().toEpochSecond()
-                + "-" + mediaEntity.getTotalChannels();
-
-        //Map all MediaEntity to there retrospective channel group
-        Map<String, List<MediaEntity>> mediaChannelGroups = mediaEntities.stream()
-            .collect(Collectors.groupingBy(getGroupByKey::apply, Collectors.toList()));
-
-        //Iterate through the mediaChannelGroups to get the MediaEntity with the lowest channel in each group
-        return mediaChannelGroups.values().stream()
-            // Filter out any empty lists
-            .filter(mediaEntities1 -> !mediaEntities1.isEmpty())
-            //Get the MediaEntity with the lowest channel in each group
-            .map(mediaEntitiesChannelGroup ->
-                     //Sort the group by channel number and return the first one
-                     mediaEntitiesChannelGroup.stream()
-                         .sorted((media1, media2) -> Integer.compare(media1.getChannel(), media2.getChannel()))
-                         .findFirst()
-                         .get()
-            )
-            .sorted(Comparator.comparing(MediaEntity::getStart)
-                        .thenComparing(MediaEntity::getEnd).reversed())
-            .toList();
+        return mediaRepository.findAllByHearingIdAndIsCurrentTrue(hearingId);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
@@ -70,7 +70,7 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Long>,
            ))  
            ORDER BY me.start DESC, me.end DESC
         """)
-    List<MediaEntity> findAllByHearingIdAndIsCurrentTrue(Integer hearingId);
+    List<MediaEntity> findAllByHearingIdAndMinimumChannelAndIsCurrentTrue(Integer hearingId);
 
 
     @Query("""

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
@@ -56,12 +56,11 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Long>,
            FROM HearingEntity he
            JOIN he.medias me
            WHERE he.id = :hearingId
-           AND me.channel = :channel
            AND me.isHidden = false
            AND me.isCurrent = true
            ORDER BY me.start DESC, me.end DESC
         """)
-    List<MediaEntity> findAllByHearingIdAndChannelAndIsCurrentTrue(Integer hearingId, Integer channel);
+    List<MediaEntity> findAllByHearingIdAndIsCurrentTrue(Integer hearingId);
 
 
     @Query("""

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/MediaRepository.java
@@ -58,6 +58,16 @@ public interface MediaRepository extends JpaRepository<MediaEntity, Long>,
            WHERE he.id = :hearingId
            AND me.isHidden = false
            AND me.isCurrent = true
+           and (me.channel = (
+               SELECT MIN(med2.channel)
+               FROM MediaEntity med2
+               WHERE med2.courtroom.id = me.courtroom.id
+               AND med2.start = me.start
+               AND med2.end = me.end
+               AND med2.totalChannels = me.totalChannels
+               AND med2.isHidden = false
+               AND med2.isCurrent = true
+           ))  
            ORDER BY me.start DESC, me.end DESC
         """)
     List<MediaEntity> findAllByHearingIdAndIsCurrentTrue(Integer hearingId);

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
@@ -198,7 +198,7 @@ class AudioServiceImplTest {
 
     @Test
     void getMediaEntitiesByHearingAndLowestChannel_shouldReturnEmptyListWhenNoMediaFound() {
-        doReturn(List.of()).when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+        doReturn(List.of()).when(mediaRepository).findAllByHearingIdAndMinimumChannelAndIsCurrentTrue(HEARING_ID);
         List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
         assertThat(mediaEntities).isEmpty();
     }
@@ -209,12 +209,12 @@ class AudioServiceImplTest {
         MediaEntity media2 = mock(MediaEntity.class);
 
         doReturn(List.of(media1, media2))
-            .when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+            .when(mediaRepository).findAllByHearingIdAndMinimumChannelAndIsCurrentTrue(HEARING_ID);
 
         List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
         assertThat(mediaEntities)
             .hasSize(2)
             .containsExactlyInAnyOrder(media1, media2);
-        verify(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+        verify(mediaRepository).findAllByHearingIdAndMinimumChannelAndIsCurrentTrue(HEARING_ID);
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImplTest.java
@@ -14,6 +14,8 @@ import uk.gov.hmcts.darts.audio.service.AudioOperationService;
 import uk.gov.hmcts.darts.audio.service.AudioService;
 import uk.gov.hmcts.darts.audio.service.AudioTransformationService;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
+import uk.gov.hmcts.darts.common.entity.CourtroomEntity;
+import uk.gov.hmcts.darts.common.entity.MediaEntity;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.HearingRepository;
@@ -26,12 +28,15 @@ import uk.gov.hmcts.darts.common.service.impl.EodHelperMocks;
 import uk.gov.hmcts.darts.datamanagement.api.DataManagementApi;
 import uk.gov.hmcts.darts.log.api.LogApi;
 
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -75,6 +80,8 @@ class AudioServiceImplTest {
 
     private EodHelperMocks eodHelperMocks;
 
+    private OffsetDateTime baseTime;
+
     @BeforeEach
     void setUp() {
         audioService = new AudioServiceImpl(
@@ -87,6 +94,7 @@ class AudioServiceImplTest {
             fileOperationService,
             audioBeingProcessedFromArchiveQuery
         );
+        baseTime = OffsetDateTime.now();
     }
 
     @AfterEach
@@ -190,5 +198,130 @@ class AudioServiceImplTest {
         audioService.setIsArchived(null, HEARING_ID);
 
         verifyNoInteractions(jdbcTemplate);
+    }
+
+
+    private MediaEntity createMediaEntity(int channel, int startTimeOffset, int endTimeOffset, int totalChannels, int courtRoomId) {
+        MediaEntity mediaEntity = new MediaEntity();
+        mediaEntity.setId(1L);
+        mediaEntity.setChannel(channel);
+        mediaEntity.setStart(baseTime.plusMinutes(startTimeOffset));
+        mediaEntity.setEnd(baseTime.plusMinutes(endTimeOffset));
+        mediaEntity.setTotalChannels(totalChannels);
+
+        CourtroomEntity courtroomEntity = new CourtroomEntity();
+        courtroomEntity.setId(courtRoomId);
+
+        mediaEntity.setCourtroom(courtroomEntity);
+        return mediaEntity;
+    }
+
+    @Test
+    void getMediaEntitiesByHearingAndLowestChannel_shouldReturnEmptyListWhenNoMediaFound() {
+        doReturn(List.of()).when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
+        assertThat(mediaEntities).isEmpty();
+    }
+
+    @Test
+    void getMediaEntitiesByHearingAndLowestChannel_singleChannelGroupReturn_shouldReturnLowest() {
+        MediaEntity media1 = createMediaEntity(1, 0, 0, 4, 0);
+        MediaEntity media2 = createMediaEntity(2, 0, 0, 4, 0);
+        MediaEntity media3 = createMediaEntity(3, 0, 0, 4, 0);
+        MediaEntity media4 = createMediaEntity(4, 0, 0, 4, 0);
+
+        doReturn(List.of(media1, media2, media3, media4))
+            .when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+
+        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
+        assertThat(mediaEntities)
+            .hasSize(1)
+            .containsExactlyInAnyOrder(media1);
+    }
+
+    @Test
+    void getMediaEntitiesByHearingAndLowestChannel_shouldClassifyDifferentStartTimeAsNewGroup() {
+        MediaEntity group1Media1 = createMediaEntity(1, 0, 0, 4, 0);
+        MediaEntity group1Media2 = createMediaEntity(2, 0, 0, 4, 0);
+        MediaEntity group2Media1 = createMediaEntity(3, 1, 0, 4, 0);
+        MediaEntity group2Media2 = createMediaEntity(4, 1, 0, 4, 0);
+
+        doReturn(List.of(group1Media1, group1Media2, group2Media1, group2Media2))
+            .when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+
+        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
+        assertThat(mediaEntities)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(group1Media1, group2Media1);
+    }
+
+    @Test
+    void getMediaEntitiesByHearingAndLowestChannel_shouldClassifyDifferentEndTimeAsNewGroup() {
+        MediaEntity group1Media1 = createMediaEntity(1, 0, 0, 4, 0);
+        MediaEntity group1Media2 = createMediaEntity(2, 0, 0, 4, 0);
+        MediaEntity group2Media1 = createMediaEntity(3, 0, 1, 4, 0);
+        MediaEntity group2Media2 = createMediaEntity(4, 0, 1, 4, 0);
+
+        doReturn(List.of(group1Media1, group1Media2, group2Media1, group2Media2))
+            .when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+
+        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
+        assertThat(mediaEntities)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(group1Media1, group2Media1);
+    }
+
+    @Test
+    void getMediaEntitiesByHearingAndLowestChannel_shouldClassifyDifferentTotalChannelsAsNewGroup() {
+        MediaEntity group1Media1 = createMediaEntity(1, 0, 0, 4, 0);
+        MediaEntity group1Media2 = createMediaEntity(2, 0, 0, 4, 0);
+        MediaEntity group2Media1 = createMediaEntity(3, 0, 0, 2, 0);
+        MediaEntity group2Media2 = createMediaEntity(4, 0, 0, 2, 0);
+
+        doReturn(List.of(group1Media1, group1Media2, group2Media1, group2Media2))
+            .when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+
+        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
+        assertThat(mediaEntities)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(group1Media1, group2Media1);
+    }
+
+    @Test
+    void getMediaEntitiesByHearingAndLowestChannel_shouldClassifyDifferentCourtRoomAsNewGroup() {
+        MediaEntity group1Media1 = createMediaEntity(1, 0, 0, 4, 0);
+        MediaEntity group1Media2 = createMediaEntity(2, 0, 0, 4, 0);
+        MediaEntity group2Media1 = createMediaEntity(3, 0, 0, 4, 1);
+        MediaEntity group2Media2 = createMediaEntity(4, 0, 0, 4, 1);
+
+        doReturn(List.of(group1Media1, group1Media2, group2Media1, group2Media2))
+            .when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+
+        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
+        assertThat(mediaEntities)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(group1Media1, group2Media1);
+    }
+
+    @Test
+    void getMediaEntitiesByHearingAndLowestChannel_multipleChannelGroups_shouldReturnLowestInEachGroup() {
+        MediaEntity groupOneMedia1 = createMediaEntity(1, 0, 0, 4, 0);
+        MediaEntity groupOneMedia2 = createMediaEntity(2, 0, 0, 4, 0);
+        MediaEntity groupOneMedia3 = createMediaEntity(3, 0, 0, 4, 0);
+        MediaEntity groupOneMedia4 = createMediaEntity(4, 0, 0, 4, 0);
+
+        MediaEntity groupTwoMedia1 = createMediaEntity(1, 2, 4, 4, 0);
+        MediaEntity groupTwoMedia2 = createMediaEntity(2, 2, 4, 4, 0);
+        MediaEntity groupTwoMedia3 = createMediaEntity(3, 2, 4, 4, 0);
+        MediaEntity groupTwoMedia4 = createMediaEntity(4, 2, 4, 4, 0);
+
+        doReturn(List.of(groupOneMedia1, groupOneMedia2, groupOneMedia3, groupOneMedia4,
+                         groupTwoMedia1, groupTwoMedia2, groupTwoMedia3, groupTwoMedia4))
+            .when(mediaRepository).findAllByHearingIdAndIsCurrentTrue(HEARING_ID);
+
+        List<MediaEntity> mediaEntities = audioService.getMediaEntitiesByHearingAndLowestChannel(HEARING_ID);
+        assertThat(mediaEntities)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(groupOneMedia1, groupTwoMedia1);
     }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-4998)


### Change description ###
# Summary of Git Diff

This Git diff introduces significant changes primarily in the `AudioController`, `AudioService`, and their respective tests. The main focus is on modifying how audio metadata is retrieved by changing the method of fetching media entities, leading to the selection of the lowest channel for each media group. Additionally, updates were made to the integration tests to reflect the revised logic.

## Highlights

- **Refactoring Method Signatures:**
  - Changed `getMediaEntitiesByHearingAndChannel` to `getMediaEntitiesByHearingAndLowestChannel` in `AudioService` and `MediaRepository`.
  
- **Logic Update in AudioService Implementation:**
  - The new implementation of `getMediaEntitiesByHearingAndLowestChannel` groups media entities by courtroom, start time, end time, and total channels, returning the media entity with the lowest channel for each group.

- **Integration Test Modifications:**
  - Updated test method names for clarity (e.g., from `getAudioMetadataGetShouldNotReturnHiddenMediaChannel1` to `getAudioMetadata_shouldReturnChannel2IfHiddenMediaChannel1`).
  - Adjusted assertions in tests to match the new JSON structure expected from the changes in media retrieval logic.

- **Improved JSON Assertion in Tests:**
  - Enhanced expected JSON format in assertions to better reflect the expected output of the modified service method.

- **New Test Cases:**
  - Added multiple test cases in `AudioServiceImplTest` to cover various scenarios for grouping media entities, ensuring robustness in functionality (e.g., handling different start times, end times, total channels, and courtrooms).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
