### PR TITLE
DMP-5162 Better differentiate between 403 and 401 errors

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestDownloadIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestDownloadIntTest.java
@@ -87,7 +87,7 @@ class AudioRequestsControllerAddAudioRequestDownloadIntTest extends IntegrationB
     }
 
     @Test
-    void addAudioRequestPostShouldReturnForbiddenError() throws Exception {
+    void addAudioRequestPost_shouldReturn401Error_whenUserNotFound() throws Exception {
 
         when(mockUserIdentity.getUserAccount()).thenReturn(null);
 
@@ -97,7 +97,7 @@ class AudioRequestsControllerAddAudioRequestDownloadIntTest extends IntegrationB
             .header("Content-Type", "application/json")
             .content(objectMapper.writeValueAsString(audioRequestDetails));
 
-        mockMvc.perform(requestBuilder).andExpect(status().isForbidden());
+        mockMvc.perform(requestBuilder).andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestPlaybackIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/audio/controller/AudioRequestsControllerAddAudioRequestPlaybackIntTest.java
@@ -86,7 +86,7 @@ class AudioRequestsControllerAddAudioRequestPlaybackIntTest extends IntegrationB
     }
 
     @Test
-    void addAudioRequestPostShouldReturnForbiddenError() throws Exception {
+    void addAudioRequestPost_shouldReturn401Error_whenNoUserAccount() throws Exception {
 
         when(mockUserIdentity.getUserAccount()).thenReturn(null);
 
@@ -96,7 +96,7 @@ class AudioRequestsControllerAddAudioRequestPlaybackIntTest extends IntegrationB
             .header("Content-Type", "application/json")
             .content(objectMapper.writeValueAsString(audioRequestDetails));
 
-        mockMvc.perform(requestBuilder).andExpect(status().isForbidden());
+        mockMvc.perform(requestBuilder).andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/TokenValidatorTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authentication/controller/impl/TokenValidatorTest.java
@@ -115,7 +115,7 @@ class TokenValidatorTest extends IntegrationBaseWithWiremock {
 
         mockMvc.perform(get(ENDPOINT_URL).header("Authorization", "Bearer " + tokenDetails.getToken()))
             .andExpect(status().isForbidden())
-            .andExpect(content().json("{\"type\":\"AUTHORISATION_106\",\"title\":\"Could not obtain user details\",\"status\":403}"))
+            .andExpect(content().json("{\"type\":\"AUTHORISATION_114\",\"title\":\"User is not active\",\"status\":403}"))
             .andReturn();
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/controller/AuthorisationControllerIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/authorisation/controller/AuthorisationControllerIntTest.java
@@ -465,7 +465,7 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
 
     @Test
     @WithMockSecurityContextWithEmailAddress(emailAddress = EMAIL_ADDRESS)
-    void getUserStateShouldFailWhenUserIsInactive() throws Exception {
+    void getUserState_shouldReturn403Error_whenUserIsInactive() throws Exception {
         // Given
         createAndSaveUser(EMAIL_ADDRESS, false);
 
@@ -478,8 +478,8 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
         // Then
         JSONAssert.assertEquals("""
                                     {
-                                      "type": "AUTHORISATION_106",
-                                      "title": "Could not obtain user details",
+                                      "type": "AUTHORISATION_114",
+                                      "title": "User is not active",
                                       "status": 403
                                     }""",
                                 mvcResult.getResponse().getContentAsString(),
@@ -489,14 +489,14 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
 
     @Test
     @WithMockSecurityContextWithEmailAddress(emailAddress = "unknown@test.com")
-    void getUserStateShouldFailWhenUserEmailDoesNotExistInDatabase() throws Exception {
+    void getUserState_shouldReturn401Error_whenUserEmailDoesNotExistInDatabase() throws Exception {
         // Given
         createAndSaveUser(EMAIL_ADDRESS, true);
 
         // When
         MvcResult mvcResult = mockMvc.perform(
                 get(ENDPOINT))
-            .andExpect(status().isForbidden())
+            .andExpect(status().isUnauthorized())
             .andReturn();
 
         // Then
@@ -504,7 +504,7 @@ class AuthorisationControllerIntTest extends PostgresIntegrationBase {
                                     {
                                       "type": "AUTHORISATION_106",
                                       "title": "Could not obtain user details",
-                                      "status": 403
+                                      "status": 401
                                     }""",
                                 mvcResult.getResponse().getContentAsString(),
                                 JSONCompareMode.NON_EXTENSIBLE

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetAnnotationsIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetAnnotationsIntTest.java
@@ -208,6 +208,16 @@ class CaseControllerGetAnnotationsIntTest extends IntegrationBase {
     }
 
     @Test
+    void casesGetAnnotationsEndpoint_shouldReturn401Error_whenUserNotFound() throws Exception {
+        CourtCaseEntity courtCaseEntity = dartsDatabase.createCase("Bristol", "case1");
+
+        mockMvc.perform(get("/cases/" + courtCaseEntity.getId() + "/annotations")
+                            .header("user_id", "9999999999"))
+
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void givenUserRequestsNonExistingHearingThenReturn404() throws Exception {
         UserAccountEntity testUser = dartsDatabase.getUserAccountStub()
             .createSuperAdminUser();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseByIdTest.java
@@ -63,13 +63,13 @@ class CaseControllerGetCaseByIdTest extends IntegrationBase {
     }
 
     @Test
-    void casesSearchGetEndpointShouldReturnForbiddenError() throws Exception {
+    void casesSearchGetEndpoint_shouldReturn401Error_whenUserNotFound() throws Exception {
         setupData();
         when(mockUserIdentity.getUserAccount()).thenReturn(null);
 
         MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, getCaseId(SOME_CASE_NUMBER, SOME_COURTHOUSE));
 
-        mockMvc.perform(requestBuilder).andExpect(status().isForbidden());
+        mockMvc.perform(requestBuilder).andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetCaseHearingsTest.java
@@ -78,7 +78,7 @@ class CaseControllerGetCaseHearingsTest extends IntegrationBase {
     }
 
     @Test
-    void caseHearingsGetEndpointShouldReturnForbidden() throws Exception {
+    void caseHearingsGet_shouldReturn401Error_whenUserNotFound() throws Exception {
         Mockito.reset(authentication);
 
         // a user that does not exist in the db
@@ -90,12 +90,12 @@ class CaseControllerGetCaseHearingsTest extends IntegrationBase {
 
         MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingEntity.getCourtCase().getId());
 
-        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isForbidden()).andReturn();
+        MvcResult response = mockMvc.perform(requestBuilder).andExpect(status().isUnauthorized()).andReturn();
 
         String actualResponse = response.getResponse().getContentAsString();
 
         String expectedResponse = """
-            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":403}
+            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":401}
             """;
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
@@ -252,7 +252,7 @@ class CaseControllerGetCaseHearingsTest extends IntegrationBase {
         MockHttpServletRequestBuilder requestBuilder = get(endpointUrl, hearingEntity.getCourtCase().getId());
 
         mockMvc.perform(requestBuilder).andExpect(status().isForbidden()).andExpect(jsonPath("$.type").value(
-            AuthorisationError.USER_DETAILS_INVALID.getType()));
+            AuthorisationError.USER_NOT_ACTIVE.getType()));
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerGetEventByCaseIdTest.java
@@ -90,7 +90,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
     }
 
     @Test
-    void casesGetEventsEndpointShouldReturnForbiddenError() throws Exception {
+    void casesGetEventsEndpoint_shouldReturn401Error_whenNoUserExists() throws Exception {
 
         when(mockUserIdentity.getUserAccount()).thenReturn(null);
 
@@ -98,7 +98,7 @@ class CaseControllerGetEventByCaseIdTest extends IntegrationBase {
             .queryParam("page_number", "1")
             .queryParam("page_size", "1");
 
-        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isForbidden());
+        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isUnauthorized());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerSearchPostTest.java
@@ -503,10 +503,10 @@ class CaseControllerSearchPostTest extends IntegrationBase {
     }
 
     @Test
-    void casesSearchPostEndpointJudgeNameInactive() throws Exception {
-        user = dartsDatabase.getUserAccountStub().createJudgeUser();
+    void casesSearchPost_shouldReturn403Error_whenUserIsInactive() throws Exception {
+        user = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         user.setActive(false);
-        setupUserAccountAndSecurityGroup(swanseaCourthouse);
+        userAccountRepository.save(user);
 
         String requestBody = """
             {
@@ -521,8 +521,7 @@ class CaseControllerSearchPostTest extends IntegrationBase {
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .content(requestBody);
         mockMvc.perform(requestBuilder).andExpect(status().isForbidden()).andExpect(jsonPath("$.type").value(
-            AuthorisationError.USER_DETAILS_INVALID.getType()));
-
+            AuthorisationError.USER_NOT_ACTIVE.getType()));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/CourthouseApiTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/controller/CourthouseApiTest.java
@@ -289,7 +289,7 @@ class CourthouseApiTest extends IntegrationBase {
     }
 
     @Test
-    void courthousesGet_ThreeCourthousesAssignedToUserInactive() throws Exception {
+    void courthousesGet_shouldReturn403Error_whenUserInactive() throws Exception {
         String courthouseName = "courthousetest";
         UserAccountEntity userAccountEntity = userStub.createAuthorisedIntegrationTestUser(false, courthouseName);
         userAccountEntity.setActive(false);
@@ -300,7 +300,7 @@ class CourthouseApiTest extends IntegrationBase {
         MockHttpServletRequestBuilder requestBuilder = get("/courthouses")
             .contentType(MediaType.APPLICATION_JSON_VALUE);
         mockMvc.perform(requestBuilder).andExpect(status().isForbidden()).andExpect(jsonPath("$.type").value(
-            AuthorisationError.USER_DETAILS_INVALID.getType()));
+            AuthorisationError.USER_NOT_ACTIVE.getType()));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetControllerTest.java
@@ -126,7 +126,7 @@ class HearingsGetControllerTest extends IntegrationBase {
     }
 
     @Test
-    void hearingsGetEndpointShouldReturnForbiddenError() throws Exception {
+    void hearingsGet_shouldReturn401Error_whenUserNotFound() throws Exception {
 
         HearingEntity hearing = dartsDatabase.createHearing(
             "testCourthouse",
@@ -144,13 +144,13 @@ class HearingsGetControllerTest extends IntegrationBase {
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, hearing.getId());
 
         MvcResult response = mockMvc.perform(requestBuilder)
-            .andExpect(MockMvcResultMatchers.status().isForbidden())
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized())
             .andReturn();
 
         String actualResponse = response.getResponse().getContentAsString();
 
         String expectedResponse = """
-            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":403}
+            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":401}
             """;
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/hearings/controller/HearingsGetEventsControllerTest.java
@@ -140,20 +140,20 @@ class HearingsGetEventsControllerTest extends IntegrationBase {
     }
 
     @Test
-    void hearingEventsGetEndpointShouldReturnForbiddenError() throws Exception {
+    void hearingEventsGet_shouldReturn401Error_whenUserNotFound() throws Exception {
         transactionalUtil.executeInTransaction(this::setUp);
 
         when(mockUserIdentity.getUserAccount()).thenReturn(null);
 
         MockHttpServletRequestBuilder requestBuilder = get(ENDPOINT_URL, hearingEntity.getId());
         MvcResult response = mockMvc.perform(requestBuilder)
-            .andExpect(MockMvcResultMatchers.status().isForbidden())
+            .andExpect(MockMvcResultMatchers.status().isUnauthorized())
             .andReturn();
 
         String actualResponse = response.getResponse().getContentAsString();
 
         String expectedResponse = """
-            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":403}
+            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":401}
             """;
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAttachTranscriptIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerAttachTranscriptIntTest.java
@@ -113,7 +113,8 @@ class TranscriptionControllerAttachTranscriptIntTest extends IntegrationBase {
     }
 
     @Test
-    void attachTranscript_shouldReturn403Error_whenUserDoesNotHavePermission() throws Exception {
+    void attachTranscript_shouldReturn401Error_whenUserNotFound() throws Exception {
+
         when(mockUserIdentity.getUserAccount()).thenReturn(null);
 
         MockMultipartFile transcript = new MockMultipartFile(
@@ -128,13 +129,13 @@ class TranscriptionControllerAttachTranscriptIntTest extends IntegrationBase {
                     URL_TEMPLATE,
                     transcriptionId
                 ).file(transcript))
-            .andExpect(status().isForbidden())
+            .andExpect(status().isUnauthorized())
             .andReturn();
 
         String actualResponse = mvcResult.getResponse().getContentAsString();
 
         String expectedResponse = """
-            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":403}
+            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":401}
             """;
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
 

--- a/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerDownloadTranscriptIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/transcriptions/controller/TranscriptionControllerDownloadTranscriptIntTest.java
@@ -139,7 +139,7 @@ class TranscriptionControllerDownloadTranscriptIntTest extends IntegrationBase {
     }
 
     @Test
-    void downloadTranscriptShouldReturnForbiddenError() throws Exception {
+    void downloadTranscript_shouldReturn401Error_whenUserNotFound() throws Exception {
         when(mockUserIdentity.getUserAccount()).thenReturn(null);
 
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.get(URL_TEMPLATE, transcriptionId)
@@ -149,13 +149,13 @@ class TranscriptionControllerDownloadTranscriptIntTest extends IntegrationBase {
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
             );
         MvcResult mvcResult = mockMvc.perform(requestBuilder)
-            .andExpect(status().isForbidden())
+            .andExpect(status().isUnauthorized())
             .andReturn();
 
         String actualResponse = mvcResult.getResponse().getContentAsString();
 
         String expectedResponse = """
-            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":403}
+            {"type":"AUTHORISATION_106","title":"Could not obtain user details","status":401}
             """;
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
 

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/exception/AuthorisationError.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/exception/AuthorisationError.java
@@ -46,6 +46,11 @@ public enum AuthorisationError implements DartsApiError {
         HttpStatus.UNAUTHORIZED,
         AuthorisationTitleErrors.USER_DETAILS_INVALID.toString()
     ),
+    USER_NOT_ACTIVE(
+        AuthorisationErrorCode.USER_NOT_ACTIVE.getValue(),
+        HttpStatus.FORBIDDEN,
+        AuthorisationTitleErrors.USER_NOT_ACTIVE.toString()
+    ),
     BAD_REQUEST_ANY_ID(
         AuthorisationErrorCode.BAD_REQUEST_ANY_ID.getValue(),
         HttpStatus.FORBIDDEN,

--- a/src/main/java/uk/gov/hmcts/darts/authorisation/exception/AuthorisationError.java
+++ b/src/main/java/uk/gov/hmcts/darts/authorisation/exception/AuthorisationError.java
@@ -43,7 +43,7 @@ public enum AuthorisationError implements DartsApiError {
     ),
     USER_DETAILS_INVALID(
         AuthorisationErrorCode.USER_DETAILS_INVALID.getValue(),
-        HttpStatus.FORBIDDEN,
+        HttpStatus.UNAUTHORIZED,
         AuthorisationTitleErrors.USER_DETAILS_INVALID.toString()
     ),
     BAD_REQUEST_ANY_ID(

--- a/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/config/security/SecurityConfig.java
@@ -183,21 +183,21 @@ public class SecurityConfig {
                     if (userAccountEntity.isActive()) {
                         filterChain.doFilter(request, response);
                     } else {
-                        writeError(response);
+                        writeError(response, HttpStatus.FORBIDDEN);
                     }
                 } catch (Exception exception) {
                     log.error("User is invalid", exception);
-                    writeError(response);
+                    writeError(response, HttpStatus.UNAUTHORIZED);
                 }
             }
         }
 
-        private void writeError(HttpServletResponse response) {
+        private void writeError(HttpServletResponse response, HttpStatus httStatus) {
             try {
-                DartsApiTrait.writeErrorResponse(response, mapper);
+                DartsApiTrait.writeErrorResponse(response, mapper, httStatus);
             } catch (IOException ex) {
                 log.error("Problem parsing the problem", ex);
-                response.setStatus(HttpStatus.FORBIDDEN.value());
+                response.setStatus(httStatus.value());
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiTrait.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/exception/DartsApiTrait.java
@@ -44,8 +44,8 @@ public interface DartsApiTrait extends AdviceTrait {
         return create(exception, getContentForException(exception), request);
     }
 
-    static void writeErrorResponse(HttpServletResponse servletResponse, ObjectMapper mapper) throws IOException {
-        servletResponse.setStatus(HttpStatus.FORBIDDEN.value());
+    static void writeErrorResponse(HttpServletResponse servletResponse, ObjectMapper mapper, HttpStatus httpStatus) throws IOException {
+        servletResponse.setStatus(httpStatus.value());
         servletResponse.setHeader("Content-Type", "application/problem+json");
         servletResponse.getWriter().write(
             getJsonForProblem(mapper, getContentForException(new DartsApiException(AuthorisationError.USER_DETAILS_INVALID))));

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
@@ -40,16 +40,6 @@ public interface UserAccountRepository extends
     List<UserAccountEntity> findByRoleAndCourthouse(int securityRole, CourthouseEntity courthouse, Set<UserAccountEntity> excludingUsers);
 
     @Query("""
-        SELECT userAccount
-        FROM UserAccountEntity userAccount
-        WHERE userAccount.active = true
-        AND userAccount.isSystemUser = true
-        AND userAccount.accountGuid = :uuid
-        """)
-    UserAccountEntity findSystemUser(String uuid);
-
-
-    @Query("""
         SELECT DISTINCT userAccount
         FROM UserAccountEntity userAccount
         JOIN userAccount.securityGroupEntities securityGroup
@@ -73,6 +63,8 @@ public interface UserAccountRepository extends
     Optional<UserAccountEntity> findByRoleAndUserId(Integer securityRoleId, Integer userId);
 
     List<UserAccountEntity> findByEmailAddressIgnoreCaseAndActive(String emailAddress, Boolean active);
+
+    List<UserAccountEntity> findByEmailAddressIgnoreCase(String emailAddress);
 
     @Modifying
     @Query("""

--- a/src/main/resources/openapi/common.yaml
+++ b/src/main/resources/openapi/common.yaml
@@ -144,10 +144,11 @@ components:
         - "AUTHORISATION_111"
         - "AUTHORISATION_112"
         - "AUTHORISATION_113"
+        - "AUTHORISATION_114"
       x-enum-varnames: [ USER_NOT_AUTHORISED_FOR_COURTHOUSE, BAD_REQUEST_CASE_ID, BAD_REQUEST_HEARING_ID, BAD_REQUEST_MEDIA_REQUEST_ID, BAD_REQUEST_MEDIA_ID,
                          BAD_REQUEST_TRANSCRIPTION_ID, USER_DETAILS_INVALID, BAD_REQUEST_ANY_ID, BAD_REQUEST_TRANSFORMED_MEDIA_ID,
                          USER_NOT_AUTHORISED_FOR_ENDPOINT, BAD_REQUEST_ANNOTATION_ID, USER_NOT_AUTHORISED_TO_USE_PAYLOAD_CONTENT, UNABLE_TO_DEACTIVATE_USER,
-                         USER_NOT_AUTHORISED_TO_ACTIVATE_USER ]
+                         USER_NOT_AUTHORISED_TO_ACTIVATE_USER, USER_NOT_ACTIVE ]
 
     AuthorisationTitleErrors:
       type: string
@@ -166,10 +167,11 @@ components:
         - "Failed to perform operation. User not authorised for payload data"
         - "Failed to deactivate user"
         - "Failed to activate user. User not authorised"
+        - "User is not active"
       x-enum-varnames: [ USER_NOT_AUTHORISED_FOR_COURTHOUSE, BAD_REQUEST_CASE_ID, BAD_REQUEST_HEARING_ID, BAD_REQUEST_MEDIA_REQUEST_ID, BAD_REQUEST_MEDIA_ID,
                          BAD_REQUEST_TRANSCRIPTION_ID, USER_DETAILS_INVALID, BAD_REQUEST_ANY_ID, BAD_REQUEST_TRANSFORMED_MEDIA_ID,
                          USER_NOT_AUTHORISED_FOR_ENDPOINT, BAD_REQUEST_ANNOTATION_ID, USER_NOT_AUTHORISED_TO_USE_PAYLOAD_CONTENT, UNABLE_TO_DEACTIVATE_USER,
-                         USER_NOT_AUTHORISED_TO_ACTIVATE_USER ]
+                         USER_NOT_AUTHORISED_TO_ACTIVATE_USER, USER_NOT_ACTIVE ]
 
     AutomatedTaskErrorCode:
       type: string


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5162

### Change description ###

- amending `USER_DETAILS_INVALID` error to return 401
- amending request filter to only set 403 error when the user is inactive
- otherwise 401 used as the user could not be found and should authenticate again

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
