### PR TITLE
DMP-5115: Optimise: ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/GenerateCaseDocumentForRetentionDateBatchProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/GenerateCaseDocumentForRetentionDateBatchProcessorIntTest.java
@@ -81,22 +81,21 @@ class GenerateCaseDocumentForRetentionDateBatchProcessorIntTest extends Integrat
         generateCaseDocumentForRetentionDateBatchProcessor.processGenerateCaseDocumentForRetentionDate(2);
 
         // then
-        CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().findById(courtCaseEntityWithNoCaseDocuments.getId()).get();
-        assertTrue(courtCaseEntity1.isRetentionUpdated());
-        assertEquals(0, courtCaseEntity1.getRetentionRetries());
+        transactionalUtil.executeInTransaction(() -> {
+            CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().findById(courtCaseEntityWithNoCaseDocuments.getId()).get();
+            assertTrue(courtCaseEntity1.isRetentionUpdated());
+            assertEquals(0, courtCaseEntity1.getRetentionRetries());
 
-        List<CaseDocumentEntity> caseDocumentEntities1 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity1);
-        assertEquals(1, caseDocumentEntities1.size());
+            List<CaseDocumentEntity> caseDocumentEntities1 = courtCaseEntity1.getCaseDocumentEntities();
+            assertEquals(1, caseDocumentEntities1.size());
 
-        CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().findById(courtCaseEntityWithCaseDocument.getId()).get();
-        assertTrue(courtCaseEntity2.isRetentionUpdated());
-        assertEquals(0, courtCaseEntity2.getRetentionRetries());
+            CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().findById(courtCaseEntityWithCaseDocument.getId()).get();
+            assertTrue(courtCaseEntity2.isRetentionUpdated());
+            assertEquals(0, courtCaseEntity2.getRetentionRetries());
 
-        List<CaseDocumentEntity> caseDocumentEntities2 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity2);
-        assertEquals(2, caseDocumentEntities2.size());
-
+            List<CaseDocumentEntity> caseDocumentEntities2 = courtCaseEntity2.getCaseDocumentEntities();
+            assertEquals(2, caseDocumentEntities2.size());
+        });
     }
 
     @Test
@@ -229,15 +228,14 @@ class GenerateCaseDocumentForRetentionDateBatchProcessorIntTest extends Integrat
         generateCaseDocumentForRetentionDateBatchProcessor.processGenerateCaseDocumentForRetentionDate(2);
 
         // then
-        CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().getReferenceById(courtCaseEntityWithNoCaseDocuments.getId());
-        List<CaseDocumentEntity> caseDocumentEntities1 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity1);
-        assertEquals(0, caseDocumentEntities1.size());
+        transactionalUtil.executeInTransaction(() -> {
+            CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().getReferenceById(courtCaseEntityWithNoCaseDocuments.getId());
+            List<CaseDocumentEntity> caseDocumentEntities1 = courtCaseEntity1.getCaseDocumentEntities();
+            assertEquals(0, caseDocumentEntities1.size());
 
-        CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().getReferenceById(courtCaseEntityWithCaseDocument.getId());
-        List<CaseDocumentEntity> caseDocumentEntities2 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity2);
-        assertEquals(1, caseDocumentEntities2.size());
-
+            CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().getReferenceById(courtCaseEntityWithCaseDocument.getId());
+            List<CaseDocumentEntity> caseDocumentEntities2 = courtCaseEntity2.getCaseDocumentEntities();
+            assertEquals(1, caseDocumentEntities2.size());
+        });
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/GenerateCaseDocumentProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/casedocument/service/GenerateCaseDocumentProcessorIntTest.java
@@ -25,7 +25,7 @@ class GenerateCaseDocumentProcessorIntTest extends IntegrationBase {
 
     @MockitoBean
     private UserIdentity mockUserIdentity;
-    
+
     @Autowired
     private GenerateCaseDocumentProcessor generateCaseDocumentProcessor;
 
@@ -90,26 +90,25 @@ class GenerateCaseDocumentProcessorIntTest extends IntegrationBase {
         generateCaseDocumentProcessor.processGenerateCaseDocument(2);
 
         // then
-        CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().findById(matchingCase1.getId()).get();
-        assertTrue("", courtCaseEntity1.isRetentionUpdated());
-        assertEquals(0, courtCaseEntity1.getRetentionRetries());
-        List<CaseDocumentEntity> caseDocumentEntities1 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity1);
-        assertEquals(1, caseDocumentEntities1.size());
+        transactionalUtil.executeInTransaction(() -> {
+            CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().findById(matchingCase1.getId()).get();
+            assertTrue("", courtCaseEntity1.isRetentionUpdated());
+            assertEquals(0, courtCaseEntity1.getRetentionRetries());
+            List<CaseDocumentEntity> caseDocumentEntities1 = courtCaseEntity1.getCaseDocumentEntities();
+            assertEquals(1, caseDocumentEntities1.size());
 
-        CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().findById(matchingCase2.getId()).get();
-        assertTrue("", courtCaseEntity2.isRetentionUpdated());
-        assertEquals(0, courtCaseEntity2.getRetentionRetries());
-        List<CaseDocumentEntity> caseDocumentEntities2 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity2);
-        assertEquals(1, caseDocumentEntities2.size());
+            CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().findById(matchingCase2.getId()).get();
+            assertTrue("", courtCaseEntity2.isRetentionUpdated());
+            assertEquals(0, courtCaseEntity2.getRetentionRetries());
+            List<CaseDocumentEntity> caseDocumentEntities2 = courtCaseEntity2.getCaseDocumentEntities();
+            assertEquals(1, caseDocumentEntities2.size());
 
-        CourtCaseEntity courtCaseEntity3 = dartsDatabase.getCaseRepository().findById(caseClosedButMaxedRetentionRetries.getId()).get();
-        assertTrue("", courtCaseEntity3.isRetentionUpdated());
-        assertEquals(2, courtCaseEntity3.getRetentionRetries());
-        List<CaseDocumentEntity> caseDocumentEntities3 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity3);
-        assertEquals(0, caseDocumentEntities3.size());
+            CourtCaseEntity courtCaseEntity3 = dartsDatabase.getCaseRepository().findById(caseClosedButMaxedRetentionRetries.getId()).get();
+            assertTrue("", courtCaseEntity3.isRetentionUpdated());
+            assertEquals(2, courtCaseEntity3.getRetentionRetries());
+            List<CaseDocumentEntity> caseDocumentEntities3 = courtCaseEntity3.getCaseDocumentEntities();
+            assertEquals(0, caseDocumentEntities3.size());
+        });
     }
 
     @Test
@@ -154,14 +153,14 @@ class GenerateCaseDocumentProcessorIntTest extends IntegrationBase {
         generateCaseDocumentProcessor.processGenerateCaseDocument(2);
 
         // then
-        CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().findById(recentlyClosedCase.getId()).get();
-        List<CaseDocumentEntity> caseDocumentEntities1 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity1);
-        assertEquals(0, caseDocumentEntities1.size());
+        transactionalUtil.executeInTransaction(() -> {
+            CourtCaseEntity courtCaseEntity1 = dartsDatabase.getCaseRepository().findById(recentlyClosedCase.getId()).get();
+            List<CaseDocumentEntity> caseDocumentEntities1 = courtCaseEntity1.getCaseDocumentEntities();
+            assertEquals(0, caseDocumentEntities1.size());
 
-        CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().findById(oldClosedCaseWithPendingRetention.getId()).get();
-        List<CaseDocumentEntity> caseDocumentEntities2 =
-            dartsDatabase.getCaseDocumentStub().getCaseDocumentRepository().findByCourtCase(courtCaseEntity2);
-        assertEquals(0, caseDocumentEntities2.size());
+            CourtCaseEntity courtCaseEntity2 = dartsDatabase.getCaseRepository().findById(oldClosedCaseWithPendingRetention.getId()).get();
+            List<CaseDocumentEntity> caseDocumentEntities2 = courtCaseEntity2.getCaseDocumentEntities();
+            assertEquals(0, caseDocumentEntities2.size());
+        });
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/AnnotationDocumentRepositoryIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/AnnotationDocumentRepositoryIntTest.java
@@ -39,29 +39,6 @@ class AnnotationDocumentRepositoryIntTest extends IntegrationBase {
     }
 
     @Test
-    void findsAnnotationDocumentsByCaseId() {
-        // given
-        var courtCaseA = PersistableFactory.getCourtCaseTestData().createSomeMinimalCase();
-        var courtCaseB = PersistableFactory.getCourtCaseTestData().createSomeMinimalCase();
-        var annotationDocument1 = createAnnotationDocumentForCases(courtCaseA);
-        var annotationDocument2 = createAnnotationDocumentForCases(courtCaseA);
-        var annotationDocument3 = createAnnotationDocumentForCases(courtCaseA);
-        createAnnotationDocumentForCases(courtCaseB);
-        createAnnotationDocumentForCases(courtCaseB);
-        dartsPersistence.saveAll(annotationDocument1, annotationDocument2, annotationDocument3);
-
-        // when
-        var result = annotationDocumentRepository.findAllByCaseId(courtCaseA.getId());
-
-        // then
-        assertThat(result.stream().map(AnnotationDocumentEntity::getId))
-            .containsExactlyInAnyOrder(
-                annotationDocument1.getId(),
-                annotationDocument2.getId(),
-                annotationDocument3.getId());
-    }
-
-    @Test
     void canGetAssociatedCasesFromAnnotationDocument() {
         var courtCaseA = PersistableFactory.getCourtCaseTestData().createSomeMinimalCase();
         var courtCaseB = PersistableFactory.getCourtCaseTestData().createSomeMinimalCase();

--- a/src/integrationTest/java/uk/gov/hmcts/darts/task/service/GenerateCaseDocumentProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/task/service/GenerateCaseDocumentProcessorIntTest.java
@@ -71,19 +71,21 @@ class GenerateCaseDocumentProcessorIntTest extends IntegrationBase {
 
         // when
         processor.processGenerateCaseDocument(courtCase.getId());
-
         // then
-        List<CaseDocumentEntity> caseDocumentEntities = caseDocumentRepository.findByCourtCase(courtCase);
-        assertThat(caseDocumentEntities.size()).isEqualTo(1);
-        CaseDocumentEntity caseDocument = caseDocumentEntities.getFirst();
-        assertThat(caseDocument.getCourtCase().getId()).isEqualTo(courtCase.getId());
+        transactionalUtil.executeInTransaction(() -> {
+            CourtCaseEntity courtCaseToAssert = caseRepository.findById(courtCase.getId()).orElseThrow();
+            List<CaseDocumentEntity> caseDocumentEntities = courtCaseToAssert.getCaseDocumentEntities();
+            assertThat(caseDocumentEntities).hasSize(1);
+            CaseDocumentEntity caseDocument = caseDocumentEntities.getFirst();
+            assertThat(caseDocument.getCourtCase().getId()).isEqualTo(courtCaseToAssert.getId());
 
-        List<ExternalObjectDirectoryEntity> eodCaseDocument = eodRepository.findByCaseDocument(caseDocument);
-        assertThat(eodCaseDocument.size()).isEqualTo(1);
+            List<ExternalObjectDirectoryEntity> eodCaseDocument = eodRepository.findByCaseDocument(caseDocument);
+            assertThat(eodCaseDocument).hasSize(1);
 
-        CourtCaseEntity courtCaseEntity = caseRepository.findById(caseDocument.getCourtCase().getId()).orElseThrow();
-        assertThat(courtCaseEntity.isRetentionUpdated()).isTrue();
-        assertThat(courtCaseEntity.getRetentionRetries()).isEqualTo(0);
+            CourtCaseEntity courtCaseEntity = caseRepository.findById(caseDocument.getCourtCase().getId()).orElseThrow();
+            assertThat(courtCaseEntity.isRetentionUpdated()).isTrue();
+            assertThat(courtCaseEntity.getRetentionRetries()).isZero();
+        });
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/AnnotationDocumentRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/AnnotationDocumentRepository.java
@@ -1,26 +1,12 @@
 package uk.gov.hmcts.darts.common.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.AnnotationDocumentEntity;
 import uk.gov.hmcts.darts.task.runner.SoftDeleteRepository;
 
-import java.util.List;
-
 @Repository
 public interface AnnotationDocumentRepository extends JpaRepository<AnnotationDocumentEntity, Long>,
     SoftDeleteRepository<AnnotationDocumentEntity, Long> {
-
-
-    @Query("""
-           SELECT annDoc
-           FROM CourtCaseEntity ca
-           JOIN ca.hearings he
-           JOIN he.annotations ann
-           JOIN ann.annotationDocuments annDoc
-           WHERE ca.id = :caseId
-        """)
-    List<AnnotationDocumentEntity> findAllByCaseId(Integer caseId);
 
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/CaseDocumentRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/CaseDocumentRepository.java
@@ -2,13 +2,8 @@ package uk.gov.hmcts.darts.common.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.hmcts.darts.common.entity.CaseDocumentEntity;
-import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
 import uk.gov.hmcts.darts.task.runner.SoftDeleteRepository;
-
-import java.util.List;
 
 public interface CaseDocumentRepository extends JpaRepository<CaseDocumentEntity, Long>,
     SoftDeleteRepository<CaseDocumentEntity, Long> {
-
-    List<CaseDocumentEntity> findByCourtCase(CourtCaseEntity courtCase);
 }

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntityTest.java
@@ -203,7 +203,7 @@ class CourtCaseEntityTest {
         List<AnnotationDocumentEntity> allAnnotations = courtCase.getAllAssociatedAnnotationDocuments();
         assertThat(allAnnotations)
             .hasSize(3)
-            .containsExactly(
+            .containsExactlyInAnyOrder(
                 hearing1Annotation1Document1,
                 hearing1Annotation1Document2,
                 hearing2Annotation1Document1

--- a/src/test/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/common/entity/CourtCaseEntityTest.java
@@ -1,8 +1,15 @@
 package uk.gov.hmcts.darts.common.entity;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import uk.gov.hmcts.darts.cases.exception.CaseApiError;
 import uk.gov.hmcts.darts.common.exception.DartsApiException;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -24,5 +31,182 @@ class CourtCaseEntityTest {
         CourtCaseEntity courtCase = new CourtCaseEntity();
         courtCase.setDataAnonymised(false);
         assertDoesNotThrow(courtCase::validateIsExpired);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void getAllAssociatedMedias_hasNullOrEmptyHearings(List<HearingEntity> hearingEntityList) {
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        courtCase.setHearings(hearingEntityList);
+        assertThat(courtCase.getAllAssociatedMedias()).isEmpty();
+    }
+
+    @Test
+    void getAllAssociatedMedias_hasHearingsWithMedia() {
+
+        MediaEntity hearing1Media1 = new MediaEntity();
+        hearing1Media1.setId(1L);//Make sure the ID is set to ensure uniqueness
+        MediaEntity hearing1Media2 = new MediaEntity();
+        hearing1Media2.setId(2L);
+        MediaEntity hearing2Media1 = new MediaEntity();
+        hearing2Media1.setId(3L);
+        MediaEntity hearing2Media2 = new MediaEntity();
+        hearing2Media2.setId(4L);
+
+        Set<MediaEntity> hearing1Medias = new HashSet<>();
+        hearing1Medias.add(hearing1Media1);
+        hearing1Medias.add(hearing1Media2);
+        hearing1Medias.add(null); // Make sure nulls within MediaEntity::getMedias are ignored
+
+        HearingEntity hearingEntity1 = new HearingEntity();
+        HearingEntity hearingEntity2 = new HearingEntity();
+        HearingEntity hearingEntity3 = new HearingEntity();
+
+
+        hearingEntity1.setMedias(hearing1Medias);
+        hearingEntity2.setMedias(Set.of(hearing2Media1, hearing2Media2));
+        hearingEntity3.setMedias(null);// Make sure nulls are ignored
+
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        List<HearingEntity> hearingEntities = new ArrayList<>();
+        hearingEntities.add(hearingEntity1);
+        hearingEntities.add(hearingEntity2);
+        hearingEntities.add(hearingEntity3);
+        hearingEntities.add(null); // Add nulls to ensure they are ignored
+        courtCase.setHearings(hearingEntities);
+        List<MediaEntity> allMedias = courtCase.getAllAssociatedMedias();
+        assertThat(allMedias)
+            .hasSize(4)
+            .containsExactlyInAnyOrder(
+                hearing1Media1,
+                hearing1Media2,
+                hearing2Media1,
+                hearing2Media2
+            );
+
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void getAllAssociatedMedias_hasNullOrEmptyMediaLinkedCase(List<MediaLinkedCaseEntity> mediaLinkedCaseEntities) {
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        courtCase.setMediaLinkedCaseList(mediaLinkedCaseEntities);
+        assertThat(courtCase.getAllAssociatedMedias()).isEmpty();
+    }
+
+    @Test
+    void getAllAssociatedMedias_hasOnlyMediaLinkedCase() {
+        MediaLinkedCaseEntity mediaLinkedCase1 = new MediaLinkedCaseEntity();
+        MediaLinkedCaseEntity mediaLinkedCase2 = new MediaLinkedCaseEntity();
+        MediaLinkedCaseEntity mediaLinkedCase3 = new MediaLinkedCaseEntity();
+
+        MediaEntity mediaLinkedCase1Media = new MediaEntity();
+        mediaLinkedCase1Media.setId(1L);// Make sure the ID is set to ensure uniqueness
+        MediaEntity mediaLinkedCase2Media = new MediaEntity();
+        mediaLinkedCase2Media.setId(2L);
+
+        mediaLinkedCase1.setMedia(mediaLinkedCase1Media);
+        mediaLinkedCase2.setMedia(mediaLinkedCase2Media);
+        mediaLinkedCase3.setMedia(null);// Make sure nulls are ignored
+
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        List<MediaLinkedCaseEntity> mediaLinkedCaseList = new ArrayList<>();
+        mediaLinkedCaseList.add(mediaLinkedCase1);
+        mediaLinkedCaseList.add(mediaLinkedCase2);
+        mediaLinkedCaseList.add(mediaLinkedCase3);
+        mediaLinkedCaseList.add(null);// Add nulls to ensure they are ignored
+        courtCase.setMediaLinkedCaseList(mediaLinkedCaseList);
+
+        List<MediaEntity> allMedias = courtCase.getAllAssociatedMedias();
+        assertThat(allMedias)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(
+                mediaLinkedCase1Media,
+                mediaLinkedCase2Media
+            );
+    }
+
+    @Test
+    void getAllAssociatedMedias_hasHearingsMediaAndLinkedCaseMedia() {
+        HearingEntity hearingEntity = new HearingEntity();
+        MediaEntity hearingMedia1 = new MediaEntity();
+        hearingMedia1.setId(1L); // Make sure the ID is set to ensure uniqueness
+        hearingEntity.setMedias(Set.of(hearingMedia1));
+
+        MediaLinkedCaseEntity mediaLinkedCase = new MediaLinkedCaseEntity();
+        MediaEntity mediaLinkedCaseMedia = new MediaEntity();
+        mediaLinkedCaseMedia.setId(2L); // Make sure the ID is set to ensure uniqueness
+        mediaLinkedCase.setMedia(mediaLinkedCaseMedia);
+
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        courtCase.setHearings(List.of(hearingEntity));
+        courtCase.setMediaLinkedCaseList(List.of(mediaLinkedCase));
+
+        List<MediaEntity> allMedias = courtCase.getAllAssociatedMedias();
+        assertThat(allMedias)
+            .hasSize(2)
+            .containsExactlyInAnyOrder(
+                hearingMedia1,
+                mediaLinkedCaseMedia
+            );
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void getAllAssociatedAnnotationDocuments_hasNullOrEmptyHearings(List<HearingEntity> hearingEntityList) {
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        courtCase.setHearings(hearingEntityList);
+        assertThat(courtCase.getAllAssociatedAnnotationDocuments()).isEmpty();
+    }
+
+    @Test
+    void getAllAssociatedAnnotationDocuments_hasHearingsWithAnnotationDocuments() {
+        AnnotationDocumentEntity hearing1Annotation1Document1 = new AnnotationDocumentEntity();
+        hearing1Annotation1Document1.setId(1L);//Make sure the ID is set to ensure uniqueness
+        AnnotationDocumentEntity hearing1Annotation1Document2 = new AnnotationDocumentEntity();
+        hearing1Annotation1Document2.setId(2L);
+        AnnotationDocumentEntity hearing2Annotation1Document1 = new AnnotationDocumentEntity();
+        hearing2Annotation1Document1.setId(3L);
+
+
+        List<AnnotationDocumentEntity> hearing1Annotation1Documents = new ArrayList<>();
+        hearing1Annotation1Documents.add(hearing1Annotation1Document1);
+        hearing1Annotation1Documents.add(hearing1Annotation1Document2);
+        hearing1Annotation1Documents.add(null);//Make sure nulls within AnnotationEntity::getAnnotationDocuments are ignored
+
+        final AnnotationEntity hearing1Annotation1 = new AnnotationEntity();
+        final AnnotationEntity hearing1Annotation2 = new AnnotationEntity();
+        final AnnotationEntity hearing2Annotation1 = new AnnotationEntity();
+        final AnnotationEntity hearing2Annotation2 = new AnnotationEntity();
+
+        hearing1Annotation1.setAnnotationDocuments(hearing1Annotation1Documents);
+        hearing1Annotation2.setAnnotationDocuments(List.of(hearing2Annotation1Document1));
+        hearing2Annotation2.setAnnotationDocuments(null);//Make sure nulls within AnnotationEntity::getAnnotationDocuments are ignored
+
+        Set<AnnotationEntity> hearing1Annotations = new HashSet<>();
+        hearing1Annotations.add(hearing1Annotation1);
+        hearing1Annotations.add(hearing1Annotation2);
+        hearing1Annotations.add(null);//Make sure nulls within HearingEntity::getAnnotations are ignored
+
+        HearingEntity hearingEntity1 = new HearingEntity();
+        HearingEntity hearingEntity2 = new HearingEntity();
+        HearingEntity hearingEntity3 = new HearingEntity();
+
+        hearingEntity1.setAnnotations(hearing1Annotations);
+        hearingEntity2.setAnnotations(Set.of(hearing2Annotation1));
+
+        hearingEntity3.setAnnotations(null);//Make sure nulls are ignored
+
+        CourtCaseEntity courtCase = new CourtCaseEntity();
+        courtCase.setHearings(List.of(hearingEntity1, hearingEntity2, hearingEntity3));
+
+        List<AnnotationDocumentEntity> allAnnotations = courtCase.getAllAssociatedAnnotationDocuments();
+        assertThat(allAnnotations)
+            .hasSize(3)
+            .containsExactly(
+                hearing1Annotation1Document1,
+                hearing1Annotation1Document2,
+                hearing2Annotation1Document1
+            );
     }
 }

--- a/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest.java
@@ -45,7 +45,9 @@ import java.util.Set;
 import static java.time.ZoneOffset.UTC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.util.CommonTestDataUtil.createCaseRetention;
 import static uk.gov.hmcts.darts.common.util.CommonTestDataUtil.createRetentionPolicyType;
@@ -56,7 +58,7 @@ import static uk.gov.hmcts.darts.test.common.data.PersistableFactory.getExternal
 
 @ExtendWith(MockitoExtension.class)
 @Slf4j
-@SuppressWarnings({"checkstyle:LineLength", "PMD.NcssCount"})
+@SuppressWarnings("PMD.NcssCount")
 class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
 
     private static final OffsetDateTime DATETIME_2025 = OffsetDateTime.of(2025, 1, 1, 10, 10, 0, 0, UTC);
@@ -122,7 +124,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
             caseDocumentRepository, transcriptionDocumentRepository, caseRetentionConfidenceReasonMapper,
             currentTimeHelper, objectMapper, mediaLinkedCaseRepository);
 
-        case1PerfectlyClosed = CommonTestDataUtil.createCaseWithId("case1", 101);
+        case1PerfectlyClosed = spy(CommonTestDataUtil.createCaseWithId("case1", 101));
         case1PerfectlyClosed.setRetentionUpdated(true);
         case1PerfectlyClosed.setRetentionRetries(1);
         case1PerfectlyClosed.setClosed(true);
@@ -131,7 +133,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         case1PerfectlyClosed.setRetConfUpdatedTs(RETENTION_UPDATED_DATE);
         CommonTestDataUtil.createHearingsForCase(case1PerfectlyClosed, 1, 3);
 
-        case2PerfectlyClosed = CommonTestDataUtil.createCaseWithId("case1", 102);
+        case2PerfectlyClosed = spy(CommonTestDataUtil.createCaseWithId("case1", 102));
         case2PerfectlyClosed.setRetentionUpdated(true);
         case2PerfectlyClosed.setRetentionRetries(2);
         case2PerfectlyClosed.setClosed(true);
@@ -140,7 +142,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         case2PerfectlyClosed.setRetConfUpdatedTs(RETENTION_UPDATED_DATE);
         CommonTestDataUtil.createHearingsForCase(case2PerfectlyClosed, 1, 1);
 
-        case3NotPerfectlyClosed = CommonTestDataUtil.createCaseWithId("case3", 103);
+        case3NotPerfectlyClosed = spy(CommonTestDataUtil.createCaseWithId("case3", 103));
         case3NotPerfectlyClosed.setRetentionUpdated(true);
         case3NotPerfectlyClosed.setRetentionRetries(1);
         case3NotPerfectlyClosed.setClosed(true);
@@ -149,7 +151,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         case3NotPerfectlyClosed.setRetConfUpdatedTs(RETENTION_UPDATED_DATE);
         CommonTestDataUtil.createHearingsForCase(case3NotPerfectlyClosed, 1, 3);
 
-        case4NotPerfectlyClosed = CommonTestDataUtil.createCaseWithId("case4", 104);
+        case4NotPerfectlyClosed = spy(CommonTestDataUtil.createCaseWithId("case4", 104));
         case4NotPerfectlyClosed.setRetentionUpdated(true);
         case4NotPerfectlyClosed.setRetentionRetries(2);
         case4NotPerfectlyClosed.setClosed(true);
@@ -158,7 +160,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         case4NotPerfectlyClosed.setRetConfUpdatedTs(RETENTION_UPDATED_DATE);
         CommonTestDataUtil.createHearingsForCase(case4NotPerfectlyClosed, 1, 1);
 
-        case5PerfectlyClosed = CommonTestDataUtil.createCaseWithId("case5", 105);
+        case5PerfectlyClosed = spy(CommonTestDataUtil.createCaseWithId("case5", 105));
         case5PerfectlyClosed.setRetentionUpdated(true);
         case5PerfectlyClosed.setRetentionRetries(1);
         case5PerfectlyClosed.setClosed(true);
@@ -230,7 +232,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
 
         when(caseService.getCourtCaseById(case1PerfectlyClosed.getId())).thenReturn(case1PerfectlyClosed);
 
-        when(mediaRepository.findAllByCaseId(case1PerfectlyClosed.getId())).thenReturn(List.of(mediaA1, mediaA2, mediaB1));
+        doReturn(List.of(mediaA1, mediaA2, mediaB1)).when(case1PerfectlyClosed).getAllAssociatedMedias();
 
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case1PerfectlyClosed)).thenReturn(Optional.of(caseRetentionA1));
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case2PerfectlyClosed)).thenReturn(Optional.of(caseRetentionB1));
@@ -273,9 +275,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
 
         when(caseService.getCourtCaseById(case1PerfectlyClosed.getId())).thenReturn(case1PerfectlyClosed);
 
-        when(mediaRepository.findAllByCaseId(case1PerfectlyClosed.getId())).thenReturn(List.of(mediaA1, mediaA2, mediaB1));
-
-        when(mediaRepository.findAllLinkedByMediaLinkedCaseByCaseId(case1PerfectlyClosed.getId())).thenReturn(List.of(mediaC1));
+        doReturn(List.of(mediaA1, mediaA2, mediaB1, mediaC1)).when(case1PerfectlyClosed).getAllAssociatedMedias();
 
         var mediaC1LinkedToCase1 = createMediaLinkedCase(mediaC1, case5PerfectlyClosed);
         //Adding mediaLinkedWithNull case (refering legacy data that has courtroom/casenumber but could not be linked to a case correctly)
@@ -323,7 +323,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
 
         when(caseService.getCourtCaseById(case3NotPerfectlyClosed.getId())).thenReturn(case3NotPerfectlyClosed);
 
-        when(mediaRepository.findAllByCaseId(case3NotPerfectlyClosed.getId())).thenReturn(List.of(mediaA1, mediaA2, mediaB1));
+        doReturn(List.of(mediaA1, mediaA2, mediaB1)).when(case3NotPerfectlyClosed).getAllAssociatedMedias();
 
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case3NotPerfectlyClosed)).thenReturn(Optional.of(caseRetentionC1));
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case4NotPerfectlyClosed)).thenReturn(Optional.of(caseRetentionD1));
@@ -339,14 +339,20 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
 
         // then
         assertEquals(CASE_NOT_PERFECTLY_CLOSED, mediaA1.getRetConfScore());
-        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\",\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case3\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\",\"ret_conf_reason\":\"AGED_CASE\"}]}";
+        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case3\"," +
+            "\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\",\"ret_conf_reason\":\"AGED_CASE\"}]}";
         JSONAssert.assertEquals(expectedResult, StringEscapeUtils.unescapeJson(mediaA1.getRetConfReason()), JSONCompareMode.NON_EXTENSIBLE);
 
         assertEquals(CASE_NOT_PERFECTLY_CLOSED, mediaA2.getRetConfScore());
         JSONAssert.assertEquals(expectedResult, StringEscapeUtils.unescapeJson(mediaA2.getRetConfReason()), JSONCompareMode.NON_EXTENSIBLE);
 
         assertEquals(CASE_NOT_PERFECTLY_CLOSED, mediaB1.getRetConfScore());
-        String expectedResult2 = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\",\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case3\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\",\"ret_conf_reason\":\"AGED_CASE\"},{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\",\"ret_conf_reason\":\"AGED_CASE\"}]}";
+        String expectedResult2 = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case3\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"ret_conf_reason\":\"AGED_CASE\"}," +
+            "{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"ret_conf_reason\":\"AGED_CASE\"}]}";
         JSONAssert.assertEquals(expectedResult2, StringEscapeUtils.unescapeJson(mediaB1.getRetConfReason()), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -365,8 +371,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         var eodB1 = getExternalObjectDirectoryTestData().eodStoredInExternalLocationTypeForMedia(ExternalLocationTypeEnum.ARM, mediaB1);
 
         when(caseService.getCourtCaseById(case1PerfectlyClosed.getId())).thenReturn(case1PerfectlyClosed);
-
-        when(mediaRepository.findAllByCaseId(case1PerfectlyClosed.getId())).thenReturn(List.of(mediaA1, mediaA2, mediaB1));
+        doReturn(List.of(mediaA1, mediaA2, mediaB1)).when(case1PerfectlyClosed).getAllAssociatedMedias();
 
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case1PerfectlyClosed)).thenReturn(Optional.of(caseRetentionA1));
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case4NotPerfectlyClosed)).thenReturn(Optional.of(caseRetentionD1));
@@ -386,7 +391,9 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         assertEquals(CASE_PERFECTLY_CLOSED, mediaA2.getRetConfScore());
 
         assertEquals(CASE_NOT_PERFECTLY_CLOSED, mediaB1.getRetConfScore());
-        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\",\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\",\"ret_conf_reason\":\"AGED_CASE\"}]}";
+        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"ret_conf_reason\":\"AGED_CASE\"}]}";
         JSONAssert.assertEquals(expectedResult, StringEscapeUtils.unescapeJson(mediaB1.getRetConfReason()), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -411,7 +418,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
 
         when(caseService.getCourtCaseById(case1PerfectlyClosed.getId())).thenReturn(case1PerfectlyClosed);
 
-        when(annotationDocumentRepository.findAllByCaseId(case1PerfectlyClosed.getId())).thenReturn(List.of(annotationDocumentA1, annotationDocumentB1));
+        doReturn(List.of(annotationDocumentA1, annotationDocumentB1)).when(case1PerfectlyClosed).getAllAssociatedAnnotationDocuments();
 
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case1PerfectlyClosed)).thenReturn(Optional.of(caseRetentionA1));
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case4NotPerfectlyClosed)).thenReturn(Optional.of(caseRetentionD1));
@@ -428,7 +435,9 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         assertEquals(CASE_PERFECTLY_CLOSED, annotationDocumentA1.getRetConfScore());
 
         assertEquals(CASE_NOT_PERFECTLY_CLOSED, annotationDocumentB1.getRetConfScore());
-        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\",\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\",\"ret_conf_reason\":\"AGED_CASE\"}]}";
+        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"ret_conf_reason\":\"AGED_CASE\"}]}";
         JSONAssert.assertEquals(expectedResult, StringEscapeUtils.unescapeJson(annotationDocumentB1.getRetConfReason()), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -472,7 +481,9 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         assertEquals(CASE_PERFECTLY_CLOSED, transcriptionDocumentA1.getRetConfScore());
 
         assertEquals(CASE_NOT_PERFECTLY_CLOSED, transcriptionDocumentB1.getRetConfScore());
-        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\",\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\",\"ret_conf_reason\":\"AGED_CASE\"}]}";
+        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"ret_conf_reason\":\"AGED_CASE\"}]}";
         JSONAssert.assertEquals(expectedResult, StringEscapeUtils.unescapeJson(transcriptionDocumentB1.getRetConfReason()), JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -484,7 +495,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         var eod = getExternalObjectDirectoryTestData().eodStoredInExternalLocationTypeForCaseDocument(ExternalLocationTypeEnum.ARM, caseDocument);
 
         when(caseService.getCourtCaseById(case1PerfectlyClosed.getId())).thenReturn(case1PerfectlyClosed);
-        when(caseDocumentRepository.findByCourtCase(case1PerfectlyClosed)).thenReturn(List.of(caseDocument));
+        doReturn(List.of(caseDocument)).when(case1PerfectlyClosed).getCaseDocumentEntities();
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case1PerfectlyClosed)).thenReturn(Optional.of(caseRetentionA1));
         when(eodRepository.findByCaseDocumentAndExternalLocationType(caseDocument, EodHelper.armLocation())).thenReturn(List.of(eod));
 
@@ -505,7 +516,7 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
         var eod = getExternalObjectDirectoryTestData().eodStoredInExternalLocationTypeForCaseDocument(ExternalLocationTypeEnum.ARM, caseDocument);
 
         when(caseService.getCourtCaseById(case4NotPerfectlyClosed.getId())).thenReturn(case4NotPerfectlyClosed);
-        when(caseDocumentRepository.findByCourtCase(case4NotPerfectlyClosed)).thenReturn(List.of(caseDocument));
+        doReturn(List.of(caseDocument)).when(case4NotPerfectlyClosed).getCaseDocumentEntities();
         when(caseRetentionRepository.findTopByCourtCaseOrderByRetainUntilAppliedOnDesc(case4NotPerfectlyClosed)).thenReturn(Optional.of(caseRetentionA1));
         when(eodRepository.findByCaseDocumentAndExternalLocationType(caseDocument, EodHelper.armLocation())).thenReturn(List.of(eod));
         when(currentTimeHelper.currentOffsetDateTime()).thenReturn(RETENTION_UPDATED_DATE);
@@ -515,7 +526,9 @@ class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImplTest {
 
         // then
         assertEquals(CASE_NOT_PERFECTLY_CLOSED, caseDocument.getRetConfScore());
-        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\",\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\",\"ret_conf_reason\":\"AGED_CASE\"}]}";
+        String expectedResult = "{\"ret_conf_applied_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"cases\":[{\"courthouse\":\"CASE_COURTHOUSE\",\"case_number\":\"case4\",\"ret_conf_updated_ts\":\"2024-06-20T10:00:00.000Z\"," +
+            "\"ret_conf_reason\":\"AGED_CASE\"}]}";
         JSONAssert.assertEquals(expectedResult, StringEscapeUtils.unescapeJson(caseDocument.getRetConfReason()), JSONCompareMode.NON_EXTENSIBLE);
     }
 


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5115)


### Change description ###
# Git Diff Summary

The provided diff shows a series of changes across multiple Java files related to integration tests, repository interfaces, and entity classes, primarily focusing on the handling of court case documents and associated entities. The changes emphasize enhancing transaction management, improving entity relationships, and refining assertions in test cases.

## Highlights

- **Transaction Management**: Many test assertions are now wrapped in `transactionalUtil.executeInTransaction()` to ensure that database operations are performed within a transaction context, enhancing consistency and reliability in tests.

- **Entity Relationship Improvements**:
  - Added `caseDocumentEntities` list to `CourtCaseEntity`, allowing direct access to associated case documents.
  - Introduced methods in `CourtCaseEntity` to retrieve all associated media and annotation documents, reducing redundant repository calls.

- **Code Cleanup**: 
  - Removed unused repository methods (e.g., `findByCourtCase` in `CaseDocumentRepository`).
  - Eliminated unnecessary queries in favor of newly added entity methods.

- **Test Cases Enhancement**:
  - Improved assertions within tests to use the newly defined entity methods for fetching associated documents, leading to cleaner and more readable test code.
  - Introduced parameterized tests to cover additional scenarios for media and annotation document retrieval, thereby increasing test coverage and robustness.

- **AnnotationDocumentRepository**: The method to find annotation documents by case ID was removed, as functionality is now handled by the `CourtCaseEntity` methods.

This diff reflects a significant refactor aimed at improving the clarity, maintainability, and performance of the application's data handling and testing mechanisms.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
