### PR TITLE
DMP-5117: ArmRetentionEventDateCalculatorAutomatedTask can get stuck processing the same unprocessable items

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArmRetentionEventDateCalculatorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/component/impl/ArmRetentionEventDateCalculatorImpl.java
@@ -54,6 +54,8 @@ public class ArmRetentionEventDateCalculatorImpl implements ArmRetentionEventDat
                 } else if (ObjectRecordStatusEnum.STORED.getId() == externalObjectDirectory.getStatusId()) {
                     log.info("Updating retention date for ARM EOD {} ", externalObjectDirectoryId);
                     return processArmUpdate(externalObjectDirectory, armRetentionDate, userAccount, externalObjectDirectoryId);
+                } else {
+                    log.info("EOD {} is not in STORED status, skipping ARM retention date update", externalObjectDirectoryId);
                 }
             } else {
                 log.warn("Retention date has not be set for EOD {}", externalObjectDirectoryId);

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -524,8 +524,18 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
 
     @Query("""
         SELECT eod.id FROM ExternalObjectDirectoryEntity eod
-        WHERE eod.externalLocationType = :externalLocationTypeEntity
+        LEFT JOIN eod.media m
+        LEFT JOIN eod.transcriptionDocumentEntity td
+        LEFT JOIN eod.caseDocument cd
+        LEFT JOIN eod.annotationDocumentEntity ad        
+        WHERE eod.externalLocationType = :externalLocationTypeEntity                
         AND eod.updateRetention = :updateRetention
+        AND (    
+             m.retainUntilTs is not null or 
+             td.retainUntilTs is not null or 
+             cd.retainUntilTs is not null or 
+             ad.retainUntilTs is not null
+        )
         """)
     List<Long> findByExternalLocationTypeAndUpdateRetention(ExternalLocationTypeEntity externalLocationTypeEntity,
                                                             boolean updateRetention, Limit limit);


### PR DESCRIPTION
### Links ###
>[Jira](https://tools.hmcts.net/jira/browse/DMP-5117)

NOTE:
Integration tests to be added after https://github.com/hmcts/darts-api/pull/2977 has been merged

### Change description ###
# Summary of Git Diff

This git diff introduces changes to two Java files related to event date calculation and database queries within the HMCTS DARTS project. The updates enhance logging for retention date updates and refine a database query to include additional joins and conditions.

## Highlights

### ArmRetentionEventDateCalculatorImpl.java
- Added an `else` condition to log a message when the external object directory is not in the `STORED` status, providing more clarity on skipped updates.
- The logging statement informs that the retention date update for the given `EOD` (External Object Directory) is being skipped.

### ExternalObjectDirectoryRepository.java
- Updated the SQL query to include additional `LEFT JOIN` statements for media and document entities associated with the `ExternalObjectDirectoryEntity`.
- Added conditions to ensure that any of the media or document entities have a non-null `retainUntilTs` timestamp to be included in the results.
- This change improves the robustness of the query by checking for retention timestamps across multiple related entities.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
