### PR TITLE
Exclude Renovate PR's from Dev Env 

### DIFF
--- a/.github/workflows/auto-label-enable-keep-helm.yml
+++ b/.github/workflows/auto-label-enable-keep-helm.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       pull-requests: write # Grant write permissions to PRs for adding labels
 
+    if: github.actor != 'renovate[bot]' # Add this condition to skip if the author is Renovate
     steps:
       - name: Add a specific label to all new PRs
         uses: actions/github-script@v6 # Use github-script for direct API interaction


### PR DESCRIPTION
### Change description ###
We're running out of database connections so excluding Renovate PR's from creating a Dev Env


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
