### PR TITLE
DMP-5212 set viq header date to local london time

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/model/ViqHeader.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/model/ViqHeader.java
@@ -3,7 +3,10 @@ package uk.gov.hmcts.darts.audio.model;
 import lombok.Value;
 
 import java.time.Instant;
-import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static uk.gov.hmcts.darts.common.util.DateConverterUtil.EUROPE_LONDON_ZONE;
+
 
 @Value
 public class ViqHeader {
@@ -36,12 +39,15 @@ public class ViqHeader {
 
     public ViqHeader(Instant instant) {
 
+        ZonedDateTime londonTime = instant.atZone(EUROPE_LONDON_ZONE);
+
         viqHeaderBytes = new byte[VIQ_HEADER_SIZE];
-        viqHeaderBytes[DAY_OFFSET] = (byte) instant.atOffset(ZoneOffset.UTC).getDayOfMonth();
-        viqHeaderBytes[MONTH_OFFSET] = (byte) instant.atOffset(ZoneOffset.UTC).getMonthValue();
-        viqHeaderBytes[MINUTE_OFFSET] = (byte) instant.atOffset(ZoneOffset.UTC).getMinute();
-        viqHeaderBytes[HOUR_OFFSET] = (byte) instant.atOffset(ZoneOffset.UTC).getHour();
-        viqHeaderBytes[SECONDS_OFFSET] = (byte) instant.atOffset(ZoneOffset.UTC).getSecond();
+        viqHeaderBytes[DAY_OFFSET] = (byte) londonTime.getDayOfMonth();
+        viqHeaderBytes[MONTH_OFFSET] = (byte) londonTime.getMonthValue();
+        viqHeaderBytes[MINUTE_OFFSET] = (byte) londonTime.getMinute();
+        viqHeaderBytes[HOUR_OFFSET] = (byte) londonTime.getHour();
+        viqHeaderBytes[SECONDS_OFFSET] = (byte) londonTime.getSecond();
+
         viqHeaderBytes[VERIFY_OFFSET_0] = (byte) VERIFY_OFFSET_VALUE_0;
         viqHeaderBytes[VERIFY_OFFSET_1] = (byte) VERIFY_OFFSET_VALUE_1;
         viqHeaderBytes[VERIFY_OFFSET_2] = (byte) VERIFY_OFFSET_VALUE_2;

--- a/src/test/java/uk/gov/hmcts/darts/audio/model/ViqHeaderTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/model/ViqHeaderTest.java
@@ -31,10 +31,35 @@ class ViqHeaderTest {
     private static final int SECONDS_OFFSET = 44;
 
     @Test
-    void shouldGenerateCorrectViqHeaderFromInstant() {
+    void shouldGenerateCorrectViqHeaderInBst() {
+        var instant = Instant.parse("2023-07-15T09:23:11Z");
 
+        byte[] header = new ViqHeader(instant).getViqHeaderBytes();
+
+        assertThat(header[DAY_OFFSET]).isEqualTo((byte) 15);
+        assertThat(header[MONTH_OFFSET]).isEqualTo((byte) 7);
+        assertThat(header[HOUR_OFFSET]).isEqualTo((byte) 10); 
+        assertThat(header[MINUTE_OFFSET]).isEqualTo((byte) 23);
+        assertThat(header[SECONDS_OFFSET]).isEqualTo((byte) 11);
+    }
+
+    @Test
+    void shouldGenerateCorrectViqHeaderInGmt() {
+        // 9:23:11 UTC = 9:23:11 GMT (no offset in winter)
+        var instant = Instant.parse("2023-01-15T09:23:11Z");
+
+        byte[] header = new ViqHeader(instant).getViqHeaderBytes();
+
+        assertThat(header[DAY_OFFSET]).isEqualTo((byte) 15);
+        assertThat(header[MONTH_OFFSET]).isEqualTo((byte) 1);
+        assertThat(header[HOUR_OFFSET]).isEqualTo((byte) 9); 
+        assertThat(header[MINUTE_OFFSET]).isEqualTo((byte) 23);
+        assertThat(header[SECONDS_OFFSET]).isEqualTo((byte) 11);
+    }
+
+    @Test
+    void shouldGenerateCorrectStaticViqHeaderFields() {
         var instant = Instant.parse("2023-04-28T09:23:11Z");
-
         byte[] header = new ViqHeader(instant).getViqHeaderBytes();
 
         assertThat(header.length).isEqualTo(1024);
@@ -45,11 +70,6 @@ class ViqHeaderTest {
         assertThat(header[VERIFY_OFFSET_4]).isEqualTo((byte) VERIFY_OFFSET_VALUE_4);
         assertThat(header[FORMAT_OFFSET_0]).isEqualTo((byte) FORMAT_OFFSET_VALUE_0);
         assertThat(header[FORMAT_OFFSET_1]).isEqualTo((byte) FORMAT_OFFSET_VALUE_1);
-        assertThat(header[DAY_OFFSET]).isEqualTo((byte) 28);
-        assertThat(header[MONTH_OFFSET]).isEqualTo((byte) 4);
-        assertThat(header[MINUTE_OFFSET]).isEqualTo((byte) 23);
-        assertThat(header[HOUR_OFFSET]).isEqualTo((byte) 9);
-        assertThat(header[SECONDS_OFFSET]).isEqualTo((byte) 11);
     }
 
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-5212

Converting UTC instant to London time within ViqHeader constructor.

Added unit tests to cover BST/GMT