### PR TITLE
DMP-5199 InboundToUnstructuredAutomatedTask - Rethrow Interrupted Exception

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
@@ -56,17 +56,9 @@ public class UnstructuredDataHelper {
         try {
             blobId = dataManagementService.saveBlobData(dataManagementConfiguration.getUnstructuredContainerName(), inputStream)
                 .getBlobName();
-            log.debug(
-                "Completed upload to unstructured data store for EOD {}. Successfully uploaded with blobId: {}",
-                eodEntity.getId(),
-                blobId
-            );
+            log.debug("Completed upload to unstructured data store for EOD {}. Successfully uploaded with blobId: {}", eodEntity.getId(), blobId);
         } catch (Exception e) {
-            log.error(
-                "Upload to unstructured data store failed for EOD {}.",
-                eodEntity.getId(),
-                e
-            );
+            log.error("Upload to unstructured data store failed for EOD {}.", eodEntity.getId(), e);
         }
         return blobId;
     }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -62,7 +62,6 @@ public class DataManagementServiceImpl implements DataManagementService {
     private final AzureCopyUtil azureCopyUtil;
     private final FileContentChecksum fileContentChecksum;
 
-
     /**
      * Note: This implementation is not memory-efficient with large files
      * use an implementation that stores the blob to a temp file instead.
@@ -155,6 +154,7 @@ public class DataManagementServiceImpl implements DataManagementService {
         return client;
     }
 
+    @SneakyThrows
     @Override
     @SuppressWarnings("PMD.UseObjectForClearerAPI")//TODO - refactor to use object for clearer API when this class is next edited
     public void copyBlobData(String sourceContainerName, String destinationContainerName, String sourceLocation, String destinationLocation) {
@@ -168,7 +168,13 @@ public class DataManagementServiceImpl implements DataManagementService {
 
             log.info("Copy completed from '{}' to '{}'. Source location: {}, destination location: {}",
                      sourceContainerName, destinationContainerName, sourceLocation, destinationLocation);
+
         } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                log.error("Exception copying file from '{}' to '{}'. Source location: {}, destination location: {}",
+                          sourceContainerName, destinationContainerName, sourceLocation, destinationLocation, e);
+                throw e;
+            }
             throw new DartsException(String.format("Exception copying file from '%s' to '%s'. Source location: %s",
                                                    sourceContainerName, destinationContainerName, sourceLocation), e);
         }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -156,7 +156,7 @@ public class DataManagementServiceImpl implements DataManagementService {
 
     @SneakyThrows
     @Override
-    @SuppressWarnings("PMD.UseObjectForClearerAPI")//TODO - refactor to use object for clearer API when this class is next edited
+    @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidInstanceofChecksInCatchClause"})
     public void copyBlobData(String sourceContainerName, String destinationContainerName, String sourceLocation, String destinationLocation) {
         try {
             String sourceContainerSasUrl = dataManagementConfiguration.getContainerSasUrl(sourceContainerName);

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -156,7 +156,7 @@ public class DataManagementServiceImpl implements DataManagementService {
 
     @SneakyThrows
     @Override
-    @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidInstanceofChecksInCatchClause"})
+    @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidInstanceofChecksInCatchClause", "java:S1193"})
     public void copyBlobData(String sourceContainerName, String destinationContainerName, String sourceLocation, String destinationLocation) {
         try {
             String sourceContainerSasUrl = dataManagementConfiguration.getContainerSasUrl(sourceContainerName);

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorImpl.java
@@ -57,6 +57,7 @@ public class InboundToUnstructuredProcessorImpl implements InboundToUnstructured
 
     @Override
     @SuppressWarnings("PMD.DoNotUseThreads")
+    @SneakyThrows
     public void processInboundToUnstructured(int batchSize) {
         log.debug("Processing Inbound data store");
         List<Long> inboundList = externalObjectDirectoryRepository.findEodsForTransfer(getStatus(STORED), getType(INBOUND),
@@ -83,7 +84,6 @@ public class InboundToUnstructuredProcessorImpl implements InboundToUnstructured
         }
     }
 
-    @SneakyThrows
     @SuppressWarnings("PMD.AvoidInstanceofChecksInCatchClause")
     private void processSingleInboundToUnstructured(Long inboundObjectId) {
         try {

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorSingleElementImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorSingleElementImpl.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.darts.datamanagement.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +37,6 @@ public class InboundToUnstructuredProcessorSingleElementImpl implements InboundT
 
     @SuppressWarnings({"java:S4790", "PMD.AvoidFileStream", "PMD.AvoidInstanceofChecksInCatchClause"})
     @Override
-    @SneakyThrows
     @Transactional
     public void processSingleElement(Long inboundEodEntityId) {
         ExternalObjectDirectoryEntity inboundEodEntity = externalObjectDirectoryRepository.findById(inboundEodEntityId).orElseThrow();

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
@@ -447,7 +447,7 @@ class DataManagementServiceImplTest {
     }
 
     @Test
-    void processInboundToUnstructured_shouldStopProcessingAndReturn_WhenThrowingInterruptedExceptionOnSecondItem() throws InterruptedException {
+    void copyBlobData_shouldStopProcessingAndReturn_WhenThrowingInterruptedException() {
         // given
         when(dataManagementConfiguration.getContainerSasUrl("darts-inbound-container"))
             .thenReturn("https://dartssastg.blob....net/darts-inbound-container?sp=r&st=2024-05-23T13...%3D");

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/DataManagementServiceImplTest.java
@@ -44,6 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -442,6 +444,31 @@ class DataManagementServiceImplTest {
         verify(blobProperties, times(1)).getMetadata();
         verify(blobProperties, times(1)).getContentMd5();
         verify(fileContentChecksum, never()).encodeToString(any());
+    }
+
+    @Test
+    void processInboundToUnstructured_shouldStopProcessingAndReturn_WhenThrowingInterruptedExceptionOnSecondItem() throws InterruptedException {
+        // given
+        when(dataManagementConfiguration.getContainerSasUrl("darts-inbound-container"))
+            .thenReturn("https://dartssastg.blob....net/darts-inbound-container?sp=r&st=2024-05-23T13...%3D");
+        when(dataManagementConfiguration.getContainerSasUrl("darts-unstructured"))
+            .thenReturn("https://dartssastg.blob....net/darts-unstructured?sp=r&st=2024-05-23T13...%3D");
+
+        // Simulate InterruptedException
+        doAnswer(invocation -> {
+            throw new InterruptedException("Simulated interruption");
+        }).when(azureCopyUtil).copy(anyString(), anyString());
+
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+
+        // when
+        assertThrows(InterruptedException.class, () ->
+            dataManagementService.copyBlobData(
+                "darts-inbound-container",
+                "darts-unstructured",
+                uuid1,
+                uuid2));
     }
 
     private void assertGetChecksumNotFound(Boolean exists) {

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorImplTest.java
@@ -58,7 +58,7 @@ class InboundToUnstructuredProcessorImplTest {
     }
 
     @Test
-    void processInboundToUnstructured_ContinuesProcessingNextIterationOnException() throws InterruptedException {
+    void processInboundToUnstructured_ContinuesProcessingNextIterationOnException() {
         when(asyncTaskConfig.getThreads()).thenReturn(20);
         when(asyncTaskConfig.getAsyncTimeout()).thenReturn(Duration.ofMinutes(5));
         // given
@@ -77,7 +77,7 @@ class InboundToUnstructuredProcessorImplTest {
     }
 
     @Test
-    void processInboundToUnstructured_shouldStopProcessingAndReturn_WhenThrowingInterruptedExceptionOnSecondItem() throws InterruptedException {
+    void processInboundToUnstructured_shouldStopProcessingAndReturn_WhenThrowingInterruptedExceptionOnSecondItem() {
         // given
         when(asyncTaskConfig.getThreads()).thenReturn(20);
         when(asyncTaskConfig.getAsyncTimeout()).thenReturn(Duration.ofMinutes(5));

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorSingleElementImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorSingleElementImplTest.java
@@ -82,7 +82,7 @@ class InboundToUnstructuredProcessorSingleElementImplTest {
     }
 
     @Test
-    void processInboundToUnstructuredAnnotation() {
+    void processInboundToUnstructuredAnnotation() throws InterruptedException {
 
         when(externalObjectDirectoryEntityInbound.getAnnotationDocumentEntity()).thenReturn(annotationDocumentEntity);
         when(externalObjectDirectoryEntityInbound.getExternalLocation()).thenReturn(EXTERNAL_LOCATION_UUID);
@@ -98,7 +98,7 @@ class InboundToUnstructuredProcessorSingleElementImplTest {
     }
 
     @Test
-    void processInboundToUnstructuredCaseDocument() {
+    void processInboundToUnstructuredCaseDocument() throws InterruptedException {
 
         when(externalObjectDirectoryEntityInbound.getCaseDocument()).thenReturn(caseDocumentEntity);
         when(externalObjectDirectoryEntityInbound.getExternalLocation()).thenReturn(EXTERNAL_LOCATION_UUID);

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorSingleElementImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorSingleElementImplTest.java
@@ -82,7 +82,7 @@ class InboundToUnstructuredProcessorSingleElementImplTest {
     }
 
     @Test
-    void processInboundToUnstructuredAnnotation() throws InterruptedException {
+    void processInboundToUnstructuredAnnotation() {
 
         when(externalObjectDirectoryEntityInbound.getAnnotationDocumentEntity()).thenReturn(annotationDocumentEntity);
         when(externalObjectDirectoryEntityInbound.getExternalLocation()).thenReturn(EXTERNAL_LOCATION_UUID);
@@ -98,7 +98,7 @@ class InboundToUnstructuredProcessorSingleElementImplTest {
     }
 
     @Test
-    void processInboundToUnstructuredCaseDocument() throws InterruptedException {
+    void processInboundToUnstructuredCaseDocument() {
 
         when(externalObjectDirectoryEntityInbound.getCaseDocument()).thenReturn(caseDocumentEntity);
         when(externalObjectDirectoryEntityInbound.getExternalLocation()).thenReturn(EXTERNAL_LOCATION_UUID);


### PR DESCRIPTION
Re-opening this PR after accidental merge of https://github.com/hmcts/darts-api/pull/3021

JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/DMP-5199

Change description
Added rethrowing of interrupted exception so the automated task can stop processing when the max lock time is acheieved

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x ] No