### PR TITLE
DMP-5199 InboundToUnstructuredAutomatedTask - Rethrow Interrupted Exception

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/helper/UnstructuredDataHelper.java
@@ -56,17 +56,9 @@ public class UnstructuredDataHelper {
         try {
             blobId = dataManagementService.saveBlobData(dataManagementConfiguration.getUnstructuredContainerName(), inputStream)
                 .getBlobName();
-            log.debug(
-                "Completed upload to unstructured data store for EOD {}. Successfully uploaded with blobId: {}",
-                eodEntity.getId(),
-                blobId
-            );
+            log.debug("Completed upload to unstructured data store for EOD {}. Successfully uploaded with blobId: {}", eodEntity.getId(), blobId);
         } catch (Exception e) {
-            log.error(
-                "Upload to unstructured data store failed for EOD {}.",
-                eodEntity.getId(),
-                e
-            );
+            log.error("Upload to unstructured data store failed for EOD {}.", eodEntity.getId(), e);
         }
         return blobId;
     }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/DataManagementServiceImpl.java
@@ -62,7 +62,6 @@ public class DataManagementServiceImpl implements DataManagementService {
     private final AzureCopyUtil azureCopyUtil;
     private final FileContentChecksum fileContentChecksum;
 
-
     /**
      * Note: This implementation is not memory-efficient with large files
      * use an implementation that stores the blob to a temp file instead.
@@ -157,8 +156,9 @@ public class DataManagementServiceImpl implements DataManagementService {
         return client;
     }
 
+    @SneakyThrows
     @Override
-    @SuppressWarnings("PMD.UseObjectForClearerAPI")//TODO - refactor to use object for clearer API when this class is next edited
+    @SuppressWarnings({"PMD.UseObjectForClearerAPI", "PMD.AvoidInstanceofChecksInCatchClause", "java:S1193"})
     public void copyBlobData(String sourceContainerName, String destinationContainerName, String sourceLocation, String destinationLocation) {
         try {
             String sourceContainerSasUrl = dataManagementConfiguration.getContainerSasUrl(sourceContainerName);
@@ -170,7 +170,13 @@ public class DataManagementServiceImpl implements DataManagementService {
 
             log.info("Copy completed from '{}' to '{}'. Source location: {}, destination location: {}",
                      sourceContainerName, destinationContainerName, sourceLocation, destinationLocation);
+
         } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                log.error("Exception copying file from '{}' to '{}'. Source location: {}, destination location: {}",
+                          sourceContainerName, destinationContainerName, sourceLocation, destinationLocation, e);
+                throw e;
+            }
             throw new DartsException(String.format("Exception copying file from '%s' to '%s'. Source location: %s",
                                                    sourceContainerName, destinationContainerName, sourceLocation), e);
         }

--- a/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/datamanagement/service/impl/InboundToUnstructuredProcessorImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.datamanagement.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
@@ -55,20 +56,21 @@ public class InboundToUnstructuredProcessorImpl implements InboundToUnstructured
 
 
     @Override
-    @SuppressWarnings("PMD.DoNotUseThreads")//TODO - refactor to avoid using Thread.sleep() when this is next edited
+    @SuppressWarnings("PMD.DoNotUseThreads")
+    @SneakyThrows
     public void processInboundToUnstructured(int batchSize) {
         log.debug("Processing Inbound data store");
         List<Long> inboundList = externalObjectDirectoryRepository.findEodsForTransfer(getStatus(STORED), getType(INBOUND),
-                                                                                          getStatus(STORED), getType(UNSTRUCTURED), 3,
-                                                                                          Limit.of(batchSize));
+                                                                                       getStatus(STORED), getType(UNSTRUCTURED), 3,
+                                                                                       Limit.of(batchSize));
 
         log.info("Found {} records to process from Inbound to Unstructured out of batch size {}", inboundList.size(), batchSize);
         AtomicInteger count = new AtomicInteger(1);
 
         List<Callable<Void>> tasks = inboundList.stream()
             .map(inboundObjectId -> (Callable<Void>) () -> {
-                log.debug("Processing Inbound to Unstructured record {} of {} with EOD id {}",
-                          count.getAndIncrement(), inboundList.size(), inboundObjectId);
+                log.info("Processing Inbound to Unstructured record {} of {} with EOD id {}",
+                         count.getAndIncrement(), inboundList.size(), inboundObjectId);
                 processSingleInboundToUnstructured(inboundObjectId);
                 return null;
             }).toList();
@@ -82,11 +84,15 @@ public class InboundToUnstructuredProcessorImpl implements InboundToUnstructured
         }
     }
 
+    @SuppressWarnings("PMD.AvoidInstanceofChecksInCatchClause")
     private void processSingleInboundToUnstructured(Long inboundObjectId) {
         try {
             singleElementProcessor.processSingleElement(inboundObjectId);
         } catch (Exception exception) {
             log.error("Failed to move from inbound file to unstructured data store for EOD id: {}", inboundObjectId, exception);
+            if (exception instanceof InterruptedException) {
+                throw exception;
+            }
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/datamanagement/service/InboundToUnstructuredProcessorImplTest.java
@@ -4,26 +4,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.darts.common.entity.ExternalObjectDirectoryEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import uk.gov.hmcts.darts.common.repository.ExternalLocationTypeRepository;
 import uk.gov.hmcts.darts.common.repository.ExternalObjectDirectoryRepository;
 import uk.gov.hmcts.darts.common.repository.ObjectRecordStatusRepository;
 import uk.gov.hmcts.darts.datamanagement.service.impl.InboundToUnstructuredProcessorImpl;
 import uk.gov.hmcts.darts.task.config.InboundToUnstructuredAutomatedTaskConfig;
-import uk.gov.hmcts.darts.util.AsyncUtil;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,6 +49,12 @@ class InboundToUnstructuredProcessorImplTest {
                                                                                 externalLocationTypeRepository,
                                                                                 singleElementProcessor,
                                                                                 asyncTaskConfig);
+        Jwt jwt = Jwt.withTokenValue("test")
+            .header("alg", "RS256")
+            .claim("sub", UUID.randomUUID().toString())
+            .claim("email", "integrationtest.user@example.com")
+            .build();
+        SecurityContextHolder.getContext().setAuthentication(new JwtAuthenticationToken(jwt));
     }
 
     @Test
@@ -55,10 +62,6 @@ class InboundToUnstructuredProcessorImplTest {
         when(asyncTaskConfig.getThreads()).thenReturn(20);
         when(asyncTaskConfig.getAsyncTimeout()).thenReturn(Duration.ofMinutes(5));
         // given
-        ExternalObjectDirectoryEntity eod1 = new ExternalObjectDirectoryEntity();
-        eod1.setId(1L);
-        ExternalObjectDirectoryEntity eod2 = new ExternalObjectDirectoryEntity();
-        eod2.setId(2L);
         when(externalObjectDirectoryRepository.findEodsForTransfer(any(), any(), any(), any(), any(), any()))
             .thenReturn(List.of(1L, 2L));
 
@@ -74,26 +77,26 @@ class InboundToUnstructuredProcessorImplTest {
     }
 
     @Test
-    void processInboundToUnstructured_throwsInterruptedException() {
+    void processInboundToUnstructured_shouldStopProcessingAndReturn_WhenThrowingInterruptedExceptionOnSecondItem() {
         // given
-        ExternalObjectDirectoryEntity eod1 = new ExternalObjectDirectoryEntity();
-        eod1.setId(1L);
-        ExternalObjectDirectoryEntity eod2 = new ExternalObjectDirectoryEntity();
-        eod2.setId(2L);
+        when(asyncTaskConfig.getThreads()).thenReturn(20);
+        when(asyncTaskConfig.getAsyncTimeout()).thenReturn(Duration.ofMinutes(5));
         when(externalObjectDirectoryRepository.findEodsForTransfer(any(), any(), any(), any(), any(), any()))
             .thenReturn(List.of(1L, 2L));
 
-        try (MockedStatic<AsyncUtil> mockedStatic = mockStatic(AsyncUtil.class)) {
-            // Mock the static method call to throw InterruptedException
-            mockedStatic.when(() -> AsyncUtil.invokeAllAwaitTermination(anyList(), any(InboundToUnstructuredAutomatedTaskConfig.class)))
-                .thenThrow(new InterruptedException("Mocked InterruptedException"));
+        doNothing().when(singleElementProcessor).processSingleElement(1L);
+        // Simulate InterruptedException
+        doAnswer(invocation -> {
+            throw new InterruptedException("Simulated interruption");
+        }).when(singleElementProcessor).processSingleElement(2L);
 
-            // when
-            inboundToUnstructuredProcessor.processInboundToUnstructured(100);
+        // when
+        inboundToUnstructuredProcessor.processInboundToUnstructured(100);
 
-        } catch (Exception e) {
-            // then
-            assertEquals("Mocked InterruptedException", e.getMessage());
-        }
+        // then
+        verify(singleElementProcessor).processSingleElement(1L);
+        verify(singleElementProcessor).processSingleElement(2L);
+        // Check to ensure that the processor stops processing after the InterruptedException
+        verifyNoMoreInteractions(singleElementProcessor);
     }
 }


### PR DESCRIPTION
Re-opening this PR after accidental merge of https://github.com/hmcts/darts-api/pull/3021

JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/DMP-5199

Change description
Added rethrowing of interrupted exception so the automated task can stop processing when the max lock time is acheieved

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x ] No