### PR TITLE
DMP-5264-DETSChildObjectRetention

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepositoryTest.java
@@ -58,31 +58,29 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     private OffsetDateTime ingestionEndDateTime;
 
     @Test
-    void testGetDirectoryIfMediaDate24Hours() throws Exception {
+    void findIdsIn2StorageLocationsBeforeTime_WhereMediaDate24Hours() throws Exception {
 
         int setupHoursBeforeCurrentTime = 24;
 
-        // setup the test data
+        // set up the test data
         generateDataWithMediaForInbound(setupHoursBeforeCurrentTime);
-
-        int hourDurationBeyondHours = setupHoursBeforeCurrentTime; // which no records are
 
         // exercise the logic
         List<Long> results = externalObjectDirectoryRepository
             .findIdsIn2StorageLocationsBeforeTime(
                 EodHelper.storedStatus(), EodHelper.storedStatus(),
                 EodHelper.inboundLocation(), EodHelper.armLocation(),
-                getCurrentDateTimeWithHoursBefore(hourDurationBeyondHours),
+                getCurrentDateTimeWithHoursBefore(setupHoursBeforeCurrentTime),
                 ExternalObjectDirectoryQueryTypeEnum.MEDIA_QUERY.getIndex(),
                 Limit.of(100_000));
 
         // assert the logic
-        assertExpectedResults(results, entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours,
-                              entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
+        assertFindIdsIn2StorageLocationsBeforeTimeExpectedResults(results, entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours,
+                                                                  entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
     }
 
     @Test
-    void testGetDirectoryIfMediaDateBeyond24Hours() throws Exception {
+    void findIdsIn2StorageLocationsBeforeTime_WhereMediaDateBeyond24Hours() throws Exception {
 
         int setupHoursBeforeCurrentTime = 26;
 
@@ -100,12 +98,12 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
                                                   Limit.of(100_000));
 
         // assert the logic
-        assertExpectedResults(results, entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours,
-                              entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
+        assertFindIdsIn2StorageLocationsBeforeTimeExpectedResults(results, entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours,
+                                                                  entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
     }
 
     @Test
-    void testGetDirectoryIfAnnotationDate24Hours() throws Exception {
+    void findIdsIn2StorageLocationsBeforeTime_WhereAnnotationDate24Hours() throws Exception {
 
         int setupHoursBeforeCurrentTime = 24;
 
@@ -123,12 +121,12 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
                 Limit.of(100_000));
 
         // assert the logic
-        assertExpectedResults(results, entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours,
-                              entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
+        assertFindIdsIn2StorageLocationsBeforeTimeExpectedResults(results, entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours,
+                                                                  entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
     }
 
     @Test
-    void testGetDirectoryIfAnnotationArmDateAndUnstructuredDateOutsideOfBounds() throws Exception {
+    void findIdsIn2StorageLocationsBeforeTime_WhereAnnotationArmDateAndUnstructuredDateOutsideOfBounds() throws Exception {
 
         int setupArmHoursBeforeCurrentTime = 24;
         int setupUnstructuredWeeksBeforeCurrentTime = 4;
@@ -146,12 +144,12 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
                 Limit.of(100_000));
 
         // assert the logic
-        assertExpectedResults(results, entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours,
-                              entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
+        assertFindIdsIn2StorageLocationsBeforeTimeExpectedResults(results, entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours,
+                                                                  entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours.size());
     }
 
     @Test
-    void testGetDirectoryIfAnnotationArmDateAndUnstructuredDateWithNoRecordsFoundDueToArmDateBeingAcceptable() throws Exception {
+    void findIdsIn2StorageLocationsBeforeTime_WhereAnnotationArmDateAndUnstructuredDateWithNoRecordsFoundDueToArmDateBeingAcceptable() throws Exception {
 
         int setupArmHoursBeforeCurrentTime = 24;
         int setupUnstructuredWeeksBeforeCurrentTime = 4;
@@ -173,7 +171,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testGetDirectoryIfMediaDateNotBeyondThreshold() throws Exception {
+    void findIdsIn2StorageLocationsBeforeTime_WhereMediaDateNotBeyondThreshold() throws Exception {
 
         int setupHoursBeforeCurrentTime = 22;
 
@@ -196,7 +194,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testFindStoredInInboundAndUnstructuredByMediaId() throws Exception {
+    void findStoredInInboundAndUnstructuredByMediaId_ShouldReturnAsExpected() throws Exception {
         // Setup
         int hoursBeforeCurrentTime = 24;
         generateDataWithMediaForInbound(hoursBeforeCurrentTime);
@@ -226,7 +224,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void testFindStoredInInboundAndUnstructuredByTranscriptionId() throws Exception {
+    void findStoredInInboundAndUnstructuredByTranscriptionId_ShouldReturnAsExpected() throws Exception {
         // Setup
         int hoursBeforeCurrentTime = 24;
         generateDataWithAnnotationForInbound(hoursBeforeCurrentTime);
@@ -256,7 +254,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void findAllByStatusAndInputUploadProcessedTsBetweenAndLimit_ReturnsResults()
+    void findAllByStatusAndInputUploadProcessedTsBetweenAndLimit_ShouldReturnAsExpected()
         throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         // given
         OffsetDateTime now = currentTimeHelper.currentOffsetDateTime();
@@ -303,7 +301,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void findAllByStatusAndDataIngestionTsBetweenAndLimit_ReturnsResults()
+    void findAllByStatusAndDataIngestionTsBetweenAndLimit_ShouldReturnAsExpected()
         throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         // given
         OffsetDateTime now = currentTimeHelper.currentOffsetDateTime();
@@ -350,7 +348,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit_Success() throws Exception {
+    void findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit_ShouldReturnAsExpected() throws Exception {
         // given
         ObjectRecordStatusEntity status = EodHelper.armRpoPendingStatus();
         ExternalLocationTypeEntity locationType = EodHelper.armLocation();
@@ -376,7 +374,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit_NoResults() {
+    void findIdsByStatusAndLastModifiedBetweenAndLocationAndLimit_ShouldReturnNoResults() {
         ObjectRecordStatusEntity status = EodHelper.armRpoPendingStatus();
         ExternalLocationTypeEntity locationType = EodHelper.armLocation();
         OffsetDateTime newStartDateTime = currentTimeHelper.currentOffsetDateTime().minusDays(2);
@@ -390,7 +388,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
     }
 
     @Test
-    void findByStatusAndDataIngestionTsWithPaging_ReturnsResults() throws Exception {
+    void findByStatusAndDataIngestionTsWithPaging_ShouldReturnAsExpected() throws Exception {
         // Given
         OffsetDateTime pastCurrentDateTime1 = OffsetDateTime.now().minusHours(2);
         OffsetDateTime pastCurrentDateTime2 = OffsetDateTime.now().minusHours(20);
@@ -478,7 +476,7 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
 
     @Transactional
     @Test
-    void updateEodStatusAndTransferAttemptsWhereIdIn_UpdatesValues() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    void updateEodStatusAndTransferAttemptsWhereIdIn_ShouldUpdatesValues() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         // Given
         List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities = externalObjectDirectoryStub.generateWithStatusAndMediaLocation(
             ExternalLocationTypeEnum.ARM, ARM_RPO_PENDING, 10, Optional.empty());
@@ -500,144 +498,6 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
             assertThat(entity.getDataIngestionTs()).isNull();
         });
 
-    }
-
-    private void assertExpectedResults(List<Long> actualResults, List<ExternalObjectDirectoryEntity> expectedResults, int resultCount) {
-        List<Long> matchesEntity = new ArrayList<>(
-            actualResults.stream().filter(expectedResult -> expectedResults.stream().anyMatch(result -> expectedResult.equals(result.getId()))).toList());
-
-        assertEquals(resultCount, matchesEntity.size());
-    }
-
-    private OffsetDateTime getCurrentDateTimeWithHoursBefore(int hours) {
-        return currentTimeHelper.currentOffsetDateTime().minusHours(hours);
-    }
-
-    private OffsetDateTime getCurrentDateTimeWithWeeksBefore(int hours) {
-        return currentTimeHelper.currentOffsetDateTime().minusHours(hours);
-    }
-
-    private void generateDataWithAnnotationForInbound(int hoursBeforeCurrentTime)
-        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        int numberOfRecordsToGenerate = 10;
-
-        OffsetDateTime lastModifiedBeforeCurrentTime = currentTimeHelper.currentOffsetDateTime().minusHours(hoursBeforeCurrentTime);
-
-        OffsetDateTime lastModifiedNotBeforeThreshold = currentTimeHelper.currentOffsetDateTime().minusHours(1);
-        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntitiesNotRelevant;
-        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities;
-        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultOutsideHours;
-        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultWithinTheHour;
-
-        externalObjectDirectoryEntitiesNotRelevant
-            = externalObjectDirectoryStub
-            .generateWithStatusAndTranscriptionOrAnnotationAndLocation(
-                ExternalLocationTypeEnum.INBOUND, ObjectRecordStatusEnum.ARM_RAW_DATA_FAILED, numberOfRecordsToGenerate, Optional.empty());
-        externalObjectDirectoryEntities
-            = externalObjectDirectoryStub
-            .generateWithStatusAndTranscriptionOrAnnotationAndLocation(
-                ExternalLocationTypeEnum.INBOUND, STORED, numberOfRecordsToGenerate, Optional.empty());
-        entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours
-            = externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2);
-
-        expectedArmRecordsResultOutsideHours
-            = externalObjectDirectoryStub
-            .generateWithStatusAndTranscriptionAndAnnotationAndArmLocation(
-                externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2), Optional.of(lastModifiedBeforeCurrentTime));
-        expectedArmRecordsResultWithinTheHour
-            = externalObjectDirectoryStub
-            .generateWithStatusAndTranscriptionAndAnnotationAndArmLocation(
-                externalObjectDirectoryEntities
-                    .subList(externalObjectDirectoryEntities.size() / 2, externalObjectDirectoryEntities.size()), Optional.of(lastModifiedNotBeforeThreshold));
-
-        int expectedRecords = externalObjectDirectoryEntitiesNotRelevant.size() + externalObjectDirectoryEntities.size()
-            + expectedArmRecordsResultOutsideHours.size() + expectedArmRecordsResultWithinTheHour.size();
-
-        // assert that the test has inserted the data into the database
-        assertEquals(expectedRecords, externalObjectDirectoryRepository.findAll().size());
-    }
-
-    private void generateDataWithAnnotationForUnstructured(int hoursBeforeCurrentTimeForArm,
-                                                           int weeksBeforeCurrentTimeForUnstructured)
-        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        int numberOfRecordsToGenerate = 10;
-
-        OffsetDateTime lastModifiedBeforeCurrentTimeForArm = currentTimeHelper.currentOffsetDateTime().minusHours(hoursBeforeCurrentTimeForArm);
-
-        OffsetDateTime lastModifiedBeforeCurrentTimeForUnstructured = currentTimeHelper.currentOffsetDateTime().minus(
-            weeksBeforeCurrentTimeForUnstructured,
-            ChronoUnit.WEEKS
-        );
-
-        OffsetDateTime lastModifiedNotBeforeThreshold = currentTimeHelper.currentOffsetDateTime().minusHours(1);
-
-        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntitiesNotRelevant;
-        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities;
-        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultOutsideHours;
-        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultWithinTheHour;
-
-        externalObjectDirectoryEntitiesNotRelevant
-            = externalObjectDirectoryStub
-            .generateWithStatusAndTranscriptionOrAnnotationAndLocation(
-                ExternalLocationTypeEnum.UNSTRUCTURED,
-                ObjectRecordStatusEnum.ARM_RAW_DATA_FAILED, numberOfRecordsToGenerate, Optional.of(lastModifiedBeforeCurrentTimeForUnstructured));
-        externalObjectDirectoryEntities
-            = externalObjectDirectoryStub
-            .generateWithStatusAndTranscriptionOrAnnotationAndLocation(
-                ExternalLocationTypeEnum.UNSTRUCTURED, STORED, numberOfRecordsToGenerate, Optional.of(lastModifiedBeforeCurrentTimeForUnstructured));
-        entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours
-            = externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2);
-
-        expectedArmRecordsResultOutsideHours
-            = externalObjectDirectoryStub.generateWithStatusAndTranscriptionAndAnnotationAndArmLocation(
-            externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2), Optional.of(lastModifiedBeforeCurrentTimeForArm));
-        expectedArmRecordsResultWithinTheHour
-            = externalObjectDirectoryStub.generateWithStatusAndTranscriptionAndAnnotationAndArmLocation(
-            expectedArmRecordsResultOutsideHours, Optional.of(lastModifiedNotBeforeThreshold));
-
-        int expectedRecords = externalObjectDirectoryEntitiesNotRelevant.size() + externalObjectDirectoryEntities.size()
-            + expectedArmRecordsResultOutsideHours.size() + expectedArmRecordsResultWithinTheHour.size();
-
-        // assert that the test has inserted the data into the database
-        assertEquals(expectedRecords, externalObjectDirectoryRepository.findAll().size());
-    }
-
-    private void generateDataWithMediaForInbound(int hoursBeforeCurrentTime)
-        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        int numberOfRecordsToGenerate = 10;
-
-        OffsetDateTime lastModifiedBeforeCurrentTime = currentTimeHelper.currentOffsetDateTime().minusHours(hoursBeforeCurrentTime);
-
-        OffsetDateTime lastModifiedNotBeforeThreshold = currentTimeHelper.currentOffsetDateTime().minusHours(1);
-
-        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntitiesNotRelevant;
-        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities;
-        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultOutsideHours;
-        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultWithinTheHour;
-        externalObjectDirectoryEntitiesNotRelevant
-            = externalObjectDirectoryStub
-            .generateWithStatusAndMediaLocation(
-                ExternalLocationTypeEnum.INBOUND, ObjectRecordStatusEnum.ARM_RAW_DATA_FAILED, numberOfRecordsToGenerate, Optional.empty());
-        externalObjectDirectoryEntities
-            = externalObjectDirectoryStub
-            .generateWithStatusAndMediaLocation(
-                ExternalLocationTypeEnum.INBOUND, STORED, numberOfRecordsToGenerate, Optional.empty());
-        entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours
-            = externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2);
-
-        expectedArmRecordsResultOutsideHours
-            = externalObjectDirectoryStub.generateWithStatusAndMediaAndArmLocation(
-            entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours, Optional.of(lastModifiedBeforeCurrentTime));
-        expectedArmRecordsResultWithinTheHour
-            = externalObjectDirectoryStub.generateWithStatusAndMediaAndArmLocation(
-            externalObjectDirectoryEntities.subList(
-                externalObjectDirectoryEntities.size() / 2, externalObjectDirectoryEntities.size()), Optional.of(lastModifiedNotBeforeThreshold));
-
-        int expectedRecords = externalObjectDirectoryEntitiesNotRelevant.size() + externalObjectDirectoryEntities.size()
-            + expectedArmRecordsResultOutsideHours.size() + expectedArmRecordsResultWithinTheHour.size();
-
-        // assert that the test has inserted the data into the database
-        assertEquals(expectedRecords, externalObjectDirectoryRepository.findAll().size());
     }
 
     @Nested
@@ -809,4 +669,593 @@ class ExternalObjectDirectoryRepositoryTest extends PostgresIntegrationBase {
             return dartsPersistence.save(eod);
         }
     }
+
+    @Test
+    void findByAnnotationDocumentIdAndExternalLocationTypes_ShouldReturnArmEod() {
+        AnnotationDocumentEntity annotationDocumentArm =
+            dartsPersistence.save(
+                PersistableFactory.getAnnotationDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .annotationDocumentEntity(annotationDocumentArm)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        AnnotationDocumentEntity annotationDocumentDets =
+            dartsPersistence.save(
+                PersistableFactory.getAnnotationDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .annotationDocumentEntity(annotationDocumentDets)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository
+            .findByAnnotationDocumentIdAndExternalLocationTypes(
+                annotationDocumentArm.getId(),
+                List.of(EodHelper.armLocation(), EodHelper.detsLocation())
+            );
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(eodArm.getId());
+    }
+
+    @Test
+    void findByAnnotationDocumentIdAndExternalLocationTypes_ShouldReturnDetsEod() {
+        AnnotationDocumentEntity annotationDocumentArm =
+            dartsPersistence.save(
+                PersistableFactory.getAnnotationDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .annotationDocumentEntity(annotationDocumentArm)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        AnnotationDocumentEntity annotationDocumentDets =
+            dartsPersistence.save(
+                PersistableFactory.getAnnotationDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .annotationDocumentEntity(annotationDocumentDets)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository
+            .findByAnnotationDocumentIdAndExternalLocationTypes(
+                annotationDocumentDets.getId(),
+                List.of(EodHelper.armLocation(), EodHelper.detsLocation())
+            );
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(eodDets.getId());
+    }
+
+    @Test
+    void findByAnnotationDocumentIdAndExternalLocationTypes_ShouldReturnArmAndDetsEods() {
+        AnnotationDocumentEntity annotationDocument =
+            dartsPersistence.save(
+                PersistableFactory.getAnnotationDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .annotationDocumentEntity(annotationDocument)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .annotationDocumentEntity(annotationDocument)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository
+            .findByAnnotationDocumentIdAndExternalLocationTypes(
+                annotationDocument.getId(),
+                List.of(EodHelper.armLocation(), EodHelper.detsLocation())
+            );
+
+        assertThat(results).hasSize(2);
+
+    }
+
+    @Test
+    void findByTranscriptionDocumentIdAndExternalLocationTypes_ShouldReturnArmEod() {
+        TranscriptionDocumentEntity transcriptionDocumentArm =
+            dartsPersistence.save(
+                PersistableFactory.getTranscriptionDocument()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .transcriptionDocumentEntity(transcriptionDocumentArm)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        TranscriptionDocumentEntity transcriptionDocumentDets =
+            dartsPersistence.save(
+                PersistableFactory.getTranscriptionDocument()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .transcriptionDocumentEntity(transcriptionDocumentDets)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByTranscriptionDocumentIdAndExternalLocationTypes(
+            transcriptionDocumentArm.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(eodArm.getId());
+    }
+
+    @Test
+    void findByTranscriptionDocumentIdAndExternalLocationTypes_ShouldReturnDetsEod() {
+        TranscriptionDocumentEntity transcriptionDocumentArm =
+            dartsPersistence.save(
+                PersistableFactory.getTranscriptionDocument()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .transcriptionDocumentEntity(transcriptionDocumentArm)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        TranscriptionDocumentEntity transcriptionDocumentDets =
+            dartsPersistence.save(
+                PersistableFactory.getTranscriptionDocument()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .transcriptionDocumentEntity(transcriptionDocumentDets)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByTranscriptionDocumentIdAndExternalLocationTypes(
+            transcriptionDocumentDets.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(eodDets.getId());
+    }
+
+    @Test
+    void findByTranscriptionDocumentIdAndExternalLocationTypes_ShouldReturnArmAndDetsEod() {
+        TranscriptionDocumentEntity transcriptionDocument =
+            dartsPersistence.save(
+                PersistableFactory.getTranscriptionDocument()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .transcriptionDocumentEntity(transcriptionDocument)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .transcriptionDocumentEntity(transcriptionDocument)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByTranscriptionDocumentIdAndExternalLocationTypes(
+            transcriptionDocument.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    void findByMediaIdAndExternalLocationTypes_ShouldReturnArmEod() {
+        MediaEntity mediaArm =
+            dartsPersistence.save(
+                PersistableFactory.getMediaTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .media(mediaArm)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        MediaEntity mediaDets =
+            dartsPersistence.save(
+                PersistableFactory.getMediaTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .media(mediaDets)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByMediaIdAndExternalLocationTypes(
+            mediaArm.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(eodArm.getId());
+    }
+
+    @Test
+    void findByMediaIdAndExternalLocationTypes_ShouldReturnDetsEod() {
+        MediaEntity mediaArm =
+            dartsPersistence.save(
+                PersistableFactory.getMediaTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .media(mediaArm)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        MediaEntity mediaDets =
+            dartsPersistence.save(
+                PersistableFactory.getMediaTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .media(mediaDets)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByMediaIdAndExternalLocationTypes(
+            mediaDets.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(eodDets.getId());
+    }
+
+    @Test
+    void findByMediaIdAndExternalLocationTypes_ShouldReturnArmAndDetsEod() {
+        MediaEntity media =
+            dartsPersistence.save(
+                PersistableFactory.getMediaTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .media(media)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .media(media)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByMediaIdAndExternalLocationTypes(
+            media.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(2);
+
+    }
+
+    @Test
+    void findByCaseDocumentIdAndExternalLocationTypes_ShouldReturnArmEod() {
+        CaseDocumentEntity caseDocumentArm =
+            dartsPersistence.save(
+                PersistableFactory.getCaseDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .caseDocument(caseDocumentArm)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        CaseDocumentEntity caseDocumentDets =
+            dartsPersistence.save(
+                PersistableFactory.getCaseDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .caseDocument(caseDocumentDets)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByCaseDocumentIdAndExternalLocationTypes(
+            caseDocumentArm.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(eodArm.getId());
+    }
+
+    @Test
+    void findByCaseDocumentIdAndExternalLocationTypes_ShouldReturnDetsEod() {
+        CaseDocumentEntity caseDocumentArm =
+            dartsPersistence.save(
+                PersistableFactory.getCaseDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .caseDocument(caseDocumentArm)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        CaseDocumentEntity caseDocumentDets =
+            dartsPersistence.save(
+                PersistableFactory.getCaseDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .caseDocument(caseDocumentDets)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByCaseDocumentIdAndExternalLocationTypes(
+            caseDocumentDets.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getId()).isEqualTo(eodDets.getId());
+    }
+
+    @Test
+    void findByCaseDocumentIdAndExternalLocationTypes_ShouldReturnArmAndDetsEod() {
+        CaseDocumentEntity caseDocument =
+            dartsPersistence.save(
+                PersistableFactory.getCaseDocumentTestData()
+                    .someMinimalBuilder()
+                    .build()
+                    .getEntity()
+            );
+        ExternalObjectDirectoryEntity eodArm = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.armLocation())
+            .caseDocument(caseDocument)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodArm);
+
+        ExternalObjectDirectoryEntity eodDets = PersistableFactory.getExternalObjectDirectoryTestData()
+            .someMinimalBuilder()
+            .externalLocationType(EodHelper.detsLocation())
+            .caseDocument(caseDocument)
+            .build()
+            .getEntity();
+        dartsPersistence.save(eodDets);
+
+        List<ExternalObjectDirectoryEntity> results = externalObjectDirectoryRepository.findByCaseDocumentIdAndExternalLocationTypes(
+            caseDocument.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+        assertThat(results).hasSize(2);
+
+    }
+
+    private void assertFindIdsIn2StorageLocationsBeforeTimeExpectedResults(
+        List<Long> actualResults, List<ExternalObjectDirectoryEntity> expectedResults, int resultCount) {
+
+        List<Long> matchesEntity = new ArrayList<>(actualResults.stream().filter(
+            expectedResult -> expectedResults.stream().anyMatch(result -> expectedResult.equals(result.getId()))).toList());
+
+        assertEquals(resultCount, matchesEntity.size());
+    }
+
+    private OffsetDateTime getCurrentDateTimeWithHoursBefore(int hours) {
+        return currentTimeHelper.currentOffsetDateTime().minusHours(hours);
+    }
+
+    private OffsetDateTime getCurrentDateTimeWithWeeksBefore(int hours) {
+        return currentTimeHelper.currentOffsetDateTime().minusHours(hours);
+    }
+
+    private void generateDataWithAnnotationForInbound(int hoursBeforeCurrentTime)
+        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        int numberOfRecordsToGenerate = 10;
+
+        OffsetDateTime lastModifiedBeforeCurrentTime = currentTimeHelper.currentOffsetDateTime().minusHours(hoursBeforeCurrentTime);
+
+        OffsetDateTime lastModifiedNotBeforeThreshold = currentTimeHelper.currentOffsetDateTime().minusHours(1);
+        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntitiesNotRelevant;
+        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities;
+        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultOutsideHours;
+        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultWithinTheHour;
+
+        externalObjectDirectoryEntitiesNotRelevant
+            = externalObjectDirectoryStub
+            .generateWithStatusAndTranscriptionOrAnnotationAndLocation(
+                ExternalLocationTypeEnum.INBOUND, ObjectRecordStatusEnum.ARM_RAW_DATA_FAILED, numberOfRecordsToGenerate, Optional.empty());
+        externalObjectDirectoryEntities
+            = externalObjectDirectoryStub
+            .generateWithStatusAndTranscriptionOrAnnotationAndLocation(
+                ExternalLocationTypeEnum.INBOUND, STORED, numberOfRecordsToGenerate, Optional.empty());
+        entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours
+            = externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2);
+
+        expectedArmRecordsResultOutsideHours
+            = externalObjectDirectoryStub
+            .generateWithStatusAndTranscriptionAndAnnotationAndArmLocation(
+                externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2), Optional.of(lastModifiedBeforeCurrentTime));
+        expectedArmRecordsResultWithinTheHour
+            = externalObjectDirectoryStub
+            .generateWithStatusAndTranscriptionAndAnnotationAndArmLocation(
+                externalObjectDirectoryEntities
+                    .subList(externalObjectDirectoryEntities.size() / 2, externalObjectDirectoryEntities.size()), Optional.of(lastModifiedNotBeforeThreshold));
+
+        int expectedRecords = externalObjectDirectoryEntitiesNotRelevant.size() + externalObjectDirectoryEntities.size()
+            + expectedArmRecordsResultOutsideHours.size() + expectedArmRecordsResultWithinTheHour.size();
+
+        // assert that the test has inserted the data into the database
+        assertEquals(expectedRecords, externalObjectDirectoryRepository.findAll().size());
+    }
+
+    private void generateDataWithAnnotationForUnstructured(int hoursBeforeCurrentTimeForArm,
+                                                           int weeksBeforeCurrentTimeForUnstructured)
+        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        int numberOfRecordsToGenerate = 10;
+
+        OffsetDateTime lastModifiedBeforeCurrentTimeForArm = currentTimeHelper.currentOffsetDateTime().minusHours(hoursBeforeCurrentTimeForArm);
+
+        OffsetDateTime lastModifiedBeforeCurrentTimeForUnstructured = currentTimeHelper.currentOffsetDateTime().minus(
+            weeksBeforeCurrentTimeForUnstructured,
+            ChronoUnit.WEEKS
+        );
+
+        OffsetDateTime lastModifiedNotBeforeThreshold = currentTimeHelper.currentOffsetDateTime().minusHours(1);
+
+        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntitiesNotRelevant;
+        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities;
+        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultOutsideHours;
+        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultWithinTheHour;
+
+        externalObjectDirectoryEntitiesNotRelevant
+            = externalObjectDirectoryStub
+            .generateWithStatusAndTranscriptionOrAnnotationAndLocation(
+                ExternalLocationTypeEnum.UNSTRUCTURED,
+                ObjectRecordStatusEnum.ARM_RAW_DATA_FAILED, numberOfRecordsToGenerate, Optional.of(lastModifiedBeforeCurrentTimeForUnstructured));
+        externalObjectDirectoryEntities
+            = externalObjectDirectoryStub
+            .generateWithStatusAndTranscriptionOrAnnotationAndLocation(
+                ExternalLocationTypeEnum.UNSTRUCTURED, STORED, numberOfRecordsToGenerate, Optional.of(lastModifiedBeforeCurrentTimeForUnstructured));
+        entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours
+            = externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2);
+
+        expectedArmRecordsResultOutsideHours
+            = externalObjectDirectoryStub.generateWithStatusAndTranscriptionAndAnnotationAndArmLocation(
+            externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2), Optional.of(lastModifiedBeforeCurrentTimeForArm));
+        expectedArmRecordsResultWithinTheHour
+            = externalObjectDirectoryStub.generateWithStatusAndTranscriptionAndAnnotationAndArmLocation(
+            expectedArmRecordsResultOutsideHours, Optional.of(lastModifiedNotBeforeThreshold));
+
+        int expectedRecords = externalObjectDirectoryEntitiesNotRelevant.size() + externalObjectDirectoryEntities.size()
+            + expectedArmRecordsResultOutsideHours.size() + expectedArmRecordsResultWithinTheHour.size();
+
+        // assert that the test has inserted the data into the database
+        assertEquals(expectedRecords, externalObjectDirectoryRepository.findAll().size());
+    }
+
+    private void generateDataWithMediaForInbound(int hoursBeforeCurrentTime)
+        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        int numberOfRecordsToGenerate = 10;
+
+        OffsetDateTime lastModifiedBeforeCurrentTime = currentTimeHelper.currentOffsetDateTime().minusHours(hoursBeforeCurrentTime);
+
+        OffsetDateTime lastModifiedNotBeforeThreshold = currentTimeHelper.currentOffsetDateTime().minusHours(1);
+
+        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntitiesNotRelevant;
+        List<ExternalObjectDirectoryEntity> externalObjectDirectoryEntities;
+        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultOutsideHours;
+        List<ExternalObjectDirectoryEntity> expectedArmRecordsResultWithinTheHour;
+        externalObjectDirectoryEntitiesNotRelevant
+            = externalObjectDirectoryStub
+            .generateWithStatusAndMediaLocation(
+                ExternalLocationTypeEnum.INBOUND, ObjectRecordStatusEnum.ARM_RAW_DATA_FAILED, numberOfRecordsToGenerate, Optional.empty());
+        externalObjectDirectoryEntities
+            = externalObjectDirectoryStub
+            .generateWithStatusAndMediaLocation(
+                ExternalLocationTypeEnum.INBOUND, STORED, numberOfRecordsToGenerate, Optional.empty());
+        entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours
+            = externalObjectDirectoryEntities.subList(0, externalObjectDirectoryEntities.size() / 2);
+
+        expectedArmRecordsResultOutsideHours
+            = externalObjectDirectoryStub.generateWithStatusAndMediaAndArmLocation(
+            entitiesToBeMarkedWithMediaOrAnnotationOutsideOfArmHours, Optional.of(lastModifiedBeforeCurrentTime));
+        expectedArmRecordsResultWithinTheHour
+            = externalObjectDirectoryStub.generateWithStatusAndMediaAndArmLocation(
+            externalObjectDirectoryEntities.subList(
+                externalObjectDirectoryEntities.size() / 2, externalObjectDirectoryEntities.size()), Optional.of(lastModifiedNotBeforeThreshold));
+
+        int expectedRecords = externalObjectDirectoryEntitiesNotRelevant.size() + externalObjectDirectoryEntities.size()
+            + expectedArmRecordsResultOutsideHours.size() + expectedArmRecordsResultWithinTheHour.size();
+
+        // assert that the test has inserted the data into the database
+        assertEquals(expectedRecords, externalObjectDirectoryRepository.findAll().size());
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/retention/service/ApplyRetentionCaseAssociatedObjectsProcessorIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/retention/service/ApplyRetentionCaseAssociatedObjectsProcessorIntTest.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.darts.common.repository.TranscriptionDocumentRepository;
 import uk.gov.hmcts.darts.common.repository.TranscriptionRepository;
 import uk.gov.hmcts.darts.common.util.EodHelper;
 import uk.gov.hmcts.darts.retention.service.impl.ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl;
-import uk.gov.hmcts.darts.test.common.MediaIdMatcher;
 import uk.gov.hmcts.darts.testutils.IntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.AnnotationStub;
 import uk.gov.hmcts.darts.testutils.stubs.CaseDocumentStub;
@@ -39,13 +38,14 @@ import java.util.UUID;
 
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.ARM;
+import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.DETS;
 import static uk.gov.hmcts.darts.common.enums.ExternalLocationTypeEnum.INBOUND;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.ARM_DROP_ZONE;
 import static uk.gov.hmcts.darts.common.enums.ObjectRecordStatusEnum.STORED;
@@ -60,50 +60,51 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     private UserAccountEntity testUser;
 
     @Autowired
-    CaseRepository caseRepository;
+    private CaseRepository caseRepository;
     @Autowired
-    HearingRepository hearingRepository;
+    private HearingRepository hearingRepository;
     @Autowired
-    CaseRetentionStub caseRetentionStub;
+    private CaseRetentionStub caseRetentionStub;
     @Autowired
-    CaseRetentionRepository caseRetentionRepository;
+    private CaseRetentionRepository caseRetentionRepository;
     @Autowired
-    MediaRepository mediaRepository;
+    private MediaRepository mediaRepository;
     @Autowired
-    ExternalObjectDirectoryStub eodStub;
+    private ExternalObjectDirectoryStub eodStub;
     @MockitoSpyBean
-    ExternalObjectDirectoryRepository eodRepository;
+    private ExternalObjectDirectoryRepository eodRepository;
     @Autowired
-    AnnotationStub annotationStub;
+    private AnnotationStub annotationStub;
     @Autowired
-    TranscriptionStub transcriptionStub;
+    private TranscriptionStub transcriptionStub;
     @Autowired
-    AnnotationRepository annotationRepository;
+    private AnnotationRepository annotationRepository;
     @Autowired
-    AnnotationDocumentRepository annotationDocumentRepository;
+    private AnnotationDocumentRepository annotationDocumentRepository;
     @Autowired
-    TranscriptionRepository transcriptionRepository;
+    private TranscriptionRepository transcriptionRepository;
     @Autowired
-    TranscriptionDocumentRepository transcriptionDocumentRepository;
+    private TranscriptionDocumentRepository transcriptionDocumentRepository;
     @Autowired
-    CourtCaseStub caseStub;
+    private CourtCaseStub caseStub;
     @Autowired
-    CaseDocumentStub caseDocumentStub;
+    private CaseDocumentStub caseDocumentStub;
     @Autowired
-    CaseDocumentRepository caseDocumentRepository;
+    private CaseDocumentRepository caseDocumentRepository;
     @MockitoSpyBean
-    ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl singleCaseProcessor;
+    private ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl singleCaseProcessor;
     @MockitoBean
-    UserIdentity userIdentity;
+    private UserIdentity userIdentity;
 
     @Autowired
-    ApplyRetentionCaseAssociatedObjectsProcessor processor;
+    private ApplyRetentionCaseAssociatedObjectsProcessor processor;
 
-    List<MediaEntity> medias;
-    CourtCaseEntity caseA;
-    CourtCaseEntity caseB;
-    CourtCaseEntity caseC;
-
+    private List<MediaEntity> medias;
+    private CourtCaseEntity caseA;
+    private CourtCaseEntity caseB;
+    private CourtCaseEntity caseC;
+    private CourtCaseEntity caseD;
+    private CourtCaseEntity caseE;
 
     @BeforeEach
     void setup() {
@@ -120,6 +121,7 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
         media 1 -> hearing A1 -> case A
         media 2 -> hearing A2 -> case A
         media 3 -> hearing C  -> case C
+        media 4 -> hearing D  -> case D
         */
 
         // given
@@ -138,6 +140,16 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
         caseC.setRetentionRetries(2);
         caseC.setClosed(true);
 
+        caseD = caseStub.createAndSaveCourtCaseWithHearings();
+        caseD.setRetentionUpdated(true);
+        caseD.setRetentionRetries(1);
+        caseD.setClosed(true);
+
+        caseE = caseStub.createAndSaveCourtCaseWithHearings();
+        caseE.setRetentionUpdated(true);
+        caseE.setRetentionRetries(1);
+        caseE.setClosed(true);
+
         medias = dartsDatabase.getMediaStub().createAndSaveSomeMedias();
 
         var hearA1 = caseA.getHearings().getFirst();
@@ -145,28 +157,40 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
         var hearA3 = caseA.getHearings().get(2);
         var hearB = caseB.getHearings().getFirst();
         var hearC = caseC.getHearings().getFirst();
+        var hearD = caseD.getHearings().getFirst();
+        var hearE = caseE.getHearings().getFirst();
+
         hearA1.addMedia(medias.getFirst());
         hearA1.addMedia(medias.get(1));
         hearA2.addMedia(medias.get(2));
         hearB.addMedia(medias.getFirst());
         hearC.addMedia(medias.get(3));
+        hearD.addMedia(medias.get(4));
+        hearE.addMedia(medias.get(5));
 
         hearingRepository.save(hearA3);
         hearingRepository.save(hearA2);
         hearingRepository.save(hearA1);
         hearingRepository.save(hearB);
         hearingRepository.save(hearC);
+        hearingRepository.save(hearD);
+        hearingRepository.save(hearE);
 
         caseRetentionStub.createCaseRetentionObject(caseA, DT_2025);
         caseRetentionStub.createCaseRetentionObject(caseA, DT_2026);
         caseRetentionStub.createCaseRetentionObject(caseB, DT_2027);
         caseRetentionStub.createCaseRetentionObject(caseB, DT_2028);
         caseRetentionStub.createCaseRetentionObject(caseC, DT_2028);
+        caseRetentionStub.createCaseRetentionObject(caseD, DT_2025);
+        caseRetentionStub.createCaseRetentionObject(caseE, DT_2025);
 
         eodStub.createAndSaveEod(medias.getFirst(), ARM_DROP_ZONE, ARM, eod -> eod.setUpdateRetention(false));
         eodStub.createAndSaveEod(medias.get(1), ARM_DROP_ZONE, ARM, eod -> eod.setUpdateRetention(false));
         eodStub.createAndSaveEod(medias.get(2), ARM_DROP_ZONE, ARM, eod -> eod.setUpdateRetention(false));
         eodStub.createAndSaveEod(medias.get(3), ARM_DROP_ZONE, ARM, eod -> eod.setUpdateRetention(false));
+        eodStub.createAndSaveEod(medias.get(4), ARM_DROP_ZONE, DETS, eod -> eod.setUpdateRetention(false));
+        eodStub.createAndSaveEod(medias.get(5), ARM_DROP_ZONE, ARM, eod -> eod.setUpdateRetention(false));
+        eodStub.createAndSaveEod(medias.get(5), ARM_DROP_ZONE, DETS, eod -> eod.setUpdateRetention(false));
 
         testUser = dartsDatabase.getUserAccountStub().getIntegrationTestUserAccountEntity();
         when(userIdentity.getUserAccount()).thenReturn(testUser);
@@ -174,10 +198,12 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
         caseRepository.save(caseA);
         caseRepository.save(caseB);
         caseRepository.save(caseC);
+        caseRepository.save(caseD);
+        caseRepository.save(caseE);
     }
 
     @Test
-    void testSuccessfullyApplyRetentionToCaseMedias() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSuccessfullyApplyRetentionToCaseMedias() {
 
         // when
         processor.processApplyRetentionToCaseAssociatedObjects(1000);
@@ -203,7 +229,46 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    void testSuccessfullyApplyRetentionToCaseMediasIncludingLinkedMedias() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSuccessfullyApplyRetentionToCaseMediasInDets() {
+
+        // when
+        processor.processApplyRetentionToCaseAssociatedObjects(1000);
+
+        // then
+        var media4 = mediaRepository.findById(medias.get(4).getId()).get();
+        assertThat(media4.getRetainUntilTs()).isEqualTo(DT_2025);
+
+        var actualCaseD = caseRepository.findById(caseD.getId());
+        assertThat(actualCaseD.get().isRetentionUpdated()).isFalse();
+        assertThat(actualCaseD.get().getRetentionRetries()).isEqualTo(1);
+
+        var detsEodsMedia4 = eodRepository.findByMediaStatusAndType(media4, EodHelper.armDropZoneStatus(), EodHelper.detsLocation());
+        assertThat(detsEodsMedia4.getFirst().isUpdateRetention()).isFalse();
+    }
+
+    @Test
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSuccessfullyApplyRetentionToCaseMediasInArmAndDets() {
+
+        // when
+        processor.processApplyRetentionToCaseAssociatedObjects(1000);
+
+        // then
+        var media5 = mediaRepository.findById(medias.get(5).getId()).get();
+        assertThat(media5.getRetainUntilTs()).isEqualTo(DT_2025);
+
+        var actualCaseE = caseRepository.findById(caseE.getId());
+        assertThat(actualCaseE.get().isRetentionUpdated()).isFalse();
+        assertThat(actualCaseE.get().getRetentionRetries()).isEqualTo(1);
+
+        var armEodsMedia5 = eodRepository.findByMediaStatusAndType(media5, EodHelper.armDropZoneStatus(), EodHelper.armLocation());
+        assertThat(armEodsMedia5.getFirst().isUpdateRetention()).isTrue();
+        var detsEodsMedia5 = eodRepository.findByMediaStatusAndType(media5, EodHelper.armDropZoneStatus(), EodHelper.detsLocation());
+        assertThat(detsEodsMedia5.getFirst().isUpdateRetention()).isFalse();
+
+    }
+
+    @Test
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSuccessfullyApplyRetentionToCaseMediasIncludingLinkedMedias() {
         // given
         MediaLinkedCaseEntity mediaLinkedCase1 = createMediaLinkedCase(medias.get(3), caseA);
         dartsDatabase.getMediaLinkedCaseRepository().save(mediaLinkedCase1);
@@ -241,10 +306,8 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    void testSuccessfullyApplyRetentionToCaseAnnotations() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSuccessfullyApplyRetentionToCaseAnnotations() {
         /*
-        Test data setup:
-
         case A -> hearing 1A -> annotation1A -> annotationDoc1, annotationDoc2
         case A -> hearing 1A -> annotation2A -> annotationDoc3
         case A -> hearing 2A -> annotation2A -> annotationDoc3
@@ -294,13 +357,13 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
         // then
         var actualAnnotationDoc1 = annotationDocumentRepository.findById(annotationDoc1.getId()).get();
         assertThat(actualAnnotationDoc1.getRetainUntilTs()).isEqualTo(DT_2028);
-        var eodsAnnotationDoc1 = eodRepository.findByAnnotationDocumentEntityAndExternalLocationType(
-            annotationDoc1, EodHelper.armLocation());
+        var eodsAnnotationDoc1 = eodRepository.findByAnnotationDocumentIdAndExternalLocationTypes(
+            annotationDoc1.getId(), List.of(EodHelper.armLocation()));
         assertThat(eodsAnnotationDoc1.getFirst().isUpdateRetention()).isTrue();
         var actualAnnotationDoc3 = annotationDocumentRepository.findById(annotationDoc3.getId()).get();
         assertThat(actualAnnotationDoc3.getRetainUntilTs()).isEqualTo(DT_2026);
-        var eodsAnnotationDoc3 = eodRepository.findByAnnotationDocumentEntityAndExternalLocationType(
-            annotationDoc3, EodHelper.armLocation());
+        var eodsAnnotationDoc3 = eodRepository.findByAnnotationDocumentIdAndExternalLocationTypes(
+            annotationDoc3.getId(), List.of(EodHelper.armLocation()));
         assertThat(eodsAnnotationDoc3.getFirst().isUpdateRetention()).isTrue();
         var actualAnnotationDoc4 = annotationDocumentRepository.findById(annotationDoc4.getId()).get();
         assertThat(actualAnnotationDoc4.getRetainUntilTs()).isEqualTo(DT_2026);
@@ -316,15 +379,12 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    void testSuccessfullyApplyRetentionToCaseTranscriptionDocuments() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSuccessfullyApplyRetentionToCaseTranscriptionDocuments() {
         /*
-        Test data setup:
-
         case A -> hearing 1 -> transcription1 -> transcriptionDoc1, transcriptionDoc2
         case A -> hearing 1 -> transcription2 -> transcriptionDoc3
         case A -> hearing 2 -> transcription2 -> transcriptionDoc3
         case B -> hearing 3 -> transcription1 -> transcriptionDoc1, transcriptionDoc2
-
         */
 
         // given
@@ -378,7 +438,7 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    void testSuccessfullyApplyRetentionToCaseDocuments() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSuccessfullyApplyRetentionToCaseDocuments() {
         /*
         Test data setup:
 
@@ -415,11 +475,11 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    void testExceptionOnOneObjectCausesRollbackOfAllChangesToAllObjectsAndProcessingOfOtherCasesContinues() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldFail_WhenOneObjectCausesRollbackToAllObjectsAndProcessingOfOtherCasesContinues() {
 
         // given
-        doThrow(RuntimeException.class).when(eodRepository).findByMediaAndExternalLocationType(argThat(
-            new MediaIdMatcher(medias.getFirst().getId())), refEq(EodHelper.armLocation()));
+        doThrow(RuntimeException.class).when(eodRepository).findByMediaIdAndExternalLocationTypes(
+            eq(medias.getFirst().getId()), refEq(List.of(EodHelper.armLocation(), EodHelper.detsLocation())));
 
         // when
         processor.processApplyRetentionToCaseAssociatedObjects(1000);
@@ -442,7 +502,7 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    void testRetentionIsNotAppliedIfAssociatedCasesAreNotAllClosed() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSetRetentionIsNotAppliedIfAssociatedCasesAreNotAllClosed() {
 
         // given
         caseB.setClosed(false);
@@ -464,7 +524,7 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    void testRetentionIsNotAppliedIfMissingArmEod() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSetRetentionIsNotAppliedIfMissingArmEod() {
 
         // given
         eodRepository.deleteAll();
@@ -489,7 +549,7 @@ class ApplyRetentionCaseAssociatedObjectsProcessorIntTest extends IntegrationBas
     }
 
     @Test
-    void testRetentionIsNotAppliedIfNoRetentionsFoundOnMediaCases() {
+    void processApplyRetentionToCaseAssociatedObjects_ShouldSetRetentionIsNotAppliedIfNoRetentionsFoundOnMediaCases() {
 
         // given
         caseRetentionRepository.deleteAll();

--- a/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/service/impl/AudioServiceImpl.java
@@ -94,8 +94,8 @@ public class AudioServiceImpl implements AudioService {
         }
     }
 
-    /*
-    Set the isAvailable flag if the media is available in the unstructured datastore.
+    /**
+     * Set the isAvailable flag if the media is available in the unstructured datastore.
      */
     @Override
     public void setIsAvailable(List<AudioMetadata> audioMetadataList) {

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/ExternalObjectDirectoryRepository.java
@@ -72,6 +72,15 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     List<ExternalObjectDirectoryEntity> findByTranscriptionDocumentEntityAndExternalLocationType(TranscriptionDocumentEntity transcriptionDocument,
                                                                                                  ExternalLocationTypeEntity externalLocationType);
 
+    @Query(
+        """
+            SELECT eod FROM ExternalObjectDirectoryEntity eod
+            WHERE eod.transcriptionDocumentEntity.id = :transcriptionDocumentId
+            AND eod.externalLocationType IN :externalLocationTypes
+            """
+    )
+    List<ExternalObjectDirectoryEntity> findByTranscriptionDocumentIdAndExternalLocationTypes(Long transcriptionDocumentId,
+                                                                                              List<ExternalLocationTypeEntity> externalLocationTypes);
 
     List<ExternalObjectDirectoryEntity> findByTranscriptionDocumentEntityAndExternalLocationTypeAndStatus(
         TranscriptionDocumentEntity transcriptionDocument,
@@ -110,22 +119,6 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
 
     @Query(
         """
-            SELECT eod FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.externalLocationType = :location
-            AND (eod.media = :media
-            or eod.transcriptionDocumentEntity = :transcription
-            or eod.annotationDocumentEntity = :annotation
-            or eod.caseDocument = :caseDocument)
-            """
-    )
-    List<ExternalObjectDirectoryEntity> findExternalObjectDirectoryByLocation(ExternalLocationTypeEntity location,
-                                                                              MediaEntity media,
-                                                                              TranscriptionDocumentEntity transcription,
-                                                                              AnnotationDocumentEntity annotation,
-                                                                              CaseDocumentEntity caseDocument);
-
-    @Query(
-        """
             SELECT eod.id FROM ExternalObjectDirectoryEntity eod
             WHERE eod.status in :failedStatuses
             AND eod.externalLocationType = :type
@@ -152,7 +145,6 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
                                                                           Integer transferAttempts,
                                                                           Limit limit);
 
-
     @Query(
         """
             SELECT eod FROM ExternalObjectDirectoryEntity eod
@@ -160,16 +152,6 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             """
     )
     List<ExternalObjectDirectoryEntity> findByStatusAndType(ObjectRecordStatusEntity status, ExternalLocationTypeEntity type);
-
-    @Query(
-        """
-            SELECT eod FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status.id in :statusList
-            AND eod.externalLocationType = :type
-            """
-    )
-    List<ExternalObjectDirectoryEntity> findByStatusIdInAndType(List<Integer> statusList,
-                                                                ExternalLocationTypeEntity type);
 
     @Query(
         """
@@ -184,15 +166,43 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     List<ExternalObjectDirectoryEntity> findByMediaAndExternalLocationType(MediaEntity media,
                                                                            ExternalLocationTypeEntity externalLocationType);
 
+    @Query(
+        """
+            SELECT eod FROM ExternalObjectDirectoryEntity eod
+            WHERE eod.media.id = :mediaId
+            AND eod.externalLocationType IN :externalLocationTypes
+            """
+    )
+    List<ExternalObjectDirectoryEntity> findByMediaIdAndExternalLocationTypes(Long mediaId,
+                                                                              List<ExternalLocationTypeEntity> externalLocationTypes);
+
     List<ExternalObjectDirectoryEntity> findByMediaAndExternalLocationTypeAndStatus(MediaEntity media,
                                                                                     ExternalLocationTypeEntity externalLocationType,
                                                                                     ObjectRecordStatusEntity status);
 
-    List<ExternalObjectDirectoryEntity> findByAnnotationDocumentEntityAndExternalLocationType(AnnotationDocumentEntity annotationDocument,
-                                                                                              ExternalLocationTypeEntity externalLocationType);
+    @Query(
+        """
+            SELECT eod FROM ExternalObjectDirectoryEntity eod
+            WHERE eod.annotationDocumentEntity.id = :annotationDocumentId
+            AND eod.externalLocationType IN :externalLocationTypes
+            """
+    )
+    List<ExternalObjectDirectoryEntity> findByAnnotationDocumentIdAndExternalLocationTypes(Long annotationDocumentId,
+                                                                                           List<ExternalLocationTypeEntity> externalLocationTypes
+    );
 
     List<ExternalObjectDirectoryEntity> findByCaseDocumentAndExternalLocationType(CaseDocumentEntity caseDocument,
                                                                                   ExternalLocationTypeEntity externalLocationTypeEntity);
+
+    @Query(
+        """
+            SELECT eod FROM ExternalObjectDirectoryEntity eod
+            WHERE eod.caseDocument.id = :caseDocumentId
+            AND eod.externalLocationType IN :externalLocationTypes
+            """
+    )
+    List<ExternalObjectDirectoryEntity> findByCaseDocumentIdAndExternalLocationTypes(Long caseDocumentId,
+                                                                                     List<ExternalLocationTypeEntity> externalLocationTypes);
 
 
     List<ExternalObjectDirectoryEntity> findByMedia(MediaEntity media);
@@ -207,8 +217,8 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
         """
             SELECT eod.id FROM ExternalObjectDirectoryEntity eod, ExternalObjectDirectoryEntity eod2
             WHERE
-            ((:externalObjectDirectoryQueryTypeEnumIndex=1 AND eod.media = eod2.media) OR                 
-            (:externalObjectDirectoryQueryTypeEnumIndex=2 
+            ((:externalObjectDirectoryQueryTypeEnumIndex=1 AND eod.media = eod2.media) OR
+            (:externalObjectDirectoryQueryTypeEnumIndex=2
             AND (eod.transcriptionDocumentEntity=eod2.transcriptionDocumentEntity OR eod.annotationDocumentEntity=eod2.annotationDocumentEntity)))
             AND eod.status = :status1
             AND eod2.status = :status2
@@ -331,26 +341,6 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
         boolean responseCleaned,
         String manifestFilename);
 
-
-    @Query(
-        """
-            SELECT eod FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status in :statuses
-            AND eod.externalLocationType = :locationType
-            AND eod.responseCleaned = :responseCleaned
-            AND eod.lastModifiedDateTime < :lastModifiedBefore
-            and (eod.manifestFile is null
-            or eod.manifestFile not like ':manifestFileBatchPrefix%')
-            order by eod.lastModifiedDateTime
-            """
-    )
-    List<ExternalObjectDirectoryEntity> findSingleArmResponseFiles(
-        List<ObjectRecordStatusEntity> statuses,
-        ExternalLocationTypeEntity locationType,
-        boolean responseCleaned,
-        OffsetDateTime lastModifiedBefore,
-        String manifestFileBatchPrefix);
-
     @Modifying(clearAutomatically = true)
     @Query(
         """
@@ -407,7 +397,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
             SELECT eod.id FROM ExternalObjectDirectoryEntity eod
             WHERE eod.status = :status
             AND eod.externalLocationType = :type
-            AND eod.media is null            
+            AND eod.media is null
             AND NOT EXISTS (select 1 from ExternalObjectDirectoryEntity eod2
             where (eod2.status = :notExistsStatus or eod2.transferAttempts >= :maxTransferAttempts)
             AND eod2.externalLocationType = :notExistsType
@@ -469,7 +459,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
                     (eod1.cad_id IS NOT NULL AND eod1.cad_id = eod2.cad_id)
                 )
             )
-            fetch first :limitRecords rows only            
+            fetch first :limitRecords rows only
             """,
         nativeQuery = true
     )
@@ -515,7 +505,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     @Query(
         """
             SELECT eod FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status = :status 
+            WHERE eod.status = :status
             AND eod.manifestFile = :manifestFile
             ORDER BY eod.lastModifiedDateTime
             """
@@ -523,9 +513,9 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     List<ExternalObjectDirectoryEntity> findAllByStatusAndManifestFile(ObjectRecordStatusEntity status, String manifestFile);
 
     @Query("""
-        SELECT eod.id FROM ExternalObjectDirectoryEntity eod        
+        SELECT eod.id FROM ExternalObjectDirectoryEntity eod
         LEFT JOIN eod.media med
-        LEFT JOIN eod.transcriptionDocumentEntity td       
+        LEFT JOIN eod.transcriptionDocumentEntity td
         LEFT JOIN eod.annotationDocumentEntity ad
         LEFT JOIN eod.caseDocument cd
         WHERE eod.externalLocationType = :externalLocationTypeEntity
@@ -533,8 +523,8 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
            (med.retainUntilTs is not null) or
            (td.retainUntilTs is not null) or
            (ad.retainUntilTs is not null) or
-           (cd.retainUntilTs is not null) 
-        )        
+           (cd.retainUntilTs is not null)
+        )
         AND eod.updateRetention = :updateRetention
         ORDER BY eod.id
         """)
@@ -673,7 +663,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     @Query(
         """
             SELECT eod FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status = :status 
+            WHERE eod.status = :status
             AND eod.inputUploadProcessedTs between :rpoCsvStartTime AND :rpoCsvEndTime
             """
     )
@@ -685,7 +675,7 @@ public interface ExternalObjectDirectoryRepository extends JpaRepository<Externa
     @Query(
         """
             SELECT eod FROM ExternalObjectDirectoryEntity eod
-            WHERE eod.status = :status 
+            WHERE eod.status = :status
             AND eod.dataIngestionTs between :rpoCsvStartTime AND :rpoCsvEndTime
             """
     )

--- a/src/main/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/retention/service/impl/ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -137,11 +138,11 @@ public class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl implemen
         var longestRetentionDate = findLongestRetentionDate(cases);
         if (longestRetentionDate != null) {
             media.setRetainUntilTs(longestRetentionDate);
-            var armEods = eodRepository.findByMediaAndExternalLocationType(media, EodHelper.armLocation());
-            updateArmEodRetention(
-                armEods,
-                format("Expecting one arm EOD for media '%s' but found zero or more than one", media.getId())
-            );
+            var armOrDetsEodList = eodRepository.findByMediaIdAndExternalLocationTypes(
+                media.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+
+            String errorMessage = format("Unexpected number of EODs {} for media '%s'", armOrDetsEodList.size(), media.getId());
+            updateRetentionForArm(armOrDetsEodList, errorMessage);
         } else {
             throw new DartsException(format("No retentions found on cases for media '%s'", media.getId()));
         }
@@ -151,11 +152,10 @@ public class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl implemen
         var longestRetentionDate = findLongestRetentionDate(cases);
         if (longestRetentionDate != null) {
             annotationDoc.setRetainUntilTs(longestRetentionDate);
-            var armEods = eodRepository.findByAnnotationDocumentEntityAndExternalLocationType(annotationDoc, EodHelper.armLocation());
-            updateArmEodRetention(
-                armEods,
-                format("Expecting one arm EOD for annotationDocument '%s' but found zero or more than one", annotationDoc.getId())
-            );
+            var armOrDetsEodList = eodRepository.findByAnnotationDocumentIdAndExternalLocationTypes(
+                annotationDoc.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+            String errorMessage = format("Unexpected number of EODs {} for annotation document '%s'", armOrDetsEodList.size(), annotationDoc.getId());
+            updateRetentionForArm(armOrDetsEodList, errorMessage);
         } else {
             throw new DartsException(format("No retentions found on cases for annotationDocument '%s'", annotationDoc.getId()));
         }
@@ -165,13 +165,29 @@ public class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl implemen
         var longestRetentionDate = findLongestRetentionDate(cases);
         if (longestRetentionDate != null) {
             transcriptionDoc.setRetainUntilTs(longestRetentionDate);
-            var armEods = eodRepository.findByTranscriptionDocumentEntityAndExternalLocationType(transcriptionDoc, EodHelper.armLocation());
-            updateArmEodRetention(
-                armEods,
-                format("Expecting one arm EOD for transcriptionDocument '%s' but found zero or more than one", transcriptionDoc.getId())
-            );
+            var armOrDetsEodList = eodRepository.findByTranscriptionDocumentIdAndExternalLocationTypes(
+                transcriptionDoc.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+            String errorMessage = format("Unexpected number of EODs {} for transcription document '%s'", armOrDetsEodList.size(), transcriptionDoc.getId());
+            updateRetentionForArm(armOrDetsEodList, errorMessage);
         } else {
             throw new DartsException(format("No retentions found on cases for transcriptionDocument '%s'", transcriptionDoc.getId()));
+        }
+    }
+
+    private void updateRetentionForArm(List<ExternalObjectDirectoryEntity> armOrDetsEodList, String errorMessage) {
+        // There should be either 1 or 2 EODs (ARM and/or DETS)
+        if (armOrDetsEodList.size() < 1 || armOrDetsEodList.size() > 2) {
+            throw new DartsException(errorMessage);
+        }
+        // Get only ARM EOD. If EOD is ARM, update EOD retention, if EOD is DETS do nothing DMP-5264
+        List<ExternalObjectDirectoryEntity> armEodList = armOrDetsEodList.stream().filter(
+            eod ->
+                EodHelper.armLocation().getId().equals(
+                    eod.getExternalLocationType().getId())
+        ).toList();
+
+        if (CollectionUtils.isNotEmpty(armEodList)) {
+            updateArmEodRetention(armEodList, errorMessage);
         }
     }
 
@@ -179,11 +195,10 @@ public class ApplyRetentionCaseAssociatedObjectsSingleCaseProcessorImpl implemen
         var longestRetentionDate = findLongestRetentionDate(List.of(courtCase));
         if (longestRetentionDate != null) {
             caseDocument.setRetainUntilTs(longestRetentionDate);
-            var armEods = eodRepository.findByCaseDocumentAndExternalLocationType(caseDocument, EodHelper.armLocation());
-            updateArmEodRetention(
-                armEods,
-                format("Expecting one arm EOD for caseDocument '%s' but found zero or more than one", caseDocument.getId())
-            );
+            var armOrDetsEodList = eodRepository.findByCaseDocumentIdAndExternalLocationTypes(
+                caseDocument.getId(), List.of(EodHelper.armLocation(), EodHelper.detsLocation()));
+            String errorMessage = format("Unexpected number of EODs {} for case document '%s'", armOrDetsEodList.size(), caseDocument.getId());
+            updateRetentionForArm(armOrDetsEodList, errorMessage);
         } else {
             throw new DartsException(format("No retentions found on courtCase for caseDocument '%s'", caseDocument.getId()));
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5264

### Change description ###

Added code so that when it looks for the EODS for the associated objects, if the the EOD is a DETS eod, the update retention is not set to true

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
