### PR TITLE
DMP-5265 ARM - Unable to parse timestamp

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/service/impl/AbstractArmBatchProcessResponseFiles.java
@@ -211,7 +211,7 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
         }
     }
 
-    OffsetDateTime getInputUploadFileTimestamp(ArmResponseInputUploadFileRecord inputUploadFileRecord) {
+    public OffsetDateTime getInputUploadFileTimestamp(ArmResponseInputUploadFileRecord inputUploadFileRecord) {
         try {
             return OffsetDateTime.parse(inputUploadFileRecord.getTimestamp(), dateTimeFormatter);
         } catch (Exception e) {
@@ -221,12 +221,12 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
         }
     }
 
-    private OffsetDateTime getUploadFileRecordProcessTime(ArmResponseUploadFileRecord armResponseUploadFileRecord) {
+    protected OffsetDateTime getUploadFileRecordProcessTime(ArmResponseUploadFileRecord armResponseUploadFileRecord) {
         try {
             return OffsetDateTime.parse(armResponseUploadFileRecord.getProcessTime(), dateTimeFormatter);
         } catch (Exception e) {
-            log.error("Unable to parse timestamp {} from ARM upload file (UF) record {}", armResponseUploadFileRecord.getProcessTime(),
-                      armResponseUploadFileRecord.getA360RecordId(), e);
+            log.warn("Unable to parse timestamp {} from ARM upload file (UF) record {}", armResponseUploadFileRecord.getProcessTime(),
+                     armResponseUploadFileRecord.getA360RecordId(), e);
             throw new IllegalArgumentException(e);
         }
     }
@@ -450,7 +450,6 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
                     deleteArmResponseFilesHelper.deleteResponseBlobs(invalidResponseFiles);
                 }
             } else {
-
                 log.warn("Unable to find external object directory with ID {} for ARM batch responses with first IL file {}, second IL file {}",
                          armResponseBatchData.getExternalObjectDirectoryId(),
                          invalidLineFileFilenameProcessor1.getInvalidLineFileFilenameAndPath(),
@@ -464,7 +463,6 @@ public abstract class AbstractArmBatchProcessResponseFiles implements ArmRespons
         } catch (Exception e) {
             log.error("Unable to update invalid line responses", e);
         }
-
     }
 
     private void setInvalidLineErrorDescription(ArmResponseInvalidLineRecord record1, ArmResponseInvalidLineRecord record2,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -244,7 +244,7 @@ darts:
       transcription-record-properties-file: properties/arm/transcription-record.properties
       annotation-record-properties-file: properties/arm/annotation-record.properties
       case-record-properties-file: properties/arm/case-record.properties
-      input-upload-response-timestamp-format: yyyy-MM-dd'T'HH:mm:ss.SSSSSS[XXXX][XXXXX]
+      input-upload-response-timestamp-format: yyyy-MM-dd'T'HH:mm:ss[.SSSSSS][XXXX][XXXXX]
 
       response-cleanup-buffer-days: 0
       batch-response-cleanup:

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/ArmBatchProcessResponseFilesImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/ArmBatchProcessResponseFilesImplTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.darts.arm.config.UnstructuredToArmProcessorConfiguration;
 import uk.gov.hmcts.darts.arm.model.blobs.ArmBatchResponses;
 import uk.gov.hmcts.darts.arm.model.blobs.ArmResponseBatchData;
 import uk.gov.hmcts.darts.arm.model.blobs.ContinuationTokenBlobs;
+import uk.gov.hmcts.darts.arm.model.record.armresponse.ArmResponseInputUploadFileRecord;
 import uk.gov.hmcts.darts.arm.service.impl.ArmBatchProcessResponseFilesImpl;
 import uk.gov.hmcts.darts.arm.util.files.BatchInputUploadFileFilenameProcessor;
 import uk.gov.hmcts.darts.authorisation.component.UserIdentity;
@@ -35,12 +36,14 @@ import uk.gov.hmcts.darts.util.AsyncUtil;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doNothing;
@@ -77,7 +80,7 @@ class ArmBatchProcessResponseFilesImplTest {
     private static final Integer BATCH_SIZE = 2;
     private static final String DATETIMEKEY = "<datetimekey>";
     private static final String INPUT_UPLOAD_RESPONSE_DATETIME = "2021-08-01T10:08:28.316382+00:00";
-    private static final String UPLOAD_RESPONSE_TIMESTAMP_FORAMT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS[XXXX][XXXXX]";
+    private static final String UPLOAD_RESPONSE_TIMESTAMP_FORAMT = "yyyy-MM-dd'T'HH:mm:ss[.SSSSSS][XXXX][XXXXX]";
 
     @Mock
     private ExternalObjectDirectoryRepository externalObjectDirectoryRepository;
@@ -103,6 +106,7 @@ class ArmBatchProcessResponseFilesImplTest {
     private AsyncTaskConfig asyncTaskConfig;
 
     private ArmBatchProcessResponseFilesImplProtectedMethodSupport armBatchProcessResponseFiles;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setupData() {
@@ -110,7 +114,7 @@ class ArmBatchProcessResponseFilesImplTest {
         lenient().when(asyncTaskConfig.getAsyncTimeout()).thenReturn(Duration.ofSeconds(10));
 
         ObjectMapperConfig objectMapperConfig = new ObjectMapperConfig();
-        ObjectMapper objectMapper = objectMapperConfig.objectMapper();
+        objectMapper = objectMapperConfig.objectMapper();
 
         when(armDataManagementConfiguration.getInputUploadResponseTimestampFormat()).thenReturn(UPLOAD_RESPONSE_TIMESTAMP_FORAMT);
 
@@ -498,6 +502,62 @@ class ArmBatchProcessResponseFilesImplTest {
             // then
             verifyNoMoreInteractions(logApi);
         }
+    }
+
+    @Test
+    void getInputUploadFileTimestamp_shouldReturnParsedOffsetDateTime_WithMilliseconds() {
+        // given
+        ArmBatchProcessResponseFilesImpl armBatchProcessResponse = new ArmBatchProcessResponseFilesImpl(
+            externalObjectDirectoryRepository,
+            armDataManagementApi,
+            fileOperationService,
+            armDataManagementConfiguration,
+            objectMapper,
+            userIdentity,
+            currentTimeHelper,
+            externalObjectDirectoryService,
+            logApi,
+            deleteArmResponseFilesHelper
+        );
+        String timestamp = "2023-06-10T14:08:28.316382+00:00";
+        ArmResponseInputUploadFileRecord inputUploadFileRecord = new ArmResponseInputUploadFileRecord();
+        inputUploadFileRecord.setTimestamp(timestamp);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(UPLOAD_RESPONSE_TIMESTAMP_FORAMT);
+
+        // when
+        OffsetDateTime result = armBatchProcessResponse.getInputUploadFileTimestamp(inputUploadFileRecord);
+
+        // then
+        assertEquals(OffsetDateTime.parse(timestamp, formatter), result);
+    }
+
+    @Test
+    void getInputUploadFileTimestamp_shouldReturnParsedOffsetDateTime_WithoutMilliseconds() {
+        // given
+        ArmBatchProcessResponseFilesImpl armBatchProcessResponse = new ArmBatchProcessResponseFilesImpl(
+            externalObjectDirectoryRepository,
+            armDataManagementApi,
+            fileOperationService,
+            armDataManagementConfiguration,
+            objectMapper,
+            userIdentity,
+            currentTimeHelper,
+            externalObjectDirectoryService,
+            logApi,
+            deleteArmResponseFilesHelper
+        );
+        String timestamp = "2023-06-10T14:08:28+00:00";
+        ArmResponseInputUploadFileRecord inputUploadFileRecord = new ArmResponseInputUploadFileRecord();
+        inputUploadFileRecord.setTimestamp(timestamp);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(UPLOAD_RESPONSE_TIMESTAMP_FORAMT);
+
+        // when
+        OffsetDateTime result = armBatchProcessResponse.getInputUploadFileTimestamp(inputUploadFileRecord);
+
+        // then
+        assertEquals(OffsetDateTime.parse(timestamp, formatter), result);
     }
 
     class ArmBatchProcessResponseFilesImplProtectedMethodSupport extends ArmBatchProcessResponseFilesImpl {

--- a/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchProcessResponseFilesImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/arm/service/impl/DetsToArmBatchProcessResponseFilesImplTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 @Isolated
 class DetsToArmBatchProcessResponseFilesImplTest {
 
-    private static final String UPLOAD_RESPONSE_TIMESTAMP_FORAMT = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS[XXXX][XXXXX]";
+    private static final String UPLOAD_RESPONSE_TIMESTAMP_FORAMT = "yyyy-MM-dd'T'HH:mm:ss[.SSSSSS][XXXX][XXXXX]";
 
     @Mock
     private ArmDataManagementApi armDataManagementApi;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5265

### Change description ###

Changed the date time format string so if the milliseonds is not present, it will still parse the date time

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
