### PR TITLE
DMP-5480 Fix issue with integration tests failing locally

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -100,7 +100,7 @@ services:
 
   darts-redis:
     container_name: darts-redis
-    image: redis:8.6.1-alpine
+    image: hmctsprod.azurecr.io/imported/redis:latest
     restart: always
     ports:
       - "6379:6379"

--- a/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/testutils/IntegrationBase.java
@@ -83,9 +83,16 @@ public class IntegrationBase extends TestBase {
 
     protected TokenStub tokenStub = new TokenStub();
 
-    private static final GenericContainer<?> REDIS = new GenericContainer<>(
-        "hmctsprod.azurecr.io/imported/redis"
-    ).withExposedPorts(6379);
+    /**
+     * Redis container image used for integration tests.
+     * <p>
+     * Defaulting to a public image avoids requiring developers/CI to authenticate to a private registry.
+     * If you need to use a private mirror, override with: -DDARTS_TEST_REDIS_IMAGE=your.registry/redis:tag
+     */
+    private static final String REDIS_IMAGE = System.getProperty("DARTS_TEST_REDIS_IMAGE", "redis:8.6.1-alpine");
+
+    private static final GenericContainer<?> REDIS = new GenericContainer<>(REDIS_IMAGE)
+        .withExposedPorts(6379);
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DMP-5480

### Change description ###

Fixed issue with integration test failing because of not able to get redis

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
