### PR TITLE
DMP-5586 Add is_data_anonymised To 3 APIs

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/audio/mapper/ObjectActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/mapper/ObjectActionMapper.java
@@ -34,6 +34,7 @@ public interface ObjectActionMapper {
 
     @Mappings({
         @Mapping(target = "id", source = "id"),
+        @Mapping(target = "isDataAnonymised", source = "courtCase.dataAnonymised"),
         @Mapping(target = "hearingDate", source = "hearingDate"),
         @Mapping(target = "caseId", source = "courtCase.id"),
         @Mapping(target = "caseNumber", source = "courtCase.caseNumber"),

--- a/src/main/java/uk/gov/hmcts/darts/audio/mapper/ObjectActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/audio/mapper/ObjectActionMapper.java
@@ -34,14 +34,14 @@ public interface ObjectActionMapper {
 
     @Mappings({
         @Mapping(target = "id", source = "id"),
-        @Mapping(target = "isDataAnonymised", source = "courtCase.dataAnonymised"),
         @Mapping(target = "hearingDate", source = "hearingDate"),
         @Mapping(target = "caseId", source = "courtCase.id"),
         @Mapping(target = "caseNumber", source = "courtCase.caseNumber"),
         @Mapping(target = "courthouse.id", source = "courtroom.courthouse.id"),
         @Mapping(target = "courthouse.displayName", source = "courtroom.courthouse.displayName"),
         @Mapping(target = "courtroom.id", source = "courtroom.id"),
-        @Mapping(target = "courtroom.name", source = "courtroom.name")
+        @Mapping(target = "courtroom.name", source = "courtroom.name"),
+        @Mapping(target = "isDataAnonymised", source = "courtCase.dataAnonymised")
     })
     AdminMediaHearingResponseItem toApiModel(HearingEntity hearingEntity);
 

--- a/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/event/mapper/EventMapper.java
@@ -101,6 +101,7 @@ public class EventMapper {
         adminGetEventResponseDetailsHearingsHearingsInner.setId(hearingEntity.getId());
         adminGetEventResponseDetailsHearingsHearingsInner.setCaseId(hearingEntity.getCourtCase().getId());
         adminGetEventResponseDetailsHearingsHearingsInner.setCaseNumber(hearingEntity.getCourtCase().getCaseNumber());
+        adminGetEventResponseDetailsHearingsHearingsInner.setIsDataAnonymised(hearingEntity.getCourtCase().isDataAnonymised());
         adminGetEventResponseDetailsHearingsHearingsInner.setHearingDate(hearingEntity.getHearingDate());
         adminGetEventResponseDetailsHearingsHearingsInner.setCourtroom(mapCourtRoom(hearingEntity.getCourtroom()));
         adminGetEventResponseDetailsHearingsHearingsInner.setCourthouse(

--- a/src/main/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingSearchResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingSearchResponseMapper.java
@@ -34,6 +34,7 @@ public class AdminHearingSearchResponseMapper {
 
             response.setId(e.getId());
             response.setHearingDate(e.getHearingDate());
+            response.setIsDataAnonymised(e.getCourtCase().isDataAnonymised());
 
             hearingsSearchResponses.add(response);
         });

--- a/src/main/resources/openapi/audio.yaml
+++ b/src/main/resources/openapi/audio.yaml
@@ -848,6 +848,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/HearingId'
+        is_data_anonymised:
+          type: boolean
         case_id:
           $ref: '#/components/schemas/CaseId'
         case_number:

--- a/src/main/resources/openapi/event.yaml
+++ b/src/main/resources/openapi/event.yaml
@@ -876,7 +876,7 @@ components:
         text:
           type: string
         is_data_anonymised:
-          type: boolean
+          $ref: '#/components/schemas/is_data_anonymised'
         courthouse:
           type: object
           properties:
@@ -964,6 +964,8 @@ components:
                 $ref: '#/components/schemas/CourthouseResponseDetails'
               courtroom:
                 $ref: '#/components/schemas/CourtroomResponseDetails'
+              is_data_anonymised:
+                $ref: '#/components/schemas/is_data_anonymised'
     AdminGetEventResponseDetails:
       type: object
       properties:
@@ -993,7 +995,7 @@ components:
         antecedent_id:
           type: string
         is_data_anonymised:
-          type: boolean
+          $ref: '#/components/schemas/is_data_anonymised'
         event_status:
           type: integer
         event_ts:
@@ -1028,6 +1030,10 @@ components:
         - "GET_COURTLOG_101"
         - "GET_COURTLOG_102"
       x-enum-varnames: [ COURTLOG_COURT_HOUSE_NOT_FOUND ]
+
+    is_data_anonymised:
+      type: boolean
+      example: false
 
     PostCourtLogsErrorCode:
       type: string

--- a/src/main/resources/openapi/hearings.yaml
+++ b/src/main/resources/openapi/hearings.yaml
@@ -310,6 +310,10 @@ paths:
 
 components:
   schemas:
+    is_data_anonymised:
+      type: boolean
+      example: false
+
     get_hearing_response:
       type: object
       properties:
@@ -372,8 +376,7 @@ components:
           type: string
           example: Record:New Case
         is_data_anonymised:
-          type: boolean
-          example: false
+          $ref: '#/components/schemas/is_data_anonymised'
 
     HearingsSearchRequest:
       type: object
@@ -544,6 +547,8 @@ components:
             name:
               type: string
               description: 'The courtroom display name'
+        is_data_anonymised:
+          $ref: '#/components/schemas/is_data_anonymised'
     HearingAuthorisation403ErrorCode:
       type: string
       enum:

--- a/src/test/java/uk/gov/hmcts/darts/audio/mapper/ObjectActionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/audio/mapper/ObjectActionMapperTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
+import uk.gov.hmcts.darts.common.entity.CourtCaseEntity;
+import uk.gov.hmcts.darts.common.entity.HearingEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectAdminActionEntity;
 import uk.gov.hmcts.darts.common.entity.ObjectHiddenReasonEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -49,6 +51,19 @@ class ObjectActionMapperTest {
         var adminActionResponse = adminMediaMapper.toApiModel(objectAdminActionEntities);
 
         assertNull(adminActionResponse);
+    }
+
+    @Test
+    void toApiModel_shouldMapIsDataAnonymisedFromHearingCourtCase() {
+        CourtCaseEntity courtCaseEntity = new CourtCaseEntity();
+        courtCaseEntity.setDataAnonymised(true);
+
+        HearingEntity hearingEntity = new HearingEntity();
+        hearingEntity.setCourtCase(courtCaseEntity);
+
+        var hearingResponse = adminMediaMapper.toApiModel(hearingEntity);
+
+        assertEquals(courtCaseEntity.isDataAnonymised(), hearingResponse.getIsDataAnonymised());
     }
 
 

--- a/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/event/mapper/EventMapperTest.java
@@ -312,6 +312,7 @@ class EventMapperTest {
         CourtCaseEntity courtCaseEntity = new CourtCaseEntity();
         courtCaseEntity.setId(123);
         courtCaseEntity.setCaseNumber("caseNumber");
+        courtCaseEntity.setDataAnonymised(true);
 
         HearingEntity hearingEntity = new HearingEntity();
         hearingEntity.setId(1);
@@ -326,6 +327,7 @@ class EventMapperTest {
         assertThat(result.getId()).isEqualTo(1);
         assertThat(result.getCaseId()).isEqualTo(123);
         assertThat(result.getCaseNumber()).isEqualTo("caseNumber");
+        assertThat(result.getIsDataAnonymised()).isEqualTo(courtCaseEntity.isDataAnonymised());
         assertThat(result.getHearingDate()).isEqualTo(hearingDate);
         assertThat(result.getCourtroom()).isEqualTo(courtroomResponseDetails);
         assertThat(result.getCourthouse()).isEqualTo(courthouseResponseDetails);

--- a/src/test/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingSearchResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/hearings/mapper/AdminHearingSearchResponseMapperTest.java
@@ -19,7 +19,7 @@ class AdminHearingSearchResponseMapperTest {
     void mapSearchResponse() {
         List<HearingEntity> hearingEntityList = new ArrayList<>();
         hearingEntityList.add(setupHearing(1));
-        hearingEntityList.add(setupHearing(2));
+        hearingEntityList.add(setupHearing(2, true));
         hearingEntityList.add(setupHearing(3));
         List<HearingsSearchResponse> actualResponse = AdminHearingSearchResponseMapper.mapResponse(hearingEntityList);
 
@@ -32,15 +32,20 @@ class AdminHearingSearchResponseMapperTest {
             assertEquals(hearingEntityList.get(i).getCourtroom().getName(), actualResponse.get(i).getCourtroom().getName());
             assertEquals(hearingEntityList.get(i).getCourtCase().getId(), actualResponse.get(i).getCase().getId());
             assertEquals(hearingEntityList.get(i).getCourtCase().getCaseNumber(), actualResponse.get(i).getCase().getCaseNumber());
+            assertEquals(hearingEntityList.get(i).getCourtCase().isDataAnonymised(), actualResponse.get(i).getIsDataAnonymised());
         }
     }
 
 
-    public static  HearingEntity setupHearing(Integer id) {
-        return setupHearing(id, id, id, id);
+    public static HearingEntity setupHearing(Integer id) {
+        return setupHearing(id, false);
     }
 
-    public static HearingEntity setupHearing(Integer id, Integer courthouseId, Integer courtroomId, Integer courtcaseId) {
+    public static HearingEntity setupHearing(Integer id, boolean isDataAnonymised) {
+        return setupHearing(id, id, id, id, isDataAnonymised);
+    }
+
+    public static HearingEntity setupHearing(Integer id, Integer courthouseId, Integer courtroomId, Integer courtcaseId, boolean isDataAnonymised) {
 
         CourthouseEntity courthouseEntity = new CourthouseEntity();
         courthouseEntity.setId(courthouseId);
@@ -53,6 +58,7 @@ class AdminHearingSearchResponseMapperTest {
         CourtCaseEntity courtCaseEntity = new CourtCaseEntity();
         courtCaseEntity.setId(courtcaseId);
         courtCaseEntity.setCaseNumber("Case number" + courtcaseId);
+        courtCaseEntity.setDataAnonymised(isDataAnonymised);
 
         HearingEntity hearingEntity = new HearingEntity();
         hearingEntity.setId(id);


### PR DESCRIPTION
### JIRA link ###

[DMP-5586](https://tools.hmcts.net/jira/browse/DMP-5586)


### Change description ###

Opening expired cases in darts-portal was causing 404 errors. The is_data_anonymised field has been added to the following endpoint responses to prevent this behaviour. 

- GET /admin/medias/<id>
- GET /admin/events/<id>
- POST /admin/hearings/search

See ticket DMP-5437.

- [x] AI-assisted

### AI Specific Change description ###

Supported test writing and understanding around data flow.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No