### PR TITLE
DMP-5272 API Validation /transcriptions/{transcription_id}/document POST Input Hardening

### DIFF
--- a/src/main/resources/openapi/transcriptions.yaml
+++ b/src/main/resources/openapi/transcriptions.yaml
@@ -456,17 +456,21 @@ paths:
           schema:
             type: integer
             format: int64
+            description: Transcription ID. Validated by the application for min and max range.
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
               required:
                 - transcript
               type: object
+              additionalProperties: false
               properties:
                 transcript:
                   type: string
                   format: binary
+                  description: Transcript file. Validated by the application for file extension, content type, and maximum size.
       responses:
         '200':
           description: OK

--- a/src/main/resources/openapi/transcriptions.yaml
+++ b/src/main/resources/openapi/transcriptions.yaml
@@ -470,7 +470,7 @@ paths:
                 transcript:
                   type: string
                   format: binary
-                  description: Transcript file. Validated by the application for file extension, content type, and maximum size.
+                  description: Transcript file. Validated by the application for file extension, content type, and maximum size (10MB).
       responses:
         '200':
           description: OK

--- a/src/test/java/uk/gov/hmcts/darts/openapi/TranscriptionOpenApiContractTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/openapi/TranscriptionOpenApiContractTest.java
@@ -81,6 +81,17 @@ class TranscriptionOpenApiContractTest {
         }
 
         @Test
+        void openApi_ShouldReturnError_WhenTranscriptionIdIsNotNumeric() {
+            Request request = SimpleRequest.Builder
+                .get("/transcriptions/not-a-number/document")
+                .build();
+
+            ValidationReport report = VALIDATOR.validateRequest(request);
+
+            assertHasMessageContaining(report, "Instance type (string) does not match any allowed primitive type");
+        }
+
+        @Test
         void openApi_ShouldReturnError_WhenUnsupportedContentTypeUsed() {
             Request request = SimpleRequest.Builder
                 .post("/transcriptions/1/document")

--- a/src/test/java/uk/gov/hmcts/darts/openapi/TranscriptionOpenApiContractTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/openapi/TranscriptionOpenApiContractTest.java
@@ -4,7 +4,9 @@ import com.atlassian.oai.validator.OpenApiInteractionValidator;
 import com.atlassian.oai.validator.model.Request;
 import com.atlassian.oai.validator.model.SimpleRequest;
 import com.atlassian.oai.validator.report.ValidationReport;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import uk.gov.hmcts.darts.util.ValidationConstants;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,5 +60,68 @@ class TranscriptionOpenApiContractTest {
         ValidationReport report = VALIDATOR.validateRequest(request);
 
         assertTrue(report.getMessages().isEmpty(), "Expected no validation errors for a valid transcription_id");
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class TranscriptionsTranscriptionIdDocumentPost {
+
+        @Test
+        void openApi_ShouldReturnNoError_WhenValidTranscriptionIdUsed() {
+            String boundary = "test-boundary";
+            Request request = SimpleRequest.Builder
+                .post("/transcriptions/1/document")
+                .withContentType("multipart/form-data; boundary=" + boundary)
+                .withBody(multipartTranscriptBody(boundary))
+                .build();
+
+            ValidationReport report = VALIDATOR.validateRequest(request);
+
+            assertTrue(report.getMessages().isEmpty(), "Expected no validation errors for a valid transcript upload request");
+        }
+
+        @Test
+        void openApi_ShouldReturnError_WhenUnsupportedContentTypeUsed() {
+            Request request = SimpleRequest.Builder
+                .post("/transcriptions/1/document")
+                .withContentType("application/json")
+                .withBody("{\"transcript\":\"Transcript content\"}")
+                .build();
+
+            ValidationReport report = VALIDATOR.validateRequest(request);
+
+            assertHasMessageContaining(report, "does not match any allowed types");
+        }
+
+        @Test
+        void openApi_ShouldReturnError_WhenRequestBodyIsMissing() {
+            Request request = SimpleRequest.Builder
+                .post("/transcriptions/1/document")
+                .withContentType("multipart/form-data")
+                .build();
+
+            ValidationReport report = VALIDATOR.validateRequest(request);
+
+            assertHasMessageContaining(report, "A request body is required but none found");
+        }
+
+        private String multipartTranscriptBody(String boundary) {
+            return String.join("\r\n",
+                               "--" + boundary,
+                               "Content-Disposition: form-data; name=\"transcript\"; filename=\"transcript.txt\"",
+                               "Content-Type: text/plain",
+                               "",
+                               "Transcript content",
+                               "--" + boundary + "--",
+                               "");
+        }
+    }
+
+    private void assertHasMessageContaining(ValidationReport report, String expectedSubstring) {
+        assertTrue(
+            report.getMessages().stream()
+                .anyMatch(message -> message.getMessage().contains(expectedSubstring)),
+            () -> "Expected validation message containing '%s' but got %s".formatted(expectedSubstring, report.getMessages())
+        );
     }
 }


### PR DESCRIPTION
### JIRA link ###

[DMP-5272](https://tools.hmcts.net/jira/browse/DMP-5272)

### Change description ###

Input validation has been added to fields in the /transcriptions/{transcription_id}/document POST schema.

- [x] AI-assisted

### AI Specific Change description ###

Understanding validation flow, and test creation.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No
