### PR TITLE
DMP-5613 Update Multiple Dependencies Flagged By Renovate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '12.2.2'
   id 'com.github.ben-manes.versions' version '0.54.0'
   id 'org.sonarqube' version '6.3.1.5724'
-  id "io.freefair.lombok" version "8.14"
+  id "io.freefair.lombok" version "8.14.4"
   id "org.openapi.generator" version "7.13.0"
   id "org.flywaydb.flyway" version "11.20.3"
   id 'maven-publish'
@@ -54,6 +54,9 @@ def swaggerList = []
 //iteration by swagger file root folder and save into swaggerList variable
 def dir = new File("$rootDir/src/main/resources/openapi/".toString())
 
+
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+
 import java.nio.file.Files
 
 import static groovy.io.FileType.FILES
@@ -66,22 +69,22 @@ dir.eachFileRecurse(FILES) { file ->
 def openApiGenerateTaskList = []
 
 // Iterate on all swagger files and generate a task for each one with the nomenclature openApiGenerate + swagger name
-swaggerList.each {
-  def apiName = it.getName().replace(".yaml", "");
+swaggerList.each { swaggerFile ->
+  def apiName = swaggerFile.getName().replace(".yaml", "")
   def taskName = "openApiGenerate" + apiName.capitalize()
   openApiGenerateTaskList << taskName
-  tasks.register(taskName, org.openapitools.generator.gradle.plugin.tasks.GenerateTask, {
-    generatorName = "spring"
-    inputSpec = "$rootDir/src/main/resources/openapi/".toString() + "${apiName}.yaml"
-    outputDir = "$buildDir/generated/openapi".toString()
-    apiPackage = "uk.gov.hmcts.darts.".toString() + "${apiName}" + ".http.api"
-    modelPackage = "uk.gov.hmcts.darts.".toString() + "${apiName}" + ".model"
+  tasks.register(taskName.toString(), GenerateTask) { GenerateTask task ->
+    task.generatorName.set("spring")
+    task.inputSpec.set("$rootDir/src/main/resources/openapi/${apiName}.yaml".toString())
+    task.outputDir.set("$buildDir/generated/openapi".toString())
+    task.apiPackage.set("uk.gov.hmcts.darts.".toString() + "${apiName}" + ".http.api")
+    task.modelPackage.set("uk.gov.hmcts.darts.".toString() + "${apiName}" + ".model")
     //    https://openapi-generator.tech/docs/generators/java/#config-options
-    skipOperationExample = true
-    openapiNormalizer = [
+    task.skipOperationExample.set(true)
+    task.openapiNormalizer.set([
         REF_AS_PARENT_IN_ALLOF: "true"
-    ]
-    configOptions = [
+    ])
+    task.configOptions.set([
         dateLibrary                         : "java8",
         interfaceOnly                       : "true",
         useTags                             : "true",
@@ -89,9 +92,9 @@ swaggerList.each {
         containerDefaultToNull              : "true",
         generatedConstructorWithRequiredArgs: "false",
         additionalModelTypeAnnotations      : "@lombok.AllArgsConstructor;@lombok.NoArgsConstructor"
-    ]
+    ])
 
-  })
+  }
 }
 
 sourceSets {
@@ -423,7 +426,7 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis'
-  implementation group: 'org.springframework', name: 'spring-webflux', version: '6.2.19'
+  implementation group: 'org.springframework', name: 'spring-webflux', version: '7.0.8'
 
   implementation group: 'org.springframework.security', name: 'spring-security-oauth2-authorization-server', version: '1.5.8'
 
@@ -439,7 +442,7 @@ dependencies {
   implementation 'org.openapitools:jackson-databind-nullable:0.2.10'
   implementation 'org.zalando:problem-spring-web-starter:0.29.1'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.16'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.17'
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '4.3.3'
   implementation 'org.springframework.retry:spring-retry:2.0.13'
 
@@ -467,7 +470,7 @@ dependencies {
   //database
   implementation 'org.postgresql:postgresql:42.7.12'
 
-  implementation 'uk.gov.service.notify:notifications-java-client:5.2.1-RELEASE'
+  implementation 'uk.gov.service.notify:notifications-java-client:6.0.1-RELEASE'
 
   implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.37'
   implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.37'
@@ -478,7 +481,7 @@ dependencies {
 
   implementation 'org.mapstruct:mapstruct:1.6.3'
   implementation group: 'org.apache.tika', name: 'tika-core', version: '3.3.1'
-  implementation group: 'org.springframework.data', name: 'spring-data-envers', version: '3.5.13'
+  implementation group: 'org.springframework.data', name: 'spring-data-envers', version: '4.1.0'
   implementation 'org.hibernate.orm:hibernate-ant:6.6.54.Final'
   implementation 'org.hibernate:hibernate-spatial:6.6.54.Final'
 
@@ -517,7 +520,7 @@ dependencies {
 
   testImplementation group: 'org.jeasy', name: 'easy-random-core', version: '5.0.0'
 
-  testImplementation 'com.atlassian.oai:swagger-request-validator-core:2.46.1'
+  testImplementation 'com.atlassian.oai:swagger-request-validator-core:3.0.0'
 
   compileJava.dependsOn = openApiGenerateTaskList
 }

--- a/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminGetCaseByIdIntTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/cases/controller/CaseControllerAdminGetCaseByIdIntTest.java
@@ -134,8 +134,8 @@ class CaseControllerAdminGetCaseByIdIntTest extends IntegrationBase {
         String actualResponse = mvcResult.getResponse().getContentAsString();
         String expectedResponse = getContentsFromFile(
             "tests/cases/CaseControllerAdminGetCaseByIdTest/testCaseOpen/expectedResponse.json");
-        expectedResponse = expectedResponse.replace("<CREATED_AT>", courtCase.getCreatedDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
-        expectedResponse = expectedResponse.replace("<LAST_MODIFIED_AT>", courtCase.getLastModifiedDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
+        expectedResponse = expectedResponse.replace("<CREATED_AT>", formatAsUtc(courtCase.getCreatedDateTime()));
+        expectedResponse = expectedResponse.replace("<LAST_MODIFIED_AT>", formatAsUtc(courtCase.getLastModifiedDateTime()));
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
 
     }
@@ -176,8 +176,8 @@ class CaseControllerAdminGetCaseByIdIntTest extends IntegrationBase {
         String actualResponse = mvcResult.getResponse().getContentAsString();
         String expectedResponse = getContentsFromFile(
             "tests/cases/CaseControllerAdminGetCaseByIdTest/testCaseClosed/expectedResponse.json");
-        expectedResponse = expectedResponse.replace("<CREATED_AT>", courtCase.getCreatedDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
-        expectedResponse = expectedResponse.replace("<LAST_MODIFIED_AT>", courtCase.getLastModifiedDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
+        expectedResponse = expectedResponse.replace("<CREATED_AT>", formatAsUtc(courtCase.getCreatedDateTime()));
+        expectedResponse = expectedResponse.replace("<LAST_MODIFIED_AT>", formatAsUtc(courtCase.getLastModifiedDateTime()));
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
 
     }
@@ -213,8 +213,8 @@ class CaseControllerAdminGetCaseByIdIntTest extends IntegrationBase {
         String expectedResponse = getContentsFromFile(
             "tests/cases/CaseControllerAdminGetCaseByIdTest/testIsAnonymised/expectedResponse.json");
         expectedResponse = expectedResponse
-            .replace("<CREATED_AT>", courtCase.getCreatedDateTime().format(DateTimeFormatter.ISO_DATE_TIME))
-            .replace("<LAST_MODIFIED_AT>", courtCase.getLastModifiedDateTime().format(DateTimeFormatter.ISO_DATE_TIME))
+            .replace("<CREATED_AT>", formatAsUtc(courtCase.getCreatedDateTime()))
+            .replace("<LAST_MODIFIED_AT>", formatAsUtc(courtCase.getLastModifiedDateTime()))
             .replace("<DATA_ANONYMISED_BY>", String.valueOf(anonymisedBy.getId()));
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
@@ -248,8 +248,8 @@ class CaseControllerAdminGetCaseByIdIntTest extends IntegrationBase {
         String expectedResponse = getContentsFromFile(
             "tests/cases/CaseControllerAdminGetCaseByIdTest/expectedResponse_isDeleted.json");
         expectedResponse = expectedResponse
-            .replace("<CREATED_AT>", courtCase.getCreatedDateTime().format(DateTimeFormatter.ISO_DATE_TIME))
-            .replace("<LAST_MODIFIED_AT>", courtCase.getLastModifiedDateTime().format(DateTimeFormatter.ISO_DATE_TIME))
+            .replace("<CREATED_AT>", formatAsUtc(courtCase.getCreatedDateTime()))
+            .replace("<LAST_MODIFIED_AT>", formatAsUtc(courtCase.getLastModifiedDateTime()))
             .replace("<CASE_DELETED_BY>", String.valueOf(deletedBy.getId()));
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
@@ -299,8 +299,8 @@ class CaseControllerAdminGetCaseByIdIntTest extends IntegrationBase {
         String expectedResponse = getContentsFromFile(
             "tests/cases/CaseControllerAdminGetCaseByIdTest/expectedResponse_withRetentionAndAdditionalCaseDetails.json");
         expectedResponse = expectedResponse
-            .replace("<CREATED_AT>", courtCase.getCreatedDateTime().format(DateTimeFormatter.ISO_DATE_TIME))
-            .replace("<LAST_MODIFIED_AT>", courtCase.getLastModifiedDateTime().format(DateTimeFormatter.ISO_DATE_TIME));
+            .replace("<CREATED_AT>", formatAsUtc(courtCase.getCreatedDateTime()))
+            .replace("<LAST_MODIFIED_AT>", formatAsUtc(courtCase.getLastModifiedDateTime()));
         JSONAssert.assertEquals(expectedResponse, actualResponse, JSONCompareMode.NON_EXTENSIBLE);
     }
 
@@ -327,5 +327,9 @@ class CaseControllerAdminGetCaseByIdIntTest extends IntegrationBase {
                 event.setTimestamp(eventDateTimes.get(index - 1));
                 return event;
             }).toList();
+    }
+
+    private static String formatAsUtc(OffsetDateTime dateTime) {
+        return dateTime.withOffsetSameInstant(UTC).format(DateTimeFormatter.ISO_DATE_TIME);
     }
 }

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/RecordManagementMatterResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/RecordManagementMatterResponse.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 import java.time.OffsetDateTime;
@@ -28,8 +30,12 @@ public class RecordManagementMatterResponse extends BaseRpoResponse {
         private String matterId;
         private String name;
         private boolean isQuickSearch;
+        // These tests read our OpenAPI YAML directly and do not need springdoc.
+        // Exclude springdoc's Swagger jars from the test runtime to avoid duplicate Swagger classes.
+        @Getter(onMethod_ = @JsonProperty("isUsedForRM"))
+        @Setter(onMethod_ = @JsonProperty("isUsedForRM"))
         @JsonProperty("isUsedForRM")
-        private boolean usedForRm;
+        private boolean isUsedForRm;
         private String description;
         private OffsetDateTime createdDate;
         private Integer type;

--- a/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/RecordManagementMatterResponse.java
+++ b/src/main/java/uk/gov/hmcts/darts/arm/client/model/rpo/RecordManagementMatterResponse.java
@@ -29,7 +29,7 @@ public class RecordManagementMatterResponse extends BaseRpoResponse {
         private String name;
         private boolean isQuickSearch;
         @JsonProperty("isUsedForRM")
-        private boolean isUsedForRm;
+        private boolean usedForRm;
         private String description;
         private OffsetDateTime createdDate;
         private Integer type;

--- a/src/test/java/uk/gov/hmcts/darts/openapi/TranscriptionOpenApiContractTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/openapi/TranscriptionOpenApiContractTest.java
@@ -27,8 +27,8 @@ class TranscriptionOpenApiContractTest {
         ValidationReport report = VALIDATOR.validateRequest(request);
 
         assertTrue(report.getMessages().stream()
-            .anyMatch(m -> m.getMessage().contains("Numeric instance is lower than the required " +
-                                                       "minimum (minimum: 1, found: -123)")));
+            .anyMatch(m -> m.getMessage().contains("must have a minimum value of 1")),
+                   () -> report.getMessages().toString());
     }
 
     @Test
@@ -41,11 +41,11 @@ class TranscriptionOpenApiContractTest {
 
         ValidationReport report = VALIDATOR.validateRequest(request);
 
-        String expectedSubstring = "Numeric instance is greater than the required maximum (maximum: "
-            + maxTranscriptionId + ", found: " + exceededTranscriptionId + ")";
+        String expectedSubstring = "must have a maximum value of " + maxTranscriptionId;
 
         assertTrue(
-            report.getMessages().stream().anyMatch(m -> m.getMessage().equals(expectedSubstring))
+            report.getMessages().stream().anyMatch(m -> m.getMessage().contains(expectedSubstring)),
+            () -> report.getMessages().toString()
         );
     }
 


### PR DESCRIPTION
### JIRA link ###

[DMP-5613](https://tools.hmcts.net/jira/browse/DMP-5613)

### Change description ###

- Update plugin io.freefair.lombok to v8.14.4
- Update plugin org.openapi.generator to v7.23.0
- Update dependency org.springdoc:springdoc-openapi-starter-webmvc-ui to v2.8.17
- Update dependency com.atlassian.oai:swagger-request-validator-core to v3
- Update dependency org.junit.jupiter:junit-jupiter to v6
- Update dependency org.springframework:spring-webflux to v7
- Update dependency org.springframework.data:spring-data-envers to v4
- Update dependency uk.gov.service.notify:notifications-java-client to v6

Fixes were made to a couple of test files, and build.gradle.

- [x] AI-assisted

### AI Specific Change description ###

Assistance on pinning down some of the more complex conflicts and error messaging.

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No