### PR TITLE
DMP-5192 CaseExpiryDeletionAutomatedTask Rethrow InterruptedException

### DIFF
--- a/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseExpiryDeleterImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/cases/service/impl/CaseExpiryDeleterImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.darts.cases.service.impl;
 
 import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Limit;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,8 @@ public class CaseExpiryDeleterImpl implements CaseExpiryDeleter {
 
     @Transactional
     @Override
+    @SuppressWarnings("PMD.AvoidInstanceofChecksInCatchClause")//Required to handle interrupted exceptions
+    @SneakyThrows
     public void delete(Integer batchSize) {
         final UserAccountEntity userAccount = userAccountService.getUserAccount();
         OffsetDateTime maxRetentionDate = currentTimeHelper.currentOffsetDateTime()
@@ -38,15 +41,18 @@ public class CaseExpiryDeleterImpl implements CaseExpiryDeleter {
 
         List<Integer> caseIds = caseRepository.findCaseIdsToBeAnonymised(maxRetentionDate, Limit.of(batchSize));
         log.info("Found {} cases to be anonymised out of a batch size {}", caseIds.size(), batchSize);
-        caseIds.forEach(courtCaseId -> {
+        for (Integer courtCaseId : caseIds) {
             try {
                 log.info("Anonymising case with id: {} because the criteria for retention has been met.", courtCaseId);
                 dataAnonymisationService.anonymiseCourtCaseById(userAccount, courtCaseId, false);
                 hearingsService.removeMediaLinkToHearing(courtCaseId);
             } catch (Exception e) {
                 log.error("An error occurred while anonymising case with id: {}", courtCaseId, e);
+                if (e instanceof InterruptedException) {
+                    throw e;
+                }
             }
-        });
+        }
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseExpiryDeleterImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/cases/service/impl/CaseExpiryDeleterImplTest.java
@@ -18,8 +18,11 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -135,6 +138,32 @@ class CaseExpiryDeleterImplTest {
     }
 
     @Test
+    void delete_shouldStopProcessingWhenInterruptedExceptionOccurs() {
+        Duration duration = Duration.ofDays(1);
+        when(config.getBufferDuration()).thenReturn(duration);
+        UserAccountEntity userAccount = mock(UserAccountEntity.class);
+        when(userIdentity.getUserAccount()).thenReturn(userAccount);
+        OffsetDateTime now = OffsetDateTime.now();
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(now);
+
+        when(caseRepository.findCaseIdsToBeAnonymised(any(), any()))
+            .thenReturn(List.of(10, 20, 30));
+        doAnswer(invocation -> {
+            throw new InterruptedException("Simulated interruption");
+        }).when(dataAnonymisationService).anonymiseCourtCaseById(userAccount, 10, false);
+
+        assertThatThrownBy(() -> caseExpiryDeleter.delete(3))
+            .isInstanceOf(InterruptedException.class)
+            .hasMessage("Simulated interruption");
+
+        verify(dataAnonymisationService).anonymiseCourtCaseById(userAccount, 10, false);
+        verify(hearingsService, never()).removeMediaLinkToHearing(10);
+        verify(dataAnonymisationService, never()).anonymiseCourtCaseById(userAccount, 20, false);
+        verify(dataAnonymisationService, never()).anonymiseCourtCaseById(userAccount, 30, false);
+        verify(caseRepository).findCaseIdsToBeAnonymised(now.minus(duration), Limit.of(3));
+    }
+
+    @Test
     void delete_shouldUseProvidedBatchSizeInLimit() {
         Duration duration = Duration.ofHours(6);
         when(config.getBufferDuration()).thenReturn(duration);
@@ -172,4 +201,3 @@ class CaseExpiryDeleterImplTest {
         verify(caseRepository).findCaseIdsToBeAnonymised(expectedMaxRetentionDate, Limit.of(1));
     }
 }
-


### PR DESCRIPTION
### JIRA link  ###

[DMP-5192](https://tools.hmcts.net/jira/browse/DMP-5192)

### Change description ###

InterruptedException is now handled in the case of an automated task reaching its max lock time. An exception is thrown and handled higher up, instead of being swallowed.

- [x] AI-assisted

### AI Specific Change description ###

Provided suggestions around thread handling and tests.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
