### PR TITLE
DMP-5312 Disable User Accounts Inactive For Six Months Or More

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,23 @@
+# DARTS Skills
+
+This folder holds reusable Codex skill guides for `darts-api`. Add future skills as separate subfolders so each guide can
+keep its instructions, examples, and README together.
+
+## Available Skills
+
+- [Automated Task Generator](automated-task-generator/README.md): creates the standard DARTS automated-task wiring,
+  including Flyway data, task configuration, runner classes, and a domain service stub.
+
+## Folder Convention
+
+Use one folder per skill:
+
+```text
+skills/
+  <skill-name>/
+    README.md
+    <skill-name>.md
+```
+
+Keep each skill focused on one repeatable workflow. Put detailed examples in the skill folder rather than the repository
+root.

--- a/skills/automated-task-generator/README.md
+++ b/skills/automated-task-generator/README.md
@@ -1,0 +1,78 @@
+# Automated Task Generator
+
+`automated-task-generator.md` is a reusable Codex guide for adding new DARTS automated tasks consistently.
+It is based on the pattern introduced by `InboundAudioFailureCorrectionAutomatedTask` in PR `hmcts/darts-api#3362`.
+
+## What It Creates
+
+Use the generator when a new scheduled or manually runnable task needs the standard DARTS automated-task wiring:
+
+- a Flyway migration in `src/main/resources/db/migration/common`
+- an `automated_task` row
+- a matching system user in `user_account`
+- an `AutomatedTaskName` enum entry
+- a Spring `@ConfigurationProperties` task config
+- a `darts.automated.task.<task-name>` block in `application.yaml`
+- a lockable task runner in `uk.gov.hmcts.darts.task.runner.impl`
+- a domain service interface and implementation stub for the business logic
+
+## Required Inputs
+
+Provide these values to the skill:
+
+```text
+Task name: <PascalCase task name, e.g. InboundAudioFailureCorrection>
+Description: <automated_task.task_description>
+User ID: <negative usr_id for the task system user>
+
+What should the automated task do?
+<Describe the data it reads, the action it performs, dependencies it may use, and the owning domain.>
+```
+
+The task-behaviour description is important. The generator uses it to decide where the service stub should live, for
+example `audio`, `datamanagement`, `arm`, `retention`, `transcriptions`, `dailylist`, or another existing domain package.
+
+Optional values include cron expression, batch size, enabled state, cron editability, lock durations, whether the task is
+manual-runnable, and whether it needs async task configuration.
+
+## How To Use
+
+Open `automated-task-generator.md`, fill in the request template, and ask Codex to generate the task from it. A good prompt
+looks like this:
+
+```text
+Use automated-task-generator.md to create a new automated task.
+
+Task name: ExampleCleanup
+Description: Cleans up example records after successful export
+User ID: -54
+
+What should the automated task do?
+Find exported example records older than 30 days, mark them as cleaned up, and record the system user as the modifier.
+This belongs in the data management domain and will likely use ExampleRecordRepository.
+
+Batch size: 1000
+Task enabled: false
+Cron expression: 0 15 2 * * *
+```
+
+## Expected Review Points
+
+After generation, check:
+
+- the Flyway migration version is unique
+- `system-user-email` exactly matches the inserted system user email
+- `AutomatedTaskName` exactly matches `automated_task.task_name`
+- the runner only handles scheduling, locking, and delegation
+- business logic lives in the selected domain service
+- focused unit tests exist once the service contains real branching, validation, mapping, repository selection, error handling, or batch logic
+
+## Local Validation
+
+Run focused tests for the touched service or runner first. Before PR handoff, run:
+
+```bash
+./gradlew check
+```
+
+If the change touches integration behaviour, also run the relevant focused `./gradlew integration --tests '<Pattern>'`.

--- a/skills/automated-task-generator/automated-task-generator.md
+++ b/skills/automated-task-generator/automated-task-generator.md
@@ -1,0 +1,198 @@
+# Create a DARTS Automated Task
+
+Use this skill when adding a new automated task to `darts-api`. It captures the current task pattern used by
+`InboundAudioFailureCorrectionAutomatedTask`: a Flyway row in `automated_task`, a matching system user, a Spring
+configuration class, a runner under `uk.gov.hmcts.darts.task.runner.impl`, and a domain service stub where the task
+business logic belongs.
+
+## Required Request Template
+
+Ask the user for these values before generating files:
+
+```text
+Task name: <PascalCase task name used in automated_task.task_name, e.g. InboundAudioFailureCorrection>
+Description: <human-readable automated_task.task_description>
+User ID: <negative usr_id for the system user, e.g. -53>
+
+What should the automated task do?
+<Describe the data it reads, the business action it performs, the repositories/services/APIs it is likely to use,
+and the domain area it belongs to, e.g. audio, ARM, data management, retention, transcription, daily list.>
+
+Optional:
+Cron expression: <Spring cron expression, default to a safe disabled/off-hours value if unknown>
+Batch size: <integer, default 1000>
+Task enabled: <true|false, default false unless the user explicitly wants it active on deploy>
+Cron editable: <true|false, default true>
+Lock at least for: <ISO-8601 duration, default PT1M>
+Lock at most for: <ISO-8601 duration, default PT45M>
+Manual runnable: <true|false, default true>
+Async task: <true|false, default false>
+```
+
+The "What should the automated task do?" answer controls where to place the service stub. Inspect existing packages
+before choosing:
+
+- Audio or media repair/linking/deletion: `src/main/java/uk/gov/hmcts/darts/audio/service`.
+- ARM, RPO, DETS, object storage, or response-file work: prefer the existing `arm`, `dets`, or `datamanagement`
+  package that already owns the closest service/repository flow.
+- Retention, case expiry, transcription, daily list, annotation, or admin work: place the service in that domain package.
+- If no clear domain exists, create a narrow service interface under the closest existing domain package rather than under
+  `task`; keep `task.runner.impl` limited to scheduling, locking, batch-size lookup, and delegation.
+
+## Generation Steps
+
+1. Derive naming:
+   - `TaskName`: exact PascalCase value for `automated_task.task_name`.
+   - `task-name`: kebab-case for `darts.automated.task.<task-name>`.
+   - `TASK_NAME_TASK_NAME`: enum constant in `AutomatedTaskName`.
+   - `TaskNameAutomatedTask`: runner class.
+   - `TaskNameAutomatedTaskConfig`: config class.
+   - `TaskNameService` and `TaskNameServiceImpl`: domain service stub names unless the domain already has a better API.
+   - `system_TaskNameAutomatedTask@hmcts.net`: default system user email, unless the user provides a specific value.
+
+2. Add a Flyway migration under `src/main/resources/db/migration/common` using the next available version:
+
+```sql
+INSERT INTO automated_task (aut_id, task_name, task_description, cron_expression, cron_editable, batch_size,
+                            created_ts, created_by, last_modified_ts, last_modified_by, task_enabled)
+VALUES (nextval('aut_seq'), '<TaskName>', '<Description>', '<Cron expression>', <cron_editable>, <batch_size>,
+        current_timestamp, 0, current_timestamp, 0, <task_enabled>);
+
+INSERT INTO user_account (usr_id, user_name, user_email_address, description, created_ts, last_modified_ts, last_modified_by, created_by, is_system_user,
+                          is_active, user_full_name)
+VALUES (<user_id>, 'system_<TaskName>AutomatedTask', 'system_<TaskName>AutomatedTask@hmcts.net',
+        'system_<TaskName>AutomatedTask',
+        current_timestamp, current_timestamp, 0, 0, true, true, 'system_<TaskName>AutomatedTask');
+```
+
+3. Add the enum entry in `src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java`:
+
+```java
+<TASK_NAME>_TASK_NAME("<TaskName>");
+```
+
+Keep enum punctuation valid: add a comma to the previous final entry, and keep the semicolon on the final entry.
+
+4. Add config in `src/main/java/uk/gov/hmcts/darts/task/config/<TaskName>AutomatedTaskConfig.java`:
+
+```java
+package uk.gov.hmcts.darts.task.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationProperties("darts.automated.task.<task-name>")
+@Getter
+@Setter
+@Configuration
+public class <TaskName>AutomatedTaskConfig extends AbstractAutomatedTaskConfig {
+}
+```
+
+Use `AbstractAsyncAutomatedTaskConfig` only when the task genuinely needs the repo's async task properties.
+
+5. Add configuration to `src/main/resources/application.yaml` under `darts.automated.task`:
+
+```yaml
+      <task-name>:
+        system-user-email: system_<TaskName>AutomatedTask@hmcts.net
+        lock:
+          at-least-for: PT1M
+          at-most-for: PT45M
+```
+
+6. Add the domain service interface in the package selected from the user's task-behaviour brief:
+
+```java
+package uk.gov.hmcts.darts.<domain>.service;
+
+@FunctionalInterface
+public interface <TaskName>Service {
+
+    void process(int batchSize);
+}
+```
+
+7. Add a stub implementation in the matching `impl` package:
+
+```java
+package uk.gov.hmcts.darts.<domain>.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.darts.<domain>.service.<TaskName>Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class <TaskName>ServiceImpl implements <TaskName>Service {
+
+    @Override
+    public void process(int batchSize) {
+        log.info("Running <TaskName> with batch size {}", batchSize);
+        // TODO: Implement task behaviour.
+    }
+}
+```
+
+Replace `process` with a domain-specific verb when the user's brief makes one obvious.
+
+8. Add the runner in `src/main/java/uk/gov/hmcts/darts/task/runner/impl/<TaskName>AutomatedTask.java`:
+
+```java
+package uk.gov.hmcts.darts.task.runner.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.<domain>.service.<TaskName>Service;
+import uk.gov.hmcts.darts.task.api.AutomatedTaskName;
+import uk.gov.hmcts.darts.task.config.<TaskName>AutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.runner.AutoloadingManualTask;
+import uk.gov.hmcts.darts.task.service.LockService;
+
+@Slf4j
+@Component
+public class <TaskName>AutomatedTask extends AbstractLockableAutomatedTask<<TaskName>AutomatedTaskConfig>
+    implements AutoloadingManualTask {
+
+    private final <TaskName>Service <taskName>Service;
+
+    public <TaskName>AutomatedTask(AutomatedTaskRepository automatedTaskRepository,
+                                   <TaskName>AutomatedTaskConfig automatedTaskConfig,
+                                   LogApi logApi,
+                                   LockService lockService,
+                                   <TaskName>Service <taskName>Service) {
+        super(automatedTaskRepository, automatedTaskConfig, logApi, lockService);
+        this.<taskName>Service = <taskName>Service;
+    }
+
+    @Override
+    protected void runTask() {
+        <taskName>Service.process(getAutomatedTaskBatchSize());
+    }
+
+    @Override
+    public AutomatedTaskName getAutomatedTaskName() {
+        return AutomatedTaskName.<TASK_NAME>_TASK_NAME;
+    }
+}
+```
+
+Use `AutoloadingManualTask` when the task should be available through the admin manual-run endpoint. Use the narrower
+autoloading interface used by comparable tasks if the task should not be manually runnable.
+
+## Tests And Checks
+
+- Add unit tests for the service implementation as soon as there is branching, validation, mapping, repository selection,
+  error handling, or batch logic.
+- Add or update integration tests when scheduling, task lookup, DB migration data, cron reload, repository queries, or
+  task administration behaviour changes.
+- Run focused tests first, then `./gradlew check` before PR handoff when practical.
+- Confirm the new migration version is unique and in `common`, not `reference/manual-data-fixes`.
+- Confirm `system-user-email` exactly matches the inserted system user's email.
+- Confirm `AutomatedTaskName.<TASK_NAME>_TASK_NAME.getTaskName()` exactly matches `automated_task.task_name`.

--- a/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/UserAccountRepositoryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/darts/common/repository/UserAccountRepositoryTest.java
@@ -8,18 +8,26 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.enums.SecurityGroupEnum;
 import uk.gov.hmcts.darts.test.common.data.PersistableFactory;
 import uk.gov.hmcts.darts.testutils.PostgresIntegrationBase;
 import uk.gov.hmcts.darts.testutils.stubs.DartsPersistence;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UserAccountRepositoryTest extends PostgresIntegrationBase {
@@ -183,6 +191,37 @@ class UserAccountRepositoryTest extends PostgresIntegrationBase {
         assertThat(users.get(0).getId(), equalTo(userAccountEntity3.getId()));
     }
 
+    @Test
+    void findInactiveUsersExcludingRoles_shouldReturnOnlyEligibleInactiveUsers() {
+        OffsetDateTime cutoffDateTime = OffsetDateTime.of(2026, 2, 14, 10, 5, 0, 0, ZoneOffset.UTC);
+        UserAccountEntity oldLastLoginUser = persistUser(
+            "old.last.login@example.net", cutoffDateTime.minusDays(1), cutoffDateTime.minusDays(1), true, false);
+        UserAccountEntity oldNeverLoggedInUser = persistUser(
+            "old.never.logged.in@example.net", cutoffDateTime.minusDays(1), null, true, false);
+        persistUser("recent.last.login@example.net", cutoffDateTime.minusDays(1), cutoffDateTime.plusDays(1), true, false);
+        persistUser("inactive.user@example.net", cutoffDateTime.minusDays(1), cutoffDateTime.minusDays(1), false, false);
+        persistUser("system.user@example.net", cutoffDateTime.minusDays(1), cutoffDateTime.minusDays(1), true, true);
+
+        UserAccountEntity superUser = persistUser(
+            "super.user@example.net", cutoffDateTime.minusDays(1), cutoffDateTime.minusDays(1), true, false);
+        UserAccountEntity superAdmin = persistUser(
+            "super.admin@example.net", cutoffDateTime.minusDays(1), cutoffDateTime.minusDays(1), true, false);
+        dartsDatabase.addUserToGroup(superUser, SecurityGroupEnum.SUPER_USER);
+        dartsDatabase.addUserToGroup(superAdmin, SecurityGroupEnum.SUPER_ADMIN);
+
+        List<UserAccountEntity> users = userAccountRepository.findInactiveUsersExcludingRoles(
+            cutoffDateTime,
+            Set.of(SUPER_USER.getId(), SUPER_ADMIN.getId()),
+            PageRequest.of(0, 10)
+        );
+
+        List<Integer> actualIds = users.stream()
+            .map(UserAccountEntity::getId)
+            .toList();
+
+        assertThat(actualIds, containsInAnyOrder(oldLastLoginUser.getId(), oldNeverLoggedInUser.getId()));
+    }
+
     @ParameterizedTest
     @MethodSource("provideTestCombinations")
     void findUsers_shouldFailWithOneNonMatchingField_WhenOtherFieldsMatch(boolean includeSystemUsers, String emailAddress, List<Integer> userIds) {
@@ -202,4 +241,23 @@ class UserAccountRepositoryTest extends PostgresIntegrationBase {
         );
     }
 
+    private UserAccountEntity persistUser(String emailAddress,
+                                          OffsetDateTime createdDateTime,
+                                          OffsetDateTime lastLoginTime,
+                                          boolean active,
+                                          boolean isSystemUser) {
+        UserAccountEntity userAccount = PersistableFactory.getUserAccountTestData().someMinimalBuilder()
+            .emailAddress(emailAddress)
+            .createdDateTime(createdDateTime)
+            .lastLoginTime(lastLoginTime)
+            .active(active)
+            .isSystemUser(isSystemUser)
+            .securityGroupEntities(new LinkedHashSet<>())
+            .build()
+            .getEntity();
+        UserAccountEntity savedUserAccount = dartsPersistence.save(userAccount);
+        savedUserAccount.setCreatedDateTime(createdDateTime);
+        savedUserAccount.setLastLoginTime(lastLoginTime);
+        return userAccountRepository.saveAndFlush(savedUserAccount);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/darts/common/repository/UserAccountRepository.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.darts.common.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.history.RevisionRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.darts.common.entity.CourthouseEntity;
 import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
@@ -16,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @Repository
+@SuppressWarnings("PMD.TooManyMethods")//Repository class so low complexity in this case
 public interface UserAccountRepository extends
     RevisionRepository<UserAccountEntity, Integer, Long>,
     JpaRepository<UserAccountEntity, Integer>,
@@ -72,6 +75,28 @@ public interface UserAccountRepository extends
         WHERE id = :userId
         """)
     void updateLastLoginTime(Integer userId, OffsetDateTime now);
+
+    @Query("""
+        SELECT DISTINCT userAccount
+        FROM UserAccountEntity userAccount
+        WHERE userAccount.active = true
+        AND userAccount.isSystemUser = false
+        AND (
+            userAccount.lastLoginTime <= :cutoffDateTime
+            OR (userAccount.lastLoginTime IS NULL AND userAccount.createdDateTime <= :cutoffDateTime)
+        )
+        AND NOT EXISTS (
+            SELECT securityGroup
+            FROM UserAccountEntity excludedUser
+            JOIN excludedUser.securityGroupEntities securityGroup
+            WHERE excludedUser = userAccount
+            AND securityGroup.securityRoleEntity.id IN :excludedRoleIds
+        )
+        ORDER BY userAccount.id ASC
+        """)
+    List<UserAccountEntity> findInactiveUsersExcludingRoles(@Param("cutoffDateTime") OffsetDateTime cutoffDateTime,
+                                                            @Param("excludedRoleIds") Set<Integer> excludedRoleIds,
+                                                            Pageable pageable);
 
     List<UserAccountEntity> findByIdInAndActive(List<Integer> userIds, Boolean active);
 

--- a/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/api/AutomatedTaskName.java
@@ -45,7 +45,8 @@ public enum AutomatedTaskName {
     MEDIA_REQUEST_CLEANUP("MediaRequestCleanUp"),
     REMOVE_OLD_ARM_RPO_PRODUCTIONS("RemoveOldArmRpoProductions"),
     ARM_RPO_BACKLOG_CATCHUP("ArmRpoBacklogCatchup", Constants.AUTOMATED_TASK_PROCESS_E2E_ARM_RPO_PENDING_PROCESS_E2E_ARM_RPO_FALSE),
-    CLEAN_UP_DETS_DATA("CleanUpDetsData");
+    CLEAN_UP_DETS_DATA("CleanUpDetsData"),
+    DISABLE_INACTIVE_USER_ACCOUNTS("DisableInactiveUserAccounts");
 
     private final String taskName;
     private final String conditionalOnSpEL;

--- a/src/main/java/uk/gov/hmcts/darts/task/config/DisableInactiveUserAccountsAutomatedTaskConfig.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/config/DisableInactiveUserAccountsAutomatedTaskConfig.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.darts.task.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationProperties("darts.automated.task.disable-inactive-user-accounts")
+@Getter
+@Setter
+@Configuration
+public class DisableInactiveUserAccountsAutomatedTaskConfig extends AbstractAutomatedTaskConfig {
+}

--- a/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DisableInactiveUserAccountsAutomatedTask.java
+++ b/src/main/java/uk/gov/hmcts/darts/task/runner/impl/DisableInactiveUserAccountsAutomatedTask.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.darts.task.runner.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.api.AutomatedTaskName;
+import uk.gov.hmcts.darts.task.config.DisableInactiveUserAccountsAutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.runner.AutoloadingManualTask;
+import uk.gov.hmcts.darts.task.service.LockService;
+import uk.gov.hmcts.darts.usermanagement.service.DisableInactiveUserAccountsService;
+
+import static uk.gov.hmcts.darts.task.api.AutomatedTaskName.DISABLE_INACTIVE_USER_ACCOUNTS;
+
+@Slf4j
+@Component
+public class DisableInactiveUserAccountsAutomatedTask
+    extends AbstractLockableAutomatedTask<DisableInactiveUserAccountsAutomatedTaskConfig>
+    implements AutoloadingManualTask {
+
+    private final DisableInactiveUserAccountsService disableInactiveUserAccountsService;
+
+    public DisableInactiveUserAccountsAutomatedTask(AutomatedTaskRepository automatedTaskRepository,
+                                                    DisableInactiveUserAccountsAutomatedTaskConfig automatedTaskConfig,
+                                                    LogApi logApi,
+                                                    LockService lockService,
+                                                    DisableInactiveUserAccountsService disableInactiveUserAccountsService) {
+        super(automatedTaskRepository, automatedTaskConfig, logApi, lockService);
+        this.disableInactiveUserAccountsService = disableInactiveUserAccountsService;
+    }
+
+    @Override
+    protected void runTask() {
+        disableInactiveUserAccountsService.process(getAutomatedTaskBatchSize());
+    }
+
+    @Override
+    public AutomatedTaskName getAutomatedTaskName() {
+        return DISABLE_INACTIVE_USER_ACCOUNTS;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/DisableInactiveUserAccountsService.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/DisableInactiveUserAccountsService.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.darts.usermanagement.service;
+
+@FunctionalInterface
+public interface DisableInactiveUserAccountsService {
+
+    void process(int batchSize);
+}

--- a/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/DisableInactiveUserAccountsServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/darts/usermanagement/service/impl/DisableInactiveUserAccountsServiceImpl.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.darts.usermanagement.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+import uk.gov.hmcts.darts.usermanagement.service.DisableInactiveUserAccountsService;
+
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.util.List;
+import java.util.Set;
+
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DisableInactiveUserAccountsServiceImpl implements DisableInactiveUserAccountsService {
+
+    private static final Period INACTIVITY_PERIOD = Period.ofMonths(6);
+    private static final Set<Integer> EXCLUDED_ROLE_IDS = Set.of(SUPER_USER.getId(), SUPER_ADMIN.getId());
+    private static final int MINIMUM_BATCH_SIZE = 1;
+
+    private final UserAccountRepository userAccountRepository;
+    private final CurrentTimeHelper currentTimeHelper;
+
+    @Override
+    @Transactional
+    public void process(int batchSize) {
+        int safeBatchSize = Math.max(batchSize, MINIMUM_BATCH_SIZE);
+        OffsetDateTime cutoffDateTime = currentTimeHelper.currentOffsetDateTime().minus(INACTIVITY_PERIOD);
+        List<UserAccountEntity> inactiveUsers = userAccountRepository.findInactiveUsersExcludingRoles(
+            cutoffDateTime,
+            EXCLUDED_ROLE_IDS,
+            PageRequest.of(0, safeBatchSize)
+        );
+
+        if (inactiveUsers.isEmpty()) {
+            log.info("No inactive user accounts found to disable");
+            return;
+        }
+
+        inactiveUsers.forEach(this::disableAndRemoveFromSecurityGroups);
+        userAccountRepository.saveAll(inactiveUsers);
+
+        log.info("Disabled {} inactive user accounts", inactiveUsers.size());
+    }
+
+    private void disableAndRemoveFromSecurityGroups(UserAccountEntity userAccount) {
+        userAccount.getSecurityGroupEntities().clear();
+        userAccount.setActive(false);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -451,6 +451,11 @@ darts:
         chunk-size: 10000
         async-timeout: 20M
         threads: 20
+      disable-inactive-user-accounts:
+        system-user-email: system_DisableInactiveUserAccountsAutomatedTask@hmcts.net
+        lock:
+          at-least-for: PT1M
+          at-most-for: PT45M
       cleanup-arm-response-files:
         system-user-email: system_CleanupArmResponseFiles@hmcts.net
         lock:

--- a/src/main/resources/db/migration/common/V1_515__DisableInactiveUserAccounts_automated_task.sql
+++ b/src/main/resources/db/migration/common/V1_515__DisableInactiveUserAccounts_automated_task.sql
@@ -1,0 +1,11 @@
+INSERT INTO automated_task (aut_id, task_name, task_description, cron_expression, cron_editable, batch_size,
+                            created_ts, created_by, last_modified_ts, last_modified_by, task_enabled)
+VALUES (nextval('aut_seq'), 'DisableInactiveUserAccounts',
+        'Disable user accounts that have not been active for six months or more and remove the user from any security groups',
+        '0 5 10 * * *', true, 1000, current_timestamp, 0, current_timestamp, 0, false);
+
+INSERT INTO user_account (usr_id, user_name, user_email_address, description, created_ts, last_modified_ts, last_modified_by, created_by, is_system_user,
+                          is_active, user_full_name)
+VALUES (-52, 'system_DisableInactiveUserAccountsAutomatedTask', 'system_DisableInactiveUserAccountsAutomatedTask@hmcts.net',
+        'system_DisableInactiveUserAccountsAutomatedTask',
+        current_timestamp, current_timestamp, 0, 0, true, true, 'system_DisableInactiveUserAccountsAutomatedTask');

--- a/src/test/java/uk/gov/hmcts/darts/task/runner/impl/DisableInactiveUserAccountsAutomatedTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/task/runner/impl/DisableInactiveUserAccountsAutomatedTaskTest.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.darts.task.runner.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.darts.common.entity.AutomatedTaskEntity;
+import uk.gov.hmcts.darts.common.repository.AutomatedTaskRepository;
+import uk.gov.hmcts.darts.log.api.LogApi;
+import uk.gov.hmcts.darts.task.api.AutomatedTaskName;
+import uk.gov.hmcts.darts.task.config.DisableInactiveUserAccountsAutomatedTaskConfig;
+import uk.gov.hmcts.darts.task.service.LockService;
+import uk.gov.hmcts.darts.usermanagement.service.DisableInactiveUserAccountsService;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DisableInactiveUserAccountsAutomatedTaskTest {
+
+    @Mock
+    private AutomatedTaskRepository automatedTaskRepository;
+    @Mock
+    private DisableInactiveUserAccountsAutomatedTaskConfig automatedTaskConfig;
+    @Mock
+    private LogApi logApi;
+    @Mock
+    private LockService lockService;
+    @Mock
+    private DisableInactiveUserAccountsService disableInactiveUserAccountsService;
+
+    private DisableInactiveUserAccountsAutomatedTask automatedTask;
+
+    @BeforeEach
+    void setUp() {
+        automatedTask = new DisableInactiveUserAccountsAutomatedTask(
+            automatedTaskRepository,
+            automatedTaskConfig,
+            logApi,
+            lockService,
+            disableInactiveUserAccountsService
+        );
+    }
+
+    @Test
+    void runTask_shouldProcessInactiveUsersWithAutomatedTaskBatchSize() {
+        AutomatedTaskEntity automatedTaskEntity = new AutomatedTaskEntity();
+        automatedTaskEntity.setBatchSize(1000);
+        when(automatedTaskRepository.findByTaskName("DisableInactiveUserAccounts")).thenReturn(Optional.of(automatedTaskEntity));
+
+        automatedTask.runTask();
+
+        verify(disableInactiveUserAccountsService).process(1000);
+    }
+
+    @Test
+    void getAutomatedTaskName_shouldReturnCorrectName() {
+        assertThat(automatedTask.getAutomatedTaskName())
+            .isEqualTo(AutomatedTaskName.DISABLE_INACTIVE_USER_ACCOUNTS);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/DisableInactiveUserAccountsServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/darts/usermanagement/service/impl/DisableInactiveUserAccountsServiceImplTest.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.darts.usermanagement.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import uk.gov.hmcts.darts.common.entity.SecurityGroupEntity;
+import uk.gov.hmcts.darts.common.entity.UserAccountEntity;
+import uk.gov.hmcts.darts.common.helper.CurrentTimeHelper;
+import uk.gov.hmcts.darts.common.repository.UserAccountRepository;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_ADMIN;
+import static uk.gov.hmcts.darts.common.enums.SecurityRoleEnum.SUPER_USER;
+
+@ExtendWith(MockitoExtension.class)
+class DisableInactiveUserAccountsServiceImplTest {
+
+    private static final OffsetDateTime CURRENT_DATE_TIME = OffsetDateTime.of(2026, 8, 14, 10, 5, 0, 0, ZoneOffset.UTC);
+    private static final OffsetDateTime CUTOFF_DATE_TIME = CURRENT_DATE_TIME.minusMonths(6);
+    private static final Set<Integer> EXCLUDED_ROLE_IDS = Set.of(SUPER_USER.getId(), SUPER_ADMIN.getId());
+
+    @Mock
+    private UserAccountRepository userAccountRepository;
+    @Mock
+    private CurrentTimeHelper currentTimeHelper;
+
+    private DisableInactiveUserAccountsServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DisableInactiveUserAccountsServiceImpl(userAccountRepository, currentTimeHelper);
+    }
+
+    @Test
+    void process_shouldDisableInactiveUsersAndRemoveThemFromSecurityGroups() {
+        UserAccountEntity inactiveUser = userAccount(123);
+        SecurityGroupEntity securityGroup = securityGroup(inactiveUser);
+        inactiveUser.getSecurityGroupEntities().add(securityGroup);
+
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(CURRENT_DATE_TIME);
+        when(userAccountRepository.findInactiveUsersExcludingRoles(CUTOFF_DATE_TIME, EXCLUDED_ROLE_IDS, PageRequest.of(0, 1000)))
+            .thenReturn(List.of(inactiveUser));
+
+        service.process(1000);
+
+        assertThat(inactiveUser.isActive()).isFalse();
+        assertThat(inactiveUser.getSecurityGroupEntities()).isEmpty();
+        verify(userAccountRepository).saveAll(List.of(inactiveUser));
+    }
+
+    @Test
+    void process_shouldUseMinimumBatchSize_WhenBatchSizeIsLessThanOne() {
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(CURRENT_DATE_TIME);
+        when(userAccountRepository.findInactiveUsersExcludingRoles(CUTOFF_DATE_TIME, EXCLUDED_ROLE_IDS, PageRequest.of(0, 1)))
+            .thenReturn(List.of());
+
+        service.process(0);
+
+        verify(userAccountRepository).findInactiveUsersExcludingRoles(CUTOFF_DATE_TIME, EXCLUDED_ROLE_IDS, PageRequest.of(0, 1));
+        verify(userAccountRepository, never()).saveAll(List.of());
+    }
+
+    @Test
+    void process_shouldNotSave_WhenNoInactiveUsersAreFound() {
+        when(currentTimeHelper.currentOffsetDateTime()).thenReturn(CURRENT_DATE_TIME);
+        when(userAccountRepository.findInactiveUsersExcludingRoles(CUTOFF_DATE_TIME, EXCLUDED_ROLE_IDS, PageRequest.of(0, 1000)))
+            .thenReturn(List.of());
+
+        service.process(1000);
+
+        verify(userAccountRepository, never()).saveAll(List.of());
+    }
+
+    private static UserAccountEntity userAccount(Integer id) {
+        UserAccountEntity userAccount = new UserAccountEntity();
+        userAccount.setId(id);
+        userAccount.setActive(true);
+        userAccount.setIsSystemUser(false);
+        return userAccount;
+    }
+
+    private static SecurityGroupEntity securityGroup(UserAccountEntity userAccount) {
+        SecurityGroupEntity securityGroup = new SecurityGroupEntity();
+        securityGroup.getUsers().add(userAccount);
+        return securityGroup;
+    }
+}


### PR DESCRIPTION
### JIRA link ###

[DMP-5312](https://tools.hmcts.net/jira/browse/DMP-5312)

### Change description ###

A new automated task, DisableInactiveUserAccounts, has been added. This disables user accounts (except for specific/higher level accounts) that have not been used for six months or more. It also removes the account from any security groups it is associated with. This does not delete accounts.

- [x] AI-assisted

### AI Specific Change description ###

Use of Codex to generate the automated task implementation, based on the Codex SKILL guide.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
